### PR TITLE
Make all TEI files compliant with TEI ALL schema

### DIFF
--- a/tei/1790_Forster_Ansichten.xml
+++ b/tei/1790_Forster_Ansichten.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1796_Goethe_Lehrjahre.xml
+++ b/tei/1796_Goethe_Lehrjahre.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1802_Novalis_Heinrich-von-Ofterdingen.xml
+++ b/tei/1802_Novalis_Heinrich-von-Ofterdingen.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1802_Novalis_Lehrlinge.xml
+++ b/tei/1802_Novalis_Lehrlinge.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1807_Kleist_Erdbeben.xml
+++ b/tei/1807_Kleist_Erdbeben.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1808_Humboldt_Ansichten-Natur.xml
+++ b/tei/1808_Humboldt_Ansichten-Natur.xml
@@ -74,9 +74,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">
@@ -90,8 +88,8 @@
     <docTitle>
      <titlePart type="main">Ansichten der Natur</titlePart>
      <titlePart type="sub">mit wissenschaftlichen Erläuterungen</titlePart>
-     <docAuthor>von Alexander von Humboldt</docAuthor>
     </docTitle>
+    <docAuthor>von Alexander von Humboldt</docAuthor>
    </titlePage>
    <div type="preface">
     <head>Vorrede zur ersten Ausgabe</head>

--- a/tei/1812_Tieck_Elfen.xml
+++ b/tei/1812_Tieck_Elfen.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1813_Goethe_Italienische-Reise.xml
+++ b/tei/1813_Goethe_Italienische-Reise.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1817_Hoffmann_Das_Fremde_Kind.xml
+++ b/tei/1817_Hoffmann_Das_Fremde_Kind.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1819_Hoffmann_Bergwerke.xml
+++ b/tei/1819_Hoffmann_Bergwerke.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1821_Hoffmann_Murr.xml
+++ b/tei/1821_Hoffmann_Murr.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1826_Heine_Harzreise.xml
+++ b/tei/1826_Heine_Harzreise.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1829_Goethe_Wanderjahre.xml
+++ b/tei/1829_Goethe_Wanderjahre.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1836_Chamisso_Reise-um-die-Welt.xml
+++ b/tei/1836_Chamisso_Reise-um-die-Welt.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1842_von-Droste-Huelshoff_Judenbuche.xml
+++ b/tei/1842_von-Droste-Huelshoff_Judenbuche.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1844_Stifter_Hochwald.xml
+++ b/tei/1844_Stifter_Hochwald.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1853_Stifter_Steine.xml
+++ b/tei/1853_Stifter_Steine.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1857_Stifter_Nachsommer.xml
+++ b/tei/1857_Stifter_Nachsommer.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1870_Keller_gruene-Heinrich.xml
+++ b/tei/1870_Keller_gruene-Heinrich.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1874_Storm_Waldwinkel.xml
+++ b/tei/1874_Storm_Waldwinkel.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1875_Keller_Seldwyla.xml
+++ b/tei/1875_Keller_Seldwyla.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1877_Spielhagen_Sturmflut.xml
+++ b/tei/1877_Spielhagen_Sturmflut.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1881_Keller_Sinngedicht.xml
+++ b/tei/1881_Keller_Sinngedicht.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1884_Raabe_Pfisters-Muehle.xml
+++ b/tei/1884_Raabe_Pfisters-Muehle.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1886_Keller_Salander.xml
+++ b/tei/1886_Keller_Salander.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1888_Storm_Schimmelreiter.xml
+++ b/tei/1888_Storm_Schimmelreiter.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1893_Telmann_Dolomiten.xml
+++ b/tei/1893_Telmann_Dolomiten.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1897_Fontane_Stechlin.xml
+++ b/tei/1897_Fontane_Stechlin.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1913_Kellermann_Tunnel.xml
+++ b/tei/1913_Kellermann_Tunnel.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1913_Scheerbart_Asteroiden-Roman.xml
+++ b/tei/1913_Scheerbart_Asteroiden-Roman.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/1920_Kafka_Bericht.xml
+++ b/tei/1920_Kafka_Bericht.xml
@@ -71,9 +71,7 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2023-03-31">

--- a/tei/Adalbert_Stifter_-_Der_beschriebene_Taennling_(1846).xml
+++ b/tei/Adalbert_Stifter_-_Der_beschriebene_Taennling_(1846).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Adolf_Pichler_-_Ein_Brautpaar_(1867).xml
+++ b/tei/Adolf_Pichler_-_Ein_Brautpaar_(1867).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Agnes_Guenther_-_Die_Heilige_und_ihr_Narr_-_Band_2_(1913).xml
+++ b/tei/Agnes_Guenther_-_Die_Heilige_und_ihr_Narr_-_Band_2_(1913).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Alois_Theodor_Sonnleitner_-_Die_Hohlenkinder__Im_Heimlichen_Grund_(1918).xml
+++ b/tei/Alois_Theodor_Sonnleitner_-_Die_Hohlenkinder__Im_Heimlichen_Grund_(1918).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Alois_Theodor_Sonnleitner_-_Die_Hohlenkinder__Im_Steinhaus_(1920).xml
+++ b/tei/Alois_Theodor_Sonnleitner_-_Die_Hohlenkinder__Im_Steinhaus_(1920).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/August_Kopisch_-_Ein_Carnevalsfest_auf_Ischia_(1856).xml
+++ b/tei/August_Kopisch_-_Ein_Carnevalsfest_auf_Ischia_(1856).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Berthold_Auerbach_-_Auf_der_Hoehe_Dritter_Band_(1865).xml
+++ b/tei/Berthold_Auerbach_-_Auf_der_Hoehe_Dritter_Band_(1865).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="medium" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="medium" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Charles_Sealsfield_-_In_der_Praerie_verirrt_(1841).xml
+++ b/tei/Charles_Sealsfield_-_In_der_Praerie_verirrt_(1841).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Christoph_von_Schmid_-_Wie_Heinrich_von_Eichenfels_zur_Erkenntnis_Gottes_kam_(1817).xml
+++ b/tei/Christoph_von_Schmid_-_Wie_Heinrich_von_Eichenfels_zur_Erkenntnis_Gottes_kam_(1817).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Clemens_Brentano_-_Aus_der_Chronika_eines_fahrenden_Schuelers_(Zweite_Fassung)_(1818).xml
+++ b/tei/Clemens_Brentano_-_Aus_der_Chronika_eines_fahrenden_Schuelers_(Zweite_Fassung)_(1818).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Clemens_Brentano_-_Die_mehreren_Wehmueller_und_ungarischen_Nationalgesichter_(1817).xml
+++ b/tei/Clemens_Brentano_-_Die_mehreren_Wehmueller_und_ungarischen_Nationalgesichter_(1817).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Curt_Grottewitz_-_Sonntage_eines_Grossstaedters_in_der_Natur_(1906).xml
+++ b/tei/Curt_Grottewitz_-_Sonntage_eines_Grossstaedters_in_der_Natur_(1906).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/David_Friedrich_Weinland_-_Rulaman_(1878).xml
+++ b/tei/David_Friedrich_Weinland_-_Rulaman_(1878).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="medium" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="medium" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/ETA_Hoffmann_-_Die_Irrungen_-_Verloren_und_Gefunden_(1820).xml
+++ b/tei/ETA_Hoffmann_-_Die_Irrungen_-_Verloren_und_Gefunden_(1820).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Eduard_von_Keyserling_-_Seine_Liebeserfahrung_(1906).xml
+++ b/tei/Eduard_von_Keyserling_-_Seine_Liebeserfahrung_(1906).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Ferdinand_von_Saar_-_Innocens_(1866).xml
+++ b/tei/Ferdinand_von_Saar_-_Innocens_(1866).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Franz_Kafka_-_Auf_der_Galerie_(1916).xml
+++ b/tei/Franz_Kafka_-_Auf_der_Galerie_(1916).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Franz_Kafka_-_Der_Geier_(1916).xml
+++ b/tei/Franz_Kafka_-_Der_Geier_(1916).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Franz_Kafka_-_Prometheus_(1918).xml
+++ b/tei/Franz_Kafka_-_Prometheus_(1918).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Franz_Kafka_-_Schakale_und_Araber_(1916).xml
+++ b/tei/Franz_Kafka_-_Schakale_und_Araber_(1916).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Friedrich_Gerstaecker_-_Der_Fischfang_am_Mississippi_(1847).xml
+++ b/tei/Friedrich_Gerstaecker_-_Der_Fischfang_am_Mississippi_(1847).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Friedrich_Gerstaecker_-_Die_Nacht_auf_dem_Walfisch_(1858).xml
+++ b/tei/Friedrich_Gerstaecker_-_Die_Nacht_auf_dem_Walfisch_(1858).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Friedrich_Gerstaecker_-_Die_Regulatoren_in_Arkansas_(1845).xml
+++ b/tei/Friedrich_Gerstaecker_-_Die_Regulatoren_in_Arkansas_(1845).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Friedrich_Gerstaecker_-_John_Wells_(1859).xml
+++ b/tei/Friedrich_Gerstaecker_-_John_Wells_(1859).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Gottfried_August_Buerger_-_Muenchhausen_(1786).xml
+++ b/tei/Gottfried_August_Buerger_-_Muenchhausen_(1786).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Gottfried_Keller_-_Die_drei_gerechten_Kammacher_(1856).xml
+++ b/tei/Gottfried_Keller_-_Die_drei_gerechten_Kammacher_(1856).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Gottfried_Keller_-_Spiegel,_das_Kaetzchen_(1856).xml
+++ b/tei/Gottfried_Keller_-_Spiegel,_das_Kaetzchen_(1856).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Gustav_Sack_-_Ein_verbummelter_Student_(1917).xml
+++ b/tei/Gustav_Sack_-_Ein_verbummelter_Student_(1917).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Heinrich_Heine_-_Schnabelewopski_(1834).xml
+++ b/tei/Heinrich_Heine_-_Schnabelewopski_(1834).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Heinrich_Laube_-_Johanna_(1837).xml
+++ b/tei/Heinrich_Laube_-_Johanna_(1837).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Heinrich_Seidel_-_Der_Rosenkoenig_(1899).xml
+++ b/tei/Heinrich_Seidel_-_Der_Rosenkoenig_(1899).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Heinrich_Seidel_-_Ein_Skizzenbuch_(1878).xml
+++ b/tei/Heinrich_Seidel_-_Ein_Skizzenbuch_(1878).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Heinrich_Seidel_-_Fliegender_Sommer_(1873).xml
+++ b/tei/Heinrich_Seidel_-_Fliegender_Sommer_(1873).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Aus_Forst_und_Flur._Vierzig_Tiernovellen_(1914).xml
+++ b/tei/Hermann_Loens_-_Aus_Forst_und_Flur._Vierzig_Tiernovellen_(1914).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Der_zweckmaessige_Meyer_und_andere_Geschichten_(1911).xml
+++ b/tei/Hermann_Loens_-_Der_zweckmaessige_Meyer_und_andere_Geschichten_(1911).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="medium" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="medium" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Heimatliche_Naturbilder_-_Da_draussen_vor_dem_Tore_(1911).xml
+++ b/tei/Hermann_Loens_-_Heimatliche_Naturbilder_-_Da_draussen_vor_dem_Tore_(1911).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Jagdgeschichten_(1914).xml
+++ b/tei/Hermann_Loens_-_Jagdgeschichten_(1914).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Kraut_und_Lot_(1911).xml
+++ b/tei/Hermann_Loens_-_Kraut_und_Lot_(1911).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Mein_braunes_Buch_(1907).xml
+++ b/tei/Hermann_Loens_-_Mein_braunes_Buch_(1907).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Mein_buntes_Buch_(1913).xml
+++ b/tei/Hermann_Loens_-_Mein_buntes_Buch_(1913).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Mein_gruenes_Buch_(1901).xml
+++ b/tei/Hermann_Loens_-_Mein_gruenes_Buch_(1901).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Hermann_Loens_-_Tiergeschichten_(1909).xml
+++ b/tei/Hermann_Loens_-_Tiergeschichten_(1909).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Jakob_Michael_Reinhold_Lenz_-_Empfindsamster_aller_Romane_(1781).xml
+++ b/tei/Jakob_Michael_Reinhold_Lenz_-_Empfindsamster_aller_Romane_(1781).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Jean_Paul_-_Schulmeisterlein_Wutz_(1790).xml
+++ b/tei/Jean_Paul_-_Schulmeisterlein_Wutz_(1790).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Jean_Qui_Rit_-_Scharfe_Geschichten_(1908).xml
+++ b/tei/Jean_Qui_Rit_-_Scharfe_Geschichten_(1908).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Jeremias_Gotthelf_-_Der_Oberamtmann_und_der_Amtsrichter_(1853).xml
+++ b/tei/Jeremias_Gotthelf_-_Der_Oberamtmann_und_der_Amtsrichter_(1853).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Jeremias_Gotthelf_-_Die_schwarze_Spinne_(1842).xml
+++ b/tei/Jeremias_Gotthelf_-_Die_schwarze_Spinne_(1842).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Jeremias_Gotthelf_-_Kurt_von_Koppigen_(1844).xml
+++ b/tei/Jeremias_Gotthelf_-_Kurt_von_Koppigen_(1844).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Johann_David_Wyss_-_Der_schweizerische_Robinson_(1812).xml
+++ b/tei/Johann_David_Wyss_-_Der_schweizerische_Robinson_(1812).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Johanna_Spyri_-_Beim_Weiden-Joseph_(1882).xml
+++ b/tei/Johanna_Spyri_-_Beim_Weiden-Joseph_(1882).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Joseph_von_Eichendorff_-_Das_Marmorbild_(1819).xml
+++ b/tei/Joseph_von_Eichendorff_-_Das_Marmorbild_(1819).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Joseph_von_Eichendorff_-_Die_Gluecksritter_(1841).xml
+++ b/tei/Joseph_von_Eichendorff_-_Die_Gluecksritter_(1841).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Joseph_von_Eichendorff_-_Libertas_und_ihre_Freier_(1848).xml
+++ b/tei/Joseph_von_Eichendorff_-_Libertas_und_ihre_Freier_(1848).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Karl_Philipp_Moritz_-_Fragmente_aus_dem_Tagebuche_eines_Geistersehers_(1787).xml
+++ b/tei/Karl_Philipp_Moritz_-_Fragmente_aus_dem_Tagebuche_eines_Geistersehers_(1787).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Klabund_-_Franziskus_(1921).xml
+++ b/tei/Klabund_-_Franziskus_(1921).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Klabund_-_Hieronymus_(1928).xml
+++ b/tei/Klabund_-_Hieronymus_(1928).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Klabund_-_Mohammed_(1917).xml
+++ b/tei/Klabund_-_Mohammed_(1917).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Klabund_-_Moreau_(1915).xml
+++ b/tei/Klabund_-_Moreau_(1915).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Kurd_Laßwitz_-_Homchen_(1902).xml
+++ b/tei/Kurd_Laßwitz_-_Homchen_(1902).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Leopold_von_Sacher-Masoch_-_Der_Capitulant_(1875).xml
+++ b/tei/Leopold_von_Sacher-Masoch_-_Der_Capitulant_(1875).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Leopold_von_Sacher-Masoch_-_Don_Juan_von_Kolomea_(1875).xml
+++ b/tei/Leopold_von_Sacher-Masoch_-_Don_Juan_von_Kolomea_(1875).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Ludwig_Aurbacher_-_Erzaehlungen,_Lieder_und_Sprueche_aus_dem_Allerley_(1847).xml
+++ b/tei/Ludwig_Aurbacher_-_Erzaehlungen,_Lieder_und_Sprueche_aus_dem_Allerley_(1847).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Ludwig_Bechstein_-_In_optima_forma_(1854).xml
+++ b/tei/Ludwig_Bechstein_-_In_optima_forma_(1854).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Ludwig_Tieck_-_Die_schoene_Magelone_(1812).xml
+++ b/tei/Ludwig_Tieck_-_Die_schoene_Magelone_(1812).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Manfred_Kyber_-_Balduin_Brummsel_und_andere_Tiergeschichten_(1933).xml
+++ b/tei/Manfred_Kyber_-_Balduin_Brummsel_und_andere_Tiergeschichten_(1933).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Marie_von_Ebner-Eschenbach_-_Krambambuli_(1884).xml
+++ b/tei/Marie_von_Ebner-Eschenbach_-_Krambambuli_(1884).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Matthias_Blank_-_Der_Mord_im_Ballsaal_(1909).xml
+++ b/tei/Matthias_Blank_-_Der_Mord_im_Ballsaal_(1909).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Max_Dauthendey_-_Der_Knabe_auf_dem_Kopf_des_Elephanten_(1909).xml
+++ b/tei/Max_Dauthendey_-_Der_Knabe_auf_dem_Kopf_des_Elephanten_(1909).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Max_Dauthendey_-_Die_Abendglocken_vom_Mijderatempel_hoeren_(1909).xml
+++ b/tei/Max_Dauthendey_-_Die_Abendglocken_vom_Mijderatempel_hoeren_(1909).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Max_Dauthendey_-_Die_acht_Gesichter_am_Biwasee_(1911).xml
+++ b/tei/Max_Dauthendey_-_Die_acht_Gesichter_am_Biwasee_(1911).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Oskar_Panizza_-_Aus_dem_Tagebuch_eines_Hundes_(1892).xml
+++ b/tei/Oskar_Panizza_-_Aus_dem_Tagebuch_eines_Hundes_(1892).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Otto_Julius_Bierbaum_-_Im_Kahne_(1895).xml
+++ b/tei/Otto_Julius_Bierbaum_-_Im_Kahne_(1895).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Paul_Ernst_-_Komoedianten-_und_Spitzbubengeschichten_(1920).xml
+++ b/tei/Paul_Ernst_-_Komoedianten-_und_Spitzbubengeschichten_(1920).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="medium" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="medium" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T4" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Paul_Heyse_-_Das_Glueck_von_Rothenburg_(1881).xml
+++ b/tei/Paul_Heyse_-_Das_Glueck_von_Rothenburg_(1881).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Peter_Rosegger_-_Jakob_der_Letzte_(1889).xml
+++ b/tei/Peter_Rosegger_-_Jakob_der_Letzte_(1889).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="medium" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="medium" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Salomon_Geßner_-_Daphnis_(1754).xml
+++ b/tei/Salomon_Geßner_-_Daphnis_(1754).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Salomon_Geßner_-_Idas_und_Mycon_(1777).xml
+++ b/tei/Salomon_Geßner_-_Idas_und_Mycon_(1777).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T1" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Sophie_Woerishoeffer_-_Das_Naturforscherschiff_(1880).xml
+++ b/tei/Sophie_Woerishoeffer_-_Das_Naturforscherschiff_(1880).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="long" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="long" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Theodor_Storm_-_Von_Kindern_und_Katzen_und_wie_sie_die_Nine_begruben_(1876).xml
+++ b/tei/Theodor_Storm_-_Von_Kindern_und_Katzen_und_wie_sie_die_Nine_begruben_(1876).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Wilhelm_Heinrich_Riehl_-_Der_stumme_Ratsherr_(1895).xml
+++ b/tei/Wilhelm_Heinrich_Riehl_-_Der_stumme_Ratsherr_(1895).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T3" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Wilhelm_Jensen_-_Karin_von_Schweden_(1872).xml
+++ b/tei/Wilhelm_Jensen_-_Karin_von_Schweden_(1872).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">

--- a/tei/Wilhelm_Raabe_-_Im_Siegeskranze_(1866).xml
+++ b/tei/Wilhelm_Raabe_-_Im_Siegeskranze_(1866).xml
@@ -71,12 +71,10 @@
      German
     </language>
    </langUsage>
-   <textDesc>
-    <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/>
-    <size key="short" xmlns="http://distantreading.net/eltec/ns"/>
-    <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/>
-    <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/>
-   </textDesc>
+    <!-- <authorGender key="M" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <size key="short" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <reprintCount key="unspecified" xmlns="http://distantreading.net/eltec/ns"/> -->
+    <!-- <timeSlot key="T2" xmlns="http://distantreading.net/eltec/ns"/> -->
   </profileDesc>
   <revisionDesc>
    <change when="2026-04-16">


### PR DESCRIPTION
## Summary

- Removed `<textDesc>` block from all 113 files — ELTeC-specific child elements (`<authorGender>`, `<size>`, `<reprintCount>`, `<timeSlot>`) made it impossible to satisfy TEI ALL requirements
- Commented out those ELTeC-specific elements rather than deleting them, to preserve the data for future reference
- Fixed misplaced `<docAuthor>` in `1808_Humboldt_Ansichten-Natur.xml`
- All 113 files now pass TEI ALL schema validation (verified with `jing`)

## Test plan

- [ ] Run `jing` against TEI ALL schema on all files in `tei/`
- [ ] Confirm 0 errors