### PR TITLE
Reassign duplicate EcoCor IDs in 9 batch-3 TEI files

### DIFF
--- a/tei/Anklam_Louise_Kindergeschichten_Der_wilde_Arno.xml
+++ b/tei/Anklam_Louise_Kindergeschichten_Der_wilde_Arno.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000138" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000208" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000138_20">
+   <p xml:id="eco_de_0000208_20">
     Der wilde Arno
    </p>
   </front>
@@ -92,220 +92,220 @@
    <div type="group">
     <head>
     </head>
-    <p xml:id="eco_de_0000138_30">
+    <p xml:id="eco_de_0000208_30">
      Arno war der Sohn einer Predigerwitwe: sein Vater war schon gestorben, als er kaum sechs Jahre zählte.
     </p>
-    <p xml:id="eco_de_0000138_40">
+    <p xml:id="eco_de_0000208_40">
      Da seiner Erziehung nun dessen strenge, leitende Hand fehlte und die Mutter gegen ihren Liebling oft allzu nachsichtig war, daher kam es auch wohl, daß er zuweilen über die Stränge schlug und recht übermütig war.
     </p>
-    <p xml:id="eco_de_0000138_50">
+    <p xml:id="eco_de_0000208_50">
      Er war ein kluger, geweckter Junge mit freundlichen blauen Augen, und trotz seiner wilden Streiche hatte ihn jedermann sehr gern. Auch seine Schulkameraden waren ihm sehr zugetan. Wenn er einmal unter ihnen fehlte, so hieß es einstimmig: »Schade, daß der Arno heute nicht hier ist, nun ist es lange nicht so lustig.« Das verhielt sich auch wohl so, denn stets war er der Anstifter aller tollen Streiche, welche die ausgelassene Knabenschar vollführte.
     </p>
-    <p xml:id="eco_de_0000138_60">
+    <p xml:id="eco_de_0000208_60">
      Von seiner Tollheit und seinem Übermut wußte auch Nachbars Knecht Jürgen ein Wort zu erzählen. Es wohnte nämlich nebenan eine Familie, die sich von Milchverkauf und Viehzucht ernährte. Obwohl er sonst mit deren Knecht Jürgen auf gutem Fuße stand, so machte er sich dennoch ein Vergnügen daraus, ihn zu foppen und zu necken, wo er nur konnte.
     </p>
-    <p xml:id="eco_de_0000138_70">
+    <p xml:id="eco_de_0000208_70">
      Wenn er sah, daß Jürgen nebenan in die Kneipe ging, um ein Schnäpschen zum Frühstück zu trinken, so schlich er sich schnell wie der Wind in den Stall. Da setzte er den Kühen Papierdüten oder Büsche auf die Hörner, band sie mit Stroh an den Schwänzen zusammen, daß es aussah, als ob diese einen Tanz aufführten. Dann schrieb er mit großen Buchstaben an die Stalltür:
     </p>
-    <p xml:id="eco_de_0000138_80">
+    <p xml:id="eco_de_0000208_80">
      ›O Jürgelein, wenn du gehst ein Schnäpschen trinken. Dann sich gleich die Kühe einander froh zuwinken. Siehst du, wie sie sich drehen und tanzen Galopp, Munter im Kreise geht es immer: Hü, ho, hopp, hopp!‹
     </p>
-    <p xml:id="eco_de_0000138_90">
+    <p xml:id="eco_de_0000208_90">
      Wenn dann der Knecht zurückkam, beobachtete er ihn lachend durch den Zaun. Wütend rief Jürgen nun, sobald er die tanzenden Kühe erblickte: »Treffe ich einmal den Schlingel, der sich solch einen gottlosen Spaß gemacht hat, nicht heil soll der mir vom Hofe kommen!«
     </p>
-    <p xml:id="eco_de_0000138_100">
+    <p xml:id="eco_de_0000208_100">
      »Was schiltst du denn so, Jürgen, wer hat dich geärgert?« fragte dann, teilnehmend aus seinem Versteck hervortretend, der Übeltäter Arno.
     </p>
-    <p xml:id="eco_de_0000138_110">
+    <p xml:id="eco_de_0000208_110">
      Da nun Jürgen ahnungslos die Geschichte erzählte, sagte er tröstend: »Beruhige dich nur, Jürgen, ein andermal werde ich aufpassen, wenn du fortgehst, und ich verspreche dir, daß ich den Schlingel mit einer tüchtigen Tracht Schläge vom Hof jagen werde, der soll an mich denken, wenn ich ihn dabei ertappe.«
     </p>
-    <p xml:id="eco_de_0000138_120">
+    <p xml:id="eco_de_0000208_120">
      »Das wäre sehr gut von dir, Arnochen«, sagte wieder besänftigt Jürgen. »Sieh doch nur, was die Range hier an die Stalltür geschmiert hat!«
     </p>
-    <p xml:id="eco_de_0000138_130">
+    <p xml:id="eco_de_0000208_130">
      Arno las und lachte, daß er sich die Seiten hielt über den gelungenen Spaß.
     </p>
-    <p xml:id="eco_de_0000138_140">
+    <p xml:id="eco_de_0000208_140">
      Doch nicht immer blieben seine übermütigen Streiche ohne unangenehme Folgen für ihn. Eines Tages, als gerade Jahrmarkt im Städtchen war, wurde er von seinem Freunde, Ernst Werner, eingeladen, ihn zu besuchen.
     </p>
-    <p xml:id="eco_de_0000138_150">
+    <p xml:id="eco_de_0000208_150">
      »Komm nur,« bat dieser, »wir wollen uns einen sehr frohen Nachmittag machen und in unserem Garten ordentlich Äpfel und Birnen schütteln.«
     </p>
-    <p xml:id="eco_de_0000138_160">
+    <p xml:id="eco_de_0000208_160">
      Das ließ sich Arno nicht zweimal anbieten. Bei den reichen Werners wurde er stets sehr gut aufgenommen; in ihrem Garten gab es gar schönes Obst, und in die Bäume klettern, das war so recht nach seinem Sinn.
     </p>
-    <p xml:id="eco_de_0000138_170">
+    <p xml:id="eco_de_0000208_170">
      Sehr gerne nahm er daher die Einladung an, und da auch seine Mutter nichts dagegen einzuwenden hatte, so fand er sich schon bald nach Tisch bei seinem Freunde ein. Ernst war sehr erfreut über sein frühes Kommen, und sie tollten zuerst nach Herzenslust in dem schönen großen Garten herum. Nachher wanderten sie mit vollgepfropften Taschen Obst zu dem nahe gelegenen Eichwäldchen hinaus, dort trafen sie noch mehrere Schulkameraden, denen sie sich anschlossen. Sie amüsierten sich nun alle prächtig zusammen, bis die beiden Freunde sich erinnerten, daß es wohl Zeit zur Rückkehr sei, wenn sie sich noch den Jahrmarkt ansehen wollten.
     </p>
-    <p xml:id="eco_de_0000138_180">
+    <p xml:id="eco_de_0000208_180">
      Da gab es nun viel zu sehen, und beide waren einig darüber, heute einen herrlichen Nachmittag verlebt zu haben. Doch man muß den Tag nicht vor dem Abend loben! Diese Erfahrung sollte auch der übermütige Arno noch machen. »Sieh nur den dicken Töpfer dort,« sagte er zu Ernst, »wie ein Löwe steht er da vor seinen Töpfen und verfolgt jeden mit grimmigen Blicken, der in die Nähe seines Platzes kommt und nichts kauft.
     </p>
-    <p xml:id="eco_de_0000138_190">
+    <p xml:id="eco_de_0000208_190">
      Ich werde einmal im Galopp über den schmalen Steg quer über seinen Platz laufen. Da komme ich ja sehr gut hinüber, ohne auch nur das geringste entzwei zu machen, aber der behäbige Meister wird natürlich einen Schreck bekommen und ein Zetergeschrei erheben. Das wird ein Hauptspaß, sage ich dir!«
     </p>
-    <p xml:id="eco_de_0000138_200">
+    <p xml:id="eco_de_0000208_200">
      »Das tue nur lieber nicht,« warnte Ernst, »du könntest dabei doch Schaden anrichten, und dann schlüge der Mensch einen furchtbaren Lärm, und du müßtest alles bezahlen!«
     </p>
-    <p xml:id="eco_de_0000138_210">
+    <p xml:id="eco_de_0000208_210">
      »Ach was!« rief Arno, »ich sage dir ja, nichts, rein gar nichts mache ich entzwei.« Und im wilden Lauf jagte er davon und über den Platz des Töpfers. Glücklich kam er denn auch wirklich, begleitet von den Flüchen und Schelten des erzürnten Meisters, fast bis zu Ende hinüber. Da aber plötzlich glitt er auf einem großen glatten Scherben, den er in seiner übermütigen Lust nicht bemerkt hatte, aus, und fiel mitten in die Tassen, Teller und Töpfe hinein.
     </p>
-    <p xml:id="eco_de_0000138_220">
+    <p xml:id="eco_de_0000208_220">
      An beiden Händen blutend, wurde er von dem erzürnten Töpfer zu seiner Mutter geführt, und die arme Witwe mußte allen Schaden, den er angerichtet, ersetzen. Das ging Arno nun aber doch sehr zu Herzen, und er fühlte tiefe Reue über seinen Übermut.
     </p>
-    <p xml:id="eco_de_0000138_230">
+    <p xml:id="eco_de_0000208_230">
      »Weine nicht, liebe Mutter,« bat er, »ich werde dir nie wieder Kummer bereiten. Ich weiß ja, wie dir oft das Geld zu dem Nötigsten fehlt, und ich will mich bemühen, recht bald etwas zu verdienen, um dir das wiederzugeben, was du heute so unnütz für mich bezahlen mußtest.«
     </p>
-    <p xml:id="eco_de_0000138_240">
+    <p xml:id="eco_de_0000208_240">
      »Ich möchte wissen, womit du wohl etwas verdienen wolltest«, erwiderte die bekümmerte Mutter. »Wenn du dich nicht änderst, dann wird nie etwas aus dir werden.«
     </p>
-    <p xml:id="eco_de_0000138_250">
+    <p xml:id="eco_de_0000208_250">
      Arno liebte seine Mutter über alles, und er war so traurig, ihr solchen Kummer gemacht zu haben, daß er einige Tage, still und nachdenklich umherging.
     </p>
-    <p xml:id="eco_de_0000138_260">
+    <p xml:id="eco_de_0000208_260">
      Die Schulkameraden neckten ihn und sagten: »Dein Besuch bei dem Herrn Töpfermeister scheint dir sehr schlecht bekommen zu sein, du machst ja ein Gesicht wie die Katze, wenn es donnert. Eigentlich kannst du doch noch von Glück sagen, daß du mit einem blauen Auge davongekommen bist.«
     </p>
-    <p xml:id="eco_de_0000138_270">
+    <p xml:id="eco_de_0000208_270">
      Nach einigen Tagen aber war die fatale Geschichte wieder vergessen, auch Arno hatte seinen Mut wiedergewonnen und war so vergnügt und der Anführer beim Spiel, wie sonst. Leider aber war er nicht so flott beim Lernen, wie bei der Ausübung mutwilliger Streiche. Nur zu oft bekam er von seinen Lehrern Verweise und Strafe wegen seiner Unaufmerksamkeit, denn selten waren seine Gedanken auf das gerichtet, was der Lehrer erklärte, weil er stets allerlei Unsinn im Kopf hatte. –Da ich nun aber so schlecht gewesen, so mancherlei von Arnos dummen Streichen zu verraten, will ich es auch wieder gutmachen und von seinen guten Seiten erzählen. Arno war, wie schon erwähnt, ein mutiger und gefälliger Junge, der mit seinen Spaßen auch recht oft gute Werke vollbrachte, wie ihr, meine lieben Leser, aus folgendem sogleich hören werdet:
     </p>
-    <p xml:id="eco_de_0000138_280">
+    <p xml:id="eco_de_0000208_280">
      Eines Tages stand er vor dem Platze einer alten Obsthändlerin, um sich Pflaumen zu kaufen. Als die Alte ihm von seinem Zehnpfennigstück fünf Pfennig herausgeben wollte, rief sie plötzlich erschrocken aus: »Ick habe meine Geldtasche verloren«, und sie suchte und suchte, überall herum, konnte sie aber doch nicht finden. »Vielleicht hab ick se och bei mich zu Hause jelassen,« sagte sie, »aber jetzt kann ick hier doch nich fortjehen, unterdessen könnte mich doch das janze Obst jestohlen werden. Oh, Jotte doch, bis zum Abend muß ick nu noch diese Angst ausstehen.«
     </p>
-    <p xml:id="eco_de_0000138_290">
+    <p xml:id="eco_de_0000208_290">
      »Gehen Sie schnell nach Hause und sehen Sie nach«, sagte Arno. »Ich will hier so lange Wache halten, bis Sie wiederkommen und wohl aufpassen, daß Ihnen kein Schaden geschehen soll.«
     </p>
-    <p xml:id="eco_de_0000138_300">
+    <p xml:id="eco_de_0000208_300">
      »Ach, junger Herr, bis bei mich zu Hause, dat is enen weiten Weg, da würde Ihn denn doch die Zeit lang werden, und Se würden nich so lange aushalten, bis dat ick wiederkommen tu«, sagte die Obsthändlerin.
     </p>
-    <p xml:id="eco_de_0000138_310">
+    <p xml:id="eco_de_0000208_310">
      Aber Arno versprach so fest, ausharren zu wollen, wie lange es auch dauern möge, daß die Alte, die doch in großer Sorge ihres Geldes wegen war, sich bereden ließ, und mit dem Versprechen, sobald als möglich wieder da sein zu wollen, abging.
     </p>
-    <p xml:id="eco_de_0000138_320">
+    <p xml:id="eco_de_0000208_320">
      »Ich will ihr alles verkaufen,« dachte Arno, »damit sie eine ganze Handvoll Geld bekommt, wenn sie zurückkehrt.«
     </p>
-    <p xml:id="eco_de_0000138_330">
+    <p xml:id="eco_de_0000208_330">
      Mit lauter Stimme rief er jedem Vorbeikommenden zu: »Kauft Obst! Solche herrlichen Früchte habt ihr noch nie gegessen! Solche prachtvollen Birnen, Äpfel und Pflaumen wie die meinigen kriegt ihr nirgends!«
     </p>
-    <p xml:id="eco_de_0000138_340">
+    <p xml:id="eco_de_0000208_340">
      Lachend und sich darüber amüsierend, standen die Leute still, traten heran und kauften wirklich alle etwas. Ein neben seinem Platze stehender Obsthändler sagte ihm Bescheid und half gefällig beim Einmessen.
     </p>
-    <p xml:id="eco_de_0000138_350">
+    <p xml:id="eco_de_0000208_350">
      Arno war sehr emsig bei der Arbeit, und als er endlich aufblickte, bemerkte er einen ganzen Schwarm seiner Kameraden abseits stehen, die ihm zusahen und sich über ihn belustigten.
     </p>
-    <p xml:id="eco_de_0000138_360">
+    <p xml:id="eco_de_0000208_360">
      »Was steht ihr denn da und gafft?« rief er. »Kommt nur und kauft mir den Rest ab. Solche schöne Birnen und solche süße, reife Pflaumen bekommt ihr nicht alle Tage!«
     </p>
-    <p xml:id="eco_de_0000138_370">
+    <p xml:id="eco_de_0000208_370">
      »Seit wann bist du denn Obsthändler geworden?« Mit dieser Frage kamen sie nun alle lachend und jubelnd angelaufen und riefen: »Hoch lebe Arno, der neue Obsthändler!«
     </p>
-    <p xml:id="eco_de_0000138_380">
+    <p xml:id="eco_de_0000208_380">
      Und wenn jeder von ihnen auch nur für zehn Pfennige kaufte, so waren es doch ihrer viele, und die Körbe waren leer, als die Alte ganz außer Atem zurückkehrte.
     </p>
-    <p xml:id="eco_de_0000138_390">
+    <p xml:id="eco_de_0000208_390">
      Natürlich war sie sehr erfreut, daß Arno in ihrer Abwesenheit so gute Geschäfte gemacht und alles verkauft hatte, was ihr wohl kaum bis zum Abend gelungen wäre.
     </p>
-    <p xml:id="eco_de_0000138_400">
+    <p xml:id="eco_de_0000208_400">
      »Womit soll ick Ihn dat danken, liebes, freundliches, junges Herrchen?« sagte sie, als ihr Arno eine ganze Handvoll Geld übergab. »Ne, Jotte doch, wat sin Se doch für enen juten Jungen. Was wird Ihr Mutterchen noch vor 'ne Freude an Ihn erleben. Jott, wenn ick enen solchen Prachtjungen hätte! Kommen Se doch man recht often und holen Se sich eine Düte Obst von mich.«
     </p>
-    <p xml:id="eco_de_0000138_410">
+    <p xml:id="eco_de_0000208_410">
      Das tat Arno aber nicht. Stets ging er in weitem Bogen auf seinem Schulwege über den Platz, weil ihn am anderen Tage die Hökerin herangerufen und ihm das schönste Obst geschenkt hatte. Er freute sich seiner guten Tat und wollte sich diese nicht bezahlen lassen.
     </p>
-    <p xml:id="eco_de_0000138_420">
+    <p xml:id="eco_de_0000208_420">
      Als er die Geschichte mit der Hökerin seiner Mutter erzählt hatte, sagte diese: »Nun, ich freue mich, daß du dir einmal einen guten Spaß gemacht hast, dergleichen Vergnügen will ich dir schon gerne erlauben.«
     </p>
-    <p xml:id="eco_de_0000138_430">
+    <p xml:id="eco_de_0000208_430">
      »Weißt du, Muttchen, was die Obsthändlerin noch gesagt hat?« fuhr Arno fort: »Ich werde dir noch viele Freude machen!«
     </p>
-    <p xml:id="eco_de_0000138_440">
+    <p xml:id="eco_de_0000208_440">
      »Das gebe Gott!« sagte die Frau Pastor. »Bis jetzt habe ich wenig Grund gehabt, das zu hoffen. Erst heute noch hat mir dein Klassenlehrer geklagt, wie zerstreut und wie unaufmerksam du in der Schule wärest, und es daher sehr fraglich sei, ob du versetzt werden könntest. Ich begreife nur gar nicht, woher du diesen Übermut und Leichtsinn hast; du müßtest doch endlich einsehen, wie nötig es in unseren knappen Verhältnissen ist, daß du recht bald durch die Klassen kommst.«
     </p>
-    <p xml:id="eco_de_0000138_450">
+    <p xml:id="eco_de_0000208_450">
      »Ich werde von jetzt an sehr fleißig werden, Muttchen«, tröstete Arno.
     </p>
-    <p xml:id="eco_de_0000138_460">
+    <p xml:id="eco_de_0000208_460">
      »Das hast du mir schon oft genug versprochen und doch nie Wort gehalten«, erwiderte betrübt die Mutter. »Ich habe mich immer so darauf gefreut, daß du einst, wie dein Vater, ein Pastor und der treue Seelsorger einer Gemeinde werden würdest, aber auf diesen Wunsch muß ich verzichten, das habe ich nun schon lange eingesehn.«
     </p>
-    <p xml:id="eco_de_0000138_470">
+    <p xml:id="eco_de_0000208_470">
      »Das glaube ich wohl auch, Mütterchen,« gab Arno kleinlaut zu, »denn zu einem Pastor passe ich doch am Ende nicht. Ich könnte mir gar nicht denken, wie es wohl möglich sein könnte, daß ich im Talar auf die Kanzel gehen sollte.« Und indem er sich in diese Würde hineindachte, mußte er so lachen, daß ihm die Tränen in die Augen traten.
     </p>
-    <p xml:id="eco_de_0000138_480">
+    <p xml:id="eco_de_0000208_480">
      »Ach, sei nicht böse, liebes, gutes Muttchen«, schmeichelte er, als er den ernsten Blick der Mutter auf sich gerichtet sah. »Ich werde dereinst ein tüchtiger Soldat werden, und wenn dann wieder Krieg wird, dann helfe ich den Feind ordentlich verhauen, und du wirst sehen, ich komme dann mit vielen Orden und vielleicht als Oberst wieder heim.«
     </p>
-    <p xml:id="eco_de_0000138_490">
+    <p xml:id="eco_de_0000208_490">
      »Das schlage dir nur ganz aus dem Sinn,« sagte die Mutter, »dazu sind wir viel zu arm. Woher sollte ich wohl die Zulage für dich nehmen? Ich will Gott danken, wenn du es dahin bringst, einst ein geachteter Kaufmann zu werden. Zum Studieren taugst du nicht, denn dazu wird dir stets die nötige Ruhe und Ausdauer fehlen. Vor allem aber strebe dahin, dereinst ein braver und rechtschaffener Mann zu werden, das bleibt doch stets die Hauptsache.«
     </p>
-    <p xml:id="eco_de_0000138_500">
+    <p xml:id="eco_de_0000208_500">
      Die fromme Frau Pastor hatte schon gar oft im Leben erfahren, wie wunderbar des Herrn Wege sind, und daß der nicht auf Sand gebaut hat, der auf ihn seine Hoffnung setzt. Und sie sollte auch wieder erleben, wie treu und sicher er die Seinen führt.
     </p>
-    <p xml:id="eco_de_0000138_510">
+    <p xml:id="eco_de_0000208_510">
      Eines Tages jagte die ganze Knabenschar, Arno als Anführer wieder voran, in dem zu der Stadt gehörigen Park umher. Sie trieben allerhand lustige Streiche und vergnügten sich nach Herzenslust.
     </p>
-    <p xml:id="eco_de_0000138_520">
+    <p xml:id="eco_de_0000208_520">
      Als sie eben noch einen hoch über den Bäumen fliegenden Drachen verfolgten, blieb Arno plötzlich stehen. »Horcht!« rief er, »war das nicht ein Schrei, der drüben vom Wasser kam?« Und so schnell wie er nur konnte, lief er der Stelle zu, von welcher ihm der Hilferuf zu kommen schien. Alle anderen folgten ihm, und sie kamen auch nur soeben noch an, um ein Kind verzweiflungsvoll mit dem Untergange ringen zu sehen. Arno besann sich nicht lange. Den Rock abwerfen und sich ins Wasser stürzen, war das Werk eines Augenblicks. Im Schwimmen war er allen an Gewandtheit voraus, und so schoß er auch jetzt pfeilschnell der Stelle zu, wo er schon den Kopf des Kindes untergehen sah. Angstvoll standen die anderen Knaben am Ufer, nirgends war eine Hilfe zu erspähen. Es war heute bei dem Winde keine Kleinigkeit, mit dem Wasser zu ringen, und sie zitterten und bangten um das Leben des Freundes. Da, endlich war es ihm gelungen, den Arm des Kindes zu erfassen, und mit größter Anstrengung suchte er nun mit ihm das Ufer zu erreichen, was ihm auch mit Aufbietung aller seiner Kräfte gelang. Als ihn aber die Freunde ans Land gezogen hatten, sank er ohnmächtig und besinnungslos zusammen. Viel zu schwer war die Arbeit für seine jungen Kräfte gewesen. Fast schien es, als sollte sein edles Rettungswerk vergebens sein, denn aus dem Körper des kleinen Mädchens, für das er so heldenmütig sein Leben gewagt hatte, schien jeder Lebensfunken gewichen zu sein, starr und steif lag sie im Grase.
     </p>
-    <p xml:id="eco_de_0000138_530">
+    <p xml:id="eco_de_0000208_530">
      Hilfesuchend spähten die Knaben umher, ob sie nirgends einen erfahrenen Beistand finden konnten. Leider aber war niemand zu bemerken, der Park schien völlig menschenleer zu sein. Endlich erblickten sie in einem Seitenwege einen einsam wandelnden Herrn, und so schnell sie nur konnten, liefen sie hin und baten ihn um seine Hilfe. Und welch glückliche Schicksalsfügung war es, daß dieser Herr gerade ein Arzt sein mußte, der nun sofort die richtigen Belebungsversuche bei beiden anstellte. Er sah sogleich, daß Arno nur erschöpft und ohnmächtig von der übergroßen Anstrengung war und daß er bald wieder zu sich kommen würde.
     </p>
-    <p xml:id="eco_de_0000138_540">
+    <p xml:id="eco_de_0000208_540">
      Hoffnungsloser stand es mit dem kleinen Mädchen, bei dem alle Bemühungen des Arztes erfolglos zu sein schienen. Schon zweifelte er daran, daß die arme Kleine je wieder erwachen werde, da rief einer der Knaben erfreut aus: »Sehen Sie, Herr Doktor, das Augenlid bewegt sich!« Der Arzt, welcher mit Reiben der Füße beschäftigt war, bemerkte nun auch dieses schwache Lebenszeichen. Nachdem er seine Versuche noch weiter fortgesetzt hatte, wurde ein leises Atmen hörbar.
     </p>
-    <p xml:id="eco_de_0000138_550">
+    <p xml:id="eco_de_0000208_550">
      »Wir müssen das Kind jetzt schnell nach Hause bringen, daß es ins Bett kommt und erwärmt wird«, sagte nun der Arzt. »Es ist das Töchterchen des Herrn von Sternau, der mit seiner Familie erst seit kurzem hierher gezogen ist und in der prächtigen Villa jenseits des Parkes wohnt.«
     </p>
-    <p xml:id="eco_de_0000138_560">
+    <p xml:id="eco_de_0000208_560">
      Die armen Eltern waren aufs tiefste erschrocken, als ihnen ihr einziges Kind, das sie schon seit einer Stunde mit größter Angst gesucht hatten, anscheinend fast tot ins Haus gebracht wurde. Ihre Verzweiflung war unbeschreiblich, als die Kleine noch lange so bewußtlos, nur ganz schwach atmend, in ihrem, mit seidenen Gardinen verhüllten Bettchen lag. Es sah aus, als würde sie nie mehr zu frischem, frohem Leben erwachen. Die unglücklichen Eltern flehten zu Gott, ihnen ihr einziges Kind, ihr Glück und ihre Freude, nicht zu nehmen.
     </p>
-    <p xml:id="eco_de_0000138_570">
+    <p xml:id="eco_de_0000208_570">
      Und der liebe Gott erhörte das Gebet der Eltern und ließ den Todesengel an dieser lieblichen Menschenknospe vorübergehen.
     </p>
-    <p xml:id="eco_de_0000138_580">
+    <p xml:id="eco_de_0000208_580">
      Nach einigen Stunden bangen, schmerzlichen Wartens schlug die Kleine müde die blauen Äuglein auf, aber nur, um sie gleich wieder zu einem festen gesunden Schlaf zu schließen.
     </p>
-    <p xml:id="eco_de_0000138_590">
+    <p xml:id="eco_de_0000208_590">
      Groß war das Glück der Eltern, als sie am Morgen mit hellem Blick und mit freundlichem Lächeln von ihrem Liebling begrüßt wurden.
     </p>
-    <p xml:id="eco_de_0000138_600">
+    <p xml:id="eco_de_0000208_600">
      In ihrer Bestürzung und Verzweiflung hatten sie gestern gar nicht daran gedacht, sich nach dem Retter ihres Kindes zu erkundigen. Das bedrückte sie nun sehr. Doch trösteten sie sich damit, daß der Arzt es wissen würde. Aber zu ihrer Betrübnis wußte auch dieser nur, daß es ein kleiner Knabe von etwa 12 Jahren gewesen, den er außer Lebensgefahr verlassen hatte, dessen Name ihm aber nicht bekannt geworden. Herr von Sternau ließ nun aber nicht nach, so lange zu suchen und zu forschen, bis er in Erfahrung gebracht hatte, wer der kleine mutige Mann war, dem er sich zu so großem Dank verpflichtet fühlte.
     </p>
-    <p xml:id="eco_de_0000138_610">
+    <p xml:id="eco_de_0000208_610">
      Nicht weniger erschrocken und unglücklich als die Eltern des kleinen Mädchens war Arnos Mutter gewesen, als sie, von einem der Knaben herbeigerufen, ihren Sohn bewußtlos und mit durchnäßten Kleidern auf der Erde liegend fand. Trotz ihres Schmerzes sorgte sie dennoch mit großer Geistesgegenwart für die richtige Hilfe. Schnell wurde er nach Hause und zu Bett gebracht, und dort erholte er sich auch bald wieder. In einigen Stunden war er wieder so munter, daß er seiner Mutter den Vorgang erzählen konnte. Und die arme Witwe, welcher der Tod schon alle ihre Lieben geraubt hatte, sagte dennoch: »Es ist recht von dir, mein Junge, daß du dich nicht erst lange bedacht, sondern mutig dein Leben für die Rettung des Kindes gewagt hast. Durch diese Tat hast du alle dummen Streiche, die du begangen, wieder gutgemacht. Ich hoffe, daß das kalte Wasser dein heißes Blut ein wenig abgekühlt haben wird, und daß du nun besonnener und ruhiger werden wirst. Gebe nur der liebe Gott, daß dein Werk nicht umsonst getan sei und daß es dem armen, kleinen Kinde ebensogut wie dir ergehen möge. Weißt du, wem die Kleine gehört und auf welche Weise sie verunglückt ist?«
     </p>
-    <p xml:id="eco_de_0000138_620">
+    <p xml:id="eco_de_0000208_620">
      Nein, das wußte Arno nicht, da er das Kind bisher noch nie gesehen hatte. Darüber konnten aber seine Freunde Auskunft geben, welche Arno am Abend besuchten. Sie hatten es von dem Arzt erfahren, welcher die Eltern des Kindes kannte.
     </p>
-    <p xml:id="eco_de_0000138_630">
+    <p xml:id="eco_de_0000208_630">
      Es war wohl eine Woche nach Arnos Rettungswerk verstrichen, als am Sonntag nachmittag ein unerwarteter Besuch die Frau Pastor überraschte. Als sie eben vom Kirchhof gekommen war, trat ein Herr und eine Dame mit einem allerliebsten kleinen Mädchen bei ihr ein.
     </p>
-    <p xml:id="eco_de_0000138_640">
+    <p xml:id="eco_de_0000208_640">
      »Wir kommen, um dem kleinen Helden, Ihrem lieben Söhnchen, unsern innigsten Dank zu bringen«, sagte Herr von Sternau, nachdem er sich und seine Gattin vorgestellt hatte. »Seinem Mut und seiner edlen Opferfähigkeit verdanken wir es nächst Gottes gnädigem Beistand, daß wir heute nicht am Grabe unseres einzigen Kindes stehen.«
     </p>
-    <p xml:id="eco_de_0000138_650">
+    <p xml:id="eco_de_0000208_650">
      Die Frau Pastor war aufs freudigste überrascht und tief gerührt beim Anblick des von ihrem Sohn geretteten hübschen Kindes.
     </p>
-    <p xml:id="eco_de_0000138_660">
+    <p xml:id="eco_de_0000208_660">
      Arno stand verlegen und tief beschämt da, als ihm Herr und Frau von Sternau nun in warmen Worten ihren Dank aussprachen. Ersterer schloß ihn in seine Arme und sagte herzlich: »Ich habe gehört, daß du, mein lieber, wackerer Junge, keinen sorgenden Vater mehr hast. Ich will fortan dein väterlicher Freund und treuer Beschützer sein, und wenn es mir deine gute Mutter gestattet, will ich helfen, dich zu einem tüchtigen Mann zu erziehen.« Auch die kleine Gertrud legte ihre weißen Ärmchen um seinen Hals und sagte: »Ich danke dir, daß du mich nicht hast im Wasser liegen lassen!« Das kam aber so possierlich heraus, daß alle lachen mußten.
     </p>
-    <p xml:id="eco_de_0000138_670">
+    <p xml:id="eco_de_0000208_670">
      Die Eltern erzählten nun auch, wie es kam, daß ihre kleine Gertrud ins Wasser gefallen war. Herr von Sternau und sein Bruder hatten am Tage vorher eine Kahnfahrt gemacht, die Kleine mitgenommen und ihr dabei Wasserrosen gepflückt. Das hatte dem kleinen Fräulein so gefallen, daß sie am anderen Tage allein in den am Ufer befestigten Kahn gestiegen war und versucht hatte, sich eine Wasserrose zu angeln. Der Kahn, der nur leicht befestigt gewesen, war losgegangen und sogleich von dem Winde bis in die Mitte des Wassers getrieben worden. Da es um die Mittagszeit und der Park daher menschenleer gewesen war, so hatte keiner weiter die Hilferufe gehört. Ohne Arnos Hilfe wäre das Kind dem Tode des Ertrinkens nicht entgangen.
     </p>
-    <p xml:id="eco_de_0000138_680">
+    <p xml:id="eco_de_0000208_680">
      Herr von Sternau sorgte nun auch wirklich wie ein Vater für Arno, sowohl für sein leibliches wie auch für sein geistiges Wohl. Obwohl seine Mutter oft bat, seiner Großmut Einhalt zu tun, so ließ er sich doch nicht zurückhalten, Arno in freigebigster Weise zu erfreuen. »Nie können wir ihm genug vergelten, was er für uns getan, immer werden wir in seiner Schuld bleiben«, antwortete er stets der Frau Pastor.
     </p>
-    <p xml:id="eco_de_0000138_690">
+    <p xml:id="eco_de_0000208_690">
      Bald hatte Herr von Sternau den munteren, netten Jungen sehr in sein Herz geschlossen, ebenso wie seine Gattin die stille, bescheidene Frau Pastor herzlich liebgewonnen hatte.
     </p>
-    <p xml:id="eco_de_0000138_700">
+    <p xml:id="eco_de_0000208_700">
      Arno war mit seiner Mutter oft in der Villa, und bei keiner Festlichkeit durften sie dort fehlen.
     </p>
-    <p xml:id="eco_de_0000138_710">
+    <p xml:id="eco_de_0000208_710">
      Da Herr von Sternau sehr reich war, so ließ er es sich nicht nehmen, der kleinen Witwenpension der Frau Pastor noch ein bestimmtes Jahrgeld zuzusetzen, so daß dieser die sie früher oft recht drückenden Existenzsorgen abgenommen waren.
     </p>
-    <p xml:id="eco_de_0000138_720">
+    <p xml:id="eco_de_0000208_720">
      Arno gab sich wohl redlich Mühe, sich der Güte seines Wohltäters wert zu machen, allein manchen mutwilligen Streich verübte er auch ferner noch. Da diese aber immer harmloser Natur blieben und er niemand damit schadete, so belustigte sich Herr von Sternau darüber und sagte, die erzürnte Frau Pastor beruhigend: »Lassen Sie nur, liebe Frau Pastor, die Jugend muß fröhlich sein und muß austoben. Solange ein wilder Junge keine böswilligen Streiche macht, kann ich ihn nicht verurteilen. Viele unserer großen Männer sind in ihrer Jugend wilde Burschen gewesen, und doch sind sie nachher so hervorragende Mitglieder der menschlichen Gesellschaft geworden. Auch unser Arno, so hoffe ich zuversichtlich, wird dereinst seinen Mann stehen und vielleicht auch noch zu Ruhm und Ehren gelangen. Er ist mutig und unverzagt, dabei offen und wahr, und das sind die besten Grundlagen zu großen Leistungen.«
     </p>
-    <p xml:id="eco_de_0000138_730">
+    <p xml:id="eco_de_0000208_730">
      »Vor allem aber möge Gott ihm Kraft geben, sich stets ein reines Herz und ein unbeflecktes Gewissen zu erhalten, denn ohne beides ist aller Ruhm und alle Weisheit wertlos«, entgegnete darauf die biedere Frau Pastor.
     </p>
-    <p xml:id="eco_de_0000138_740">
+    <p xml:id="eco_de_0000208_740">
      Nun, meine lieben Leser, wißt ihr für heute genug von dem wilden Arno, später werde ich euch noch mehr von ihm erzählen. Ich weiß noch eine ganze Anzahl von seinen lustigen Streichen, die ich noch alle zum besten geben werde. Mit der kleinen Gertrud hatte er sich schon gleich am ersten Tage ihrer Bekanntschaft sehr angefreundet. Da er sehr geschickt in Schnitzarbeiten war, so verfertigte er allerlei nette Spielsachen für seine kleine Freundin. Dagegen pflückte Gertrud manch schönes Erdbeersträußchen für ihren lieben Arno, und später beschenkte sie ihren Retter mit hübschen, kunstvollen Stickereien, als sie in solchen erst Unterricht hatte. Die Eltern freuten sich über die Freundschaft der beiden, und ich zweifle durchaus nicht daran, daß die holde Gertrud dereinst die glückliche Frau Arnos werden wird.
     </p>
    </div>

--- a/tei/Bernhard_Marie_Heimatluft.xml
+++ b/tei/Bernhard_Marie_Heimatluft.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000139" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000209" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000139_20">
+   <p xml:id="eco_de_0000209_20">
     Heimatluft
    </p>
   </front>
@@ -92,904 +92,904 @@
    <div type="group">
     <head>
     </head>
-    <p xml:id="eco_de_0000139_30">
+    <p xml:id="eco_de_0000209_30">
      »Sie entschuldigen, mein Herr – sitzen Sie vielleicht lieber rückwärts? Darf ich Ihnen vielleicht meinen Platz anbieten?«
     </p>
-    <p xml:id="eco_de_0000139_40">
+    <p xml:id="eco_de_0000209_40">
      »Danke. Nein. Ich sitze sehr gut hier.«
     </p>
-    <p xml:id="eco_de_0000139_50">
+    <p xml:id="eco_de_0000209_50">
      »So so! Ich meinte nur so. Erlauben Sie, daß ich mir eine Zigarre anzünde?«
     </p>
-    <p xml:id="eco_de_0000139_60">
+    <p xml:id="eco_de_0000209_60">
      »Aber bitte, dies ist ja kein Nichtraucherabteil.«
     </p>
-    <p xml:id="eco_de_0000139_70">
+    <p xml:id="eco_de_0000209_70">
      »Das ist wahr. Na, denn werde ich also –. Wollen Sie nicht auch probieren? Sehr gutes Kraut! Aus Hamburg importiert! – Ich war nämlich eben in Hamburg.«
     </p>
-    <p xml:id="eco_de_0000139_80">
+    <p xml:id="eco_de_0000209_80">
      »Besten Dank. Ich rauche sehr selten.«
     </p>
-    <p xml:id="eco_de_0000139_90">
+    <p xml:id="eco_de_0000209_90">
      »Na, dies ist aber 'n feines Zigarrchen, auf Wort! Kennen Sie Hamburg? Forsche Stadt – was? Kann sich so bald nichts mit vergleichen. Da gewesen?«
     </p>
-    <p xml:id="eco_de_0000139_100">
+    <p xml:id="eco_de_0000209_100">
      »O ja!«
     </p>
-    <p xml:id="eco_de_0000139_110">
+    <p xml:id="eco_de_0000209_110">
      »Sie müssen doch zugeben – fein! Ja – ja – ja – was ich noch sagen wollte: fahren Sie weit?«
     </p>
-    <p xml:id="eco_de_0000139_120">
+    <p xml:id="eco_de_0000209_120">
      »Noch sechs Stunden!«
     </p>
-    <p xml:id="eco_de_0000139_130">
+    <p xml:id="eco_de_0000209_130">
      »Sechs Stunden? Ich auch so lange! Wie sich das trifft! Auch nach W. hinunter?«
     </p>
-    <p xml:id="eco_de_0000139_140">
+    <p xml:id="eco_de_0000209_140">
      »Ja!«
     </p>
-    <p xml:id="eco_de_0000139_150">
+    <p xml:id="eco_de_0000209_150">
      »Sind wir also Leidensgefährten! Obgleich von Leiden eigentlich nichts zu reden ist, hier in der ersten Klasse. Ich fahr' sonst nicht erster Klasse – immer in der zweiten – die ist auch ganz gut. Und Zeiten hat's gegeben, wie ich noch jung war, wo ich froh gewesen bin, wenn ich hab' können in die dritte Klasse einsteigen. Ja, ja ja! Können mir glauben! Ich schäm' mich nicht, drüber zu sprechen. Warum sollt' ich mich auch schämen? Seine Eltern beerben und sich auf'n großen Sack voll Geld setzen und dann den Vornehmen spielen und alles erster Güte haben … i, da kann jeder kommen! Aber sich selbst was verdienen und ordentlich schanzen, so von der Pike auf – und dann hinter sich sehen und sagen können: Ist alles deins! Hast du dir alles selber erworben! Das klingt anders – können Sie mir auf Wort glauben!
     </p>
-    <p xml:id="eco_de_0000139_160">
+    <p xml:id="eco_de_0000209_160">
      »Gewiß!«
     </p>
-    <p xml:id="eco_de_0000139_170">
+    <p xml:id="eco_de_0000209_170">
      Es war die knappste Form der Zustimmung, die knappste Form der Höflichkeit; ein halb unterdrückter Seufzer folgte dem einzigen Worte. Da hatte der Zufall wieder mal zwei auffällige Gegensätze zusammengewürfelt: einen Reisenden, der schweigen, und einen, der reden wollte. Und rettungslos waren sie aneinander geschmiedet. Der Eilzug raste mit ihnen in die warme, dunstige Sommernacht hinaus, und außer ihnen beiden war keine Menschenseele im Wagenabteil erster Klasse.
     </p>
-    <p xml:id="eco_de_0000139_180">
+    <p xml:id="eco_de_0000209_180">
      Hätte Georg Unger gewußt, was ihm bevorstand, er würde vorgegeben haben, kein Deutsch zu verstehen. Damit war's aber zu spät. Wie, wenn er sich schlafend stellte, obwohl er nicht eine Spur müde war?
     </p>
-    <p xml:id="eco_de_0000139_190">
+    <p xml:id="eco_de_0000209_190">
      Er lehnte den Kopf hintenüber und schloß die Augen.
     </p>
-    <p xml:id="eco_de_0000139_200">
+    <p xml:id="eco_de_0000209_200">
      »Ach, Sie werden doch nicht schlafen wollen? Nein, hören Sie, dazu würd' ich Ihnen nicht raten! Dauert nicht lang', und der Schaffner kommt und löscht die Lampen aus, und es wird hell draußen. Und wenn es erst hell ist – na, dann schläft man doch nicht mehr, – dann setzt man sich ans Fenster und guckt raus. Ganz nette Gegend hier, müssen Sie wissen. Gott, na nein, die Schweiz ist es ja nun natürlich nicht – aber schönen Wald kriegen wir zu sehen und auch ganz hübsche Höhenzüge und Seen – na, für die Seen ist's ja hier herum ganz berühmt, das werden Sie doch wissen!«
     </p>
-    <p xml:id="eco_de_0000139_210">
+    <p xml:id="eco_de_0000209_210">
      Keine Rettung! Der dicke, grauhaarige Herr mit dem roten Gesicht – er sah nach einem Weinhändler aus – war nicht still zu bekommen. Höchstens hätte Georg Unger sackgrob werden müssen, und das wollte er nicht.
     </p>
-    <p xml:id="eco_de_0000139_220">
+    <p xml:id="eco_de_0000209_220">
      Tatsache war: Georg Unger gefiel dem dicken, roten Herrn, seine äußere Erscheinung imponierte ihm, und er beschloß, ohne weiteres mit ihm anzuknüpfen. War jener schweigsam und zurückhaltend … er war desto redseliger.
     </p>
-    <p xml:id="eco_de_0000139_230">
+    <p xml:id="eco_de_0000209_230">
      Dabei hatte der dicke Herr ein so gutmütiges, breites Gesicht und solche kleine freundlich zwinkernde Äugelchen, daß schon ein ganz bedeutender Grad von übler Laune dazu gehörte, dies harmlos zufriedene Geschöpf Gottes hart anzulassen. Zudem sprach er Georg Ungers Heimatsdialekt – den hatte er undenklich lange nicht gehört, und wenn ihm tausend Menschen bewiesen hätten, daß dieser ostpreußische Dialekt unschön sei … . er würde ihnen zugestanden haben: Ja, ja, Sie haben ganz recht – aber – eben – schön ist er doch!«
     </p>
-    <p xml:id="eco_de_0000139_240">
+    <p xml:id="eco_de_0000209_240">
      Nicht für das Ohr schön. – Das war wirklich unmöglich! Schön fürs Herz! Und in Georg Unger war dieser bis dahin höchst verständig funktionierende Muskel plötzlich aufgewacht und machte ganz sonderbare Sprünge, und es zitterte beständig durch ihn hin eine Empfindung, die halb Rührung war und halb Mitleid, und halb Beschämung und halb Sehnsucht, und halb Neugierde … ach, nun war es schon viel mehr als ein Ganzes, was da zusammenkam! – Gern hätte er in sich hineingelauscht und versucht, aus all den verworrenen Anklängen eine bestimmte Melodie zu bilden – aber da bilde sich mal jemand eine Melodie, wenn solch ein kompaktes, rotes Individuum einem gegenübersitzt und schwatzt, als ob es dafür bezahlt würde!
     </p>
-    <p xml:id="eco_de_0000139_250">
+    <p xml:id="eco_de_0000209_250">
      »Sehen Sie,« begann der Dicke jetzt von neuem – er schnaufte vernehmlich beim Atemholen und schneuzte sich mit dem Geräusch einer kleinen Trompete – »mein Gewerbe führt mich allerwärts hin. Ich bin Weinhändler,« – also richtig! dachte Georg Unger – »hab' von ganz klein angefangen, aber jetzt hat die Geschichte schon so'n ganz ansehnlichen Schwung gekriegt, und mein Umsatz ist nicht schlecht. Kommt nämlich alles aufs Renommee an, das einer als Kaufmann hat. Taugt das nichts – na, adieu Partie, denn ist die ganze Geschichte Essig! Was ich sagen wollte – – – wenn einer da so in der Welt herumkarriolt, denn muß man sich ja sagen: 's gibt allerlei Schönes auswärts zu holen, so wie man's zu Hause nie und nimmermehr hat. Nee – und dennoch: 's ist nun 'mal zu Haus', und jedesmal, wenn ich in meine Gegend zurückkomm' … hast du nicht gesehn – ist wieder die alte Geschichte: ich freu' mich, und ich kann mir nicht helfen!«
     </p>
-    <p xml:id="eco_de_0000139_260">
+    <p xml:id="eco_de_0000209_260">
      Georg Unger nickte nur zu diesen Worten, aber in sein bis dahin kühl gelassen dreinblickendes Gesicht, das dem Weinhändler so »vornehm« erschien und darum ihm, dem Mann aus dem Volke, so imponierte – in dies Gesicht kam ein solcher Ausdruck von Wärme und freudiger Zustimmung, daß der Dicke bei sich dachte: »Jetzt endlich hab' ich die richtige Saite angeschlagen! Mit dem Heimatsgefühl, da hab' ich diesen feinen Kunden beim Wickel!«
     </p>
-    <p xml:id="eco_de_0000139_270">
+    <p xml:id="eco_de_0000209_270">
      »Sie sind ja nun kein Deutscher!« fuhr er behaglich fort, nachdem er geräuschvoll an seiner Zigarre gesogen hatte. »So was hat man ja bald raus. Engländer oder Amerikaner, nicht wahr? Das letztere. Na, sehn Sie woll! Aber deswegen können Sie mich immer ganz gut verstehen. Warum soll 'n Amerikaner nicht auch sein Vaterland lieben können, frag' ich!«
     </p>
-    <p xml:id="eco_de_0000139_280">
+    <p xml:id="eco_de_0000209_280">
      »Eben!« bestätigte Georg lächelnd.
     </p>
-    <p xml:id="eco_de_0000139_290">
+    <p xml:id="eco_de_0000209_290">
      »Die Leute tun immer so, als hätten wir Deutschen die Heimatsliebe extra gepachtet. Unsinn, sag' ich! Das liegt im Menschen, und damit Punktum! Ich für meine Person – Gott, ich könnt' ja auch in Hamburg leben oder in Frankfurt am Main – schöne Stadt, Frankfurt am Main – oder meinetwegen in Berlin, obgleich Berlin – na, ich weiß nicht – Berlin, das ist mir beinahe zu großstädtisch, da verkrümelt sich der Mensch, er weiß nicht wie! Aber nein, ich bin nicht mal in W. geboren – auf so 'nem Dorf, wissen Sie, zehn, zwölf Meilen davon – aber ich bin da zu Geld und Ansehen gekommen und hab' da geheiratet und alles – na, der Mensch muß schließlich nicht undankbar sein! Wenn ich da nun sitzen bleib' als wohlhabender Bürgersmann und zahl' redlich meine Steuern und red' in der Stadtverordnetenversammlung und geb' meinen Anteil zu wohltätigen Zwecken, helf' da Waisenhäuser einzurichten und Hospitäler zu bauen, und die Leute kommen nachher und bedanken sich bei mir – na, sehn Sie 'mal, es liegt so was drin! Man wird ja der Narr nicht sein und sich was drauf einbilden, wenn man hilft und gibt – aber, weiß der Himmel, man greift doch 'n bißchen tiefer in die Tasche wenn es heißt: es ist für unsere Stadt, für die Stadt, in der man lebt, die einen sozusagen zum Mann gemacht hat!«
     </p>
-    <p xml:id="eco_de_0000139_300">
+    <p xml:id="eco_de_0000209_300">
      »Natürlich!« stimmte Georg bei. Dann, nach einer kleinen Pause, fragte er in unbefangenem Tone: »Ist denn Ihr W. eine hübsche Stadt?«
     </p>
-    <p xml:id="eco_de_0000139_310">
+    <p xml:id="eco_de_0000209_310">
      »Gott – hübsch – hübsch?« Etwas verlegen zog der Weinhändler die Achseln hoch. »Für mich schon – ob für den Fremden? Weiß ich nicht recht, glaub' ich auch nicht recht! 's hat 'ne nette, idyllische Umgebung – viel Wasser und Wald, wissen Sie – und 'n schönes, altes Schloß, wir nennen es Ruine, aber es sind noch respektable Reste von dem alten Bau da, liegt sehr malerisch, das Ganze, und ist 'n Restaurant dabei. Des Abends da Krebse, in Kümmel abgekocht, zu essen, oder geschmorte Pilze, und dann kommt so sachtchen der Vollmond herauf und steht überm See – das ist Ihnen nicht bitter! W. hat 'n gutes Gymnasium, ist auch Garnison, Ulanen, und die Stadt hat sich in den letzten – na, wollen mal sagen achtzehn bis zwanzig Jahren gewaltig aufgenommen. Wer seitdem nicht darin war, der würd' es kaum wieder erkennen.«
     </p>
-    <p xml:id="eco_de_0000139_320">
+    <p xml:id="eco_de_0000209_320">
      »Wirklich?«
     </p>
-    <p xml:id="eco_de_0000139_330">
+    <p xml:id="eco_de_0000209_330">
      Die Stimme des »Amerikaners« klang ein wenig bedeckt. »Können mir auf Wort glauben. Was ist nicht alles gebaut worden in der Zeit! Von den öffentlichen Gebäuden gar nicht zu reden …, bloß die Privatleute! Keiner will hinter dem andern zurückstehen – der eine baut sich 'n Schweizerhaus und der andere 'ne feine Villa, in dem Stil und in dem. Ich hab' auch so'n Ding – hat schwer Geld gekostet, ist Barock, sagt mein Baumeister. Sehr hübsch anzusehen, aber nicht viel darin unterzubringen, ist mir nicht geräumig genug.«
     </p>
-    <p xml:id="eco_de_0000139_340">
+    <p xml:id="eco_de_0000209_340">
      »Gehört auch ein Garten dazu?«
     </p>
-    <p xml:id="eco_de_0000139_350">
+    <p xml:id="eco_de_0000209_350">
      »Will ich meinen! Meine Frau sagt, der ist eigentlich die Hauptsache. Wenn ich kann, nehm' ich mir nächstens den Nachbargarten noch dazu; da ist nämlich der Besitzer davon gestorben, so'n richtiges Original.«
     </p>
-    <p xml:id="eco_de_0000139_360">
+    <p xml:id="eco_de_0000209_360">
      »In der Tat? Das müssen Sie mir erzählen! Ich habe immer gehört, die deutschen Originale stürben aus!«
     </p>
-    <p xml:id="eco_de_0000139_370">
+    <p xml:id="eco_de_0000209_370">
      »Tun sie auch, obgleich andere Nationen ja meines Wissens auch kein Monopol auf Originale haben! Ja, aber der alte Kordeleit!« Der Weinhändler setzte sich behaglich und breit zurecht und brannte sich eine frische Zigarre an. »Den hat ganz W. gekannt, und die Leute waren ordentlich stolz auf ihn. Nicht, daß er liebenswürdig war! Ein sacksiedegrober Kerl und niederträchtig launenhaft – in manchem Punkt so knauserig, daß es schon schmutzig zu nennen war – und auf der andern Seite ganz unvermutet plötzlich wieder von einer solchen Großmut, daß es an Verschwendung grenzte. Seine Hinterlassenschaft soll denn auch gar nicht so groß sein – er war zu eigensinnig, ließ sich nichts raten mit Papieren und Hypotheken und so was. Je mehr einer ihm zuredete, um so widerborstiger wurd' er, setzte seinen Dickkopf auf und litt lieber allen Schaden, als daß er zugab: Du hast recht gehabt und ich bin im Unrecht. Mit seinem Testament tun sie sich schrecklich geheimnisvoll – Gott, mir kann es egal sein, mich könnt' ebensogut der türkische Sultan zum Erben einsetzen wie der alte Kordeleit –, aber die Juniussens werden sich nicht schlecht grämen!«
     </p>
-    <p xml:id="eco_de_0000139_380">
+    <p xml:id="eco_de_0000209_380">
      »Sollen die die Erben sein?«
     </p>
-    <p xml:id="eco_de_0000139_390">
+    <p xml:id="eco_de_0000209_390">
      »Sollen? Ich weiß nicht! Sie waren so'n bißchen verwandt mit dem Alten – durch den Scheffel Erbsen gejagt, wie's bei uns heißt. Der Junius war Kaufmann, ist dann runtergekommen, eigentlich ohne seine Schuld, er hat Pech gehabt, war auch nicht besonders findig – da hat er sich denn beim alten Kordeleit nützlich gemacht, soweit dessen Eigensinn das zuließ. Junius hat Reisen für ihn gemacht, ihm An- und Verkäufe vermittelt, kurz, er ging bei ihm aus und ein. Um die Familie hat sich der Alte wenig bekümmert – es sind fünf, nein, sechs Kinder da, und alle noch zu erziehen. Frau Junius ist viel krank und ihr Mann kann nichts Rechtes mehr verdienen; bei den kleinen Agenturgeschäften kommt nichts raus, und zu den großen gehört Kapital und 'n flottes Renommee – das hat der arme Teufel nicht! Nun mag er sich in aller Stille wohl Rechnung auf einen Anteil am Geld des alten Kordeleit gemacht haben – verdenk' es ihm, wer kann! Leibeserben sind keine – der Alte war Junggeselle – nahe Verwandte existieren auch nicht. Aber da muß kurz vor dem Tode des Alten zwischen den beiden was passiert sein – sie haben in Kordeleits Arbeitszimmer fürchterlich laut miteinander gesprochen, dann ist der Junius mit 'nem fuchsfeuerroten Gesicht herausgestürzt und hat mit den Türen geknallt, daß das Haus zitterte. – Und jetzt sagen ja die Leute, er und seine Familie kriegen keinen Heller von der ganzen Bescherung. Gott, und die Juniussens könnten das brauchen! Vier Jungen im Haus und zwei Mädels, die kranke Frau – und das nagt nun alles zusammen am Hungertuch!«
     </p>
-    <p xml:id="eco_de_0000139_400">
+    <p xml:id="eco_de_0000209_400">
      »Wer ist denn nun Erbe?«
     </p>
-    <p xml:id="eco_de_0000139_410">
+    <p xml:id="eco_de_0000209_410">
      »Ja, wenn ich das wüßte! Die sagen, die Stadt kriegt alles, und die sagen, 's geht alles nach Berlin zu irgend 'ner gemeinnützigen Stiftung – und welche wieder munkeln was von 'nem Verwandten, auf den sich der Alte mit einem Male besonnen hat. An die Stadt und die Stiftungen glaub' ich nicht recht – der alte Kordeleit hat sich oft so giftig und eklig über dergleichen ausgesprochen, daß er schon den Verstand nicht mehr beisammen gehabt haben müßt', um so was zu tun. Na, warten wir's ab. Um die Juniussens tut's mir aber leid, sie haben so nette Kinder. Ja, ja, ja, wie das so auf der lieben Gotteswelt zugeht!«
     </p>
-    <p xml:id="eco_de_0000139_420">
+    <p xml:id="eco_de_0000209_420">
      Nach dieser philosophischen Schlußbemerkung stockte das Gespräch für eine Weile ganz. Der Weinhändler seufzte ein paarmal, schüttelte den Kopf, seufzte von neuem und nickte dann ein. Die glimmende Zigarre fiel ihm vom Mund weg in die Wagenpolster. Georg Unger hob sie hastig auf und zerstampfte sie im Aschenbecher.
     </p>
-    <p xml:id="eco_de_0000139_430">
+    <p xml:id="eco_de_0000209_430">
      Auch der Eintritt des Schaffners, der die Lampe zu löschen kam, weckte den behaglichen Herrn nicht aus seinem Schlummer. Die Reisemütze bis auf den Hinterkopf zurückgeschoben, den Mund halb offen, ließ seine Physiognomie gerade nicht den Ausdruck hoher Intelligenz erkennen. Nachdem es ihm ein paarmal in der Kehle gegurgelt und gebrodelt hatte, als sei er am Ersticken, setzte ein regelmäßiges Schnarchen ein, das an kunstgerechtes Holzzersägen erinnerte.
     </p>
-    <p xml:id="eco_de_0000139_440">
+    <p xml:id="eco_de_0000209_440">
      Georg Unger schob sachte den Vorhang vom Fenster zurück und blickte in die rasch lichter werdende Landschaft hinaus. Es war Morgendämmerung.
     </p>
-    <p xml:id="eco_de_0000139_450">
+    <p xml:id="eco_de_0000209_450">
      Um die Höhenzüge, von denen der Weinhändler gesprochen, wanden sich noch dichte Nebel wie weiße, wallende Tücher, sie krochen gleichsam an den grünen Bergen hin. So rasch der Zug fuhr, man sah doch, wie der erwachende, frische Morgen den Bäumen über die Häupter strich, bis sie erschauerten und sich wie schlafestrunken schüttelten. Jetzt eine weite Wiese, auf der es wie ein zartes, graues Perlennetz ausgespannt lag; über Nacht war starker Tau gefallen. Am Waldesrand schwankte langes dünnes Gras wie grünes Haar. Dicht, dicht brauste der Bahnzug an einem großen Roggenfelde vorüber; daraus stieg es auf mit einem hellen, zarten Zwitscherlaut und hob sich auf bebenden Flügelchen empor, leicht und schön, wie von der Luft rückwärts getragen – die erste erwachende Lerche.
     </p>
-    <p xml:id="eco_de_0000139_460">
+    <p xml:id="eco_de_0000209_460">
      Es sproßte etwas auf im stillen Herzen des Zuschauers, blühte gleichsam darin empor wie rasch sich entfaltende Blumen. Schwach und süß war ihr Duft; aus fernen Tagen kam er herüber – aus Tagen der Kindheit!
     </p>
-    <p xml:id="eco_de_0000139_470">
+    <p xml:id="eco_de_0000209_470">
      Auf seinen Vater entsann er sich nur undeutlich – ein großer, hagerer Mann war es gewesen, der viel hustete und seine Kinder nur wenig um sich dulden konnte. Georgs älterer Bruder, Eduard, sah dem Vater ähnlich – lang und schmal in die Höhe geschossen, mit gewölbtem Rücken und vornüberhängenden Schultern. Eduard war sehr fleißig in der Schule, ein sogenannter »Musterknabe«, von früh bis spät bei den Büchern zu finden und bei dem jüngeren Bruder nicht sonderlich beliebt, da er ihm fortwährend als Beispiel vorgehalten wurde. Dann war da noch die kleine Schwester, das Trudchen, ein niedliches, munteres Ding, das im Hause manchen Schabernack machte, aber auch viel Lust und Lachen hineinbrachte mit seinem hellen Stimmchen und den funkelnden dunklen Augen.
     </p>
-    <p xml:id="eco_de_0000139_480">
+    <p xml:id="eco_de_0000209_480">
      Seit des Vaters Tode wurden die drei Kinder von der Mutter regiert – einer resoluten Frau, der es gar nicht darauf ankam, ihren heranwachsenden Söhnen rechts und links ein Paar Ohrfeigen auszuteilen, wenn sie nach ihrer Ansicht »nicht gut taten«. Der älteste »büffelte« ihr zu viel, brannte bis in die halbe Nacht Petroleum und ruinierte sich die ohnehin schon schwache Brust vollends mit Stubenhocken. Numero zwei, der liebe Georg, trieb sich wieder zu viel draußen umher, fertigte seine Schulaufgaben mit genialer Flüchtigkeit ab, scheuerte Knie und Ellenbogen an seinen Anzügen vorzeitig durch, rieb sich grundsätzlich nie die Füße an der Strohmatte im Hausflur ab und besaß einen Appetit, der ans Unheimliche grenzte. Das Trudchen war allgemeiner Liebling, aber nach der Mutter Ansicht hätte es auch mehr Stetigkeit beim Strickstrumpfe und Zeichentuche entwickeln können, anstatt mit dem Georg Boot zu fahren oder auf den Apfelbaum im Garten zu klettern.
     </p>
-    <p xml:id="eco_de_0000139_490">
+    <p xml:id="eco_de_0000209_490">
      Dieser Apfelbaum und dieser Garten! Ob sie wohl beide noch existierten, ebenso wie der Mann hier im rasch dahinsausenden Eisenbahnzug sie in Erinnerung hatte?
     </p>
-    <p xml:id="eco_de_0000139_500">
+    <p xml:id="eco_de_0000209_500">
      Ob der kraftstrotzende, mächtige Baum mit den weitausladenden Zweigen wohl immer noch im Frühjahr wie ein gewaltiges rosig schimmerndes Bukett anzusehen war, und ob er im Herbst seine zahllosen, rot und goldig geflammten Früchte trug, die so saftig waren und nach Wein schmeckten?
     </p>
-    <p xml:id="eco_de_0000139_510">
+    <p xml:id="eco_de_0000209_510">
      Auf einem sanft abfallenden grünen Rasenfleck stand der Apfelbaum hart am Zaun, und ein Paar von seinen Zweigen hingen über diesen Zaun herüber in des Nachbars Garten hinein. An diesen Ästen saßen natürlich auch Äpfel, und Georg und Trude ärgerten sich, wenn sie hörten, wie die schönen Früchte mit einem dumpfen Schall jenseit ihres Gartens zur Erde fielen. Was brauchte der alte Kordeleit, der immer so sauertöpfisch aussah und sich sicherlich gar nichts aus Obst machte, ihre Äpfel? Die Mutter freilich ermahnte die Kinder von Zeit zu Zeit, hübsch artig gegen den »Onkel« zu sein – Georg möge immer die Mütze abnehmen und freundlich »Guten Tag!« sagen und Trude solle knicksen – aber nachdem die Kinder das einige Male versucht und zum Dank nichts weiter geerntet hatten als ein dumpfes Brummen und einen nichts weniger als einladenden Blick aus zwei finster dreinschauenden, umbuschten Augen, unterließen sie jede Höflichkeitserweisung, und die Erklärung der Mutter, der alte Kordeleit sei sehr reich und »eigentlich« noch mit ihnen verwandt, da er Papas Vetter im zweiten Gliede gewesen sei, machte nicht den geringsten Eindruck. Die Sonntagmorgen, wenn man faul und zufrieden im hohen Grase lag und die Schatten der schwankenden Zweige abwechselnd mit zuckenden Sonnenblitzen einem über das Gesicht liefen! Die Hände unter dem Haupt verschränkt – rund umher der Duft von Gras und Erde – ein Jubilieren der Vögel in der Luft und fernhin das Läuten der Kirchenglocken, die grell und lärmend klangen in der Nähe – »Richtige Dorfkirchenglocken!« behauptete Georg damals verächtlich – aber aus der Entfernung förmlich harmonisch wirkten!
     </p>
-    <p xml:id="eco_de_0000139_520">
+    <p xml:id="eco_de_0000209_520">
      Glückliche Zeiten auch, wenn unten im See das kleine, notdürftig ausgeflickte Boot, das noch aus Vaters »guter Zeit« stammte, losgekettet wurde und Georg mit einem oder zwei Kameraden über den von Sonnengold funkelnden Wasserspiegel hinglitt, aus dem knirschenden Schutzwall des Schiffes heraus, das sich widerwillig teilte, um den Kahn durchzulassen – und nun rauschte eine Kette wilder Enten empor, und der helle, harte Schrei des Kiebitz wurde laut, bis allgemach, wie sie weiter in den See hineinkamen, nichts mehr hörbar war als das Glucksen des Wassers, das an einer schadhaften Planke des gebrechlichen Fahrzeugs leckte. Zuweilen auch kam die kleine Schwester mit – heimlich, hinter Mamas Rücken – und saß dem »großen Bruder« gegenüber, stolz und glücklich, die beiden runden Händchen an die Seitenwände des Kahns geklammert, die großen Kinderaugen mit entzücktem Staunen auf, den sonnenüberblitzten Seespiegel geheftet. Man angelte auch im See und suchte Mama durch Überreichung von zwei, drei Schleien mit diesen Wasserfahrten zu versöhnen – aber die Mutter pflegte ärgerlich zu fragen, was sie mit den »Katzenfischen« eigentlich solle – das sei nicht genug für den einen und für den andern, und Georg solle endlich den »Unsinn« lassen.
     </p>
-    <p xml:id="eco_de_0000139_530">
+    <p xml:id="eco_de_0000209_530">
      Sie war nicht weich und mitteilungsbedürftig, die Mutter, aber daß sie ihre Kinder recht aus Herzensgrunde liebte und bestrebt war, das Beste aus ihnen zu machen, das wußten diese doch, trotz der gelegentlichen Ohrfeigen und Scheltworte. Selten, sehr selten kam über die Lippen der hart arbeitenden, unermüdlich tätigen Frau ein Liebesausdruck, selten in ihre scharf umherspähenden Augen ein warmer Blick, – wenn es aber geschah, so war dies ihren Kindern wie ein Orden, und sie teilten es einander stolz mit: »Du, die Mutter hat mich gelobt!« »Du, heut' ist die Mutter mit mir zufrieden gewesen!«
     </p>
-    <p xml:id="eco_de_0000139_540">
+    <p xml:id="eco_de_0000209_540">
      Sie wirtschaftete ohne Dienstboten, scheute sich vor der gröbsten Arbeit nicht und verlangte ohne weiteres von »ihren Jungens«, daß sie ihr das Holz klein machten, schwere Sachen heimtrugen und andere Dinge verrichteten, die sich mit der Würde von Gymnasiasten nur schwer vereinigen ließen. Diese Würde imponierte Frau Unger wenig, sie ging von dem Grundsätze aus, daß keine Arbeit eine Schande sei, sie schneiderte auch für die heranwachsenden Knaben die Anzüge selbst und ließ sich durch Klagen über zu kurze Westen und »komisch sitzende Hosen« wenig rühren. Taschengeld gab es nur äußerst wenig, die Schularbeiten mußten pünktlich erledigt werden. Und doch! welch feiner goldener Duft lag über diesen Kindheitstagen! Der Glanzpunkt in der Familie Unger war der »amerikanische Onkel«– nicht der traditionelle Nabob, nicht von dem herkömmlichen Nimbus eines Goldmeeres umgeben, immerhin aber eine gewichtige, oft mit Erfolg zitierte Persönlichkeit. Daß dieser einzige Bruder der Mutter in seiner Jugend ein leichtsinniger Schlingel gewesen war, der seinen Eltern schwere Sorgen gemacht hatte, so daß sie froh waren, als er jenseit des »großen Wassers« untergebracht war, wurde den Kindern wohlweislich verschwiegen. Es hieß einfach, Onkel Georg habe »drüben« sein Glück versuchen wollen und dasselbe, nach manchem Mißerfolg, auch gefunden. Er war Plantagenbesitzer – vornehmlich Zuckerrohr – in der Nähe von Pernambuco geworden, war unverheiratet geblieben, schrieb sehr seltene und lakonische Briefe, schickte aber unweigerlich und regelmäßig zu jedem Weihnachtsfeste eine Summe, die dem spärlichen Haushalt der Frau Unger tüchtig aushalf, so daß ihr der jedesmalige Zusatz des Bruders: »Kauft Euch jeder eine Kleinigkeit dafür, da ich doch nicht wissen kann, was Ihr braucht!« förmlich lächerlich erschien. Ohne diese weihnachtlichen »Kleinigkeiten« aus Südamerika hätte sie kaum, gewußt, wie sie den laufenden Ausgaben für Kinder und Hausstand gerecht werden sollte.
     </p>
-    <p xml:id="eco_de_0000139_550">
+    <p xml:id="eco_de_0000209_550">
      Georg war kaum fünfzehnjährig und hatte eben das Obersekundanerzeugnis errungen, da langte zu ganz ungewöhnlicher Zeit, kurz nach Ostern, einer von den lakonischen Briefen des Onkels an.
     </p>
-    <p xml:id="eco_de_0000139_560">
+    <p xml:id="eco_de_0000209_560">
      »Liebe Schwester! Ich habe bis jetzt so gut wie gar nichts für Dich tun können« (das nennt er »nichts« – all diese reichlichen Sendungen! dachte Frau Unger gerührt), »indessen es zieht sich aus weitverzweigten Unternehmungen, wie ich sie habe, schwer etwas Namhaftes heraus. Jetzt habe ich Dir einen Vorschlag zu machen: Schick mir einen von Deinen Jungen herüber! Es soll sein Schaden nicht sein, ich will ihn mir anlernen und zuziehen, Du bekommst ihn für immer von der Tasche, und bei mir ist er gut aufgehoben. Reisegeld schicke ich anbei. Bis Hamburg kann der Junge allein fahren, da soll er sich Steintorweg Nummer zwölf melden. Einer von unseren Exporteuren, F. Harder, geht in guten drei Wochen mit dem Südamerikanischen Lloyddampfer »Manila« hinüber, wird ihn unter seine Flügel nehmen und bei mir in Pernambuco abliefern, Gott befohlen! Dein Bruder Georg.«
     </p>
-    <p xml:id="eco_de_0000139_570">
+    <p xml:id="eco_de_0000209_570">
      – – »Einen von Deinen Jungen!«
     </p>
-    <p xml:id="eco_de_0000139_580">
+    <p xml:id="eco_de_0000209_580">
      Das klang so einfach, und im Grunde genommen war ja auch die Sache höchst einfach! Es konnte nämlich überhaupt nur von einem Jungen die Rede sein, und dieser eine war Georg! Eduard, dem älteren, schauderte die Haut, wenn er nur daran dachte, zu Schiff übers Meer zu sollen und Kaufmann zu werden. Er versicherte mit feierlichem Ernst, sterben zu müssen, wenn man ihm das zumute … er wolle sein Abiturium machen – in einem Jahre war es für ihn Zeit dazu! – und dann Mathematik studieren … Könne er das nicht, so müsse er sich mindestens das Leben nehmen.
     </p>
-    <p xml:id="eco_de_0000139_590">
+    <p xml:id="eco_de_0000209_590">
      Die Mutter zuckte freilich die Achseln zu solchen »albernen Redensarten«, aber es war ersichtlich, daß auch sie ihren Eduard gar nicht im Ernst als Kandidaten in der »amerikanischen Frage« ansah, ihr stand es augenblicklich fest, Georg müsse zum Onkel hinüber. Er wurde nicht viel gefragt, und wäre es der Fall gewesen, er hätte jedermann aufs lebhafteste versichert, er ginge sehr gern, er freue sich auf seine neue Existenz jenseit des Meeres. Es war auch die Wahrheit – – was da unklar und unausgesprochen auf dem tiefsten Untergrund seiner Seele lag wie Wehmut, wie Scheu, wie Bangen – er hätte es nicht in Worte fassen können, und wäre selbst das gewesen, er hätte sich dieses Empfindens geschämt!
     </p>
-    <p xml:id="eco_de_0000139_600">
+    <p xml:id="eco_de_0000209_600">
      Für eine kurze Zeit war Georg ganz Hauptperson im Hause, wurde schleunigst von der Schule abgemeldet, mußte Abschiedsbesuche machen, hier und dort – viele waren es nicht –, bekam neue Anzüge, beim besten Schneider von W. gefertigt, da das »Reisegeld« sehr üppig bemessen war, durfte sich Lieblingsgerichte bestellen und selbständig allerlei Dinge einhandeln, nach denen sein Sinn stand: ein schönes Messer mit Korkenzieher und Sektbrecher (so wenig Aussicht es auch für ihn gab, letzteres Instrument für eigenen Gebrauch zu verwerten), ein feines Notizbuch mit zahllosen Taschen, ein »großartiges« Portemonnaie, sogar eine Zigarrentasche – warum sollte ein angehender südamerikanischer Plantagenbesitzer nicht rauchen? Mit einem Worte, diese letzte Zeit in der alten Heimat bot dem Knaben so viel des Ungewohnten, Schmeichelhaften, Neuen, daß er sich diesem Reize willig hingab und jenes unklare Etwas, wenn es sich jemals hervorwagen wollte, halb ärgerlich, halb verlegen zurückdrängte.
     </p>
-    <p xml:id="eco_de_0000139_610">
+    <p xml:id="eco_de_0000209_610">
      Bis dann der große Augenblick der Trennung, der Abfahrt nach Hamburg herankam. Schon am Abend zuvor war die Mutter spät am Abend in Georgs Stübchen gekommen – Eduard löste noch im Wohnzimmer eine mathematische Aufgabe – hatte sich zu ihm auf den Bettrand gesetzt, sein Gesicht in ihre beiden hartgearbeiteten Hände genommen und mit etwas unsicherer Stimme zu ihm gesagt: »Nicht wahr, mein Kind, du bleibst mir brav? Machst deinem guten Vater und mir Ehre? Lange Reden kann ich dir nicht halten, ich kann dich nur bitten: sei wahr, sei arbeitsam, sei verständig! Hab' Gott vor Augen und im Herzen; er ist bei dir, wo du auch bist. Wenn dir die Menschen vorreden wollen, es gebe keinen Gott, und es sei kindisch, an ihn zu glauben – ich, deine Mutter, sag' es dir: ich hab' Gottes Hauch und Gottes Hand verspürt hundertfach in meinem Leben, und ich bitte ihn, daß er dich behütet und segnet!« Dann hatte die Mutter den Sohn auf Augen und Mund geküßt und war rasch davongegangen, aber ein paar heiße Tränen waren auf Georgs Stirn gefallen.
     </p>
-    <p xml:id="eco_de_0000139_620">
+    <p xml:id="eco_de_0000209_620">
      Als er nun schon im Abteil saß und seine Augen über die drei wohlbekannten Gesichter hinwandern ließ, da fiel es ihm auf, wie alt doch die Mutter schon aussah und wie müde mit ihrem grauen Haar und der gebückten Haltung. Und Eduard – wie blaß, wie eingefallen sein Gesicht, wie schmal seine Brust! Einzig die Trude war frisch und blühend! Zum ersten Male fiel es dem sorglosen Knaben, mit voller Schwere aufs Gemüt, was diese Trennung eigentlich bedeute, wie es leicht sich ereignen könne, daß er einen von diesen drei ihm am nächsten stehenden Menschen nicht mehr wiederzusehen bekäme – einen – vielleicht gar zwei! – – Und er war zur Tür hinaus, das Trittbrett hinunter – rasch, impulsiv, wie es seine Art war – hatte die Mutter in die Arme genommen, ungestüm geküßt und geflüstert: »Gott, Mütterchen, wenn du doch mit könntest!« Darauf packte er den langen Eduard an beiden Schultern und schüttelte ihn tüchtig: »Ede, bleib gesund, hörst du? Und schreib auch manchmal!« – In der nächsten Minute saß er wieder auf seinem Platz und schluckte mannhaft an seinen Tränen, während der Zug sich in Bewegung setzte.
     </p>
-    <p xml:id="eco_de_0000139_630">
+    <p xml:id="eco_de_0000209_630">
      Hamburg hatte dem Knaben gewaltig imponiert, die Überfahrt ihm derartig Interesse erregt, daß es zum Heimweh bei ihm nicht kam. Seekrank wurde er nicht, er tummelte sich den ganzen Tag auf dem Schiff umher, schloß mit den meisten Passagieren gute Freundschaft, war allgemein beliebt und lernte, ohne daß er sich dessen bewußt wurde, eine ganze Menge: Brocken fremder Sprachen, allerlei Hantierungen, die ihm später zugute kamen. Eingehen auf anderer Leute Eigenart, Beobachten fremder Nationalitäten. Spät abends warf er sich müde auf sein Lager und schlief den traumlosen Schlummer gesunder Jugend.
     </p>
-    <p xml:id="eco_de_0000139_640">
+    <p xml:id="eco_de_0000209_640">
      Die fremdländische Welt Südamerikas versetzte ihn zunächst in ungemessenes Erstaunen; er hatte daheim versucht, sich ein Bild seines neuen Lebens zu machen, allein dasselbe entsprach der Wirklichkeit in keinem Zuge. Onkel Georg, der tatkräftigste, unermüdlichste Mann, den man sich denken konnte, ließ dem Neffen zu ausführlichem Beobachten und zu stillem Staunen wenig Zeit, – er nahm ihn überallhin mit, ließ ihn lernen, lernen, theoretisch und praktisch, mit und ohne Unterweisung, von der Pike auf, so daß der deutsche Knabe kaum zur Besinnung kam. Heute auf dem Kontorstuhl in Pernambuco sitzen und rechnen, morgen einen Negertransport meilenweit ins Land hinein überwachen helfen, übermorgen beim Ernten des Zuckerrohrs eine Rolle spielen – in dem sonnengebräunten, schneeweiß gekleideten jungen Pflanzer mit dem riesigen Schutzhut, aus leichtem Bast geflochten, hätte niemand sobald den schlanken Obersekundaner wiedererkannt, der in W. seine Bücher und Hefte zur Schule trug.
     </p>
-    <p xml:id="eco_de_0000139_650">
+    <p xml:id="eco_de_0000209_650">
      Im ganzen vertrugen sich Onkel und Neffe Georg gut miteinander – vertrugen sich besser, als sie sich verstanden. Der Onkel hatte sich das Deutschreden völlig abgewöhnt – mit dem Schreiben ging's zur Not noch – er war ganz Spanier geworden, und seine Unterhaltung mit dem deutschen Neffen hatte einen ganz kuriosen Charakter; das gab sich aber bald; denn Georg der Jüngere sah ein, daß er in möglichst kurzer Zeit die Landessprache lernen müsse, und so »paukte« er spanische Grammatik und radebrechte unverdrossen mit den Leuten, bis er sich zur Not verständigen, dann sich ziemlich gut ausdrücken, endlich geläufig reden konnte.
     </p>
-    <p xml:id="eco_de_0000139_660">
+    <p xml:id="eco_de_0000209_660">
      Und das Heimweh?
     </p>
-    <p xml:id="eco_de_0000139_670">
+    <p xml:id="eco_de_0000209_670">
      Das schlief in einem Winkel seines Herzens, wagte sich nur zuweilen hervor und wurde rasch wieder beschwichtigt und zur Ruhe gebracht. »Es hilft zu nichts – also darf es nicht sein!« sagte sich Georg mit festem Entschluß, und in seinen Briefen an die Seinigen betonte er nur immer wieder, wie gut er es habe, wenn auch nicht ganz leicht, und wie »riesig interessant« sein jetziges Leben sei. Da kam – er mochte etwas über zwei Jahre in Südamerika sein – eine Trauerbotschaft von daheim: Bruder Eduard war gestorben. Sein vom Vater ererbtes Lungenleiden hatte plötzlich unheimliche Dimensionen angenommen, Onkel Georg hatte schleunigst Geld zu einem Aufenthalt in Meran geschickt, aber bereits in der dritten Woche seines dortigen Aufenthaltes war der blasse, junge Mensch sanft hinübergeschlummert.
     </p>
-    <p xml:id="eco_de_0000139_680">
+    <p xml:id="eco_de_0000209_680">
      Unerwartet kam Georg diese Nachricht nicht. Der ältere Bruder war immer sehr schwächlich gewesen, die Mutter hatte oft sorgenvoll vor sich hingeseufzt: »Der bleibt mir nicht am Leben! Den behalte ich nicht mehr lange, der hat seines armen Vaters Krankheit!« Dennoch nahm Georg sich die Kunde sehr zu Herzen, ging für längere Zeit stiller und nachdenklicher umher als sonst, und grübelte über jeden brüderlichen Zwist, den er herbeigeführt, über jedes rauhe, unbedachte Wort, das er dem stillen Eduard gesagt hatte.
     </p>
-    <p xml:id="eco_de_0000139_690">
+    <p xml:id="eco_de_0000209_690">
      Aber das Leben ging seinen Gang weiter, bewegt und abwechselungsreich, die Verantwortung mehrte sich gleich der Arbeit, und Georgs vielseitige Tätigkeit forderte den ganzen Menschen. Er war beinahe schon ganz getröstet, als eine neue Nachricht aus der alten Heimat anlangte, diesmal ganz unerwartet; das lustige Trudchen war einem typhösen Fieber zum Opfer gefallen – in wenigen Tagen gesund und tot!
     </p>
-    <p xml:id="eco_de_0000139_700">
+    <p xml:id="eco_de_0000209_700">
      Diesmal bedurfte es bei Georg viel längerer Zeit, bis er sich beruhigte. Er konnte es gar nicht verstehen, nicht fassen, wie das hatte kommen können! Die kleine Schwester stand ihm so rosig, so blühend in der Erinnerung, daß er es kaum glauben konnte, sie solle tot sein! Das Kind war ihm sehr lieb gewesen, er hatte in der Stille allerlei Pläne an seine Zukunft geknüpft. Trude würde ein sehr hübsches Mädchen werden, der Onkel müsse sie »hinüberkommen« lassen, sobald sie erwachsen sei, und sie würde einen von diesen schwerreichen jungen Spaniern heiraten, die um Pernambuco herum ihre ausgedehnten Besitzungen hatten und wie die Fürsten auf ihrer Hazienda lebten. Daß die Mutter der einzigen Tochter nachfolgte, verstand sich wohl von selbst – die sollte dann endlich auch ein anderes Leben kennen lernen als die ewige Plage und Arbeit von früh bis spät!
     </p>
-    <p xml:id="eco_de_0000139_710">
+    <p xml:id="eco_de_0000209_710">
      Nun lag das rosige, hübsche Kind im stillen Grabe, und die schönen Zukunftspläne waren vernichtet!
     </p>
-    <p xml:id="eco_de_0000139_720">
+    <p xml:id="eco_de_0000209_720">
      Dem übers Meer gezogenen jungen Menschen blieb jetzt nur noch, die Mutter, und seltsam war es, wie er sich fortan viel in seinen Gedanken mit ihr beschäftigte, einen förmlichen stillen Kultus mit ihr trieb. Er sah die vor der Zeit gealterte Frau in ihrem schlichten Trauerkleid auf den Friedhof gehen – ach, sie hatte nur ein Kind dort schlummernd, das andere schlief fern in Meran! – sich neben den blumigen Hügel setzen und traurig all der begrabenen Hoffnungen denken, die dies Grab umschloß. Wieviel kann gerade eine heranwachsende Tochter einer verwitweten Mütter sein! Und das Trudchen war eine so kleine Schmeichelkatze gewesen, so ein herziges, frohes Kind! Wie der einsamen Frau wohl ums Herz sein mußte, wenn sie vom Friedhofe nach Hause ging und sie unterwegs Mütter traf, die ihr zwölf- bis dreizehnjähriges Töchterchen neben sich hatten! Und wie sie sich verlassen fühlen mußte in ihrer stillen Häuslichkeit! Kein buntes Kinderkleid an der Wand hängend, kein vergessenes Strickzeug, kein beiseite geworfenes Schulbuch mehr wegzuräumen, kein Schelmengesichtchen, das zum Fenster hereinsah und lachte – alles so öde – so lautlos! Da sanken denn die ehemals so unermüdet tätigen Hände wohl schlaff nieder. – Für wen denn noch arbeiten? Für wen noch schaffen?
     </p>
-    <p xml:id="eco_de_0000139_730">
+    <p xml:id="eco_de_0000209_730">
      Georg Unger beschäftigte sich sehr ernstlich mit dem Gedanken, nach Deutschland zurückzugehen und bei der Mutter zu bleiben. Aber welche Stellung hätte er daheim einnehmen sollen? Der Onkel hatte, ihn »angelernt« – gewiß – aber auf seine eigene Art und Weise, in einer Methode, die sicher kein einziger deutscher Kaufherr verstanden, geschweige denn gebilligt haben würde. Es war überhaupt gar keine »Methode« gewesen. Georg war nicht Disponent, nicht Prokurist, nicht Kassierer oder Korrespondent, er war etwas von dem allen, verstand auch fließend spanisch und englisch zu reden, wußte mit den Zuckerplantagen und Magazinen Bescheid – wie aber all dies in Deutschland verwerten? Die Mutter herüberholen? Ob sie wohl kommen, sich in ihren vorgerückten Jahren von der alten Heimat, ihren wenigen Freunden, dem Grabe des Gatten und dem der Tochter trennen würde? Der amerikanische Bruder war ihr völlig fremd geworden, von dem Sohne würde sie wenig genug haben, da seine vielseitige Tätigkeit ihn stark beanspruchte. Allein auf sich angewiesen in dem fremden Lande, mußte die alte Frau das Heimweh fassen – – – und was dann?
     </p>
-    <p xml:id="eco_de_0000139_740">
+    <p xml:id="eco_de_0000209_740">
      So verging in Zaudern und Überlegen wieder ein neues Jahr. Georgs Briefe wurden häufiger und wärmer – die der Mutter kamen immer spärlicher. »Kind, Du weißt doch, ich bin nie eine flinke Briefschreiberin gewesen,« hieß es, »und in letzter Zeit will die Feder gar nicht vom Fleck. Du brauchst deswegen nicht zu denken, daß ich krank bin – nein, das nicht! Du mußt Dich um mich alte Frau überhaupt nicht so »haben«, lieber Sohn, wir stehen alle in Gottes Hand! Wie er will!« – –
     </p>
-    <p xml:id="eco_de_0000139_750">
+    <p xml:id="eco_de_0000209_750">
      Ja, wie Gott will! Und er wollte, daß die einsame Mutter heimgerufen wurde zu denen, die vor ihr hingegangen waren. Still und schmerzlos schlummerte sie hinüber, und die Kunde von dem dritten Trauerfall ging über den Ozean.
     </p>
-    <p xml:id="eco_de_0000139_760">
+    <p xml:id="eco_de_0000209_760">
      Losgelöst von allen Heimatbanden! Allein in der weiten Welt! Es war dem jungen Menschen zumute, als er die Nachricht erhielt, wie wenn ihm die Stelle in der Brust, wo sonst ein warmes, junges Herz geschlagen hatte, plötzlich eiskalt und leer geworden war. Ohne Geschwister – es hatte ihm sehr weh getan, aber er hatte es ertragen lernen müssen. Ohne Mutter – was sollte er auf der Welt, wenn sie nicht mehr da war?
     </p>
-    <p xml:id="eco_de_0000139_770">
+    <p xml:id="eco_de_0000209_770">
      Onkel Georg war es leid um die Schwester, leid auch um den Neffen, aber er verstand es nicht, seine Teilnahme in Worte zu kleiden. Der echte matter of fact man, dem Erfolg und Gelderwerb im Leben alles bedeutet, fand er sich mit bestehenden Tatsachen in seiner raschen, praktischen Weise ab. »Sterben müssen wir alle – wohl dem, der im Leben genützt hat und seine Stellung ausfüllen konnte. Das hat sie getan nach besten Kräften, das muß dich trösten, Junge!«
     </p>
-    <p xml:id="eco_de_0000139_780">
+    <p xml:id="eco_de_0000209_780">
      Ach, jawohl, das war leicht gesagt! Georg verzichtete darauf, den Onkel mit seinem nagenden Schmerz, mit seiner heißen Sehnsucht vertraut zu machen. Er arbeitete von früh bis spät, er leistete so viel, daß selbst der anspruchsvolle Oheim zufrieden sein mußte, aber es war nicht die Freude an der Tätigkeit allein, die ihn dazu trieb; müde mußte er werden – todmüde, daß er fast über seine Füße fiel, wenn er schlafen sollte und im traumlosen Schlummer Vergessenheit finden. Die Mutter und die Heimat konnte er darum doch nicht verschmerzen!
     </p>
-    <p xml:id="eco_de_0000139_790">
+    <p xml:id="eco_de_0000209_790">
      In den langen Jahren, die seit dem Tode seiner Mutter vergangen waren, hatte Georg Unger immer nicht dazu kommen können, einmal nach Deutschland »hinüberzugehen«, wie es doch sein heimlicher brennender Wunsch war. Die Geschäftsverbindungen erforderten keine derartige Reise, und sonst – wie hätte Georg sie vor dem Onkel motivieren sollen? Sehnsucht nach einer kleinen deutschen Stadt und nach ein paar Gräbern – – er wußte genau, daß sein Pflegevater ihn mit bedauerndem Kopfschütteln gefragt haben würde, ob er etwa den Sonnenstich bekommen oder auf sonst irgend welche Weise seinen gesunden Menschenverstand eingebüßt hätte! Zu reisen bekam er genug – nach Santos, Rio de Janeiro, auch nach Nordamerika hinein. Großartige Städtebilder, pittoreske Landschaften rollten sich vor ihm auf, er kam sich selbst zuweilen lächerlich vor mit seiner Sehnsucht nach der alten Heimat, in der es doch kein Zuhause mehr für ihn gab – für immer abtun ließ sich diese Sehnsucht darum doch nicht!
     </p>
-    <p xml:id="eco_de_0000139_800">
+    <p xml:id="eco_de_0000209_800">
      Onkel Georg war ein sehr alter Mann geworden, immer aber noch rüstig. Er ließ den Neffen jetzt viel selbständig schalten und walten, behielt sich nur den Oberbefehl über ganz wichtige Dinge vor. Über seine Zukunftspläne ließ er »Georg den Zweiten« nicht im unklaren. Wollte der Neffe gelegentlich etwas waghalsig vorgehen, sich in Unternehmungen einlassen, deren Tragweite sich nicht recht übersehen ließ, so hieß es wohl: »Dummer Kerl, so nimm Vernunft an! Wenn so und soviel bei der Geschichte verloren geht, so ist das dir aus der Tasche genommen! Der Mensch muß sich doch auf seinen Vorteil verstehen, er darf sich selbst nicht zum Schaden arbeiten!«
     </p>
-    <p xml:id="eco_de_0000139_810">
+    <p xml:id="eco_de_0000209_810">
      Dreiundzwanzig Jahre waren verflossen, seitdem der schmächtige, fünfzehnjährige Knabe damals von W. abgefahren war; in dem großen, breitschultrigen Mann mit dem Bronzegesicht und der stolzen Kopfhaltung hätte ihn wohl kaum die eigene Mutter, wäre sie noch am Leben, wiedererkannt. Er hatte übrigens viel von dieser Mutter, die zielbewußte Pflichttreue, die erstaunliche Arbeitskraft, die rasch zufassende Intelligenz, zum Glück auch die robuste Gesundheit. Ob wohl die Mutter auch in ihrem Gemüt so weich, so hingebend gewesen war und nur dem eisernen »Muß« zuliebe alle nutzlosen Gefühlsanwandlungen erfolgreich unterdrückt hatte?
     </p>
-    <p xml:id="eco_de_0000139_820">
+    <p xml:id="eco_de_0000209_820">
      Liebesabenteuer hatte Georg Unger einige erlebt, eins davon hatte um ein Haar mit einer Heirat abgeschlossen; es war eine sehr hübsche kokette Kreolin im Spiel gewesen, die sich den wohlhabenden Deutschen einfangen wollte. Dem waren noch in zwölfter Stunde über die wohlwollende Absicht die Augen aufgegangen, – und sowohl er als auch die Kreolin, waren um eine wertvolle Erfahrung und eine etwas, peinliche Erinnerung reicher. Der Oheim ermunterte zuweilen den Neffen, zu heiraten, aber da er selbst ihm mit so schlechtem Beispiel vorangegangen war, so fielen diese gelegentlichen Ermahnungen auf unfruchtbaren Boden.
     </p>
-    <p xml:id="eco_de_0000139_830">
+    <p xml:id="eco_de_0000209_830">
      Da traf plötzlich ein Brief in Pernambuco ein an Herrn Georg Unger, ein deutscher Brief mit dem lange, lange nicht gesehenen Stempel der Heimatstadt. Ein gewisser Justizrat Hein zeigte dem höchst erstaunten Plantagenbesttzer an, Herr Jakob Anton Kordeleit in W. sei vor etwa vierzehn Tagen verstorben und habe in seinem rechtskräftig abgefaßten Testament ihn, Herrn Alfred Waldemar Georg Unger, wohnhaft zu Pernambuco in Südamerika, zu seinem Universalerben ernannt. Äußerst wünschenswert wäre es nun, so sagte der Brief des Juristen weiter, wenn sich besagter Universalerbe persönlich in W. einfinden würde, es seien eine Menge Legate da, Grundbesitz, Mobiliar, verschiedene zum Teil kostbare Sammlungen, Man würde eine Masse von Weitläufigkeiten vermeiden und viel Geld sparen, wenn Herr Unger sich entschließen könnte, die Angelegenheit selbst zu ordnen.
     </p>
-    <p xml:id="eco_de_0000139_840">
+    <p xml:id="eco_de_0000209_840">
      So erstaunt Georg war, sich als Erben des vergessenen und verschollenen Herrn Kordeleit zu sehen, den er selbst in seinen Knabenjahren kaum gekannt hatte – sein Entschluß, »hinüberzugehen«, stand augenblicklich fest. Selbst der Onkel fühlte sich verpflichtet, ihm noch zuzureden. Wo Geld auf dem Spiele stand, siegte sein praktischer Sinn über jede sonstige Bedenklichkeit. Er ließ sich von dem Neffen genau über alles instruieren, was dieser auf eigene Hand unternommen hatte, und in verhältnismäßig kurzer Zeit saß Georg auf dem Dampfer und fuhr nach Hamburg. Dort hielt er sich nur wenige Tage auf, gerade so lange, wie seine geschäftlichen Verbindungen dies erforderten. Es zog ihn – zog ihn wie mit Händen hinüber nach seiner Heimat.
     </p>
-    <p xml:id="eco_de_0000139_850">
+    <p xml:id="eco_de_0000209_850">
      Und jetzt wehte ihn durch das herabgelassene Fenster bereits die Heimatluft an – warm und feucht, von dem leicht aufsteigenden Wasserdunst gesättigt. In hellem Grün prangten die Bäume am Wegesrand, die Birken wehten ihm den Willkommensgruß zu mit ihren lichten Schleiern – und nun, da eben der Zug dicht neben einem Wärterhäuschen still hielt – rief da nicht der Kuckuck aus dem jungen Gehölz am Wege? Wahrhaftig! Träumerisch noch und wie verschlafen, aber vollkommen deutlich kam es herüber: »Kuckuck – Kuckuck.« Georg atmete tief und drückte die Augen ein. Klang nicht von fern, fernher ein keckes Stimmchen an sein Ohr:
     </p>
-    <p xml:id="eco_de_0000139_860">
+    <p xml:id="eco_de_0000209_860">
      »Kuckuck, sag' eben. Wie lang' soll ich noch leben?«
     </p>
-    <p xml:id="eco_de_0000139_870">
+    <p xml:id="eco_de_0000209_870">
      Es hatte nicht viele Jahre mehr zu verzeichnen gehabt, das kleine, lachlustige Trudchen!
     </p>
-    <p xml:id="eco_de_0000139_880">
+    <p xml:id="eco_de_0000209_880">
      »Hören Sie mal, ich glaub' wahrhaftig, ich habe geschlafen! Ne, aber so was!« Der dicke Weinhändler reckte und streckte sich, rieb sich die Augen und gähnte so gewaltig, daß ihm beinahe die Tränen kamen. »Nehmen Sie mir schon nicht übel, daß ich so gottesjämmerlich gähnen muß. Meine Frau schilt mich jedesmal, sie sagt, es schickt sich nicht. Na aber, wenn ich doch nicht anders kann! Der Tausend! Ist ja schon ganz bekannte Gegend! Sind ja gar nicht mehr weit von W. Sie kennen das hier herum nicht – was?«
     </p>
-    <p xml:id="eco_de_0000139_890">
+    <p xml:id="eco_de_0000209_890">
      »Nein – gar nicht!« Georg sprach die Wahrheit. Es sah ihm hier alles fremd aus – alles! Dreiundzwanzig Jahre in der Fremde gewesen! Beinahe ein Menschenalter hindurch!
     </p>
-    <p xml:id="eco_de_0000139_900">
+    <p xml:id="eco_de_0000209_900">
      »Was ich doch noch fragen wollte – ja, ja, ja! Wo gedenken Sie abzusteigen in W.?«
     </p>
-    <p xml:id="eco_de_0000139_910">
+    <p xml:id="eco_de_0000209_910">
      »Keine Idee. Ich wollte Sie bitten, mir freundlichst ein Hotel zu nennen!«
     </p>
-    <p xml:id="eco_de_0000139_920">
+    <p xml:id="eco_de_0000209_920">
      »Na, daran fehlt's nicht, wir haben ja mehrere!« Die blinzelnden Äuglein des feisten Herrn gingen über den schlichten und doch eleganten Touristenanzug seines Gegenübers hin, über die modischen braunen Lederschuhe, das nach Juchten duftende Handkofferchen, die feine Tasche mit dem großen Monogramm.
     </p>
-    <p xml:id="eco_de_0000139_930">
+    <p xml:id="eco_de_0000209_930">
      »Wenn ich Ihnen raten darf, versuchen Sie's im »Goldenen Adler«! Hübsche, hohe Zimmer, flinke Bedienung, vorzügliches Essen. Auf die Preise wird es Ihnen doch wohl nicht so ganz besonders ankommen.«
     </p>
-    <p xml:id="eco_de_0000139_940">
+    <p xml:id="eco_de_0000209_940">
      »Nicht so sehr!«
     </p>
-    <p xml:id="eco_de_0000139_950">
+    <p xml:id="eco_de_0000209_950">
      »Na also! Dach' ich mir! Ich empfehl' den »Goldenen Adler« nicht nur darum, weil er seine Weine von mir nimmt – wissen Sie, so was fänd' ich kleinlich! Nein, aber das Hotel ist wirklich gut!«
     </p>
-    <p xml:id="eco_de_0000139_960">
+    <p xml:id="eco_de_0000209_960">
      »Ich zweifle nicht daran und danke Ihnen sehr!« »Nicht Ursach'! Und wenn Sie da Lafitte trinken, dann werden Sie an mich denken! Ich sag' nichts weiter! Das Weinchen lobt sich selbst!«
     </p>
-    <p xml:id="eco_de_0000139_970">
+    <p xml:id="eco_de_0000209_970">
      Georg Unger sagte auch nichts weiter, und der Zug setzte sich von neuem in Bewegung.
     </p>
-    <p xml:id="eco_de_0000139_980">
+    <p xml:id="eco_de_0000209_980">
      Es war mittlerweile ganz hell geworden. Die Sonne mußte schon herauf sein, ein ansehnlicher, gegen Osten hingebreiteter Buchenwald entzog einstweilen die Tageskönigin den Blicken der Reisenden. Über den Spitzen der Bäume aber hing es wie ein feiner, rosiger Duft, der rasch in eine leuchtende Goldfarbe überging und die Buchenwipfel wie in Flammen badete. Oft, oft hatte Georg »drüben« die Sonne aufgehen sehen, und welche fremde, märchenhafte Wunderwelt hatten ihre Strahlen ihm gezeigt … aber der deutsche Buchenwald und die Heimat waren nicht dabei gewesen! Der Bahnzug beschrieb jetzt eine ansehnliche Kurve … Da hing der glühende Sonnenball gleich einer lodernden Fackel seltsam nahe und seltsam niedrig über einem hellgrünen, leise im Morgenwinde schwankenden Kornfeld und spiegelte sich weiterhin in der klaren Wasserfläche eines mäßig großen Sees, dessen Ufer von manneshohen Schilfstauden eingefaßt war.
     </p>
-    <p xml:id="eco_de_0000139_990">
+    <p xml:id="eco_de_0000209_990">
      »Da haben wir die Wahrzeichen unserer Gegend, von denen ich Ihnen sagte!« bemerkte der Weinhändler nicht ohne einen gewissen Stolz. »Wasser und Wald! Sieht sich nicht so übel an, sollt' ich meinen!«
     </p>
-    <p xml:id="eco_de_0000139_1000">
+    <p xml:id="eco_de_0000209_1000">
      Georg nickte nur. Rechtshin am Horizont dämmerten Türme in der Ferne auf – wie Schemen schwebten sie in der klaren, stillen Morgenluft, aber der »Amerikaner« kannte sie gut, die schlanken, spitzen Türme der Nikolaikirche, die Kuppel des alten Domes, die »Nadeln« des Rathauses … Gott, Gott, wie weit, weltenweit lag ihm seine Kindheit, seine Jugend!
     </p>
-    <p xml:id="eco_de_0000139_1010">
+    <p xml:id="eco_de_0000209_1010">
      »Da ist schon unser W. zu sehen!« erklärte der dicke Herr wichtig. »Paar feine, alte Kirchen – dann das Rathaus, die neuen Markthallen, das Gesellschaftshaus – müssen sich das alles ansehen. Mir kommt es immer vor, als wenn das Ganze zu mir gehört, so'n Stück von mir selbst ist – man ist da eben mit der Zeit so hineingewachsen!«
     </p>
-    <p xml:id="eco_de_0000139_1020">
+    <p xml:id="eco_de_0000209_1020">
      Der Zug hielt noch an zwei kleinen Stationen. Georg ertappte sich auf einer zehrenden inneren Ungeduld, die ihn doch wieder wundernahm. Wer erwartete ihn denn in W.? Auf wen hätte er sich freuen können? Warum nicht kaltblütig abwarten, bis er sich am Ziele fand?
     </p>
-    <p xml:id="eco_de_0000139_1030">
+    <p xml:id="eco_de_0000209_1030">
      Aus dem goldigen Dunst, der das ferne Stadtbild umhüllte, wuchsen mit der Zeit feste Formen heraus. Bei einer neuen leichten Krümmung des Weges wurde der See sichtbar; er rollte sich auf wie ein ungeheures Blatt Silberpapier, von der nun siegreich emporsteigenden Sonne mit einem schwachen Purpurschein übergossen. An den Ufern schwebte noch schemenhaft der Nebel hin, huschte scheu die mit saftigem Grün bestandenen Böschungen entlang. Hier und dort standen verstreute Häuschen – jetzt kamen regelmäßig hingestellte Gebäude, eine ganze Straßenflucht. Das war früher alles nicht gewesen. Die Stadt hatte sich ausgebreitet, griff mit gestreckten Armen vor sich her, rechtshin, linkshin, zog alles in ihr Bereich, was früher unberührte, urwüchsige Natur gewesen war.
     </p>
-    <p xml:id="eco_de_0000139_1040">
+    <p xml:id="eco_de_0000209_1040">
      Stattliche Fabrikgebäude wurden sichtbar. Natürlich! wo wären die denn nicht zu finden gewesen, diese Merksteine einer im Sturmschritt vorwärtshastenden Kultur? Verschwindend klein und schlicht gegen die Kolosse, die Georg Unger täglich drüben in Amerika gesehen, ihm aber doch so fremd, so störend in dem Heimatsbilde, wie seine treue Erinnerung es festgehalten hatte, daß er mit einer einzigen wegräumenden Handbewegung alles hätte beiseite schieben mögen, was ihm da »im Wege stand«, um den ursprünglichen Charakter wieder herzustellen. – Unter Dampfen und Schnauben fuhr der Zug endlich in eine neue geräumige Bahnhofshalle ein. Der dicke Weinhändler suchte sein Gepäck zusammen.
     </p>
-    <p xml:id="eco_de_0000139_1050">
+    <p xml:id="eco_de_0000209_1050">
      »Hotelomnibus zum ›Goldnen Adler‹ finden Sie an der Bahn. Hoffe, mit meiner Empfehlung des Gasthauses Ehre einzulegen. Adieu, mein Herr – habe die Ehre! Sehr erfreut gewesen, Ihre Bekanntschaft zu machen! Wollen W. wohl bald wieder verlassen? Würde Sie sonst bitten, mir die Freude Ihres Besuches zu schenken – Sperlingsgasse achtundzwanzig! Ja, ja, ja – man kann nie wissen, wie so alles im Leben herumkommt!«
     </p>
-    <p xml:id="eco_de_0000139_1060">
+    <p xml:id="eco_de_0000209_1060">
      »Das weiß Gott! Man kann nie wissen!« wiederholte Georg beinahe feierlich.
     </p>
-    <p xml:id="eco_de_0000139_1070">
+    <p xml:id="eco_de_0000209_1070">
      Mit einem jähen Ruck hielt der Zug. Eine der ersten Erscheinungen, die dem Aussteigenden in der Halle ins Auge fielen, war der Hoteldiener des »Goldenen Adlers«, der mit devot abgezogener Mütze die Weisung des Fremden entgegennahm, mit dem Gepäck vorauszufahren – der Besitzer dieses Gepäckes wollte zu Fuß in etwa einer halben Stunde nachfolgen und bitte um ein warmes Frühstück in englischem Stil: »Tee – gebackenen Schinken – flaumweiche Eier – geröstetes Weißbrot und Butter – Sie werden ja Bescheid wissen!«
     </p>
-    <p xml:id="eco_de_0000139_1080">
+    <p xml:id="eco_de_0000209_1080">
      »Sehr wohl, mein Herr! In einer halben Stunde also!«
     </p>
-    <p xml:id="eco_de_0000139_1090">
+    <p xml:id="eco_de_0000209_1090">
      »In einer guten halben Stunde!«
     </p>
-    <p xml:id="eco_de_0000139_1100">
+    <p xml:id="eco_de_0000209_1100">
      Georg stand unschlüssig, sah dem davonrollenden Wagen nach, gewahrte, wie der Weinhändler in eine kleine einspännige Droschke stieg und davonfuhr. Es war ihm alles neu, alles fremd. Diesen Platz, diese Straßen hatte es vor dreiundzwanzig Jahren nicht gegeben. Welchen Weg hatte er zu nehmen? Gleichviel, das würde sich finden! Den »Goldenen Adler« kannte hier sicher jedermann! – Er kreuzte den Platz und bog aufs Geratewohl in eine der daranstoßenden Straßen ein, die mit hübschen Gebäuden im Villenstil besetzt war.
     </p>
-    <p xml:id="eco_de_0000139_1110">
+    <p xml:id="eco_de_0000209_1110">
      Alles still und unbelebt in dieser Straße. Verstand sich von selbst, es war ja noch so früh! Heruntergelassene weiße Vorhänge an den Fenstern, hier und da gestickte Stores. Das bißchen Leben, das der eben angekommene Bahnzug mitgebracht hatte, verlief sich rasch; außer ein paar verschlafen aussehenden Bäckerjungen, einem Milchwagen, der langsam über das Pflaster stolperte, und einem verdrossen dahertrottenden Zeitungsausträger war weit und breit nichts zu erblicken.
     </p>
-    <p xml:id="eco_de_0000139_1120">
+    <p xml:id="eco_de_0000209_1120">
      Schon wollte das weich aufwallende Gefühl der Heimatsliebe, das von Georg Besitz ergriffen hatte, einer bedenklichen Ernüchterung weichen – – da, mit einem Male blieb er wie gebannt stehen und lauschte: es fingen Kirchenglocken an zu läuten. Dieselben Glocken waren es, die er als Knabe grell und unmelodisch genannt hatte, und sie konnten es in dreiundzwanzig Jahren nicht gelernt haben, lieblich zu tönen – aber ihm gab der altvertraute Klang einen Schlag aufs Herz, daß ihm fast der Atem aussetzte. Die ersten Zeilen eines Gedichtes kamen ihm in den Sinn, das er einst vor langen Jahren gelesen hatte:
     </p>
-    <p xml:id="eco_de_0000139_1130">
+    <p xml:id="eco_de_0000209_1130">
      »Und ich liebe sie doch! – Dumpf und trübe nannte ich einst Die Glocken der Heimat! Doch heute, da klingen sie über das Meer So wehmutselig – so wunderbarlich, Daß auch mein lachendes Herz Ihr Echo wird!«
     </p>
-    <p xml:id="eco_de_0000139_1140">
+    <p xml:id="eco_de_0000209_1140">
      Er hatte sie klingen gehört über das Meer – wie oft – wie oft! Und wie er jetzt dastand, das Haupt gebeugt, und lauschte, sah er im Geist eine dürftig gekleidete, vor der Zeit gealterte Frau des Weges daherkommen, die führte ein kleines, niedliches Mädchen an der Hand, das immer wieder ermahnt werden mußte, man dürfe auf dem Wege zur Kirche nicht hüpfen, sondern müsse hübsch verständig und langsam gehen – und hinter den beiden schritten zwei kaum dem Knabenalter entwachsene Jünglinge, etwas unwillig, weil es wieder in die Kirche ging, etwas verlegen, weil sie ein Gesangbuch tragen mußten, sorgfältig nach rechts und links ausspähend, ob man auch keine Bekannten träfe, vor allem keine Schulkameraden, die sich über die »Frömmigkeit« von Ungers »Alten« aufhielten – – und die Kirchenglocken läuteten! Weder der Bäckerjunge noch der Zeitungsausträger beachteten den Fremden, der wie angewurzelt mitten auf der Straße stand und horchte, aber hätten sie es getan, er würde ihrer nicht geachtet haben. Die alten Kirchenglocken sangen ihm einen Gruß, daß ihm das Herz zitterte vor Sehnsucht und vor Schmerz. Wieder daheim, endlich, aber fremd geworden und allein!
     </p>
-    <p xml:id="eco_de_0000139_1150">
+    <p xml:id="eco_de_0000209_1150">
      Der Vormittag verging für Georg Unger in Verhandlungen mit Justizrat Hein, in welchem er einen verständigen, etwas nüchternen Juristen fand. Das rasch zufassende Verständnis und die praktische Art des »Amerikaners« gefielen wiederum dem Beamten gut, und die Manier des Fremden, den Kostenpunkt rasch zu erledigen und jedem zu seinem Rechte zu verhelfen, ließ den Justizrat doppelt froh sein, diesen Mann hier herüberzitiert zu haben – die Angelegenheiten wickelten sich ab wie am Röllchen.
     </p>
-    <p xml:id="eco_de_0000139_1160">
+    <p xml:id="eco_de_0000209_1160">
      Haus und Garten des verstorbenen Rentiers Kordeleit waren gleichfalls Eigentum Georg Ungers geworden. »Das Haus ist alt, ziemlich baufällig, entspricht in keiner Beziehung den Anforderungen der Jetztzeit!« warf der Justizrat gesprächsweise hin. »Sie müssen natürlich trachten, den alten Kasten baldmöglichst loszuschlagen – der Kaufschilling wird immerhin nicht ganz unbedeutend sein; denn es ist viel Terrain da; das Haus selbst ist weitläufig angelegt, vor allem aber gehört ein großer Garten dazu – natürlich alles drin verfallen und verwildert; der alte Herr hatte sein Geld zu lieb und ließ alle fünf gerade gehen. Vorstellungen nützten da nichts, im Gegenteil, gossen nur Öl ins Feuer!« »Waren Sie eigentlich mit dem alten Kordeleit befreundet, Herr Justizrat?«
     </p>
-    <p xml:id="eco_de_0000139_1170">
+    <p xml:id="eco_de_0000209_1170">
      »Befreundet? I wo! Kein Gedanke dran! Der wunderliche alte Kauz hatte nur einen einzigen Freund auf der weiten Gotteswelt, auf den er sich fest verlassen konnte, wie er zu sagen pflegte – und dieser einzige Freund war er selbst! Bis vor kurzem hatte er so 'ne Art Umgang mit einer Familie Junius hier – bißchen heruntergekommene Leute, aber durchaus nett und anständig. Das ging so lange, bis der Verstorbene mal mit Junius, dem Vater, zusammenprallte – weshalb, das hat niemand erfahren! – und zwar gleich so, daß sie sich nicht mehr sehen konnten. Junius betrat das Kordeleitsche Haus nicht mehr, und der Alte ging überhaupt nicht aus; wer etwas von ihm haben wollte, der mußte zu ihm kommen.«
     </p>
-    <p xml:id="eco_de_0000139_1180">
+    <p xml:id="eco_de_0000209_1180">
      »Weiß dieser Herr Junius, daß ich Herrn Kordeleits Universalerbe geworden bin?«
     </p>
-    <p xml:id="eco_de_0000139_1190">
+    <p xml:id="eco_de_0000209_1190">
      »Gott bewahre – Gott bewahre! Der Alte hatte schon vor Jahren testiert, sich natürlich Kodizille, Änderungen etc. vorbehalten. Na, nach dem Krach mit Junius hat er dann von diesem Rechte Gebrauch gemacht, hat auch 'nen Brief an Sie, Herr Unger, geschrieben, der versiegelt zu den Akten gekommen und natürlich nur in Ihre Hände niederzulegen ist!«
     </p>
-    <p xml:id="eco_de_0000139_1200">
+    <p xml:id="eco_de_0000209_1200">
      »Kann ich den Brief haben?«
     </p>
-    <p xml:id="eco_de_0000139_1210">
+    <p xml:id="eco_de_0000209_1210">
      »Aber gewiß! Wenn Sie heute gegen Abend Ihr neues Besitztum inspizieren, schicke ich Ihnen den Brief durch den Boten hinüber.« – – – – – – –
     </p>
-    <p xml:id="eco_de_0000139_1220">
+    <p xml:id="eco_de_0000209_1220">
      Die Stadt W. war weder so klein noch so kleinstädtisch, wie Georg sie in der Erinnerung hatte. Er hatte gefürchtet, rasch aufzufallen, die Neugier der guten Bürger zu erregen, als mutmaßlicher Erbe des alten Kordeleit angestaunt, beneidet zu werden. Nichts von alledem geschah. Seine Ankunft im »Goldenen Adler«, das wirklich ein empfehlenswertes Hotel war und eine ganz ansehnliche Fremdenliste aufwies, blieb ziemlich unbeachtet, man bediente ihn gut und aufmerksam, war aber anscheinend an überseeische, fein auftretende Gäste gewöhnt, und wenn Georg durch die Straßen schritt, so kehrten sich durchaus nicht die Menschengesichter mit der stummen Frage: »Wer bist du, und was willst du hier?« nach ihm um. Hier und da musterte ein ihm entgegenkommendes Individuum, zumal weiblichen Geschlechts, seine imponierende Erscheinung mit diskretem Wohlgefallen, aber das war ihm schon recht häufig passiert, selbst »drüben« in Amerika, und er machte hier wieder die Erfahrung, daß dreiundzwanzig Jahre eine lange Zeit sind, die die Physiognomie einer Stadt gewaltig ändern, ihre Einwohnerzahl fast verdoppeln und die Leute an den Fremdenverkehr gewöhnen können. Der alte Kordeleit war der jetzigen Generation beinahe fremd und jedenfalls ganz gleichgültig geworden. Früher hatte er samt seinen Sonderbarkeiten und seinem Gelde in W. eine Rolle gespielt, war beobachtet und bekrittelt worden. Dem heutigen Geschlecht war er nur eine Mythe, und wenn der dicke Weinhändler gegen Georg Unger behauptet hatte, ganz W. habe den alten Grobian gekannt und sei stolz auf ihn gewesen, so konnte er damit höchstens die älteren Leute meinen, oder er hatte sich überhaupt einer gehörigen Übertreibung schuldig gemacht. Nach Tisch und einem beinahe zweistündigen Schlummer auf dem bequemen Sofa des Gastzimmers ging Georg Unger zum Friedhof hinaus. Er fand sich nicht ganz so geschwind aus dem Gewirr der Gassen und Gäßchen hinaus wie er es sich gedacht hatte, aber erst einmal zum Tor hinausgekommen, erkannte er sofort den altvertrauten Weg wieder, den er so oft mit Mutter und Geschwistern gegangen war, um das Grab des Vaters aufzusuchen.
     </p>
-    <p xml:id="eco_de_0000139_1230">
+    <p xml:id="eco_de_0000209_1230">
      Wieviel mehr weiße Steine, Gußeisenkreuze, grüne Gräber seit all den Jahren, die er in der Fremde zugebracht hatte, dazugekommen waren! Und neben dem Hügel des Vaters die beiden anderen Hügel, die die Mutter, die kleine Schwester bargen. Es wurde Georg schwer, fast unmöglich, sich vorzustellen, daß diese beiden, die er so lebensvoll verlassen, wirklich hier unten ruhten, es wollte bei ihm zu keinem rechten Gefühl der Trauer, der Andacht kommen. Unruhig und aufgeregt flatterten seine unsteten Gedanken hierhin, dorthin, so sehr er sich innerlich auch darum schalt, und wenn es ihm endlich mühsam gelungen war, sich das Bild der Mutter und der Schwester zusammenzustellen, so stob es unmittelbar darauf wieder auseinander, und dieselbe Unrast kam von neuem über ihn, diese quälende Sucht, an allerlei gleichgültige Dinge zu denken, während die Seele bestrebt ist, sich einem einzigen beherrschenden Gefühl hinzugeben.
     </p>
-    <p xml:id="eco_de_0000139_1240">
+    <p xml:id="eco_de_0000209_1240">
      Dazu kam, daß die Gräber in, ihrem Aussehen ernüchternd wirkten. Georg hatte regelmäßig in Pausen Geld zu ihrer Erhaltung und Pflege geschickt, sie sahen auch keineswegs vernachlässigt aus, aber poesielos, und ohne jeden Reiz. Steif und gerade, wie Soldaten, waren Blumen auf die Hügel gepflanzt, die weder in ihrer Farbe noch in ihrer Anordnung zueinander stimmten, man sah so recht die gleichgültige, bezahlte Hand, die maschinenmäßig ihre Pflicht getan. Georg hatte ein paar schöne Kränze aus dem größten Blumengeschäft mitgenommen und legte sie auf die Gräber; sie paßten aber wieder nicht zu dem bereits vorhandenen Schmuck, und es gab ein stimmungsloses Durcheinander, das den Augen wie dem Herzen wehtat. Er ging schließlich zur Stadt zurück, erfragte den besten Gärtner und besprach mit diesem ausführlich eine Erneuerung des Gräberschmuckes »von Grund aus«, wobei das Geld nicht gespart zu werden brauchte.
     </p>
-    <p xml:id="eco_de_0000139_1250">
+    <p xml:id="eco_de_0000209_1250">
      Als er sich gegen Abend im Kordeleitschen Hause einfand, traf er dort einen Boten des Justizrats Hein an, der ihm die Tür öffnete, sämtliche Schlüssel übergab, sowie auch einige Papiere, von denen der Justizrat bereits mit ihm gesprochen, unter ihnen der mit einem altmodischen viereckigen Siegel versehene Brief des alten Kordeleit an seinen Universalerben – ein großes, steifes, etwas vergilbtes Kuvert, auf dem in wunderlich verschnörkelten, ein wenig zittrigen Zügen die Aufschrift zu lesen war: »An Herrn Georg Unger. Wohlgeboren. Zur Zeit Pernambuco. Südamerika. Nach meinem Tode eigenhändig zu öffnen und allein zu lesen.«
     </p>
-    <p xml:id="eco_de_0000139_1260">
+    <p xml:id="eco_de_0000209_1260">
      Georg lohnte den Boten ab, begleitete den Mann bis zur Haustür, schloß hinter dem Davongehenden ab und blieb in seinem neuen Eigentum allein.
     </p>
-    <p xml:id="eco_de_0000139_1270">
+    <p xml:id="eco_de_0000209_1270">
      Es sah alt und ziemlich verwahrlost aus, dies »neue« Besitztum. Ein ungeheurer Hausflur, in dem es nach Staub und Moder roch, breite ausgetretene Treppenstufen, die ins obere Stockwerk führten und die bei jedem Schritt knackten und krachten, die Zimmer groß, unwohnlich, dürftig möbliert, die Dielen ausgetreten, ganze Säulen tanzender, wirbelnder Stäubchen in den breiten Sonnenbahnen, die durch die ungeputzten Fensterscheiben hereinfluteten. Ab und zu ein alter Schrank mit schöner, geschwärzter Schnitzerei, ein nachgedunkeltes Bild in schweren Rahmen, ein blinder Kronleuchter mit seinen Kristallbehängen, das meiste aber steifer, geschmack- und wertloser Hausrat, für den der Trödler kaum ein paar hundert Mark zahlen mochte!
     </p>
-    <p xml:id="eco_de_0000139_1280">
+    <p xml:id="eco_de_0000209_1280">
      Georg war als Knabe ein paarmal in diesem Hause gewesen, um gelegentliche Bestellungen seiner Mutter auszurichten. Er war jedesmal ungern gegangen und unverbindlich empfangen worden. Der alte Kordeleit hatte das Kind nie zum Sitzen genötigt, ihm nie eine Frucht, ein Stück Kuchen oder ein Geldstück geschenkt, ihm nicht das mindeste Wohlwollen bewiesen – und jetzt mit einem Male stand dies längst zum Mann herangereifte Kind mitten im Hause des wunderlichen Alten und sollte dessen Erbe sein! Eine seltsame, unerklärliche, eine freudlose Erbschaft, die noch dazu etwas Bedrückendes hatte; denn Georg fielen eben die Worte des jovialen Weinhändlers ein: »Um die Juniussens tut mir's aber leid, sie haben so nette Kinder!«
     </p>
-    <p xml:id="eco_de_0000139_1290">
+    <p xml:id="eco_de_0000209_1290">
      Wie ein Eindringling erschien sich Georg diesen Leuten gegenüber, die den Verstorbenen in dessen letzten Jahren gekannt, ihm gewissermaßen nahegestanden hatten und denen dies Geld notwendiger war als ihm, dem südamerikanischen Plantagenbesitzer! – Der Schreibtisch des Verstorbenen! Ein altes Mahagonimöbel von ungefälligen, harten Linien. Wie unwillig drehte sich der Schlüssel im Schloß, es gab einen kreischenden Ton. Innen ein paar Fächer, Schubladen, mit kleinen Ringen zum Aufziehen versehen; Georg öffnete sie nacheinander: Rechnungen, Geschäftsanzeigen, ein Bauplan – nichts Nennenswertes weiter. Hier unten ein Brief in einer runden, festen Kaufmannshand.
     </p>
-    <p xml:id="eco_de_0000139_1300">
+    <p xml:id="eco_de_0000209_1300">
      »Sehr geehrter Herr!
     </p>
-    <p xml:id="eco_de_0000139_1310">
+    <p xml:id="eco_de_0000209_1310">
      Wir stehen seit Jahren in einem gewissen Verkehr, das heißt, ich tue Sekretärdienste bei Ihnen und besorge die geschäftlichen Angelegenheiten, die Sie, bei Ihrem Alter und Ihrer ausgesprochenen Abneigung gegen jeden persönlichen Kontakt mit Menschen, nicht selbst erledigen wollen.
     </p>
-    <p xml:id="eco_de_0000139_1320">
+    <p xml:id="eco_de_0000209_1320">
      Ich habe mich, das Zeugnis dürften Sie mir ausstellen müssen, niemals Ihnen aufgedrängt, Sie nie mit meinen Familienverhältnissen behelligt; Sie haben es, sehr geehrter Herr, auch freilich sorgfältig vermieden, mich jemals danach zu fragen. Wenn mich die bittere Not nicht zwänge, ich würde nie freiwillig zu Bekenntnissen schreiten, für die ich weder Interesse noch Teilnahme voraussetzen darf. Aber eben – leider – die bittere Not zwingt mich dazu!
     </p>
-    <p xml:id="eco_de_0000139_1330">
+    <p xml:id="eco_de_0000209_1330">
      Ich bin nicht länger imstande, die Meinigen zu ernähren. Schon zwei Quartale stundet uns die nachsichtige Güte unseres Hauswirtes die Miete; das dürfte nicht lange mehr geschehen. Beim Arzt, beim Apotheker habe ich nicht bezahlen können, was mich unsäglich peinigt und demütigt. Meine Frau ist fast immer krank. Meine älteste Tochter hat, mich gestern mit Tränen gebeten, sie rasch etwas Praktisches lernen zu lassen, sei es doppelte Buchführung oder Telegraphendienst – sie wolle durchaus selbst etwas Geld verdienen. Ich habe diese Bitte, so schwer es mir fiel, abschlagen müssen. Abgesehen davon, daß meine Tochter noch sehr jung und von zarter Gesundheit ist, abgesehen davon, daß ich ihr zur Erlernung irgend eines Berufes kein Geld geben kann – sie ist im Hause absolut unentbehrlich, sie ersetzt mir die Hausfrau, den jüngeren Geschwistern die Mutter; sie arbeitet von früh bis spät, es ruht alles auf ihren Schultern. Wie sollte sie die Zeit finden, stundenlang außer dem Hause einer anderen Beschäftigung nachzugehen! – Meine Söhne gehen zur Schule; der älteste, der sehr befähigt ist, hat eine Freistelle, die beiden anderen sollen bezahlen, und ich habe das Geld nicht. – –
     </p>
-    <p xml:id="eco_de_0000139_1340">
+    <p xml:id="eco_de_0000209_1340">
      Sehr geehrter Herr Kordeleit, ich flehe Sie an: helfen Sie mir in meiner Not! Sie werden fragen, wovon ich Ihnen ein eventuelles Darlehn wiedererstatten will – ich muß Ihnen antworten: ich weiß es nicht! Geben Sie mir mehr für Sie zu schreiben, zu arbeiten, zu tun – viel mehr noch als bisher! Es soll mir nichts zu schwer sein – – nur ich bitte, ich beschwöre Sie, lassen Sie es meine arme, kranke Frau, lassen Sie es meine unschuldigen Kinder nicht entgelten, daß ihr Gatte und Vater es nicht verstanden hat, ihnen eine sorgenlose Lebenslage zu schaffen.
     </p>
-    <p xml:id="eco_de_0000139_1350">
+    <p xml:id="eco_de_0000209_1350">
      Ich harre in Angst und Sorge Ihrer Entscheidung. Möge Gott Ihr Herz voll Mitgefühl sein lassen!
     </p>
-    <p xml:id="eco_de_0000139_1360">
+    <p xml:id="eco_de_0000209_1360">
      Stets Ihr hochachtungsvoll ergebener Ernst Junius.«
     </p>
-    <p xml:id="eco_de_0000139_1370">
+    <p xml:id="eco_de_0000209_1370">
      Georg ließ den Brief auf die Tischplatte fallen und sah mit gerunzelten Brauen vor sich hin.
     </p>
-    <p xml:id="eco_de_0000139_1380">
+    <p xml:id="eco_de_0000209_1380">
      War diese Zuschrift die Ursache gewesen, weshalb der Alte sich mit Junius entzweit hatte? Wahrscheinlich! Wie Georg den alten Mann in der Erinnerung hatte, würde er jede derartige Bitte, von wem sie immer kam und wie beweglich sie auch klang, unberücksichtigt gelassen haben. Der geängstigte Gatte und Vater war vielleicht in Person erschienen, hatte gebeten, war dringend geworden – und die Folge davon war der endgültige Bruch, dessen der Weinhändler Erwähnung getan hatte. Wer weiß – wenn Junius diesen Brief nicht geschrieben, wenn er den Alten nicht um Geld gebeten hätte – – vielleicht wäre er jetzt der Erbe dieses Vermögens geworden, das Georg Unger unerwartet in den Schoß fiel! Das Mißbehagen in der Seele des Mannes wuchs und wuchs.
     </p>
-    <p xml:id="eco_de_0000139_1390">
+    <p xml:id="eco_de_0000209_1390">
      Nichts weiter im Schreibtisch zu finden, weder rechts noch links. Nun noch den Brief des wunderlichen Erblassers! Das Siegel knirschte, der steife Bogen faltete sich auseinander. Es waren nur wenige Zeilen:
     </p>
-    <p xml:id="eco_de_0000139_1400">
+    <p xml:id="eco_de_0000209_1400">
      »Herrn Alfred Waldemar Georg Unger z. Z. Pernambuco in Südamerika.
     </p>
-    <p xml:id="eco_de_0000139_1410">
+    <p xml:id="eco_de_0000209_1410">
      Ich werde mein bisheriges Testament umstoßen und Sie zu meinem Universalerben ernennen. Das wird Sie befremden. Ich habe aber meine Gründe dafür. Ich habe Sie nicht aus den Augen verloren, obwohl Sie in Amerika sind und ich in Deutschland lebe. Ich weiß, daß Sie kein Verschwender sind, daß Sie arbeiten gelernt haben und den Wert des Geldes zu schätzen wissen. Mein Geld soll keinem Hungerleider zugute kommen, sondern einem Menschen, der zu erwerben und zusammenzuhalten versteht.
     </p>
-    <p xml:id="eco_de_0000139_1420">
+    <p xml:id="eco_de_0000209_1420">
      Jakob Anton Kordeleit.«
     </p>
-    <p xml:id="eco_de_0000139_1430">
+    <p xml:id="eco_de_0000209_1430">
      Da war es: »Mein Geld soll keinem Hungerleider zugute kommen!« Mit dieser Bezeichnung war Junius gemeint, es war kein Zweifel. Wie oft, wie oft hat schon die Bitte um ein Darlehn das bißchen sogenannte »Freundschaft« zwischen zwei Menschen über den Haufen geworfen!
     </p>
-    <p xml:id="eco_de_0000139_1440">
+    <p xml:id="eco_de_0000209_1440">
      Georg Unger schloß die Klappe des Schreibtisches zu und atmete schwer. Ihm war, als würde die Luft zu eng, zu bedrückend in dem dumpfigen, seit lange nicht gelüfteten Räume. Oder war es nur diese Erbschaft, die ihn so bedrückte? Er wußte den Wert des Geldes zu schätzen, jawohl! Aber dies Geld, das einem anderen, der darbte, entzogen wurde, um ihm zugewendet zu werden, von einem fremden, harten, alten Mann, dies Geld, das ihm wie zum Hohn in den Schoß geworfen wurde: »Da, nimm du es meinetwegen, obgleich du mir fremd und gleichgültig bist – nimm es, nur damit es der andere nicht bekommt!« – – Konnte das ihn freuen? Konnte darauf Segen ruhen?
     </p>
-    <p xml:id="eco_de_0000139_1450">
+    <p xml:id="eco_de_0000209_1450">
      Er war zum Fenster getreten, riß es weit auf, den zweiten Flügel gleichfalls – die hereinströmende, weiche Sommerluft nahm den Druck auf seiner Brust nicht von ihm. Aber zugleich mit dieser Luft flutete eine breite Welle goldroten Sonnenlichtes in das unwohnliche Zimmer, solches intensive Sonnengold, wie der Abend es mit sich bringt, dem die Tageskönigin alle Gluten und alle Farbenpracht schenkt, ehe sie scheiden muß. Georgs wandernder Blick fiel auf ein junges, prangendes Laub, auf Busch und Baum – ein Stück des verwilderten Kordeleitschen Gartens lag vor ihm. Hinaus aus dem Zimmer – hinaus in den Garten! Vielleicht wurde ihm im Freien leichter ums Herz; er nahm sich nicht mehr die Zeit, seinen Hut mitzunehmen, den er in einem der anderen Zimmer achtlos auf einen Tisch geworfen hatte.
     </p>
-    <p xml:id="eco_de_0000139_1460">
+    <p xml:id="eco_de_0000209_1460">
      Ein säuselnder Hauch, der leisen Rosenduft auf seinen Schwingen trug, hob dem Hinaustretenden leicht das Haar von der Stirn empor. Der vernachlässigte Garten lag da wie in flüssiges Gold gebadet. Der Flieder hatte abgeblüht, die Obstbäume trugen nicht mehr ihr duftiges, weißes Kleid. Dafür prangte Schneeballenstrauch und Goldregenbusch in üppigem Flor, der Jasmin entfaltete seine weißen Blüten, rosa und gelbe Akazien ließen ihre vollen Traubendolden herniederhängen, und die zarte Rose »Mädchenerröten« schloß zu Hunderten ihre lieblichen Kelche auf.
     </p>
-    <p xml:id="eco_de_0000139_1470">
+    <p xml:id="eco_de_0000209_1470">
      Die ausgedehnten Glasflächen waren überreich mit Gänseblümchen, mit Maßliebchen und Tausendschön durchflickt, von den wenigen, hier und da eingestreuten, ungepflegten Blumenbeeten nickten schwere weiße und tiefrote Nelkenbüschel.
     </p>
-    <p xml:id="eco_de_0000139_1480">
+    <p xml:id="eco_de_0000209_1480">
      Georg sah mit achtsamem Blick um sich. Erkannte er hier etwas wieder? Dort rechts hinüber das hohe, schmiedeeiserne Gitter, das hatte dazumal natürlich noch nicht existiert, dahinter lag sicher der Garten des reichen Weinhändlers, der sich inzwischen hier angekauft und niedergelassen hatte. Die Seite interessierte ihn nicht sonderlich. Aber die andere, die linke, wo »unser Garten« gewesen, war gar nicht groß, wahrlich nicht schön, und dennoch ein Stück Kinderparadies, in welchem selbst der traditionelle Apfelbaum nicht fehlte!
     </p>
-    <p xml:id="eco_de_0000139_1490">
+    <p xml:id="eco_de_0000209_1490">
      Mit so hastigen Schritten, als gelte es, etwas Verlorenes einzubringen, ging Georg quer über den blumigen Rasen, am blühenden Gebüsch vorbei – vorbei auch an einem alten verfallenen Gartenhaus, dessen er sich dunkel entsann. – Hier war noch der derbgezimmerte, plumpe Lattenzaun, rissig, baufällig, mit grünlichen Moosflechten überzogen, und dort, ganz am Ende des Zaunes, die mächtig ausladenden Zweige des alten Apfelbaumes, die weit in den Kordeleitschen Garten überhingen.
     </p>
-    <p xml:id="eco_de_0000139_1500">
+    <p xml:id="eco_de_0000209_1500">
      »Junge, wie sehen deine Hosen bloß aus! Hast du richtig schon wieder auf dem Apfelbaum gesessen? Und hast die Trude auch dazu verleitet? Da sind zwei Risse im Kleid; Kinder, Kinder, es ist nicht mit euch auszukommen, geht mal wieder ohne Abendbrot zu Bett für euren Ungehorsam!«
     </p>
-    <p xml:id="eco_de_0000139_1510">
+    <p xml:id="eco_de_0000209_1510">
      Ganz deutlich meinte Georg die scheltende Stimme der Mutter zu hören. Dafür vernahm er jetzt jenseit des Lattenzaunes ein Huschen und Trippeln; hier fehlte ja eine Latte, das gab einen bequemen Durchblick! Drei, vier helle Mädchenkleider, ein paar schlanke Gestalten, eine kleinere, untersetzte – braune und blonde Zöpfe, eine, die einen hübsch gewundenen, dicken Knoten trug in leicht gekraustem, dunklem Haar. Keins von den Mädchen sprach, sie gingen alle vier – nein, eine fünfte tauchte eben noch auf – mit gesenkten Häuptern bedächtig einher, bückten sich zuweilen und pflückten etwas; dann und wann klang es zu dem Lauscher hinüber wie ein verhaltenes Kichern. Johannisabend! Der alte, alte Brauch der »neunerlei Kräuter«, die man am Sonnenwendabende pflücken muß, ohne zu sprechen, über die Schulter ins Haus werfen und unter das Kopfkissen legen soll; was man dann träumt, soll Bedeutung haben für das kommende Jahr! Der »Südamerikaner« entsann sich der alten Sitte mit einem Schlage, er hatte als Junge oft genug die Mädchen verspottet und auf alle Weise zum Reden verleiten wollen, entrüstet darüber, wenn es ihm nicht gelang, und die »dummen Dinger«, die sonst so entsetzlich schwatzhaft waren, standhaft schwiegen.
     </p>
-    <p xml:id="eco_de_0000139_1520">
+    <p xml:id="eco_de_0000209_1520">
      Wurden denn diese hier gar nicht in Versuchung geführt? Blieben sie ungestört, wie sie da in ihren hellen Sommerfähnchen lautlos im purpurnen Abendsonnenschein durch den Garten huschten?
     </p>
-    <p xml:id="eco_de_0000139_1530">
+    <p xml:id="eco_de_0000209_1530">
      Als habe sein Gedanke Gestalt gewonnen, so wurde es jetzt drüben hinter der steifen Taxushecke lebendig. Mit Hallo und Hussa setzten ein Paar halbwüchsige Jungen über die niedrige grüne Mauer weg, purzelten übereinander, verlegten den Mädchen den Weg: »Du, Grete, deine Mama fragt nach dir!« »Paula, dein Kanarienvogel ist fortgeflogen!« »Hast du nicht mein Messer gesehen, Elsbeth?« »Du, Elsbeth, der Vater läßt dich fragen, wo du seine Morgenschuhe gelassen hast.« »Hörst du nicht, Elsbeth? Vaters Morgenschuhe! Er braucht sie! Wo sind sie geblieben? Na, dummes Frauenzimmer, du mußt doch sagen, wo du sie gelassen hast!«
     </p>
-    <p xml:id="eco_de_0000139_1540">
+    <p xml:id="eco_de_0000209_1540">
      Die Mädchen wehrten die Quälgeister ab, mit Kopfschütteln und Händewinken, keine sprach ein Wort. Offenbar nahmen sie's heilig ernst mit ihrem Gelübde des Schweigens.
     </p>
-    <p xml:id="eco_de_0000139_1550">
+    <p xml:id="eco_de_0000209_1550">
      Die Jungen wurden dreister, suchten ihnen die schon gesammelten »Kräuter« zu entreißen, zerrten an den niederhängenden Zöpfen. Eine Blondine in Blau drehte sich kurz herum und schlug den größten zudringlichen Bengel derb auf die Finger.
     </p>
-    <p xml:id="eco_de_0000139_1560">
+    <p xml:id="eco_de_0000209_1560">
      »Au, Grete, bist du aber grob!«
     </p>
-    <p xml:id="eco_de_0000139_1570">
+    <p xml:id="eco_de_0000209_1570">
      »Na, Elsbeth, du wirst gute Schelte kriegen, wenn du nicht sagst, wo Vaters Morgenschuhe stecken! Er will sie doch anziehen, hörst du. Vater wird sich schon wundern, wenn wir ihm sagen, daß du hier im Garten rumkriechst und solchen Blödsinn machst!«
     </p>
-    <p xml:id="eco_de_0000139_1580">
+    <p xml:id="eco_de_0000209_1580">
      Georg Unger zog durch die Zaunlücke einen Zweig seines alten Apfelbaumes zu sich nieder und fühlte sich dadurch auf seinem Lauscherposten noch mehr geborgen. Das junge Völkchen war übrigens ohnehin vollkommen unbefangen. Wie sollte eins unter ihnen darauf kommen, in dem seit Monaten vereinsamten Kordeleitschen Garten einen stillen Beobachter zu vermuten?
     </p>
-    <p xml:id="eco_de_0000139_1590">
+    <p xml:id="eco_de_0000209_1590">
      War eins von den Mädchen hübsch? Georg konnte das zunächst nicht feststellen. Einige waren ihm zu weit entfernt, die anderen kehrten ihm konsequent den Rücken zu, höchstens sah er flüchtig ein Stückchen Profil. Die mit dem dunklen Haarknoten war hübsch gewachsen und anmutig in ihren Bewegungen; rasch und zierlich wie ein Schwälbchen glitt sie zwischen den Gesträuchen einher. Einer von den Jungen jagte hinter ihr her und suchte sie zu fangen; sie lief rasch um die Taxushecke, war für eine Weile gar nicht zu sehen, kam dann drüben wieder zum Vorschein, bog dem Verfolger, der ihr ganz nahe war, überaus geschickt aus dem Wege, immer ihr grünes Sträußchen in der Hand haltend, und stand dann einen, Augenblick ganz in Georgs Nähe still. Ja, sie war hübsch, sehr hübsch sogar.
     </p>
-    <p xml:id="eco_de_0000139_1600">
+    <p xml:id="eco_de_0000209_1600">
      »Habt ihr noch nicht euer dummes Grünzeug zusammen? Gott, was Mädchen immer langsam sind!«
     </p>
-    <p xml:id="eco_de_0000139_1610">
+    <p xml:id="eco_de_0000209_1610">
      »Paula, die Sonne ist schon hinunter, nun könnt ihr doch reden!«
     </p>
-    <p xml:id="eco_de_0000139_1620">
+    <p xml:id="eco_de_0000209_1620">
      »Wenn du aber nicht von Vaters Morgenschuhen träumst, Elsbeth, dann heiß' ich Mops! Na, und wenn du das träumst, was hast du dann?« »Daß ihr schon was Vernünftiges träumen wollt, so grasgrün und dämlich, wie ihr noch seid!«
     </p>
-    <p xml:id="eco_de_0000139_1630">
+    <p xml:id="eco_de_0000209_1630">
      Brüder haben das Privilegium, stets ungezogen gegen ihre Schwestern zu sein – und daß dies zwei Geschwister sein mußten, war ersichtlich! Bei dem etwa vierzehnjährigen Jungen derselbe schlanke, feste Gliederbau wie bei dem Mädchen, dasselbe feine Profil, die dunklen, langen Wimpern.
     </p>
-    <p xml:id="eco_de_0000139_1640">
+    <p xml:id="eco_de_0000209_1640">
      »Du, sei doch nicht so gräßlich dumm, Elsbeth! Jetzt kannst du mir doch antworten!«
     </p>
-    <p xml:id="eco_de_0000139_1650">
+    <p xml:id="eco_de_0000209_1650">
      Sie wies statt dessen stumm mit der ausgestreckten Hand nach der Sonne hinüber, die immer noch goldflammend durch die Bäume sah.
     </p>
-    <p xml:id="eco_de_0000139_1660">
+    <p xml:id="eco_de_0000209_1660">
      »Na, meinethalben! Bleib, wo du bist, dummes Gör. Bist mir viel zu langweilig, Adieu!«
     </p>
-    <p xml:id="eco_de_0000139_1670">
+    <p xml:id="eco_de_0000209_1670">
      Mit drei schnellen Sätzen war der Quälgeist auf und davon durch raschelndes Gebüsch. Das Mädchen war stehen geblieben und zählte ganz vertieft und aufmerksam die gesammelten Pflänzchen; Georg konnte sehen, wie sich lautlos die Lippen bewegten: »Sechs – sieben – acht« – sie bückte sich und pflückte ein Stengelchen Labkraut, das zu ihren Füßen wuchs.
     </p>
-    <p xml:id="eco_de_0000139_1680">
+    <p xml:id="eco_de_0000209_1680">
      Da kam es den schmalen Gartenweg entlang, wie kleine trippelnde Kinderschritte. Und ein in blaugestreiften Sommerstoff gekleidetes Wichtchen, sicher noch keine drei Jahre alt, eine dicht am Kelche abgerissene rote Nelke im zusammengeballten Fäustchen haltend, bog um die Ecke, stieß einen hellen Jubelruf aus, als es die Mädchengestalt entdeckte, und setzte sich alsdann in einen solchen Sturmschritt, daß es ins Stolpern kam und von dem hastig zuspringenden Fräulein eben noch vor dem Fallen bewahrt wurde.
     </p>
-    <p xml:id="eco_de_0000139_1690">
+    <p xml:id="eco_de_0000209_1690">
      »Sieh, die ßöne Bume! Is für dich – die ßöne Bume – für dich!«
     </p>
-    <p xml:id="eco_de_0000139_1700">
+    <p xml:id="eco_de_0000209_1700">
      Das junge Mädchen hatte das Blondköpfchen auf den Arm gehoben und drückte es zärtlich an sich. Wieder sah sie hinüber, wo müde, rote Sonnenaugen durch das Blättergewirr blinzelten – die Tageskönigin war dicht am Untergehen, aber noch küßten ihre letzten Strahlen die Erde.
     </p>
-    <p xml:id="eco_de_0000139_1710">
+    <p xml:id="eco_de_0000209_1710">
      Die dicken Kinderhändchen mühten sich mit ungeschicktem Eifer, die rote Nelke in das dunkle Haar des Mädchens zu stecken – es wollte eine ganze Weile nicht gelingen, aber das junge Geschöpf hielt geduldig still. Unter dem Gewicht des dicken kleinen Buben neigte sich die schlanke Gestalt leicht nach links hinüber – man sah aber, daß sie gewöhnt war, Kinder auf den Arm zu nehmen, sah es an der sicheren Art, mit der sie den Kleinen hielt, sah es auch an der heiteren Zärtlichkeit, mit der sie ihm zulächelte – einer Zärtlichkeit, die bei ganz jungen Mädchen häufig schon die künftige liebevolle Mutter verrät. Georg Unger hätte hinzutreten und dem zarten Wesen die Bürde abnehmen mögen; damit jedoch hätte er seinen bequemen Beobachterposten aufgeben müssen, und das wollte er nicht.
     </p>
-    <p xml:id="eco_de_0000139_1720">
+    <p xml:id="eco_de_0000209_1720">
      Die Nelke saß jetzt endlich fest, dicht über dem seinen, rosigen Ohr, mitten hinein in das dunkle Haargekräusel gebettet. Es sah eigentümlich reizvoll aus.
     </p>
-    <p xml:id="eco_de_0000139_1730">
+    <p xml:id="eco_de_0000209_1730">
      »Danke sagen– ßön danke sagen!« verlangte das Blondköpfchen ungeduldig.
     </p>
-    <p xml:id="eco_de_0000139_1740">
+    <p xml:id="eco_de_0000209_1740">
      Ein letzter, schräge verzitternder Sonnenstrahl glitt matt an den Baumwipfeln entlang, zuckte noch einmal auf und erlosch. Die Sonne war hinunter.
     </p>
-    <p xml:id="eco_de_0000139_1750">
+    <p xml:id="eco_de_0000209_1750">
      »Sollst du denn Blumen abreißen, du kleiner Unart – sollst du denn? Noch dazu Blumen mit einem so kurzen Stengel?« fragte eine weiche, etwas bedeckte Mädchenstimme in kosendem Ton. Dazu griff sich die Fragestellerin eins von den winzigen, dicken Händchen und klopfte leise darauf. Das Blondchen schien genau zu wissen, was es von dieser »Strafe« zu halten hatte; denn es kicherte vergnügt und versteckte sein rundes Gesicht an des Mädchens Schulter.
     </p>
-    <p xml:id="eco_de_0000139_1760">
+    <p xml:id="eco_de_0000209_1760">
      Bei dieser unerwarteten Wendung bekam es aber den Fremden in seinem Versteck zu sehen, und des Kindes Augen erweiterten sich von neuem. Es streckte mit wichtiger Miene das Zeigefingerchen aus und rief eifrig: »Da Mann, da Mann!«
     </p>
-    <p xml:id="eco_de_0000139_1770">
+    <p xml:id="eco_de_0000209_1770">
      Das junge Mädchen fuhr überrascht herum, und der »Mann« konnte nichts anderes tun, als den Zweig des Apfelbaumes, den er noch immer gefaßt hielt, loslassen, sich verbeugen und vortreten. »Verzeihung, mein gnädiges Fräulein, ich wollte Sie gewiß nicht erschrecken. Ich bin aber zufällig Zeuge eines Brauches gewesen, der mir, da ich von jenseit des Meeres herkomme, fremd ist, und Sie würden mir einen wirklichen Dienst erweisen, wenn Sie die Liebenswürdigkeit hätten, mich über diese Sitte aufzuklären!«
     </p>
-    <p xml:id="eco_de_0000139_1780">
+    <p xml:id="eco_de_0000209_1780">
      Dies log nun Georg Unger natürlich, da er ganz gut wußte, um welche Sitte es sich handelte, aber wer wollte es ihm verdenken, wenn er ein so liebreizendes junges Wesen ein wenig länger neben sich festhalten wollte?
     </p>
-    <p xml:id="eco_de_0000139_1790">
+    <p xml:id="eco_de_0000209_1790">
      Sie war durchaus nicht erschreckt; denn der Anblick des fein gekleideten Herrn mit dem bronzefarbenen Gesicht hatte keineswegs etwas Zurückstoßendes an sich – seine fremdartige Aussprache mißfiel ihr ebensowenig; unwillkürlich sandte sie nur einen suchenden Blick um sich – war denn von ihren jungen Gefährten kein einziger mehr da?
     </p>
-    <p xml:id="eco_de_0000139_1800">
+    <p xml:id="eco_de_0000209_1800">
      Nein! Kein helles Kleid, kein farbiges Band schimmerte durch die Büsche – nur ganz von fern scholl ein gedämpftes Lachen aus der Tiefe des Gartens herüber.
     </p>
-    <p xml:id="eco_de_0000139_1810">
+    <p xml:id="eco_de_0000209_1810">
      »Meinen Sie die Johanniskräuter?« fragte das junge Mädchen etwas befangen und blickte unwillkürlich auf das grüne Sträußchen in ihrer Rechten herab.
     </p>
-    <p xml:id="eco_de_0000139_1820">
+    <p xml:id="eco_de_0000209_1820">
      »Ja, die meine ich! Wenigstens sah ich Sie das da pflücken, und Ihre Gefährtinnen taten das gleiche. Dabei verweigerten Sie es, Antwort zu geben, wenn jemand Sie etwas fragte!«
     </p>
-    <p xml:id="eco_de_0000139_1830">
+    <p xml:id="eco_de_0000209_1830">
      »Ja, das darf man auch nicht tun, sonst hat das Ganze keinen Sinn!« erklärte sie eifrig. »Man muß am Sonnenwendabend neun verschiedene Kräuter pflücken und darf nicht reden dabei … überhaupt nicht reden, ehe die Sonne hinunter ist!«
     </p>
-    <p xml:id="eco_de_0000139_1840">
+    <p xml:id="eco_de_0000209_1840">
      »Und dann?«
     </p>
-    <p xml:id="eco_de_0000139_1850">
+    <p xml:id="eco_de_0000209_1850">
      »Und dann legt man sich die Kräuter unter das Kissen … was man dann in der Nacht träumt, geht ganz bestimmt in Erfüllung.«
     </p>
-    <p xml:id="eco_de_0000139_1860">
+    <p xml:id="eco_de_0000209_1860">
      »Wenn man aber gar nichts träumt?«
     </p>
-    <p xml:id="eco_de_0000139_1870">
+    <p xml:id="eco_de_0000209_1870">
      »O – aber – ja, aber ich träume immer irgend etwas!«
     </p>
-    <p xml:id="eco_de_0000139_1880">
+    <p xml:id="eco_de_0000209_1880">
      »Hübsches?« forschte er lächelnd.
     </p>
-    <p xml:id="eco_de_0000139_1890">
+    <p xml:id="eco_de_0000209_1890">
      »Oft etwas Hübsches und dann auch einen schrecklichen Unsinn – wie's grade kommt! Willst du wohl, kleiner Nichtsnutz!«
     </p>
-    <p xml:id="eco_de_0000139_1900">
+    <p xml:id="eco_de_0000209_1900">
      Dieser letzte Ausruf galt dem Bübchen, das sich langweilte und seine Zeit damit auszufüllen suchte, mit seinen runden Fäustchen das dunkle Haar, das ihm so nahe war, zu zausen.
     </p>
-    <p xml:id="eco_de_0000139_1910">
+    <p xml:id="eco_de_0000209_1910">
      »Er muß Ihnen ja weh tun, gnädiges Fräulein!«
     </p>
-    <p xml:id="eco_de_0000139_1920">
+    <p xml:id="eco_de_0000209_1920">
      »Ist nicht so schlimm damit. Er hat gradezu eine Passion dafür, mein Haar zu raufen!«
     </p>
-    <p xml:id="eco_de_0000139_1930">
+    <p xml:id="eco_de_0000209_1930">
      »Auch muß er Ihnen viel zu schwer sein!«
     </p>
-    <p xml:id="eco_de_0000139_1940">
+    <p xml:id="eco_de_0000209_1940">
      »Gott bewahre! Ich bin so daran gewöhnt, Kinder herumzuschleppen, und sie kommen auch gern zu mir!«
     </p>
-    <p xml:id="eco_de_0000139_1950">
+    <p xml:id="eco_de_0000209_1950">
      »Das will ich Ihnen aufs Wort glauben. Man sagt, das sind gute Menschen, zu denen die Kinder Vertrauen haben … sagt man nicht so?«
     </p>
-    <p xml:id="eco_de_0000139_1960">
+    <p xml:id="eco_de_0000209_1960">
      »Ich denke!«
     </p>
-    <p xml:id="eco_de_0000139_1970">
+    <p xml:id="eco_de_0000209_1970">
      »Und wollen wir einmal hier die Probe machen?«
     </p>
-    <p xml:id="eco_de_0000139_1980">
+    <p xml:id="eco_de_0000209_1980">
      »Welche denn?«
     </p>
-    <p xml:id="eco_de_0000139_1990">
+    <p xml:id="eco_de_0000209_1990">
      »Ob ich ein guter Mensch bin, natürlich! Der Kleine – ist's Ihr Bruder?« »Ja, – mein jüngster!«
     </p>
-    <p xml:id="eco_de_0000139_2000">
+    <p xml:id="eco_de_0000209_2000">
      »Und wie heißt er?«
     </p>
-    <p xml:id="eco_de_0000139_2010">
+    <p xml:id="eco_de_0000209_2010">
      »Sag schnell, wie du heißt! Wird's bald? Ganz schnell sagen!«
     </p>
-    <p xml:id="eco_de_0000139_2020">
+    <p xml:id="eco_de_0000209_2020">
      Der Kleine warf einen schelmischen Blick auf die große Schwester und sagte fröhlich: »Dudu!«
     </p>
-    <p xml:id="eco_de_0000139_2030">
+    <p xml:id="eco_de_0000209_2030">
      »Pfui, sollst du so sagen? Du bist ja schon ein großer Junge, du kannst deinen richtigen Namen ganz schön aussprechen. Also fix! Wie heißt du?«
     </p>
-    <p xml:id="eco_de_0000139_2040">
+    <p xml:id="eco_de_0000209_2040">
      Der kleine Schelm warf den Kopf in den Nacken und krähte vor Vergnügen. »Dudu, Dudu!« rief er immer von neuem.
     </p>
-    <p xml:id="eco_de_0000139_2050">
+    <p xml:id="eco_de_0000209_2050">
      »Ulrich ist er getauft!« erklärte das junge Mädchen zwischen Ärger und Lachen. »Das ist nicht leicht auszusprechen, aber er kann es sehr gut, wenn er nur will. Wart' du, Elsbeth hat dich gar nicht mehr lieb, will nichts mehr von dir wissen, wenn du so unartig bist.«
     </p>
-    <p xml:id="eco_de_0000139_2060">
+    <p xml:id="eco_de_0000209_2060">
      »Wenn Elsbeth nichts mehr von dir wissen will – vielleicht kommst du dann zu mir?« Georg Unger trat auf eine der unteren Quersprossen des Lattenzaunes und streckte über die Staketen herüber seine Arme nach dem Kinde aus. »Komm her zu mir, Dudu! Komm!«
     </p>
-    <p xml:id="eco_de_0000139_2070">
+    <p xml:id="eco_de_0000209_2070">
      Der Kleine zögerte ein Weilchen, – aber, sei es, daß ihm der fremde »Onkel« gefiel, sei es, daß die Aussicht, auf diesen beiden starken Armen so hoch emporgehoben zu werden, bis dicht an die grünen Baumzweige heran, ihn reizte – – er atmete tief auf, stieß dann einen zwitschernden Laut aus wie ein Vögelchen, das aufstiegen möchte, und streckte verlangend beide Händchen aus.
     </p>
-    <p xml:id="eco_de_0000139_2080">
+    <p xml:id="eco_de_0000209_2080">
      »Das wundert mich, wundert mich wirklich!« rief Elsbeth erstaunt. »Er geht sonst nicht leicht zu Fremden.«
     </p>
-    <p xml:id="eco_de_0000139_2090">
+    <p xml:id="eco_de_0000209_2090">
      Georg griff zu und hob das zappelnde Bübchen auf seinen Arm. »Meine Probe als ›guter‹ Mensch ist bestanden, gnädiges Fräulein!« sagte er triumphierend. Er hatte lange, lange kein Kind auf dem Arme gehabt – es war ihm ein eigentümlich wohliges Gefühl, das warme, weiche Körperchen so nahe an sich zu fühlen. »Komm, kleines Menschenkind, wir zwei wollen gut Freund miteinander sein!«
     </p>
-    <p xml:id="eco_de_0000139_2100">
+    <p xml:id="eco_de_0000209_2100">
      »Bedank dich bei dem Onkel, Dudu!« gebot Elsbeth jenseit des Lattenzaunes; »hab' den Onkel lieb!«
     </p>
-    <p xml:id="eco_de_0000139_2110">
+    <p xml:id="eco_de_0000209_2110">
      Daraufhin hob der Kleine sein sammetweiches Händchen auf und streichelte damit zutraulich an Georgs Wangen auf und nieder. Der hielt ganz still, ihm wurde ganz gerührt zumute. Solch einen Jungen möchtest du haben – für solch einen Jungen würdest du gern arbeiten und erwerben, ging es ihm durch den Sinn – und dann zuckte blitzschnell noch ein zweiter Gedanke hinterher, wie eine Frage: »Tut es denn aber der Junge allein? Ist nichts weiter dabei, als der Junge?«
     </p>
-    <p xml:id="eco_de_0000139_2120">
+    <p xml:id="eco_de_0000209_2120">
      Er mußte lächeln, wie er das dachte; ihm war eigentümlich froh zu Sinn in der Gesellschaft, in welcher er sich eben jetzt befand. Und deutsch war ihm zumute und heimatlich – »Sonnwendabend daheim!« Es lief ihm bei dieser Vorstellung ein reizvoll prickelndes Gefühl, das er bisher noch gar nicht gekannt hatte, durch die Glieder.
     </p>
-    <p xml:id="eco_de_0000139_2130">
+    <p xml:id="eco_de_0000209_2130">
      Mit seinen kraftvollen Armen hob er das Bübchen auf wie ein federleichtes Spielzeug, setzte es rittlings auf seine Schulter und sah zu, wie es mit den runden Händchen in die Baumzweige griff, daß die Blätter umherstoben. »Sie halten ihn fest, ganz fest – bitte, ja?« fragte Elsbeth besorgt. »Er ist so unruhig und lebhaft.«
     </p>
-    <p xml:id="eco_de_0000139_2140">
+    <p xml:id="eco_de_0000209_2140">
      »Er ist sicher bei mir wie in seiner Mutter Arm, Sie können sich darauf verlassen!« Zur Bekräftigung dieser Worte griff Georg sich eins der strammen Kinderbeinchen und legte es über seine Schulter.
     </p>
-    <p xml:id="eco_de_0000139_2150">
+    <p xml:id="eco_de_0000209_2150">
      »Er wird Sie mit seinen staubigen Schuhen schmutzig machen!«
     </p>
-    <p xml:id="eco_de_0000139_2160">
+    <p xml:id="eco_de_0000209_2160">
      »Ach, Staub klopft sich leicht ab!« warf er hin und sah angelegentlich auf das liebliche junge Mädchengesicht, das ihm so nahe war. »Hübsch – sehr hübsch sogar!« mußte er von neuem denken; aber das war es nicht allein, was ihm gefiel. Der Blick, mit dem das junge Wesen auf das Kind sah, der behütende, zärtliche Blick tat es ihm an.
     </p>
-    <p xml:id="eco_de_0000139_2170">
+    <p xml:id="eco_de_0000209_2170">
      »Sie fühlen sich ganz verantwortlich für Dudu, ja?« fragte er rasch, aus Angst, sie könnte das Gespräch für beendet ansehen und ihn verlassen.
     </p>
-    <p xml:id="eco_de_0000139_2180">
+    <p xml:id="eco_de_0000209_2180">
      »Ach ja!« nickte sie, seufzte leise dazu, und über ihre beweglichen Züge lief ein Schatten. Die offen und groß emporgeschlagenen Augen umflorten sich, halb deckten sich die langen Wimpern wieder darüber. »Ich hab' ihn in Obacht genommen, solange er auf der Welt ist. Mutterchen ist beinahe immer krank und kann sich wenig um ihn kümmern, ich hab' ihn selbst aufgezogen und bin furchtbar stolz auf ihn. Den hätten Sie sehen sollen, als er ein paar Monate alt war! Ganz, ganz klein und jämmerlich, die Ärmchen und Beinchen so dünn, im Gesicht Falten wie ein alter Mann, und gewinselt und gewimmert hat er Tag und Nacht. Mutterchen hat hundertmal zu mir gesagt, ich solle mich nicht so mit ihm abquälen, wir bekommen ihn ja doch nicht groß!«
     </p>
-    <p xml:id="eco_de_0000139_2190">
+    <p xml:id="eco_de_0000209_2190">
      – – – »Mutterchen!« Wie schön ihm das klang, altvertraut und doch wieder neu! So hatte auch er gesagt, als er ein Knabe war, und nie, nie in all den langen dreiundzwanzig Jahren hatte er einen Menschen sagen hören: »Mutterchen!«
     </p>
-    <p xml:id="eco_de_0000139_2200">
+    <p xml:id="eco_de_0000209_2200">
      »Manchmal natürlich bin ich ärgerlich auf Dudu gewesen, wenn er mich gar nicht schlafen ließ,« fuhr Elsbeth fort, und ihr Gesichtchen hellte sich mehr und mehr auf, wie sie weiter sprach: »Aber wie ich dann noch merkte, daß es mit ihm wurde, da setzte ich auch meinen Ehrgeiz drein, ihn in die Höhe zu bekommen. Jetzt sehen Sie sich mal seine Arme und Beinchen an, und was für festes Fleisch er hat! Unser Arzt sagt, ich könnte mir eine Prämie ausbitten für unseren Jüngsten, und ich könnte in eine Kinderheilstätte eintreten als Pflegerin. Das tät' ich auch gleich, wenn sie mich zu Hause nicht so notwendig brauchten.«
     </p>
-    <p xml:id="eco_de_0000139_2210">
+    <p xml:id="eco_de_0000209_2210">
      »Für ein junges Mädchen wie Sie, mein Fräulein, gäbe es doch wohl einen anderen Beruf!«
     </p>
-    <p xml:id="eco_de_0000139_2220">
+    <p xml:id="eco_de_0000209_2220">
      »Ein junges Mädchen wie ich? Wie meinen sie das?« gab sie unbefangen zurück und sah ihm aufmerksam ins Gesicht. »Denken Sie, ich bin zu schwächlich dazu? Gar nicht; ich kann viel mehr leisten, als die meisten Menschen mir zutrauen.«
     </p>
-    <p xml:id="eco_de_0000139_2230">
+    <p xml:id="eco_de_0000209_2230">
      »Nicht allein das. Aber es ist ein schwerer und verantwortlicher Beruf, kranke Kinder zu pflegen, und die Jugend hat das Anrecht darauf, sich eine sorglose, heitere Zukunft zu träumen und zu wünschen.« »Ich nicht!« erwiderte sie ernst, ohne aber dabei traurig und entmutigt auszusehen. »Dem einen wird es so im Leben bestimmt, dem anderen so, das muß man hinnehmen, und danach muß man sich einrichten, sagt mein Vater immer.«
     </p>
-    <p xml:id="eco_de_0000139_2240">
+    <p xml:id="eco_de_0000209_2240">
      »Ihrem Herrn Vater dürfte es leichter werden als Ihnen, das zu sagen und danach zu handeln.«
     </p>
-    <p xml:id="eco_de_0000139_2250">
+    <p xml:id="eco_de_0000209_2250">
      »Gar nicht!« unterbrach sie ihn beinahe heftig. »Mein Vater hat ein sehr schweres, hartes Leben, und man muß ihn bewundern, wenn er nicht verbittert und ungerecht wird!«
     </p>
-    <p xml:id="eco_de_0000139_2260">
+    <p xml:id="eco_de_0000209_2260">
      Sie biß sich leicht in die Lippen, als fürchtete sie, schon zu viel gesagt zu haben, und die großen, klaren Augen, in denen sich jede Empfindung widerspiegelte, sahen förmlich vorwurfsvoll nach ihm hin: Wie kommst du dazu, dies alles aus mir herauszulocken? Und wie komme ich dazu, dir das alles zu sagen? – Er las die Frage aus dem Blick, und ihm war, als müßte er rasch eine Antwort darauf finden.
     </p>
-    <p xml:id="eco_de_0000139_2270">
+    <p xml:id="eco_de_0000209_2270">
      »Ihr Herr Vater,« begann er ein wenig unsicher, »ist mir freilich ganz fremd; ich vermute nur in ihm den jetzigen Besitzer dieses Gartens.«
     </p>
-    <p xml:id="eco_de_0000139_2280">
+    <p xml:id="eco_de_0000209_2280">
      »Nein, ach nein!« Elsbeth schüttelte nachdrücklich das Köpfchen. »Wir haben kein Haus und keinen Garten. Meine beste Freundin wohnt hier, und deren Eltern sind so gut und erlauben, daß wir, ich und unsere Kinder, oft hierher kommen und uns ein bißchen auslaufen dürfen. Der Garten, in dem Sie stehen, ist ja viel größer – da sind wir früher auch manchmal gewesen.«
     </p>
-    <p xml:id="eco_de_0000139_2290">
+    <p xml:id="eco_de_0000209_2290">
      »Beim alten Kordeleit?« »Ja, beim alten Kordeleit! Oder eigentlich nicht bei ihm – – er saß in seinem Arbeitszimmer, wenn wir da waren, er konnte Kinder nicht leiden. Mein Vater hat früher allerlei für ihn geschrieben und besorgt.«
     </p>
-    <p xml:id="eco_de_0000139_2300">
+    <p xml:id="eco_de_0000209_2300">
      »So sind sie Fräulein Junius?«
     </p>
-    <p xml:id="eco_de_0000139_2310">
+    <p xml:id="eco_de_0000209_2310">
      »Elsbeth Junius – ja! Woher wissen –«
     </p>
-    <p xml:id="eco_de_0000139_2320">
+    <p xml:id="eco_de_0000209_2320">
      Weiter kam das junge, Mädchen nicht. Aus der Tiefe des Gartens scholl der dringliche Ruf: »Elsbeth! Elsbeth!« Zugleich schimmerten helle Kleider durch die Büsche, im Gesträuch brach und knackte es, und eine kecke Knabenstimme wurde laut: »Dummes Ding, sitzest du vielleicht auf deinen Ohren? Elsbeth! Wenn die nicht wieder irgend eine alte Scharteke gefunden hat und schmökert –«
     </p>
-    <p xml:id="eco_de_0000139_2330">
+    <p xml:id="eco_de_0000209_2330">
      »Sie suchen mich! Ich muß fort! Komm, Dudu!« Sie hob die Arme hoch, um den Kleinen in Empfang zu nehmen. Er hatte die Zeit während des Gesprächs dazu benutzt, ein paar kleine Zweige vom Apfelbaum abzureißen und bedächtig mit seinen dicken Fingerchen Blatt um Blatt davon abzuzupfen. – – Es wurde Georg Unger schwer, das Geschöpfchen, das es sich auf seiner Schulter so bequem gemacht hatte, Elsbeth abzugeben. Was aber konnte er unter den obwaltenden Umständen anderes tun, als die weiche, warme Last hinüberzureichen? Seine Hände und Elsbeths Hände berührten sich dabei, und wieder ging das heiße, wohlige Rieseln, das er zuvor schon empfunden, über ihn hin.
     </p>
-    <p xml:id="eco_de_0000139_2340">
+    <p xml:id="eco_de_0000209_2340">
      »Leben Sie wohl, Fräulein Junius!« Er verneigte sich tief. »Ich hoffe zuversichtlich, unser erstes Zusammentreffen wird nicht unser einziges sein!«
     </p>
-    <p xml:id="eco_de_0000139_2350">
+    <p xml:id="eco_de_0000209_2350">
      Sie wußte nicht recht, was sie darauf erwidern sollte, schämte sich ihrer Ungewandtheit, wurde rot und sah von ihm fort. In ihrer Verlegenheit beschäftigte sie sich mit Dudu, nahm ihm die Blättchen aus dem Haar, las ihm die Halme vom Kittel und fugte endlich mit einer halben Verbeugung ein schüchternes »Adieu!«
     </p>
-    <p xml:id="eco_de_0000139_2360">
+    <p xml:id="eco_de_0000209_2360">
      Georg stand und sah ihr nach, wie sie, so schnell, daß die eilfertig neben ihr hertrippelnden Kinderfüßchen kaum Schritt mit ihr zu halten vermochten, durch den von Haselnußsträuchen gebildeten Pfad hindurchging.
     </p>
-    <p xml:id="eco_de_0000139_2370">
+    <p xml:id="eco_de_0000209_2370">
      Einmal hörte er ihre Stimme noch, wie sie dem Knaben antwortete; er konnte aber nicht mehr verstehen, was sie sagte. Busch und Baum hatten sie seinem Blicke längst entzogen, rasch sank die Dämmerung nieder, hier und da schwatzte noch ein müdes Vogelstimmchen ein paar verlorene Laute – immer noch stand der Heimgekehrte da, wie wenn er lauschte. Gleich einer lauen Flut strömten alte Erinnerungen, neue Hoffnungen, Zukunftsgedanken über ihn her. Das also waren die Juniusschen Kinder, um die es den Weinhändler so leid tat – die Kinder, denen er das Erbe nehmen sollte!
     </p>
-    <p xml:id="eco_de_0000139_2380">
+    <p xml:id="eco_de_0000209_2380">
      Er schüttelte sich, als wehre er etwas Unwillkommenes heftig von sich ab, und dann ging er langsam, verträumt und versonnen durch den dämmerdunklen Garten zurück. Aber das Haus betrat er nicht wieder; er ging eine Lindenallee hinauf und hinab – wie lange, hätte er später nicht sagen können. Starke Rosen- und Jasmindüfte wehten über ihn hin, und am nachgedunkelten Himmel blinzelten in schwachem Goldglanze die ersten Sterne.
     </p>
-    <p xml:id="eco_de_0000139_2390">
+    <p xml:id="eco_de_0000209_2390">
      »Daheim!« sagte er halblaut vor sich hin und atmete aus tiefster Brust. »Wie fang' ich es an? Wie fang' ich es denn nur an?« fragte sich Georg Unger am Morgen des nächstfolgenden Tages. Er hatte sich die Frage schon während der Nacht, die er nicht ganz durchschlafen konnte, vorgelegt – eine Antwort aber hatte er nicht gefunden.
     </p>
-    <p xml:id="eco_de_0000139_2400">
+    <p xml:id="eco_de_0000209_2400">
      »Unrecht Gut gedeihet nicht!« hatte seine verstorbene Mutter hundertmal zu ihren Kindern gesagt. Nun, in gewissem Sinn war freilich das Erbe des alten Kordeleit kein unrechtes Gut. Er hatte nicht danach gestrebt, es sich zuzuwenden, hatte sozusagen keinen Finger darum gerührt; es war ihm von selbst in den Schoß gefallen! Dennoch!! Er wußte, dies Erbe oder wenigstens ein Teil desselben war einem anderen zugedacht gewesen, einem, der es notwendig brauchte, viel, viel nötiger als er selbst. In diesem Sinne war das ererbte Geld für ihn »unrechtes Gut«. Das hatte er schon empfunden, als er in des alten Kordeleit Zimmer gesessen und die beiden Briefe gelesen hatte – er empfand es mit zehnfacher Stärke, seitdem er Elsbeth Junius gesehen und gesprochen hatte! – – – Er konnte nicht zu ihrem Vater hingehen und ihm sagen: »Lieber Herr, Sie sind durch mich, ohne mein Wissen und Willen, benachteiligt worden, und ich weiß, daß Sie in Not sind – – – nehmen Sie so und so viel von meinem Erbteil und helfen Sie sich selbst und den Ihrigen damit weiter!« – – Zehn gegen eins zu wetten, der Mann mußte das übelnehmen, mußte ihn fragen, mit welchem Recht er, Georg Unger, der ihm wildfremde Mann aus Südamerika, daherkäme, um ihm etwas zu schenken – zehn gegen eins zu wetten, Junius würde das Anerbieten entrüstet zurückweisen. Das Sonderbare bei der Sache war, daß Georg das sehr deutliche Gefühl hatte, er habe sehr wohl ein Recht darauf, sich in Herrn Junius' Familienangelegenheiten einzumischen und sie zu den seinigen zu machen. Er kannte den Mann gar nicht, aber er hätte vor ihn hintreten und zu ihm sprechen mögen: »Laß mich dir helfen! Ich bin dir ja gar nicht fremd. Ich gehöre ja zu euch!« Wie er das hätte motivieren sollen, das wußte er nicht, aber er empfand es nun einmal.
     </p>
-    <p xml:id="eco_de_0000139_2410">
+    <p xml:id="eco_de_0000209_2410">
      Seine Rechte blätterte in dem Adreßbuch, das er sich hatte vom Kellner aufs Zimmer bringen lassen, die Linke zerkrümelte mechanisch ein Frühstücksbrötchen. »E. Junius, Kommissionär, Mühlendamm Nr. 28«, hatte er gelesen und sich die Adresse mit leichter Mühe gemerkt. Am Mühlendamm, mein Gott, da hatte er mit Eduard Schleusen gebaut und für Trude Schiffchen geschnitzt, in die sie ihre Püppchen setzte, um sie dann vorsichtig auf dem kleinen Mühlenteich an einem langen Bande schwimmen zu lassen. Durch ein Wehr war der Mühlenteich mit dem See in Verbindung und den See mußte er selbstverständlich wiedersehen. Wenn er dabei an den Häusern des Mühlendammes vorüberkam, so konnte er sich ja Nummer 28 einmal ansehen. Weiter wollte er nichts, weiter konnte er leider nichts wollen.
     </p>
-    <p xml:id="eco_de_0000139_2420">
+    <p xml:id="eco_de_0000209_2420">
      Wie er langsam dahinschlenderte – diese Langsamkeit war geboten; denn es war ein heißer Junitag und die Sonne, brannte schon um diese Vormittagsstunde mit ungewöhnlicher Glut – kam es ihm vor, als habe er während seines kurzen Aufenthalts in seiner Vaterstadt schon erstaunlich viel erlebt. Im Grunde genommen war es gar nicht der Fall, aber das Gefühl von etwas besonders Wichtigem und Merkwürdigem, das hier seit gestern in sein Leben getreten war, ließ ihn nicht los. Zugleich war er sich mit großer Deutlichkeit der Tatsache bewußt, daß er hier in Deutschland ein total anderer Mensch war als in Amerika. Der Mann, der »drüben« in seinem Kontor am Pulte saß und Briefe durchsah, Wechsel diskontierte, Warenlager inspizierte und mit Leuten aus aller Herren Ländern verkehrte, war in keinem Punkte mit dem zu vergleichen, der hier in sich gekehrt durch die Straßen wandelte. Fernab, weit, weit hinter ihm lagen all die Beschlüsse, Berechnungen und Ideen, die ihn dort so ausschließlich beschäftigt hatten – sie waren ihm gleichgültig, es war, als gingen sie ihn nichts mehr an, während er sich doch sagen mußte, daß sie zum großen Teil sein Lebensschiff zu steuern hatten. Wie wenn er mit dem weißen Tropenanzuge seinen bisherigen Menschen abgelegt und mit den Tuchkleidern einen neuen angezogen hätte, – – so ausgetauscht kam er sich vor. Die Heimatluft war um ihn hergebreitet, wie ein Zaubermantel, der ihn sein früheres Dasein vergessen, ihn wie mit einem Schlage dreiundzwanzig Jahre seines Lebens überspringen ließ.
     </p>
-    <p xml:id="eco_de_0000139_2430">
+    <p xml:id="eco_de_0000209_2430">
      Nur daß er nicht mehr so kindisch sorglos empfand wie vor jenen dreiundzwanzig Jahren! Nur daß der ungezügelte knabenhafte Übermut, der ihn damals regiert hatte, nicht wiederkommen wollte und konnte! Dabei war ihm doch merkwürdig jung zumute – Sorgen und Grübeleien und Bedenken fielen gleichsam Stück für Stück während des Gehens von ihm ab. – Dies alles machte er sich nur halb klar, wie er einherging und immer achtsam: »Mühlendamm achtundzwanzig – – – Mühlendamm achtundzwanzig!« innerlich vor sich hin sagte, als wäre das eine Zauberformel, die er um Gottes willen nicht vergessen dürfe, sollte nicht schweres Unglück dadurch entstehen! – Nur einen flüchtigen Blick warf er auf Mühlenteich und Wehr, die doch beide so viele Erinnerungen für ihn bargen, in denen er recht zu schwelgen gedacht hatte – wie mit Händen zog es ihn weiter!
     </p>
-    <p xml:id="eco_de_0000139_2440">
+    <p xml:id="eco_de_0000209_2440">
      Ein ziemlich niedriges, baufälliges Häuschen! Abseits von den übrigen gelegen, die mit ihren Gittern und Gärtchen teils einen ganz stattlichen, teils einen gemütlich idyllischen Eindruck machten. Nummer achtundzwanzig tat nicht das eine und nicht das andere; es lag nicht sehr weit vom Ufer des Sees, hatte keinen Garten um sich herum und mußte wohl ziemlich feucht und ungesund sein; denn der Abputz war an vielen Stellen heruntergefallen, und wo er noch vorhanden war, zeigte er kreisrunde dunkle Flecke, wie von Moder und Nässe. Das schwere Ziegeldach war an einer Seite schief herabgesunken, wie wenn das Häuschen sich seiner Armseligkeit schämte und sich die Kappe übers Gesicht ziehen wollte – – daß die Leute, die hier hausten, dies halb unfreiwillig taten, weil sie wenig zahlen konnten, war wie durch eine Inschrift von dem vernachlässigten Gebäude herunterzulesen.
     </p>
-    <p xml:id="eco_de_0000139_2450">
+    <p xml:id="eco_de_0000209_2450">
      Die Tür fest geschlossen, kein Mensch am Fenster zu sehen. Hier waren ein Paar dunkle Rouleaus herabgelassen, dort war ein Stückchen weiße Gardine sichtbar. Welchen Vorwand nahm Georg Unger nur, hineinzukommen in dies arme, kleine Haus? Und wieder, viel stärker noch als zuvor, dies sonderbare, unabweisliche Empfinden an ihm: »So laßt mich doch zu euch ein! Fordert mich doch auf näherzutreten, und nehmt unbedenklich meine Hilfe an! Ich gehöre ja zu euch!«
     </p>
-    <p xml:id="eco_de_0000139_2460">
+    <p xml:id="eco_de_0000209_2460">
      Wie ein Dieb, der seine günstige Gelegenheit verpaßt hat, schlich er sich endlich davon, immer wieder blickte er zurück auf das kleine alte Haus, das ihm zuzurufen schien: »Komm doch und hilf! Du kannst es ja. Warum also tust du es nicht?«
     </p>
-    <p xml:id="eco_de_0000139_2470">
+    <p xml:id="eco_de_0000209_2470">
      Unten am Rande des Sees, der still wie ein bleierner Spiegel in der Sonnenglut träumte, war ein Fährhaus errichtet worden, und fünf, sechs buntgemalte Kähne schaukelten auf dem Wasser. Sie wären zu vermieten, sagte ein graubärtiger Alter, der bei Georgs Annäherung aus dem Fährhause zum Vorschein kam – auf eine Stunde – zwei, drei Stunden, je nachdem es gewünscht würde, und die Nachfrage sei oft, namentlich an Sonntagen, so stark, daß zwei Dutzend Gondeln nicht ausreichen würden.
     </p>
-    <p xml:id="eco_de_0000139_2480">
+    <p xml:id="eco_de_0000209_2480">
      Georg nickte zerstreut dazu und stieg in eins der Fahrzeuge ein, während der Alte, heftig aus einem Pfeifchen qualmend, die Ruder einhakte und die Kette losmachte.
     </p>
-    <p xml:id="eco_de_0000139_2490">
+    <p xml:id="eco_de_0000209_2490">
      »Soll ich denn mitkommen oder fahren der Herr selbst?«
     </p>
-    <p xml:id="eco_de_0000139_2500">
+    <p xml:id="eco_de_0000209_2500">
      »Ich rudere allein!«
     </p>
-    <p xml:id="eco_de_0000139_2510">
+    <p xml:id="eco_de_0000209_2510">
      Georg lächelte ein wenig, während er mit hastigen Ruderschlägen das Boot bewegte, daß es wie ein Pfeil über den glatten Wasserspiegel schoß. Er hatte rudern können, als er noch keine sieben Jahre alt war, und alt und morsch genug war der Kahn gewesen, den er damals zur Verfügung gehabt hatte.
     </p>
-    <p xml:id="eco_de_0000139_2520">
+    <p xml:id="eco_de_0000209_2520">
      So alt und morsch wie das Fahrzeug da drüben, das sich eben aus knirschendem Schilf hervorarbeitete. Ein schlankgewachsener Junge in Hemdärmeln stand im Vorderteile des Bootes und stieß mit dem Ruder ab, während ein anderer, etwas größerer Knabe bemüht war, mit dem zweiten Ruder ein paar von den weißen Wasserrosen mit goldigem Kelch, die zwischen breiten Mummelblättern schwammen, an ihren langen, schleimigen Stengeln heranzuziehen. Ein dritter Junge, kleiner als jene beiden, lag lang hingestreckt über die beiden plumpen Ruderbänke, hatte seine Jacke als Kopfkissen genommen, die Hände im Genick verschränkt und schlief augenscheinlich. Außer diesen drei Insassen des Kahns bewegte sich noch etwas unruhiges Blaues darin herum, das Georg von seinem Standpunkte aus nicht genau unterscheiden konnte.
     </p>
-    <p xml:id="eco_de_0000139_2530">
+    <p xml:id="eco_de_0000209_2530">
      Er mußte eine Weile rudern, bis er nahe genug herangekommen war, um deutlich zu sehen, und nun gewahrte er, daß, dies unruhige Etwas ein kleiner blonder, in blaugestreiften Sommerstoff gekleideter Knirps war, der am Boden des Nachens jetzt auf allen vieren umherkroch, jetzt sich aufrichtete, um wieder zusammenzusinken – und Georg Unger kannte den blonden Knirps! – Merkwürdig, daß der unvermutete Anblick eines kleinen Kindes ihn so erregte! Ihm schlug wahrhaftig das Herz rascher vor Freude über das Wiedersehen mit Dudu; er fühlte wieder das warme Körperchen in seinen Armen, fühlte die weichen Blondhärchen, die seine Wange streiften –
     </p>
-    <p xml:id="eco_de_0000139_2540">
+    <p xml:id="eco_de_0000209_2540">
      Plötzlich hielt er mit dem Rudern inne und blickte angestrengt hinüber, was ihm einigermaßen durch den grellen Sonnenschein erschwert wurde, der die weite Wasserfläche wie einen spiegelnden Metallschild flimmern ließ. Die beiden Knaben drüben hatten nicht acht auf das Kind, das eben über den schlafenden dritten weggeklettert war, sich jetzt weit über den Rand des alten, flachgebauten Kahns neigte und bemüht war, mit beiden Händchen eine der schwimmenden weißen Wasserrosen zu haschen. Die begehrlichen Fingerchen griffen nach der Blume, aber diese saß fest an ihrem langen elastischen Stengel und ließ sich nicht abreißen; der leichte Nachen geriet bedenklich ins Schwanken …
     </p>
-    <p xml:id="eco_de_0000139_2550">
+    <p xml:id="eco_de_0000209_2550">
      Georg setzte die beiden hohlen Hände an den Mund.
     </p>
-    <p xml:id="eco_de_0000139_2560">
+    <p xml:id="eco_de_0000209_2560">
      »Das Kind!« rief er mit voller Kraft seiner Lungen hinüber. »Gebt auf das Kind acht!«
     </p>
-    <p xml:id="eco_de_0000139_2570">
+    <p xml:id="eco_de_0000209_2570">
      Es war zu spät. Ehe nur die beiden Knaben die Köpfe wenden konnten, hatte das Bürschchen das Gleichgewicht verloren und war kopfüber ins Wasser gefallen. Im ersten Schrecken stürzten beide Jungen an den Rand des Bootes, drängten einander beiseite, um beizuspringen – das kleine Fahrzeug kippte – kippte – schlug um, ein gellender Angstschrei – dann alles still!
     </p>
-    <p xml:id="eco_de_0000139_2580">
+    <p xml:id="eco_de_0000209_2580">
      Während der Dauer einiger Herzschläge saß Georg Unger wie gelähmt da, mit den Händen mechanisch die Ruder festhaltend, und seine weitgeöffneten Augen starrten nach der Unglücksstelle hinüber, wo der umgekehrte Nachen auf dem Wasser schwamm. Dann aber kam Leben in ihn, er warf den Rock ab, zog die Ruder ein, sprang mit einem Satze in den See und schwamm so rasch er konnte, in langen, weitausholenden Stößen hinüber.
     </p>
-    <p xml:id="eco_de_0000139_2590">
+    <p xml:id="eco_de_0000209_2590">
      »Vier Menschenleben! Vier!« sagte es in ihm, während seine Arme die stille, warme Flut teilten. »Und junge – hoffnungsvolle! Wirst du imstande sein, sie alle vier zu retten – oder – –«
     </p>
-    <p xml:id="eco_de_0000139_2600">
+    <p xml:id="eco_de_0000209_2600">
      Er hob während des Schwimmens den Kopf hoch und spähte hinüber. Einer der Knaben hielt sich mit beiden Händen an einer Planke des umgestülpten Kahnes fest und rief mit halberstickter Stimme um Hilfe. Von den anderen war nichts zu sehen. Aber dort – dort – tauchte nicht etwas Blaues unter den Mummelblättern und Seerosen auf? Da wieder! Er packte zu, ehe es von neuem zu sinken vermochte, und hielt mit eisernem Griff das Bübchen fest, das gestern so lebensvoll und lachend auf seinem Arme gesessen hatte.
     </p>
-    <p xml:id="eco_de_0000139_2610">
+    <p xml:id="eco_de_0000209_2610">
      »Hier, nimm ihn! Halt ihn mit einer Hand oben auf dem Boot fest und dich halte mit der andern!« Atemlos rief er es dem Knaben zu und hob das Kind auf den umgestürzten Nachen. Dann tauchte er in die Tiefe hinab, um weiter zu suchen. Ihm war am meisten bange um den schlafenden Knaben, der, ohne Ahnung irgend welcher Gefahr, mitten aus dem festen, gesunden Kinderschlafe plötzlich ins Wasser geschleudert worden war und sich voraussichtlich nicht im geringsten selbst helfen konnte.
     </p>
-    <p xml:id="eco_de_0000139_2620">
+    <p xml:id="eco_de_0000209_2620">
      Nach Luft ringend, Ohren und Augen voll strömenden Wassers, kam Georg nach einer Weile wieder zur Oberfläche empor, er hatte sich nicht die Zeit genommen, seine Schuhe abzuziehen, die ihn beim Schwimmen hinderten – die Kleider hatten sich rasch voll Wasser gesogen und hemmten seine Bewegungen. – Nichts gefunden!! – »Zwei Menschenleben! Zwei! klang es in ihm, ehe er sich anschickte, abermals zu tauchen. Einen verlorenen Blick noch warf er nach dem Kahn hinüber.
     </p>
-    <p xml:id="eco_de_0000139_2630">
+    <p xml:id="eco_de_0000209_2630">
      Waren das nicht zwei Köpfe dort am Rande des Fahrzeuges, statt des einen bisher? Nein – er täuschte sich wohl. Mit einer hastigen Bewegung strich er sich das Wasser aus den Augen – ja doch! Da hing neben dem ersten Knaben der zweite, leichenblaß und erschöpft, die Augen angstvoll aufgerissen.
     </p>
-    <p xml:id="eco_de_0000139_2640">
+    <p xml:id="eco_de_0000209_2640">
      »Ich komme! Ich helfe dir! Halt dich noch!«
     </p>
-    <p xml:id="eco_de_0000139_2650">
+    <p xml:id="eco_de_0000209_2650">
      Und während er das rief, schwamm er heran – drei Stöße – vier – sechs – noch einer – und er hob den Jungen bei den Knien empor und half ihm auf das Boot zu klettern. Den kleinen Dudu, dessen Köpfchen schlaff vornüber hing, reichte er gleichfalls hinauf, während der älteste Knabe allein emporklimmte.
     </p>
-    <p xml:id="eco_de_0000139_2660">
+    <p xml:id="eco_de_0000209_2660">
      Zum dritten Male tauchte Georg unter, um zu suchen.
     </p>
-    <p xml:id="eco_de_0000139_2670">
+    <p xml:id="eco_de_0000209_2670">
      »Einer noch! Der letzte!« – Er biß die Zähne zusammen – die Gedanken begannen ihm schon durcheinander zu wirbeln, in den Ohren verspürte er ein starkes Brausen, die Arme waren ihm wie voll Blei. »Ein einziger noch! Du mußt ihn finden! Du mußt!«
     </p>
-    <p xml:id="eco_de_0000139_2680">
+    <p xml:id="eco_de_0000209_2680">
      Einen Augenblick kam er empor, um nach Luft zu ringen, – – ihm war es, als höre er Stimmen, Zurufe vom Ufer her, aber das Sausen in seinen Ohren übertäubte jedes andere Geräusch, – es war ihm ja auch so gleichgültig, wenn er jetzt hier unterging – hier starb – hier, in der alten Heimat.
     </p>
-    <p xml:id="eco_de_0000139_2690">
+    <p xml:id="eco_de_0000209_2690">
      Und mit einem Schlage durchzuckte es ihn wie neue Kraft, wie neuer Lebensmut! Nein, er wollte nicht untersinken – nicht sterben – wollte dem Wasser seine Beute nicht lassen … er nicht! Er hatte noch viel zu erwarten vom Leben – es war ihm ja das Beste, das Höchste noch schuldig geblieben! Er wußte mit einem Mal, was dies Beste und Schönste für ihn war; das junge, liebe Mädchengesicht, das sich mit zärtlichem Lächeln über das Kind geneigt hatte …
     </p>
-    <p xml:id="eco_de_0000139_2700">
+    <p xml:id="eco_de_0000209_2700">
      Wenn dies sein letzter, klarer, bewußter Gedanke sein sollte, so war er ihm süß. Aber nein – aber nein! Leben – leben wollen und glücklich sein! Nicht nur immer arbeiten und. erwerben und sich mühen … glücklich wollte er werden!
     </p>
-    <p xml:id="eco_de_0000139_2710">
+    <p xml:id="eco_de_0000209_2710">
      Wie er das dachte, fühlte er bei einer neuen Schwimmbewegung einen Stoß gegen seinen Körper. Blindlings griff er zu – stieß die Last mit beiden Händen gewaltsam über sich empor, half mit Kopf und Schultern nach, versuchte Wasser zu treten – die Brust keuchte ihm, daß er zu ersticken meinte … da war er endlich oben und in unmittelbarer Nähe seines eigenen Nachens, der sacht auf dem Wasser hin und her schaukelte.
     </p>
-    <p xml:id="eco_de_0000139_2720">
+    <p xml:id="eco_de_0000209_2720">
      Er warf den bewußtlosen Knaben hinein wie einen toten Ballen, klammerte sich mit den beiden Händen an den Rand des Kahnes und hing so für einige Augenblicke in völliger Erschöpfung; endlich versuchte er sich emporzuziehen, aber die Glieder versagten ihm den Dienst. Von neuem glaubte er Stimmen zu hören, von neuem kam das Gefühl stumpfer Apathie, völliger Gleichgültigkeit gegen das Leben über ihn, und dann wieder, wie eine Vision, das lächelnde Mädchengesicht. »Sterben hier in der Heimat? Nein – leben – leben für sie – mit ihr!« Da war er im Boot – da hörte er das Brausen wieder – gewaltig und stark, wie aus einer ungeheuren Muschel – da tönte es wie Glockenläuten – »die Glocken der Heimat« – nahe – ganz nahe – und dann wurde es mit einem Male ganz dunkel und ganz still um ihn her …
     </p>
-    <p xml:id="eco_de_0000139_2730">
+    <p xml:id="eco_de_0000209_2730">
      Lastende Schwere in Haupt und Gliedern – feuchte Wärme um den ganzen Körper herum – tanzende Funkenschwärme hinter den geschlossenen Augenlidern – halblaute Stimmen um ihn her … Das waren Georg Ungers erste verworrene Wahrnehmungen, als er wieder zu sich kam.
     </p>
-    <p xml:id="eco_de_0000139_2740">
+    <p xml:id="eco_de_0000209_2740">
      Er wußte sofort, was mit ihm geschehen war, machte aber fürs erste gar keine Anstrengung, die Augen zu öffnen, seine Umgebung zu prüfen. Eine Anstrengung wäre das jedenfalls für ihn gewesen, so zum Tode erschöpft, wie er sich fühlte … warum also sich quälen? Das Bewußtsein, die vier jungen Menschenleben gerettet zu haben, hielt ihn wie eine weiche, wohlige Hülle umfangen, deckte ihn gleichsam zu. »Du kannst schlafen und ruhen,« sagte es in ihm, »du hast es dir verdient!« Mehr konnte er vorderhand nicht denken.
     </p>
-    <p xml:id="eco_de_0000139_2750">
+    <p xml:id="eco_de_0000209_2750">
      »Wie lange es dauert, bis der Arzt kommt!« rief eine ängstlich klagende Frauenstimme.
     </p>
-    <p xml:id="eco_de_0000139_2760">
+    <p xml:id="eco_de_0000209_2760">
      »Er kann ja noch gar nicht hier sein!« beschwichtigte ein tiefes Organ. »Setz dich hierher – so! Du kannst dich ja kaum noch auf den Füßen halten. Um die Jungens sei ganz außer Sorge: sie sind alle vier ins Bett gesteckt, Elsbeth brüht heißen Tee für sie auf, und höchstens Dudu wird 'nen leichten Schnupfen davontragen.«
     </p>
-    <p xml:id="eco_de_0000139_2770">
+    <p xml:id="eco_de_0000209_2770">
      »Du meinst bestimmt, es hat ihnen nichts geschadet?«
     </p>
-    <p xml:id="eco_de_0000139_2780">
+    <p xml:id="eco_de_0000209_2780">
      »Nicht die Spur! Aber die Wasserfahrten in dem infamen Boot sollen sie sich wohl vergehen lassen! Heute noch kriegen unsere beiden ihren Denkzettel!«
     </p>
-    <p xml:id="eco_de_0000139_2790">
+    <p xml:id="eco_de_0000209_2790">
      »Ach, Väterchen! Du wirst sie doch nicht schlagen?«
     </p>
-    <p xml:id="eco_de_0000139_2800">
+    <p xml:id="eco_de_0000209_2800">
      »Aber feste! Das muß sein – hab' du nur ein Einsehen dafür! Ein vierzehnjähriger Schlingel, wie unser Kurt, muß erstens wissen, daß der Kahn absolut nichts taugt, muß zweitens schon wissen, daß mit Menschenleben nicht zu spielen ist, und drittens, daß er seinem Vater zu gehorchen hat. Und den kleinen Kerl, den Dudu, mitzunehmen! Um den wär's rettungslos geschehen gewesen ohne den fremden Herrn – denn in solcher Todesangst denkt kaum ein Erwachsener an etwas anderes, als an sein eigenes Leben, geschweige denn tun es diese Jungen!«
     </p>
-    <p xml:id="eco_de_0000139_2810">
+    <p xml:id="eco_de_0000209_2810">
      Ein leises Aufschluchzen klang dazwischen!
     </p>
-    <p xml:id="eco_de_0000139_2820">
+    <p xml:id="eco_de_0000209_2820">
      »Gott, Gott, unser süßer Junge! Ich kann's nicht ausdenken!«
     </p>
-    <p xml:id="eco_de_0000139_2830">
+    <p xml:id="eco_de_0000209_2830">
      »Ruhig, Mamachen, du hast ihn ja wieder!«
     </p>
-    <p xml:id="eco_de_0000139_2840">
+    <p xml:id="eco_de_0000209_2840">
      »Wenn nur der arme Herr erst wieder zum Bewußtsein käme! Unsere Elsbeth hat laut aufgeschrien, wie sie ihn brachten, sie war ganz außer sich!«
     </p>
-    <p xml:id="eco_de_0000139_2850">
+    <p xml:id="eco_de_0000209_2850">
      »Kein Wunder – sie hat – da ist sie ja! Wie geht's den Jungens, Elsbeth?«
     </p>
-    <p xml:id="eco_de_0000139_2860">
+    <p xml:id="eco_de_0000209_2860">
      »Ach, gut. Sie trinken ihren Tee!« sagte die junge Stimme hastig. »Der Arzt kommt, ich sah ihn durchs Fenster – wollt ihr ihm nicht entgegengehen, ihn vorbereiten – ihm sagen –«
     </p>
-    <p xml:id="eco_de_0000139_2870">
+    <p xml:id="eco_de_0000209_2870">
      Georg horte das Rascheln von Frauenkleidern, er hörte Schritte sich entfernen und eine Tür klappen. War er nun mit Elsbeth allein?
     </p>
-    <p xml:id="eco_de_0000139_2880">
+    <p xml:id="eco_de_0000209_2880">
      Ehe er noch, um dies festzustellen, die schweren Lider heben konnte, fühlte er einen warmen Hauch auf seiner rechten Hand, die auf der über ihn gebreiteten Decke lag – und jetzt den leisen Druck zweier weichen, frischen Lippen; da ging, wie gestern im Garten, nur viel intensiver, das wohlige, wonnige Rieseln über ihn hin und machte ihn warm bis ins innerste Herz hinein. Seine Augen blieben aber geschlossen – warum das junge Geschöpf beschämen, das seiner heißen Dankbarkeit einen so impulsiven Ausdruck lieh.
     </p>
-    <p xml:id="eco_de_0000139_2890">
+    <p xml:id="eco_de_0000209_2890">
      Wieder klappte die Tür, Schritte kamen näher.
     </p>
-    <p xml:id="eco_de_0000139_2900">
+    <p xml:id="eco_de_0000209_2900">
      »Herr Doktor, ach, bitte, bitte!« – das war wieder Elsbeths bange Stimme – »helfen Sie, um Gottes willen! Er liegt noch immer ohne Bewußtsein! Er hat meine drei Brüder gerettet – alle drei – aber er selbst –«
     </p>
-    <p xml:id="eco_de_0000139_2910">
+    <p xml:id="eco_de_0000209_2910">
      Ein leises Aufweinen unterbrach die gestammelten Worte.
     </p>
-    <p xml:id="eco_de_0000139_2920">
+    <p xml:id="eco_de_0000209_2920">
      »Nur ruhig Blut, kalt Blut, Elschen! Sind ja sonst solch tapferes Frauenzimmerchen! Bringen Sie erst mal Mama heraus, und dann bitt' ich mir 'n paar scharfe Bürsten und gewärmte Decken aus. Den Papa behalt' ich als Assistent hier. Hoho! Unser Lebensretter ist gar nicht mehr bewußtlos! Der bewegt sich schon! Ergebenster Diener, mein werter Herr! Brauchen Sie denn überhaupt noch den Arzt?«
     </p>
-    <p xml:id="eco_de_0000139_2930">
+    <p xml:id="eco_de_0000209_2930">
      Georg lächelte ein wenig, antworten konnte er noch nicht. Langsam taten seine müden Augen sich auf, und das erste, was sie sahen, war Elsbeths reizendes Gesicht, welches mit dem schönen, zärtlichen Lächeln, das es ihm sofort angetan hatte, über ihn neigte. – – –
     </p>
-    <p xml:id="eco_de_0000139_2940">
+    <p xml:id="eco_de_0000209_2940">
      Sie ließen ihn nicht fort, er mußte bis gegen Abend bei ihnen bleiben. Trockene Kleider waren für ihn aus seinem Hotel geholt worden, und in der Mutter Lehnsessel, den er durchaus als Patient und Ehrengast einnehmen mußte, seine weiche, dunkelrote Reisedecke über die Knie gebreitet, etwas blaß, etwas müde, aber im übrigen vollkommen wohl – so saß Herr Georg Unger aus Pernambuco in Südamerika jetzt mitten in der Familie Junius, gehätschelt, gepflegt und bewundert, und durfte sich gar nicht mehr den Kopf darüber zerbrechen, wie er es anfangen sollte, die Bekanntschaft dieser guten Leute zu machen. Ja, selbst der Frage, wie es anzustellen sei, das Vermächtnis des alten Kordeleit jenen zuzuwenden, die es weit mehr verdienten und brauchten, als er selber, war er im Laufe dieses Tages um ein gutes Stück näher gerückt, – sein Weg lag ganz einfach vorgezeichnet da!
     </p>
-    <p xml:id="eco_de_0000139_2950">
+    <p xml:id="eco_de_0000209_2950">
      Dudu saß auf seinen Knien, zupfte an seiner Uhrkette, streichelte sein Gesicht, die Knaben hatten Geographiebuch und Karte zur Hand, lauschten atemlos seinen Erzählungen und fragten tausend Dinge, die er wußte, und tausend andere, die er nicht wußte. Herr Junius ließ seine Hand kaum los, die Mutter wurde nicht müde, ihm gerührt zu danken – der blassen Frau kamen immer wieder die Tränen, wenn sie bedachte, welch entsetzlicher Verlust ihr gedroht hatte.
     </p>
-    <p xml:id="eco_de_0000139_2960">
+    <p xml:id="eco_de_0000209_2960">
      Und Elsbeth?
     </p>
-    <p xml:id="eco_de_0000139_2970">
+    <p xml:id="eco_de_0000209_2970">
      Elsbeth ging ab und zu, sorgte für alles, mußte für alles aufkommen; sie brachte den dampfenden Grog auf des Arztes Verordnung, sie deckte den Tisch im besten Zimmer und brannte den Kaffee – sie kümmerte sich um die kleinen Geschwister und teilte ihnen zu – anzusehen wie Werthers Lotte, wie sie dastand und jedem sein Vesperbrot gab, sie reichte der Mutter die Medizin und dem Vater sein Pfeifchen – der Gast hatte herzlich wenig von ihr, aber er folgte ihr mit den Blicken, wo sie ging und stand, und es gab etwas, wie ein geheimes Einverständnis zwischen ihnen: »Weißt du noch – gestern im Garten – die Johanniskräuter?« »Gewiß, ich weiß nur zu gut! Aber schweig darüber, die andern brauchen es nicht zu erfahren!« »Keinesfalls dürfen sie das! Wen geht es etwas an, als dich und mich!« – Ein Wagen war herbeigeholt worden, der Gast mußte endlich fort. Er wurde so dringend, so stürmisch von allen Seiten gebeten, bald wiederzukommen, als kostete ihm dies das denkbar größte Opfer. Um so anerkennenswerter war seine liebenswürdige Bereitwilligkeit, mit der er es immer wieder versprach! Herr Junius, ein hagerer, gebeugter Mann mit einnehmenden Zügen, geleitete ihn hinaus und drückte ihm in tiefer Bewegung die Hand.
     </p>
-    <p xml:id="eco_de_0000139_2980">
+    <p xml:id="eco_de_0000209_2980">
      »Was Sie mir und uns allen heute getan haben, verehrter, lieber Herr Unger, wäre mit allen Schätzen der Welt für uns nicht aufzuwiegen. Ich bin leider ein armer Mann, ohne Einfluß, ohne Stellung, – ich kann darum nur das eine sagen: verfügen Sie über mich und die Meinigen. Unser Dank bleibt Ihnen lebenslänglich! Was ich bin, was ich habe, es gehört Ihnen, und Gott wolle geben, daß ich jemals imstande wäre, Ihnen nur einen kleinen Teil meiner großen Dankesschuld abzutragen!«
     </p>
-    <p xml:id="eco_de_0000139_2990">
+    <p xml:id="eco_de_0000209_2990">
      Da drückte Georg Unger dem Mann fest die Hand und sagte, indem er ihm bedeutungsvoll in die Augen sah:
     </p>
-    <p xml:id="eco_de_0000139_3000">
+    <p xml:id="eco_de_0000209_3000">
      »Ich nehme Sie beim Wort, verehrter Herr, verlassen Sie sich darauf!«
     </p>
-    <p xml:id="eco_de_0000139_3010">
+    <p xml:id="eco_de_0000209_3010">
      Sie hat ihm ein schönes, ein köstliches Geschenk gemacht und auf den Lebensweg mitgegeben, die alte Heimat: ein liebendes und geliebtes Weib!
     </p>
-    <p xml:id="eco_de_0000139_3020">
+    <p xml:id="eco_de_0000209_3020">
      Georg Unger nahm seine Elsbeth mit hinüber über den Ozean, und Ernst Junius bezahlte seine Dankesschuld mit seinem liebsten Kinde. Aber sein und seiner Familie Dasein war fortan leicht und sorgenfrei. Das alte Kordeleitsche Haus ist in seinen Besitz übergegangen, es hallt wider von Lust und Lachen, und der freundliche, sonnige Garten wird von spielenden Kindern belebt. Kaum drei Jahre nach dem Tode des alten Kordeleit schrieb Georg Unger an die Angehörigen seiner Frau, daß seine definitive Übersiedelung nach Deutschland nur noch eine Frage der Zeit wäre, da sein Onkel vor wenigen Tagen gestorben und nur noch der Termin abzuwarten sei, bis das weitverzweigte Geschäft ohne beträchtlichen Verlust aufgelöst und der Landbesitz in andere Hände übergegangen wäre. Seit er in der alten Heimat geweilt und dort sein Lebensglück gefunden hätte, wäre er nie mehr in Pernambuco heimisch gewesen, trotzdem er Elsbeth an seiner Seite hatte – rasch wolle er drüben alles abzuschließen suchen; er könne es kaum mehr erwarten, und seine Frau mit ihm, wieder Heimatluft zu atmen.
     </p>
    </div>

--- a/tei/Bindschedler_Ida_Die_Turnachkinder_im_Sommer.xml
+++ b/tei/Bindschedler_Ida_Die_Turnachkinder_im_Sommer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000140" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000210" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000140_20">
+   <p xml:id="eco_de_0000210_20">
     Die Turnachkinder im Sommer
    </p>
   </front>
@@ -93,433 +93,433 @@
     <head>
      Aufs Land hinaus.
     </head>
-    <p xml:id="eco_de_0000140_30">
+    <p xml:id="eco_de_0000210_30">
      Das frühe Morgenlicht schien in die kleine Stube, in der Hans schlief. Er träumte von einem Kampf im Schulhofe; aber wie es im Traume so geht, die Schulbuben verwandelten sich unversehens in wilde Krieger, die mit Schwertern aufeinander losgingen. Bum, bum –! wie das tönte, wenn sie auf die Schilder schlugen! … Hans fuhr in die Höhe und öffnete die Augen. Es dröhnte immer noch fort, ein ganz gewaltiges Hämmern und Klopfen. Nein, das waren gar nicht Schilde, auf die man schlug – das waren die Kisten, die man drunten zuhämmerte, und die Bettladen, die man auseinanderklopfte! Heute war ja ausser Weihnacht der allerschönste Tag des Jahres! Heut zog man aufs Land in die liebe Seeweid hinaus!
     </p>
-    <p xml:id="eco_de_0000140_40">
+    <p xml:id="eco_de_0000210_40">
      Hans sprang aus dem Bett zum Fenster.
     </p>
-    <p xml:id="eco_de_0000140_50">
+    <p xml:id="eco_de_0000210_50">
      »Hurra, hurra!« schrie er in den Hof hinunter; der Hausknecht Ulrich mit dem Hammer in der Hand sah auf.
     </p>
-    <p xml:id="eco_de_0000140_60">
+    <p xml:id="eco_de_0000210_60">
      »Hurra, Hansel!« antwortete er. Und da ihm zu allem immer gleich ein Gesang einfiel, begann er mit seiner Basstimme das Wanderlied zu singen:
     </p>
-    <p xml:id="eco_de_0000140_70">
+    <p xml:id="eco_de_0000210_70">
      »Kamerad, ich nehm' den Stab zur Hand Und sag' dir heut ade …«
     </p>
-    <p xml:id="eco_de_0000140_80">
+    <p xml:id="eco_de_0000210_80">
      Nur hätte Ulrich eigentlich umgekehrt singen müssen; denn er blieb den Sommer über in der Stadt im Geschäft, wo er seine Arbeit hatte.
     </p>
-    <p xml:id="eco_de_0000140_90">
+    <p xml:id="eco_de_0000210_90">
      Als Hans angezogen war, sprang er die Treppe hinunter und auf eine Türe zu, an der er einen Augenblick horchte.
     </p>
-    <p xml:id="eco_de_0000140_100">
+    <p xml:id="eco_de_0000210_100">
      »Die schlafen natürlich noch wie die Ratten!« dachte er und legte die Hände als Trompete an den Mund:
     </p>
-    <p xml:id="eco_de_0000140_110">
+    <p xml:id="eco_de_0000210_110">
      »Tütütüh – tütütüh –!« blies er aus aalten Kräften, und um sicher zu sein, dass sein Morgenruf gut gewirkt habe, machte er die Türe auf.
     </p>
-    <p xml:id="eco_de_0000140_120">
+    <p xml:id="eco_de_0000210_120">
      Da lagen die beiden Schwestern, die fast neunjährige Marianne und das siebenjährige Lotti, unter ihren Decken am Boden. Die Bettstellen hatte Ulrich schon gestern abend herausgetragen, und die Kinder hatten bloss ihre Matratzen gehabt. Das war ein Vergnügen gewesen! Sie hatten lange mit dem kleinen Werner um die Bettstücke herumgetanzt und ihre Matratzen in diese und dann in jene Ecke gezogen, um zu sehen, wo es am schönsten zu schlafen sei, bis Sophie gekommen war und sie ein wenig gescholten hatte.
     </p>
-    <p xml:id="eco_de_0000140_130">
+    <p xml:id="eco_de_0000210_130">
      Jetzt sahen sie beide ganz verschlafen auf Hans.
     </p>
-    <p xml:id="eco_de_0000140_140">
+    <p xml:id="eco_de_0000210_140">
      »Ach du! warum weckst du einen auf mit deinem dummen Tütütüh!« sagte Marianne und legte ihren Kopf mit den blonden, wirren Zöpfen wieder aufs Kissen.
     </p>
-    <p xml:id="eco_de_0000140_150">
+    <p xml:id="eco_de_0000210_150">
      »Das ist gar nicht dumm«, erwiderte Hans. »Ihr solltet froh sein, dass ich euch wecke! Ihr denkt wohl gar nicht, was heute für ein Tag ist –?«
     </p>
-    <p xml:id="eco_de_0000140_160">
+    <p xml:id="eco_de_0000210_160">
      Aber Lotti hatte schon ihre Füsse draussen und zog eilig die Strümpfe an.
     </p>
-    <p xml:id="eco_de_0000140_170">
+    <p xml:id="eco_de_0000210_170">
      »Marianne, Marianne! in der Nacht hab' ich's ganz vergessen! wir ziehen ja heut in die Seeweid hinaus –! Geschwind, Marianne! wir müssen unsere Puppen zur Reise richten!«
     </p>
-    <p xml:id="eco_de_0000140_180">
+    <p xml:id="eco_de_0000210_180">
      »Euere Puppen könnt ihr noch lange richten«, sagte Hans. »Zuerst kommt etwas Wichtigeres: wir müssen den Abschiedsumzug halten; er wird sehr schön; ich hab' mir's gestern ausgedacht. In einer Viertelstunde solltet ihr im Hof sein.«
     </p>
-    <p xml:id="eco_de_0000140_190">
+    <p xml:id="eco_de_0000210_190">
      Die Schwestern klatschten in die Hände.
     </p>
-    <p xml:id="eco_de_0000140_200">
+    <p xml:id="eco_de_0000210_200">
      »Ja, ja, in einer Viertelstunde!«
     </p>
-    <p xml:id="eco_de_0000140_210">
+    <p xml:id="eco_de_0000210_210">
      »Den Werner lasst aber lieber noch schlafen«, meinte Hans; »er hält uns nur auf.«
     </p>
-    <p xml:id="eco_de_0000140_220">
+    <p xml:id="eco_de_0000210_220">
      Doch kaum hatte Hans die Türe zugemacht, als der kleine Werner in seinem Bettchen, das man ihm gelassen, sich aufstellte und über das hohe Gitter hinausrief: »Auch aufstehen, auch aufstehen!«
     </p>
-    <p xml:id="eco_de_0000140_230">
+    <p xml:id="eco_de_0000210_230">
      »Ach, Werner, schlaf du noch ein wenig!« sagten Marianne und Lotti zugleich; denn sie waren so eilig.
     </p>
-    <p xml:id="eco_de_0000140_240">
+    <p xml:id="eco_de_0000210_240">
      Aber Werner wollte nicht mehr schlafen. Er versuchte, mit seinen dicken Beinchen über das Gitter weg zu klettern; da musste Marianne doch hinzuspringen. Werner hätte fallen können. Und wie er sie nun um den Hals fasste, brachte sie ihn nicht mehr los; er war so ein herziger Bub und konnte so nett betteln. Weder Mama noch Sophie waren da, um zu helfen; so mussten denn Marianne und Lotti abwechselnd sich selbst anziehen und den kleinen Werner. Sie wuschen ihn auch, und er schrieb gehörig, gerade wie alle Morgen bei Sophie; also hatten sie es recht gemacht.
     </p>
-    <p xml:id="eco_de_0000140_250">
+    <p xml:id="eco_de_0000210_250">
      Nun waren die drei fertig und suchten Hans im Hofe. Hans stand unter dem Vordach, wo in einer Ecke Moos und Tannenreiser lagen. Man hatte das vor acht Tagen gebraucht, um die Stubentüre zu bekränzen, als Papa von der Reise zurückgekommen war. Hans hatte ein paar lange Stäbe vor sich und war eifrig daran, sie mit dem Grün und mit roten Papierstreifen zu verzieren.
     </p>
-    <p xml:id="eco_de_0000140_260">
+    <p xml:id="eco_de_0000210_260">
      »Endlich!« sagte er, als die Mädchen unter der Hoftür erschienen. »Bei euch hat eine Viertelstunde scheint's dreissig Minuten. Und den Werner bringt ihr auch mit –!«
     </p>
-    <p xml:id="eco_de_0000140_270">
+    <p xml:id="eco_de_0000210_270">
      Doch als der kleine Bub auf ihn zulief und bat: »Mir auch einen Stock geben – bitte, bitte!« da strich ihm der grosse Bruder über den Kopf und sagte freundlich: »Ja, ja, Werner bekommt einen Stock.«
     </p>
-    <p xml:id="eco_de_0000140_280">
+    <p xml:id="eco_de_0000210_280">
      Und nun kam noch der Schnauzel, der Hund, auf Hans zu und wedelte stark mit dem Schwanz, als wollte er sagen: »Mir auch, mir auch!«
     </p>
-    <p xml:id="eco_de_0000140_290">
+    <p xml:id="eco_de_0000210_290">
      Da lachten die Kinder, und Marianne steckte dem Schnauzel einen grünen Zweig in das Halsband.
     </p>
-    <p xml:id="eco_de_0000140_300">
+    <p xml:id="eco_de_0000210_300">
      »Wenn der wüsste, dass er dableiben muss, wär' er nicht so vergnügt«, sagte sie.
     </p>
-    <p xml:id="eco_de_0000140_310">
+    <p xml:id="eco_de_0000210_310">
      Es war ein wenig ärgerlich, dass nun mitten in die Zurüstung hinein Sophie zum Frühstück rief. Aber in der Stube ging's auch lustig zu, recht drunter und drüber. Fast alle Dinge waren schon eingepackt; Löffel fanden sich nur noch zwei, und Marianne und Lotti hatten zusammen ein Milchschüsselchen. Jedes trank immer einen Schluck; sie lachten und stiessen sich, so dass die Milch fast verschüttet wurde. Hans machte dem Werner grosse Brocken, dass es aufspritzte, und erzählte, das seien Meerschiffe, die im Sturm versinken. Mama und das Kindermädchen Sophie gingen nur hie und da eilig durchs Zimmer und trugen Wäsche und Körbe hinaus. Solche Unordnung im Hause dünkte die Kinder wunderschön.
     </p>
-    <p xml:id="eco_de_0000140_320">
+    <p xml:id="eco_de_0000210_320">
      Aber nun ging es wieder in den Hof, wo der Abschiedsumzug geordnet wurde. Jedes der Kinder erhielt einen grünen Stab und steckte sich in den Gürtel, oder wo es anging, kleine Tannzweige. Hans stellte sich voran; hinter ihm kam Marianne, dann Lotti und Werner; der Schnauzel machte den Beschluss.
     </p>
-    <p xml:id="eco_de_0000140_330">
+    <p xml:id="eco_de_0000210_330">
      Erst schritt man dreimal im Hof herum; Hans sprach das Gedicht, das er gemacht hatte und in das Marianne und Lotti bald auch einstimmten; nur der kleine Werner sagte alles verkehrt. Hansens Gedicht hiess:
     </p>
-    <p xml:id="eco_de_0000140_340">
+    <p xml:id="eco_de_0000210_340">
      Ade, ade, du altes Haus! Nun geht es bald zum Tor hinaus. Wir ziehn heut in die Seeweid ein; Dort wird's im Sommer herrlich sein. Wir kommen wieder mit dem Schnee; Du altes Haus, ade, ade!
     </p>
-    <p xml:id="eco_de_0000140_350">
+    <p xml:id="eco_de_0000210_350">
      Dann ging es die Treppe hinauf und vor Papas Bureau. Sonst hatte es Papa nicht gern, wenn man so zu viert oder fünft kam; aber heute klopfte Hans frisch an und machte auf. Man musste doch dem Bureau Lebewohl sagen. Der Herr Oberauer und der Herr Frei sassen schon an ihrem Schreibpult und sahen erstaunt auf die grün geschmückte Schar. Papa kam aus der innern Stube:
     </p>
-    <p xml:id="eco_de_0000140_360">
+    <p xml:id="eco_de_0000210_360">
      »Was gibt's denn jetzt?«
     </p>
-    <p xml:id="eco_de_0000140_370">
+    <p xml:id="eco_de_0000210_370">
      Da machten alle vier Kinder eine tiefe Verbeugung; nur der Schnauzel konnte das nicht. Papa lachte, und die Herren lachten mit. »Papa, Papa,« riefen Marianne und Lotti, »wir können ein Gedicht! Hans hat es selbst gemacht!«
     </p>
-    <p xml:id="eco_de_0000140_380">
+    <p xml:id="eco_de_0000210_380">
      Sie sagten alle miteinander das Abschiedslied auf, und da Werner immer mithelfen wollte und man ihn korrigieren musste, entstand ein ganzer Tumult. Aber da nahm Papa die Türe in die Hand. »Schön, Hans, schön! doch jetzt macht, dass ihr weiterkommt!«
     </p>
-    <p xml:id="eco_de_0000140_390">
+    <p xml:id="eco_de_0000210_390">
      Vom Bureau ging's hinauf in die Küche. Balbine, die Geschirr in einen Korb packte, fand Hansens Gedicht auch sehr hübsch; aber die war froh, als die Kinder aus all den Tellern und Töpfen wieder draussen waren.
     </p>
-    <p xml:id="eco_de_0000140_400">
+    <p xml:id="eco_de_0000210_400">
      Aus dem hintern Schlafzimmer kam grade Sophie.
     </p>
-    <p xml:id="eco_de_0000140_410">
+    <p xml:id="eco_de_0000210_410">
      »Bitte, Sophie«, sagten die Kinder, »dürfen wir zum Schwesterlein hinein? Es muss doch auch wissen, dass man heute aufs Land zieht!«
     </p>
-    <p xml:id="eco_de_0000140_420">
+    <p xml:id="eco_de_0000210_420">
      »Was euch immer einfällt –! Meinetwegen! Aber leis und manierlich!« Sie liess die grüne Schar ins Zimmer ein. Das Schwesterlein lag in seinem Korbwagen. Es hiess eigentlich Hedwig; aber das galt erst für später. Es war gerade zehn Wochen alt und noch ganz winzig. Man konnte nicht mit ihm spielen; doch die Kinder liebten es sehr, und Marianne durfte es manchmal, wenn es im Kissen lag, auf den Schoss nehmen.
     </p>
-    <p xml:id="eco_de_0000140_430">
+    <p xml:id="eco_de_0000210_430">
      Jetzt sah das Schwesterlein mit grossen Augen auf die Geschwister, und als sie ihm, so leis sie konnten, ihr Abschiedslied aufsagten, da blinzelte es ein wenig.
     </p>
-    <p xml:id="eco_de_0000140_440">
+    <p xml:id="eco_de_0000210_440">
      »Es lacht, es lacht!« riefen die Kinder, und jedes behauptete: »Mich hat es angelacht, mich –!«
     </p>
-    <p xml:id="eco_de_0000140_450">
+    <p xml:id="eco_de_0000210_450">
      »Ja, ja, es hat euch alle angelacht«, sagte Sophie; »aber jetzt lasst mir mein Kleines in Ruhe!«
     </p>
-    <p xml:id="eco_de_0000140_460">
+    <p xml:id="eco_de_0000210_460">
      Droben im dritten Stockwerk waren schon die Läden zugemacht; im grossen Zimmer standen Sofa und Klavier mit grauen Tüchern verhängt; es war ganz dunkel. Werner fasste Mariannes Hand und drückte den Kopf an ihre Schürze.
     </p>
-    <p xml:id="eco_de_0000140_470">
+    <p xml:id="eco_de_0000210_470">
      »Wenn er sich da schon fürchtet, so kann man ihn nicht mit in die Holzkammer nehmen«, sagte Hans. »Werner, setz' dich unten auf die Treppe! Wir müssen nun hinauf und bis auf die Zinne.«
     </p>
-    <p xml:id="eco_de_0000140_480">
+    <p xml:id="eco_de_0000210_480">
      »Werner auch auf die Zinne!« rief der kleine Bub. Aber es war wirklich besser, dass er unten blieb. Dir oberste Treppe war steil wie eine Leiter und hatte schrecklich hohe Stufen.
     </p>
-    <p xml:id="eco_de_0000140_490">
+    <p xml:id="eco_de_0000210_490">
      Doch prächtig war's da droben. Man konnte über den Kornplatz wegsehen und über die ganze Stadt und ihr Lebewohl zurufen. Die Kinder jauchzten und schwenkten ihre grünen Stäbe. Die Frühlingssonne schien über die Dächer; an den hohen grauen Münstertürmen vorbei sah man den hellen See, und weit, weit draussen, wo die Pappeln standen, war die Seeweid!
     </p>
-    <p xml:id="eco_de_0000140_500">
+    <p xml:id="eco_de_0000210_500">
      Plötzlich deutete Marianne auf den Kornplatz hinunter, der am Flusse lag.
     </p>
-    <p xml:id="eco_de_0000140_510">
+    <p xml:id="eco_de_0000210_510">
      »Hans, Lotti!« rief sie, »das Schiff, das Schiff –!«
     </p>
-    <p xml:id="eco_de_0000140_520">
+    <p xml:id="eco_de_0000210_520">
      Und nun stürmten sie hintereinander alle Treppen hinunter und zur Haustüre hinaus über den Kornplatz. Hans und der Schnauzel waren die ersten.
     </p>
-    <p xml:id="eco_de_0000140_530">
+    <p xml:id="eco_de_0000210_530">
      Da fuhr das Schiff heran. Es war ein grosses, breites Fahrzeug mit ganz flachem Boden. Drei Schiffleute lenkten es mit langen Stachelstangen und hielten an, wo die steinernen Stufen zum Kornplatz hinaufführten. Die Männer banden das Schiff mit festen Stricken an die Pfähle und schritten dann über den Platz dem Turnachhause zu. Denn sie waren bestellt, um die Möbel, Betten, Kisten und Körbe zu holen und auf dem Schiffe in die Seeweid hinauszuführen.
     </p>
-    <p xml:id="eco_de_0000140_540">
+    <p xml:id="eco_de_0000210_540">
      Die Kinder liefen hinter den Männern drein und klatschten in die Hände. Im Hause ging es nun mit grossem Gepolter und Rufen treppab und treppauf. Die Kinder wollten auch helfen und trugen Stühle und leichtere Sachen auf das Schiff; denn es war prachtvoll da auf- und abzugehen wie auf einer Insel!
     </p>
-    <p xml:id="eco_de_0000140_550">
+    <p xml:id="eco_de_0000210_550">
      Aber Mama mahnte die Kinder, ihre eigenen Sachen zusammenzuholen und das, was zurückblieb, aufzuräumen. »Den Werner nehmt ihr auch dazu, Hans. Der kleine Bursche ist ganz betrübt.«
     </p>
-    <p xml:id="eco_de_0000140_560">
+    <p xml:id="eco_de_0000210_560">
      Werner stand im Korridor und sah zu, wie alle Leute an ihm vorbei die Treppe hinunter liefen. Hinaus durfte er leider nicht; es war zu gefährlich für ihn auf dem Schiff, das gar keine Seitenwände hatte. Nun war er sehr glücklich, als Hans ihn rief.
     </p>
-    <p xml:id="eco_de_0000140_570">
+    <p xml:id="eco_de_0000210_570">
      Die beiden trugen alles mögliche heraus, die Baukasten auch und einen ganzen Stoss Bücher.
     </p>
-    <p xml:id="eco_de_0000140_580">
+    <p xml:id="eco_de_0000210_580">
      »Und mein Pferd, Hans! Mein Pferd auch mit,« schrie Werner eifrig und zog seinen Braunen am Kopf daher.
     </p>
-    <p xml:id="eco_de_0000140_590">
+    <p xml:id="eco_de_0000210_590">
      Aber Balbine schlug die Hände zusammen, als sie das Zeug sah.
     </p>
-    <p xml:id="eco_de_0000140_600">
+    <p xml:id="eco_de_0000210_600">
      »Du liebe Güte, Buben, all den Kram! Ihr wollt euch wohl ein besonderes Schiff mieten?«
     </p>
-    <p xml:id="eco_de_0000140_610">
+    <p xml:id="eco_de_0000210_610">
      Mama kam auch heraus: »Nein, Hans, das tragt nur wieder weg. In der Seeweid draussen gibt es Spiel und Unterhaltung genug –! Den kleinen Baukasten für Werner, die Malschachtel und meinetwegen drei oder vier Bücher. Aber nicht den dicken Lederstrumpf; den kannst du ja auswendig! Und mein kleiner Wernermann – wozu denn das hölzerne Pferd, wo draussen die lebendigen Kaninchen sind Und die Hühner und Kühe und vielleicht ein Kälbchen –?«
     </p>
-    <p xml:id="eco_de_0000140_620">
+    <p xml:id="eco_de_0000210_620">
      »Vielleicht ein Kälbchen –!« rief Werner erwartungsvoll und führte seinen Braunen wieder in den Stall hinterm Ofen. Auch Hans gehorchte. Dann ging er zu den Mädchen hinüber, die unter ihren Puppen hantierten.
     </p>
-    <p xml:id="eco_de_0000140_630">
+    <p xml:id="eco_de_0000210_630">
      »Wenn ihr meint, dass ihr das alles mitnehmen dürft!« sagte er und steckte die Hände in die Hosentaschen.
     </p>
-    <p xml:id="eco_de_0000140_640">
+    <p xml:id="eco_de_0000210_640">
      Lotti drückte zärtlich ihre drei Kinder in die Arme, und Marianne lief zu Mama; aber da liess sich nicht viel machen.
     </p>
-    <p xml:id="eco_de_0000140_650">
+    <p xml:id="eco_de_0000210_650">
      »Jedes nimmt eine Puppe mit«, entschied Mama, »und Mariannes Wagen genügt; in dem können die beiden Kinder den Sommer über auch schlafen. Ihr wisst, dass wir in der Seeweid nicht so viel Platz haben.«
     </p>
-    <p xml:id="eco_de_0000140_660">
+    <p xml:id="eco_de_0000210_660">
      »Aber unsere Badepüppchen doch, Mama, unsere Badepüppchen?« riefen die beiden Mädchen, und Hans stimmte ein; denn sie hatten sich zusammen ausgedacht, draussen aus Schindeln eine kleine Badanstalt in den See zu bauen. Die fünf Porzellanpuppen, nicht viel länger als ein Finger, schon in roten und blauen Schwimmanzügen, die Marianne selbst gemacht hatte, durften noch in den Puppenwagen gelegt werden. Lotti besann sich lange vor ihren Kindern; endlich wählte sie das Julchen mit dem braunen Zopf, und Marianne nahm Ella, welche die Augen auf- und zumachte. Die Puppenkinder bekamen ihre Hüte und Kragen, damit sie sich auf der Reise nicht erkälteten, und wurden ermahnt, den zurückbleibenden Schwesterchen artig Adieu zu sagen.
     </p>
-    <p xml:id="eco_de_0000140_670">
+    <p xml:id="eco_de_0000210_670">
      Da fiel Sophie noch etwas ein: »Weisst du, Marianne, ihr könntet alle unsaubere Puppenwäsche zusammensuchen und in dieses kleine Tuch binden. Dann haltet ihr einmal am See eine ordentliche Wäsche.«
     </p>
-    <p xml:id="eco_de_0000140_680">
+    <p xml:id="eco_de_0000210_680">
      Marianne und Lotti fanden das sehr nett; sie durchmusterten ihr sämtliches Zeug und zogen das Puppenbettchen ab; es gab ein ganz tüchtiges Bündel, das Lotti dann zum Schiff trug.
     </p>
-    <p xml:id="eco_de_0000140_690">
+    <p xml:id="eco_de_0000210_690">
      Vom Münster läutete es jetzt elf Uhr, und gleich darauf kam der Bäckerbursche mit zwei riesengrossen flachen Brotkuchen auf runden Holzbrettern. Der eine war reichlich mit kleinen Speckwürfeln und Kümmel bestreut; auf dem andern lagen dicht geschichtet Apfelstücke mit Zucker und Zimmet darüber. Die beiden Kuchen dufteten herrlich durch die ganze Wohnung.
     </p>
-    <p xml:id="eco_de_0000140_700">
+    <p xml:id="eco_de_0000210_700">
      Und nun gab es das allerseltsamste Mittagessen vom ganzen Jahr. Kein Tischtuch, keine Bestecke, bloss ein paar Teller und ein Messer. Die Grossen setzten sich auch nicht einmal recht hin; die Kleinen aber taten es mit vielem Behagen. Zuerst bekam jedes Kind ein grosses Stück Speckkuchen. Lotti dachte, als sie das ihre mit beiden Händen hielt, sie hätte bis am Abend daran zu essen. Aber es ging sehr leicht und rasch; auch mit dem Apfelkuchen. Hans und Marianne meinten, sie könnten eigentlich ganz gut noch ein drittes Stück essen; doch sie wollten nicht darum bitten; denn Mama mochte nicht, dass man unmässig war.
     </p>
-    <p xml:id="eco_de_0000140_710">
+    <p xml:id="eco_de_0000210_710">
      »Wenn Mama uns jetzt nur das eine erlaubt!« sagten sie und berieten am Fenster.
     </p>
-    <p xml:id="eco_de_0000140_720">
+    <p xml:id="eco_de_0000210_720">
      »Das letzte Mal haben wir nicht mitdürfen,« sagte Marianne etwas kleinmütig.
     </p>
-    <p xml:id="eco_de_0000140_730">
+    <p xml:id="eco_de_0000210_730">
      »Da hat es geregnet, und der See hatte starke Wellen!« erklärte Hans.
     </p>
-    <p xml:id="eco_de_0000140_740">
+    <p xml:id="eco_de_0000210_740">
      »Und das vorletzte Mal –?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_750">
+    <p xml:id="eco_de_0000210_750">
      »O, da hatte ich Halsweh, und ihr wart noch zu klein! Nein, diesmal dürfen wir sicher. Es wäre schrecklich, wenn wir nicht dürften!«
     </p>
-    <p xml:id="eco_de_0000140_760">
+    <p xml:id="eco_de_0000210_760">
      Und wirklich, Mama erlaubte es.
     </p>
-    <p xml:id="eco_de_0000140_770">
+    <p xml:id="eco_de_0000210_770">
      »Ja, Kinder, ihr dürft auf dem Schiff mitfahren. Werner natürlich nicht; der kommt mit mir und mit dem Schwesterlein in der Droschke nach. Versprecht mir nur, dass ihr vernünftig sein wollt und still sitzt. Hans, du weisst, du hast nicht zu helfen und keine Stange und kein Ruder anzurühren. Die Schiffleute werden schon allein fertig!«
     </p>
-    <p xml:id="eco_de_0000140_780">
+    <p xml:id="eco_de_0000210_780">
      Die Kinder versprachen alles Gute und liefen jubelnd zum Schiff hinunter, um sich jetzt schon die Plätze auszusuchen. Der Herr Nachbar stand eben unter der Türe seiner Apotheke.
     </p>
-    <p xml:id="eco_de_0000140_790">
+    <p xml:id="eco_de_0000210_790">
      »Herr Lorez, wir dürfen mitfahren!« Die Kinder sprangen auf ihn zu, um Lebewohl zu sagen.
     </p>
-    <p xml:id="eco_de_0000140_800">
+    <p xml:id="eco_de_0000210_800">
      »Nun denn, gut Glück, ihr Meerfahrer!« sagte Herr Lorez lachend und gab ihnen als Reisestärkung eine kleine Schachtel Malzbonbons mit.
     </p>
-    <p xml:id="eco_de_0000140_810">
+    <p xml:id="eco_de_0000210_810">
      Endlich kam am Nachmittag der grosse Augenblick der Abfahrt.
     </p>
-    <p xml:id="eco_de_0000140_820">
+    <p xml:id="eco_de_0000210_820">
      »Nun ist alles beisammen«, sagten die Männer und machten sich daran, die dicken Seile zu lösen. Marianne und Lotti setzten sich vorn auf einen Schemel, jede ihre Puppe im Arm. Sie waren so vergnügt, dass sie die Füsse gar nicht stillhalten konnten. Hans sass hinter ihnen auf einer Kommode. Auf der Ufermauer standen eine Reihe grosser und kleiner Buben.
     </p>
-    <p xml:id="eco_de_0000140_830">
+    <p xml:id="eco_de_0000210_830">
      »Ade, ade! wir möchten auch mit!« schrien sie, und Hans schwenkte grüssend seine Fahne zum Hause zurück, wo Mama mit Werner herauswinkte und Papa mit den Herren des Bureaus unterm Fenster stand. Von Ulrich und vom Schnauzel hatte man schon vorher Abschied genommen.
     </p>
-    <p xml:id="eco_de_0000140_840">
+    <p xml:id="eco_de_0000210_840">
      Das Schiff fing an sich zu bewegen. Klatschend schlug das Wasser an den Holzboden. Mit aller Kraft stiessen die Männer ihre Stachelstangen in den Grund; denn sie mussten das schwere Fahrzeug gegen die starke Strömung flussaufwärts bringen.
     </p>
-    <p xml:id="eco_de_0000140_850">
+    <p xml:id="eco_de_0000210_850">
      »Wenn es uns nur nicht an die Pfähle hinunter nimmt!« sagte einer. »Das Wasser ist gehörig gewachsen, seit in den Bergen der Schnee schmilzt.«
     </p>
-    <p xml:id="eco_de_0000140_860">
+    <p xml:id="eco_de_0000210_860">
      Hans sah gespannt zu. Wenn es etwas gäbe, dann, dachte er bei sich, müsste er doch am Ende helfen. Mama konnte noch hinuntersehen und würde ihm vielleicht zunicken.
     </p>
-    <p xml:id="eco_de_0000140_870">
+    <p xml:id="eco_de_0000210_870">
      Aber das Schiff fuhr nun ruhig dahin und der Brücke zu, unter deren dunkelm Bogen die Männer durchlenkten.
     </p>
-    <p xml:id="eco_de_0000140_880">
+    <p xml:id="eco_de_0000210_880">
      »Jetzt gehen die Leute und die Wagen über unsere Köpfe, und wir spüren es gar nicht!« lachte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_890">
+    <p xml:id="eco_de_0000210_890">
      Da wurde es plötzlich frei und weit und sonnig. Der ganze See lag vor den Augen der Kinder. das Wasser wurde tiefer. Vorher hatte man durch die grünlich klaren Wellen alle Steine des Grundes und die seltsamen langen Wasserpflanzen gesehen, die sich flussabwärts schlängelten. Nun verschwand der Boden und man sah in eine bläuliche Tiefe. Die Schiffleute hatten ihre Stachelstangen mit den Rudern vertauscht, und es ging vorbei an den letzten Häusern der Stadt und zu den ersten Landhäusern, die mit ihren kleinen Buchten und den alten überhängenden Bäumen traulich im Sonnenschein da lagen.
     </p>
-    <p xml:id="eco_de_0000140_900">
+    <p xml:id="eco_de_0000210_900">
      »Aber unsere Seeweid ist doch am allerschönsten!« erklärte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_910">
+    <p xml:id="eco_de_0000210_910">
      Auf einmal hörten die Kinder hinter sich ein gewaltiges Rauschen und Stampfen; Hans von seinem erhöhten Sitze aus konnte am besten zurücksehen.
     </p>
-    <p xml:id="eco_de_0000140_920">
+    <p xml:id="eco_de_0000210_920">
      »Es ist ein Dampfschiff!« rief er. »Es ist der Neptun! Der gibt die schönsten Wellen. Das ist der nette Steuermann mit dem roten Bart – Marianne, Lotti – winkt doch!«
     </p>
-    <p xml:id="eco_de_0000140_930">
+    <p xml:id="eco_de_0000210_930">
      Hans streckte sich, so hoch er konnte, und grüsste mit seiner Fahne, während die Mädchen ihre Taschentücher schwenkten.
     </p>
-    <p xml:id="eco_de_0000140_940">
+    <p xml:id="eco_de_0000210_940">
      Das Dampfschiff fuhr in stolzem Bogen nahe vorbei, und der Steuermann erkannte die Winkenden. Er blieb unbeweglich an seinem Steuerruder; denn das durfte er keinen Augenblick verlassen; aber er lachte mit dem ganzen Gesicht. Das sind ja die Turnachkinder! dachte er. Nun wird's wieder lebhaft in der Seeweid!
     </p>
-    <p xml:id="eco_de_0000140_950">
+    <p xml:id="eco_de_0000210_950">
      Das Schiff hob und senkte sich in den Wellen des Neptun; das Wasser spritzte über den Rand herein und den Kindern als lustiger, frischer Sprühregen ins Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_960">
+    <p xml:id="eco_de_0000210_960">
      Jetzt tauchte aus dem Wasser ein hoher grauer Stein auf, die Thomassäule. Marianne sah sie zuerst.
     </p>
-    <p xml:id="eco_de_0000140_970">
+    <p xml:id="eco_de_0000210_970">
      »Die Thomassäule! Hans! Nun kommt gleich die Seeweid! Dort sind die Pappeln, und die Mauer von der obern Einfahrt erkenn' ich gut!«
     </p>
-    <p xml:id="eco_de_0000140_980">
+    <p xml:id="eco_de_0000210_980">
      »Wenn wir nur innerhalb vorbeifahren; dann kommen wir ganz nahe an die Thomassäule hin«, sagte Hans.
     </p>
-    <p xml:id="eco_de_0000140_990">
+    <p xml:id="eco_de_0000210_990">
      Und wirklich, die Männer lenkten nach links, obgleich der alte Steppinger dagegen war.
     </p>
-    <p xml:id="eco_de_0000140_1000">
+    <p xml:id="eco_de_0000210_1000">
      »Da können wir artig aufsitzen!« brummte er.
     </p>
-    <p xml:id="eco_de_0000140_1010">
+    <p xml:id="eco_de_0000210_1010">
      Das Wasser wurde ganz seicht; man sah auf dem bräunlichen Grunde die grossen runden Kiesel. Auf der Thomassäule stand eine grau und weisse Bachstelze und wippte lustig mit dem Schwänzchen, als wollte sie die Schiffsgesellschaft auslachen.
     </p>
-    <p xml:id="eco_de_0000140_1020">
+    <p xml:id="eco_de_0000210_1020">
      Ritsch – ritsch – machte es auf einmal und gab einen starken Stoss. Man war richtig aufgefahren. Die Männer sahen einander an und sagten sich Worte, die nicht sehr höflich klangen. Sie griffen eilig nach den Stachelstangen, um das schwere Schiff vom Fleck zu bringen.
     </p>
-    <p xml:id="eco_de_0000140_1030">
+    <p xml:id="eco_de_0000210_1030">
      Marianne und Lotti fassten sich etwas ängstlich an den Händen:
     </p>
-    <p xml:id="eco_de_0000140_1040">
+    <p xml:id="eco_de_0000210_1040">
      »Du, Hans! wenn wir nun gar nicht wegkämen, gar nicht in die Seeweid –?«
     </p>
-    <p xml:id="eco_de_0000140_1050">
+    <p xml:id="eco_de_0000210_1050">
      Aber Hans hörte nicht. Er sah immer auf Steppinger. Wenn Mama wüsste, wie gut Hans mit der Stachelstange umgehen konnte, hätte sie ihm gewiss nicht verboten zu helfen.
     </p>
-    <p xml:id="eco_de_0000140_1060">
+    <p xml:id="eco_de_0000210_1060">
      Ritsch – mit einem Ruck war das Schiff aufgesessen, mit einem Ruck kam es endlich wieder in Gang. Ohne weiteren Zwischenfall fuhr es nun ruhig der Seeweid zu; nur als man an dem kleinen Landungssteg unter der Gartenmauer anhielt, flog Hansens Mütze ins Wasser; er hatte es gar so eilig gehabt, aus dem Schiff zu springen. Steppinger fischte sie wieder auf.
     </p>
-    <p xml:id="eco_de_0000140_1070">
+    <p xml:id="eco_de_0000210_1070">
      »Mama, es war wundervoll!« schrie Hans. »Der Neptun kam ganz nah an und vorbei, und neben der Thomassäule sind wir aufgefahren …«
     </p>
-    <p xml:id="eco_de_0000140_1080">
+    <p xml:id="eco_de_0000210_1080">
      Marianne und Lotti umarmten den kleinen Werner, der mit Mama am Stege stand und auch von seiner Fahrt erzählen wollte. Aber es war keine Zeit dazu. Es gab soviel Herrlichkeiten jetzt. Wohin wollte man zuerst rennen –? Nach allen Seiten zog es einen zugleich.
     </p>
-    <p xml:id="eco_de_0000140_1090">
+    <p xml:id="eco_de_0000210_1090">
      »Ich muss einmal schnell meine Kammer sehen!« rief Hans und flog die Treppen hinauf bis unters Dach in seine kleine Stube und dann in den Taubenschlag, von wo er ein glückliches Juhuh! hinausschrie, so dass die Tauben ihm entsetzt um den Kopf flatterten.
     </p>
-    <p xml:id="eco_de_0000140_1100">
+    <p xml:id="eco_de_0000210_1100">
      Unten aber bettelte Werner: »Zum Kälbchen, Marianne! das Kälbchen ansehen –«
     </p>
-    <p xml:id="eco_de_0000140_1110">
+    <p xml:id="eco_de_0000210_1110">
      Die Kinder liefen unter den blühenden Birnbäumen hinüber zum Stall. Doch als Werner das Kälbchen sah, das bei seiner braun und weiss gefleckten Mutter stand, fürchtete er sich.
     </p>
-    <p xml:id="eco_de_0000140_1120">
+    <p xml:id="eco_de_0000210_1120">
      »Ich will kein grosses Kälbchen! ich will ein kleines – eins zum auf den Arm nehmen –«
     </p>
-    <p xml:id="eco_de_0000140_1130">
+    <p xml:id="eco_de_0000210_1130">
      Die Kinder lachten; aber der Knecht Jakob führte den Werner zu einem Verschlag: »Da ist etwas zum auf den Arm nehmen!« und er zog ein junges graues Kaninchen heraus. Werner drückte es zärtlich an sich. Es war seidenweich.
     </p>
-    <p xml:id="eco_de_0000140_1140">
+    <p xml:id="eco_de_0000210_1140">
      »O, Jakob! mir auch eins, mir auch eins!« riefen Hans und die Mädchen, und jedes erhielt eines von den strampelnden Tieren auf den Schoss. Marianne wollte das ihre gar nicht mehr loslassen und band ihm, damit sie es morgen wieder kenne, ein blaues Bändchen um, das sie in der Tasche hatte.
     </p>
-    <p xml:id="eco_de_0000140_1150">
+    <p xml:id="eco_de_0000210_1150">
      »Das ist noch viel netter als die Puppen, Lotti! und Mama hat es gewusst. Drum hat sie uns nur die Ella und das Julchen mitnehmen lassen.«
     </p>
-    <p xml:id="eco_de_0000140_1160">
+    <p xml:id="eco_de_0000210_1160">
      Hans aber drängte, dass man wieder zum See hinunter komme, und lief voraus bis ans Ende des Obstgartens, der durch keine Mauer und kein Gitter vom See getrennt war. DA lag das weite blaue Wasser. Drüben am andern Ufer sah man die Dörfer mit den weissen Häusern und am obern Ende des Sees die fernen Schneeberge, die von der Abendsonne beleuchtet waren. Der See warf langsam kleine Wellen über das flache Kiesufer. Werner bückte sich, um den schimmernden Schaum zu streicheln, und fiel dabei ein wenig ins Wasser.
     </p>
-    <p xml:id="eco_de_0000140_1170">
+    <p xml:id="eco_de_0000210_1170">
      »So, Werner«, sagte Hans, »nun bist du getauft; nun bist zu auch ein Seebub. Letztes Jahr liess dich Mama noch nicht mit uns an den See; da warst du noch zu klein. Aber wir, wir sind ein paarmal getunkt worden! Weisst du noch, Marianne, wie du von der Badhaustreppe gefallen bist? Und das Lotti, das wollte die Enten füttern und sprang mit dem letzten Brotbrocken selbst hinein! Und damals im Schilfmeer, als wir gegen Onkel Alfred kämpften und alle drei ins Wasser plumpsten –!«
     </p>
-    <p xml:id="eco_de_0000140_1180">
+    <p xml:id="eco_de_0000210_1180">
      Die Kinder liefen hintereinander zum Schilfmeer. Es lag unten vor der Gartenmauer. Im Sommer, wenn der Schilf grün und hoch stand, war Onkel Alfred manchmal mit ihnen hineingerudert, dass es rauschte und krachte und man in grosse Gefahr kam, stecken zu bleiben. Das war immer prachtvoll gewesen. In Zeiten, wo der See niedrig war, stand der Schilf trocken, und man ging dann wie durch einen dichten Urwald. In der Ecke ragten noch ein paar Pfähle auf von einer Robinsonhütte, die Hans gebaut hatte.
     </p>
-    <p xml:id="eco_de_0000140_1190">
+    <p xml:id="eco_de_0000210_1190">
      »Dies Jahr bauen wir noch eine grössere, schönere, einen indianischen Wigwam«, sagte Hans. »Vielleicht gibt mir Onkel Alfred sein altes Rehfell als Dach, und dann kommt ein Feuerherd hin; da kochen wir das Abendessen –«
     </p>
-    <p xml:id="eco_de_0000140_1200">
+    <p xml:id="eco_de_0000210_1200">
      Die Kinder sahen einander an, und auf einmal fiel ihnen ein, dass die schrecklichen Hunger hatten.
     </p>
-    <p xml:id="eco_de_0000140_1210">
+    <p xml:id="eco_de_0000210_1210">
      »Ich auch hab' Hunger!« sagte Werner und rieb sich über seine kleine Schürze. Aber als sie ins Haus kamen und in die Küche schauten, war da kein Feuer und keine Balbine.
     </p>
-    <p xml:id="eco_de_0000140_1220">
+    <p xml:id="eco_de_0000210_1220">
      »Au, au!« machte Hans. »Heut gibt's scheint's trockenes Brot, wie beim Däumling und seinen sechs Brüdern.«
     </p>
-    <p xml:id="eco_de_0000140_1230">
+    <p xml:id="eco_de_0000210_1230">
      »Ja, Vom Däumling erzählen!« rief Werner sofort, der nichts lieber hörte als Märchen.
     </p>
-    <p xml:id="eco_de_0000140_1240">
+    <p xml:id="eco_de_0000210_1240">
      Doch heute brauchte man keine zu erzählen. Heute ging es von selbst zu wie im Märchen. Als die Kinder sich daran machten, Mama zu suchen, kam es in bedächtigen Tritten die Treppe herunter: voran Frau Völklein, die dicke alte Frau Völklein von droben.
     </p>
-    <p xml:id="eco_de_0000140_1250">
+    <p xml:id="eco_de_0000210_1250">
      »Grüss Gott, Kinderlein!« rief sie mit ihrer hohen, freundlichen Stimme. »Grüss Gott, Kinderlein! Da hab' ich etwas zu Abend gekocht, weil Mama und Balbine doch keine Zeit finden.«
     </p>
-    <p xml:id="eco_de_0000140_1260">
+    <p xml:id="eco_de_0000210_1260">
      Sie trug eine grosse Schüssel voll prächtiger braungerösteter Bratwürstchen, und hinter ihr folgte Grite, die Magd, mit einem dampfenden Kartoffelbrei.
     </p>
-    <p xml:id="eco_de_0000140_1270">
+    <p xml:id="eco_de_0000210_1270">
      »Nein, heute geht's euch aber fast zu gut!« sagte Mama, als alles am Tisch sass. »Vom Morgen bis zum Abend lauter Lust und Vergnügen! Wollt ihr dran denken, wenn dann die Tage etwa wieder Unangenehmes und Langweiliges bringen und wollt ihr immer recht zufrieden und artig bleiben?«
     </p>
-    <p xml:id="eco_de_0000140_1280">
+    <p xml:id="eco_de_0000210_1280">
      »Ja, Mama! Ja, Mama!« versprachen die Kinder.
     </p>
-    <p xml:id="eco_de_0000140_1290">
+    <p xml:id="eco_de_0000210_1290">
      Und als der schöne Tag nun zu Ende war und die Kinder in ihren Betten lagen, da meinte Marianne, als sie ihr tägliches Nachtgebet gesagt hatte, das sei eigentlich gar nicht genug.
     </p>
-    <p xml:id="eco_de_0000140_1300">
+    <p xml:id="eco_de_0000210_1300">
      »Mama, weisst du kein Gebet, das besonders für diesen Tag passt?« fragte sie Mama, die vor ihrem Bette stand.
     </p>
-    <p xml:id="eco_de_0000140_1310">
+    <p xml:id="eco_de_0000210_1310">
      »Sprich du zum lieben Gott nur, so wie du selber denkst, Kind«, sagte Mama.
     </p>
-    <p xml:id="eco_de_0000140_1320">
+    <p xml:id="eco_de_0000210_1320">
      Marianne setzte sich noch einmal auf und Lotti drüben auch. »Lieber Gott«, betete Marianne, »ich dank' dir vielmal für den schönen Tag und dass du uns den See und den Garten und den Schilf und alles gegeben hast. Ich bin so vergnügt! Und ich will auch recht brav sein und nicht streiten mit Hans und mit Lotti. Amen.«
     </p>
-    <p xml:id="eco_de_0000140_1330">
+    <p xml:id="eco_de_0000210_1330">
      Mama gab ihr den Gutenachtkuss und ging hinaus.
     </p>
-    <p xml:id="eco_de_0000140_1340">
+    <p xml:id="eco_de_0000210_1340">
      Aber Marianne hielt die Augen offen; sie konnte noch nicht einschlafen. Es war nicht ganz dunkel; sie sah deutlich die dicken hellen Blumen auf der Tapete.
     </p>
-    <p xml:id="eco_de_0000140_1350">
+    <p xml:id="eco_de_0000210_1350">
      »Lotti, schläfst du?« fragte sie.
     </p>
-    <p xml:id="eco_de_0000140_1360">
+    <p xml:id="eco_de_0000210_1360">
      »Nein, gar nicht!« gab Lotti zurück. »Ich muss immer an den Garten denken. Ich hab' eine solche Lust, zum Fenster hinauszuklettern und einmal schnell um die Tanne herumzuspringen. Vorher kann ich gewiss nicht einschlafen.«
     </p>
-    <p xml:id="eco_de_0000140_1370">
+    <p xml:id="eco_de_0000210_1370">
      Lotti huschte zum Bett hinaus und ans Fenster. Die Luft war lau und roch süss von Blüten. Der Mond stand hoch am Himmel, und rings um ihn schwammen schöne weisse Wolken. Die Bäume waren wie mit Silber übergossen.
     </p>
-    <p xml:id="eco_de_0000140_1380">
+    <p xml:id="eco_de_0000210_1380">
      »Marianne, komm! das ist schön –!«
     </p>
-    <p xml:id="eco_de_0000140_1390">
+    <p xml:id="eco_de_0000210_1390">
      Das Schlafzimmer lag zu ebener Erde, und im Nu waren die beiden Kinder draussen und sprangen in ihren langen weissen Nachthemden zur Tanne in der Mitte des Rasens.
     </p>
-    <p xml:id="eco_de_0000140_1400">
+    <p xml:id="eco_de_0000210_1400">
      »Ach, du liebe Güte – Gespenster!« rief eine Stimme. Es war Balbine, die noch ein wenig im Garten sass.
     </p>
-    <p xml:id="eco_de_0000140_1410">
+    <p xml:id="eco_de_0000210_1410">
      Nun trat auch Papa aus der Wohnstube: »Gespenster –? Wahrhaftig, da laufen sie! Ganz merkwürdige Gespenster! das eine mit den blonden Zöpfen gleicht auffallend unserer Marianne und das andere dem Lotti – '«
     </p>
-    <p xml:id="eco_de_0000140_1420">
+    <p xml:id="eco_de_0000210_1420">
      »Kinder, Kinder!« mahnte Mama. »Ihr wollt euch wohl erkälten! Marsch, zurück ins Bett!«
     </p>
-    <p xml:id="eco_de_0000140_1430">
+    <p xml:id="eco_de_0000210_1430">
      Papa lachte.
     </p>
-    <p xml:id="eco_de_0000140_1440">
+    <p xml:id="eco_de_0000210_1440">
      »Na, es soll ja eigentlich gesund sein, im feuchten Gras herumzuspazieren!«
     </p>
-    <p xml:id="eco_de_0000140_1450">
+    <p xml:id="eco_de_0000210_1450">
      Marianne und Lotti stiegen rasch wieder zu ihrem Fenster hinein und schlüpften unter die Decke. Sie schwatzten noch ein Weilchen; aber bald fielen ihnen die Augen zu, und sie schliefen fest und gut die ganze Nacht hindurch.
     </p>
    </div>
@@ -527,544 +527,544 @@
     <head>
      Pfahlbauergeschichten
     </head>
-    <p xml:id="eco_de_0000140_1460">
+    <p xml:id="eco_de_0000210_1460">
      Die Familie Turnach war nun schon drei Wochen in der Seeweid, und wie Mama vorausgesagt hatte: neben dem Schönen und Lustigen war hin und wieder auch etwas Unangenehmes und Langweiliges gekommen. Einmal hatte Marianne zwei Nächte hindurch Zahnweh gehabt; Hans hatte wegen Husten und Halsweh ein paar Tage im Zimmer bleiben müssen. Lotti war gesund gewesen; aber ihr waren die Strickstunden, zu denen sie sich etwa an Regentagen mit Marianne hinsetzen musste, immer eine grosse Betrübnis. Auch war es schrecklich, wenn man Aufgaben hatte und draussen die Sonne durch die Bäume schien und die Wellen plätscherten. Marianne und Lotti bekamen noch nicht viel auf; aber Hans, der schon zehn Jahre alt war, hatte allerlei zu schreiben und zu lernen. Manchmal wollte so ein Gedicht gar nicht in den Kopf hinein. Immer musste Hans wieder von vorn anfangen:
     </p>
-    <p xml:id="eco_de_0000140_1470">
+    <p xml:id="eco_de_0000210_1470">
      »Es ritt ein Herr, das war sein Recht; Zu Fusse hiess er gehn den Knecht – – – – – – – – – – den Knecht …«
     </p>
-    <p xml:id="eco_de_0000140_1480">
+    <p xml:id="eco_de_0000210_1480">
      Vom Garten her hörte man Marianne und Lotti lachen; sie liefen über die niedrige Mauer und machten in der Ecke, wo der Efeu eine ganze Laube bildete, eine Puppenwohnung.
     </p>
-    <p xml:id="eco_de_0000140_1490">
+    <p xml:id="eco_de_0000210_1490">
      »Marianne, du hast deine Rechnung auch noch nicht gemacht!« rief Hans hinüber.
     </p>
-    <p xml:id="eco_de_0000140_1500">
+    <p xml:id="eco_de_0000210_1500">
      »Ich muss sie erst auf übermorgen machen!« sagte Marianne und wiegte sich behaglich in ihrem Efeubusch.
     </p>
-    <p xml:id="eco_de_0000140_1510">
+    <p xml:id="eco_de_0000210_1510">
      Hans seufzte und begann noch einmal, indem er sich beide Ohren zuhielt:
     </p>
-    <p xml:id="eco_de_0000140_1520">
+    <p xml:id="eco_de_0000210_1520">
      »Es ritt ein Herr, das war sein Recht; Zu Fusse hiess er gehn den Knecht. Er reitet über Stock und Stein, Dass kaum der Knecht kam hintendrein …«
     </p>
-    <p xml:id="eco_de_0000140_1530">
+    <p xml:id="eco_de_0000210_1530">
      Es kostete wirklich eine Anstrengung, tapfer bei dem langweiligen Gedicht zu bleiben, wo draussen alles so sonnig und lustig war …
     </p>
-    <p xml:id="eco_de_0000140_1540">
+    <p xml:id="eco_de_0000210_1540">
      Aber heute, als Hans erwachte, gab es keine Plage und keine Aufgabe. Es war Sonntag, früher, schöner Sonntagmorgen. Hans stand schnell auf und machte sich fertig. Doch als er herunterkam, war er gar nicht der erste: Papa war schon am See und löste eben das kleine Ruderschiff los, das frisch weiss, blau und rot angestrichen am Landungssteg lag. Marianne und Lotti in ihren hellen Sonntagskleidern sassen auf der Schiffbank. Es war immer ein Hauptvergnügen, wenn Papa, der so selten Zeit hatte, die Kinder einmal ruderte.
     </p>
-    <p xml:id="eco_de_0000140_1550">
+    <p xml:id="eco_de_0000210_1550">
      Hans sprang hinter Papa ins Schiff und ergriff die Sitzruder, um sie einzuhängen.
     </p>
-    <p xml:id="eco_de_0000140_1560">
+    <p xml:id="eco_de_0000210_1560">
      »Ich kann eigentlich auch stehrudern«, sagte er.
     </p>
-    <p xml:id="eco_de_0000140_1570">
+    <p xml:id="eco_de_0000210_1570">
      »Nein, nein, Papa, lieber du! bei dir geht's so ruhig und schnell!« riefen die Mädchen. »Hans, der tut mit jedem Ruderschlag so einen Ruck –«
     </p>
-    <p xml:id="eco_de_0000140_1580">
+    <p xml:id="eco_de_0000210_1580">
      »Aber ich kann's doch wenigstens«, gab Hans zurück, »während Lotti noch nicht einmal sitzrudern kann. Bei der geht's immer im Kreis herum – so –«! Er tat mit dem Ruder ein paar ungeschickte Schläge.
     </p>
-    <p xml:id="eco_de_0000140_1590">
+    <p xml:id="eco_de_0000210_1590">
      »Das wäre nun hübsch, wenn ihr an dem prächtigen Sonntagmorgen mit einander streiten wolltet!« sagte Papa. »Wenn Lotti noch nicht gut rudert, so kann sie dafür singen. Fangt einmal an, ein schönes Lied!«
     </p>
-    <p xml:id="eco_de_0000140_1600">
+    <p xml:id="eco_de_0000210_1600">
      Lotti sah auf Marianne. »Wollen wir das traurige, weisst du, das und Ulrich gelehrt hat:«
     </p>
-    <p xml:id="eco_de_0000140_1610">
+    <p xml:id="eco_de_0000210_1610">
      »Zu Strassburg auf der Schanz Da ging mein Trauern an …«
     </p>
-    <p xml:id="eco_de_0000140_1620">
+    <p xml:id="eco_de_0000210_1620">
      »Nein, wart'«, sagte Marianne. »Zuerst: Lobt froh – das passt für den Sonntagmorgen.«
     </p>
-    <p xml:id="eco_de_0000140_1630">
+    <p xml:id="eco_de_0000210_1630">
      »Lobt froh den Herrn Ihr jugendlichen Chöre …«
     </p>
-    <p xml:id="eco_de_0000140_1640">
+    <p xml:id="eco_de_0000210_1640">
      begannen Lotti und Marianne mit hellen Stimmen. Hans und Papa sangen mit. Dann kam ein zweites und drittes Lied, schliesslich auch Lottis Lieblingslied.
     </p>
-    <p xml:id="eco_de_0000140_1650">
+    <p xml:id="eco_de_0000210_1650">
      Papa fuhr langsam hinaus auf den blauen, schimmernden See, dann gegen die Thomassäule und dem Ufer entlang; als er zurückkehrte, sah man Mama im Garten winken.
     </p>
-    <p xml:id="eco_de_0000140_1660">
+    <p xml:id="eco_de_0000210_1660">
      »Ei, was ist denn das für ein Sängerfest da draussen?« rief sie. »Der ganze Verein ist jetzt freundlich zum Frühstück eingeladen!«
     </p>
-    <p xml:id="eco_de_0000140_1670">
+    <p xml:id="eco_de_0000210_1670">
      Aber – »du liebe Güte!« würde Balbine gesagt haben, wie sah der Frühstückstisch aus –! Im Brotkorbe lagen, weil es Sonntag war, etwa ein Dutzend Butterhörnchen, und jedes – nein, es war zu arg! – jedes verunstaltet, verstümmelt; alle vierundzwanzig Spitzen waren abgebrochen und verschwunden! Die Familie war sprachlos. Wer konnte das getan haben! Man sah ringsum, dann unter den Tisch; man sah sich gegenseitig an. Endlich rief eines: »Wo ist denn Werner?«
     </p>
-    <p xml:id="eco_de_0000140_1680">
+    <p xml:id="eco_de_0000210_1680">
      Ja, wo war Werner? Mama hatte ihn bei Balbine geglaubt; aber Balbine, die nun auch herein kam und die Hände zusammenschlug ob dem Anblick, wusste nichts.
     </p>
-    <p xml:id="eco_de_0000140_1690">
+    <p xml:id="eco_de_0000210_1690">
      Nun lief alles hinaus: »Werner! Werner –« Und Mama wollte schon ängstlich werden, als um die Hausecke der kleine Mann erschien, aber ebenfalls in schlechtem Zustande. Seine Hände und seine weisse Schürze waren ganz schmutzig und schwarz von feuchter Erde. Er war etwas verlegen, als er die ganze Schar auf sich zukommen sah und hielt die kleine Faust über die Augen.
     </p>
-    <p xml:id="eco_de_0000140_1700">
+    <p xml:id="eco_de_0000210_1700">
      »Werner, mein Bub, komm einmal her!«
     </p>
-    <p xml:id="eco_de_0000140_1710">
+    <p xml:id="eco_de_0000210_1710">
      Mama zog ihn ins Zimmer.
     </p>
-    <p xml:id="eco_de_0000140_1720">
+    <p xml:id="eco_de_0000210_1720">
      »Was sind denn das für hässliche, schwarze Hände?«
     </p>
-    <p xml:id="eco_de_0000140_1730">
+    <p xml:id="eco_de_0000210_1730">
      »Ich – ich hab' müssen graben!« stotterte Werner, ohne Mama anzusehen.
     </p>
-    <p xml:id="eco_de_0000140_1740">
+    <p xml:id="eco_de_0000210_1740">
      »O Mama! dann weiss Werner nichts von den Hörnchen, dann ist er unschuldig!« rief Marianne, die den kleinen Bruder zärtlich liebte und ihn bei jeder Gelegenheit verteidigte.
     </p>
-    <p xml:id="eco_de_0000140_1750">
+    <p xml:id="eco_de_0000210_1750">
      Aber Werner sah gar nicht sehr unschuldig aus. Er versuchte, sich aus Mamas Händen loszumachen, und als die auf den Tisch nach dem Brotkorbe zeigte, drückte er die Augen zu.
     </p>
-    <p xml:id="eco_de_0000140_1760">
+    <p xml:id="eco_de_0000210_1760">
      »Nein, Werner, jetzt sag' lieber rasch und ehrlich heraus: Hast du alle unsere schönen Butterhörnchen zerbrochen?«
     </p>
-    <p xml:id="eco_de_0000140_1770">
+    <p xml:id="eco_de_0000210_1770">
      Nun sah der Kleine Mama an, und seine Augen füllten sich mit Tränen; aber er brachte kein Wort heraus.
     </p>
-    <p xml:id="eco_de_0000140_1780">
+    <p xml:id="eco_de_0000210_1780">
      »Stellt euch nicht so vor ihn hin«, sagte Mama zu Hans und Lotti, »gerade als ob es euch Spass machen würde, euer Brüderlein in Verlegenheit zu sehen. Komm, mein Bub, sag' es der Mama leise –«
     </p>
-    <p xml:id="eco_de_0000140_1790">
+    <p xml:id="eco_de_0000210_1790">
      Da drückte Werner sein Mäulchen an Mamas Ohr und flüsterte etwas hinein.
     </p>
-    <p xml:id="eco_de_0000140_1800">
+    <p xml:id="eco_de_0000210_1800">
      »O, o! Was für einen unartigen Buben haben wir doch, den man gar nicht allein im Zimmer lassen kann! Und wo sind denn die vielen, vielen Zipfel hingekommen? Hast du sie gar alle aufgegessen –?«
     </p>
-    <p xml:id="eco_de_0000140_1810">
+    <p xml:id="eco_de_0000210_1810">
      »Nein, nicht aufgegessen!«
     </p>
-    <p xml:id="eco_de_0000140_1820">
+    <p xml:id="eco_de_0000210_1820">
      »Aber was in aller Welt hast du mit ihnen angefangen?«
     </p>
-    <p xml:id="eco_de_0000140_1830">
+    <p xml:id="eco_de_0000210_1830">
      Werner hob den Kopf, als ob ihm der Mut wieder käme.
     </p>
-    <p xml:id="eco_de_0000140_1840">
+    <p xml:id="eco_de_0000210_1840">
      »Ich – ich hab' Pf – Pfahlbauten daraus gemacht.« Er sah stolz im Kreis herum, weil er das schwere Wort hatte sagen können.
     </p>
-    <p xml:id="eco_de_0000140_1850">
+    <p xml:id="eco_de_0000210_1850">
      »Pfahlbauten –? was sagt er da –?« fragte Papa sehr belustigt. »Das wird ja immer werkwürdiger. Komm her, du kleiner Prähistoriker, und erzähle uns, wie man Pfahlbauten macht aus den Zipfeln von Butterhörnchen!«
     </p>
-    <p xml:id="eco_de_0000140_1860">
+    <p xml:id="eco_de_0000210_1860">
      »Ich hab' es so gemacht wie – Hans und Marianne und Lotti.«
     </p>
-    <p xml:id="eco_de_0000140_1870">
+    <p xml:id="eco_de_0000210_1870">
      »Aha«, sagte Papa. »Also steckt ihr Grossen hinter der Geschichte. Wartet nur, ihr kommt nachher an die Reihe! Nun, mein Wernermann, willst du uns wenigstens mitteilen, wo du deine interessanten Pfahlbauten angelegt hast?«
     </p>
-    <p xml:id="eco_de_0000140_1880">
+    <p xml:id="eco_de_0000210_1880">
      Werner schüttelte den Kopf; er wurde nun wieder fast übermütig. Erst nach vielem Drängen gab er nach und lief den andern voraus in den Garten zu einer abgelegenen Ecke, wo ein paar dichte Fliederbüsche standen. Die kleine Schaufel, die Werner geschenkt bekommen hatte, lag da auf der Erde.
     </p>
-    <p xml:id="eco_de_0000140_1890">
+    <p xml:id="eco_de_0000210_1890">
      Hans fing an zu graben; die »Pfahlbauten« steckten nicht tief. Aber wie sah das schöne Brot aus! von der feuchten Erde ganz schwarz und ungeniessbar. Die Kinder wollten den Kleinen necken. Was das für ein Einfall war von dem Wernerlein!
     </p>
-    <p xml:id="eco_de_0000140_1900">
+    <p xml:id="eco_de_0000210_1900">
      Aber Mama fand, dass er doch ein wenig Strafe verdiene: »Du siehst nun, denke ich, doch ein, dass du etwas sehr Dummes gemacht hast und etwas Unrechtes dazu. Darfst du denn eigentlich vom Tisch wegnehmen, was die nicht gehört, und es verderben? – Nun geh nur zu Sophie, dass sie dir das Werktagskleidchen anzieht; in diesem Schmutz wollen wir dich nicht sehen. Und lass dir ein Stück Brot in der Küche geben. Was du von den Butterhörnchen übrig gelassen, das reicht kaum für uns; du bekommst natürlich nichts davon.«
     </p>
-    <p xml:id="eco_de_0000140_1910">
+    <p xml:id="eco_de_0000210_1910">
      Werner zog ein Mäulchen und weinte ein wenig; dann lief er zu Sophie.
     </p>
-    <p xml:id="eco_de_0000140_1920">
+    <p xml:id="eco_de_0000210_1920">
      »Nun möcht' ich aber doch wissen, Kinder«, begann Papa, »wie Werner auf die Pfahlbauten gekommen ist und was für wunderliches Zeug ihr ihm vorgemacht habt!«
     </p>
-    <p xml:id="eco_de_0000140_1930">
+    <p xml:id="eco_de_0000210_1930">
      Die Kinder sahen einander an und lachten.
     </p>
-    <p xml:id="eco_de_0000140_1940">
+    <p xml:id="eco_de_0000210_1940">
      »Ach, Papa, das war ganz anders. Das war etwas sehr Ernsthaftes, was wir taten, und Werner hat zugeschaut; Aber er hat es natürlich gar nicht verstanden!«
     </p>
-    <p xml:id="eco_de_0000140_1950">
+    <p xml:id="eco_de_0000210_1950">
      »Also heraus denn mit dieser sehr ernsthaften Sache! Ihr macht mich wirklich neugierig!«
     </p>
-    <p xml:id="eco_de_0000140_1960">
+    <p xml:id="eco_de_0000210_1960">
      Ja, das war eine lange Geschichte, und wenn man ganz von vorn anfangen wollte, waren es eigentlich zwei.
     </p>
-    <p xml:id="eco_de_0000140_1970">
+    <p xml:id="eco_de_0000210_1970">
      An einem Samstag nachmittag, zwei Wochen vor dem Ereignis mit den Butterhörnchen, kam Hans aus dem Hause mit einem grossen, weiten Einmachglas, das Mama ihm geschenkt hatte.
     </p>
-    <p xml:id="eco_de_0000140_1980">
+    <p xml:id="eco_de_0000210_1980">
      Marianne und Lotti richteten eben am See die Puppenbadeanstalt wieder her, die sie tags zuvor aus kleinen Pflöcken und Schindeln gebaut hatten, die aber von den Dampfschiffwellen zerstört worden war. Die Porzellanpüppchen warteten im Sand.
     </p>
-    <p xml:id="eco_de_0000140_1990">
+    <p xml:id="eco_de_0000210_1990">
      »Kommt!« sagte Hans. »Wir gehen ins Klaregg hinaus und sehen, ob wir dort etwas finden für unser Aquarium.«
     </p>
-    <p xml:id="eco_de_0000140_2000">
+    <p xml:id="eco_de_0000210_2000">
      »Ins Klaregg –! Gleich, Hans!« rief Lotti, packte schnell mit Marianne die Badepüppchen zusammen und holte die Hüte.
     </p>
-    <p xml:id="eco_de_0000140_2010">
+    <p xml:id="eco_de_0000210_2010">
      Die drei Kinder gingen zwischen den Weissdornhecken und Feldern hinaus zum Klaregg. Hans trug das Glas, Marianne eine Botanisierbüchse und Lotti ein altes Schmetterlingsnetz, mit dem man auch fischen konnte. Das Klaregg lag wie die Seeweid am Wasser. Es bildete eine kleine Halbinsel, die in den See hinausragte und von einem Bach durchflossen war. Ringsum standen Weiden und Erlenbüsche; dazwischen gab es kleine Wassertümpel und Teichlein, in denen allerlei lustiges Getier sein Wesen trieb: kleine Frösche und grosse stattliche mit grünem, gestreiftem Rücken und weissen Bauch. Die konnten schwimmen und tauchen, als ob sie es beim Schwimmlehrer gelernt hätten. Und ihre Kleinen, wie sahen die lächerlich aus! Dicke dunkle Köpfe und ein kleiner Schwanz dran; das war alles. Lotti konnte immer gar nicht glauben, dass aus diesen komischen schwarzen Fischlein Frösche würden mit richtigen vier Beinen. In einem anderen Wasserloche tauchten tief aus dem Grunde schwarze Molche auf in schlängelnder Bewegung. Auf der Unterseite waren die goldgelb. Auch seltsame Käfer oder Spinnen fuhren da auf dem Wasser herum wie Schlittschuhläufer. Und auf dem trockenen steinigen Land, wo weisser Klee und blaue Salbei wucherten und wo es so gut nach Thymian roch, huschten prächtige Eidechsen hin und her, bräunliche und smaragdgrüne. Wenn man eine in die Hand nahm, konnte man sehen, was für eine schöne Zeichnung die kleinen Schuppen bildeten und welche hübsche, goldglänzende Äuglein das kleine Tier hatte, das seine lange zweispitzige Zunge zeigte und blitzschnell wieder einzog.
     </p>
-    <p xml:id="eco_de_0000140_2020">
+    <p xml:id="eco_de_0000210_2020">
      Die Turnachkinder hatten eine grosse Liebe zu allen Tieren. Aber leider war Mama mit dieser Liebe nicht immer einverstanden.
     </p>
-    <p xml:id="eco_de_0000140_2030">
+    <p xml:id="eco_de_0000210_2030">
      »Wenn ihr die Tiere fangt und herumschleppt«, sagte sie, »tut ihr ihnen gar nichts Gutes. Am liebsten haben sie es, wenn ihr sie in Ruhe lasst.«
     </p>
-    <p xml:id="eco_de_0000140_2040">
+    <p xml:id="eco_de_0000210_2040">
      »O, Mama, wir tun ihnen nicht weh. Die Eidechsen tragen wir bloss in den Garten. Da können sie ja so gut leben wie im Klaregg. Das ist dann so hübsch, wenn wir sie immer wieder auf den Gartenwegen sehen! Und den Fröschen und Molchen tun wir Sumpfwasser in das Einmachglas und Schlammpflanzen und als Insel einen Stein; da können sie hinaufsitzen, wenn sie gern wollen im Trockenen sein. Bitte, Mama!«
     </p>
-    <p xml:id="eco_de_0000140_2050">
+    <p xml:id="eco_de_0000210_2050">
      Da erlaubte denn Mama, dass die Kinder hie und da eines der Tiere heimbrachten. Aber die Frösche und Molche mussten sie nach einem oder zwei Tagen immer wieder ins Klaregg zurücktragen und in Freiheit setzen. Lotti nahm dann jedesmal wortreichen Abschied von dem Amphibium, das sich schleunigst entfernte und nicht die geringste Anhänglichkeit zeigte trotz der liebevollen Behandlung.
     </p>
-    <p xml:id="eco_de_0000140_2060">
+    <p xml:id="eco_de_0000210_2060">
      Nur einmal sprang ein grosser Frosch freiwillig zurück in das Glas, das von den Kindern Aquarium genannt wurde. Unter Jubel trugen sie ihn wieder nach Hause.
     </p>
-    <p xml:id="eco_de_0000140_2070">
+    <p xml:id="eco_de_0000210_2070">
      »Das ist ja ganz ähnlich wie in der schönen Geschichte von dem getreuen Sklaven, die ich einmal als Kind gelesen habe«, sagte Balbine. »Er hat, glaub' ich, Alexius geheissen.«
     </p>
-    <p xml:id="eco_de_0000140_2080">
+    <p xml:id="eco_de_0000210_2080">
      Alexius – nun hatte der anhängliche Frosch einen Namen. Nachdem er auf Mamas Anordnung zum zweitenmal ins Klaregg getragen worden war, behielten ihn die Kinder im Auge. Er gewohnte den Ganzen Sommer denselben Wassertümpel. Manchmal sass er unbeweglich auf einem Stein. Die Kinder behaupteten, er sehe sie freundlich an und wolle gewiss gern wieder ein wenig in die Seeweid kommen; er lasse sich auch ganz leicht fangen. So geschah es, dass er noch ein paarmal in der Turnachfamilie zu Gast war. Jeder im Hause kannte den dicken Alexius.
     </p>
-    <p xml:id="eco_de_0000140_2090">
+    <p xml:id="eco_de_0000210_2090">
      An dem Samstag jedoch, da die Kinder mit Glas und Netz und Botanisierbüchse ausgezogen waren, schien es nichts zu geben fürs Aquarium. Sie kauerten alle drei über einem kleinen Tümpel und sahen in das trübe Wasser, aber umsonst.
     </p>
-    <p xml:id="eco_de_0000140_2100">
+    <p xml:id="eco_de_0000210_2100">
      »Marianne«, sagte Hans, »du musst mit dem Stock im Wasser hin und her fahren; dann schwimmen die Molche vielleicht bei mir herauf.«
     </p>
-    <p xml:id="eco_de_0000140_2110">
+    <p xml:id="eco_de_0000210_2110">
      Marianne bewegte ihren Stock; kein Molch wurde sichtbar.
     </p>
-    <p xml:id="eco_de_0000140_2120">
+    <p xml:id="eco_de_0000210_2120">
      »Ich möchte wissen«, sagte sie, »was eigentlich da unten ist. Es muss etwas Flaches, Grosses sein; ich kann es mit dem Stocke vorwärts stossen.«
     </p>
-    <p xml:id="eco_de_0000140_2130">
+    <p xml:id="eco_de_0000210_2130">
      Hans kam hinzu. Das musste man herausbringen. Er legte sich auf den Boden und griff, nachdem er den Ärmel aufgestülpt, hinein; aber er kam nicht auf den Grund und fiel beinahe ins Wasser. Nun suchte er sich auch einen Stecken und einen für Lotti, und mit vereinten Kräften machten sie sich daran, das geheimnisvolle Ding zu heben. Einmal brachten sie es fast heraus; es war rund und schwarz, sank aber wieder zurück in den schlammigen Grund. Alle drei Kinder schrien laut auf. Hans sagte, Lotti sei schuld, und Lotti klagte Marianne an. Das zweitemal brach Hansens Stock, und es war wieder nichts. Das drittemal brachten sie das Ding vollständig ans Tageslicht. Es war schwer wie von Stein und etwa so gross wie ein Essteller. Hans trug es zum See, um die schwarze, schlammige Kruste abzuwaschen. Er rieb und rieb.
     </p>
-    <p xml:id="eco_de_0000140_2140">
+    <p xml:id="eco_de_0000210_2140">
      »Es kommt ein Kranz heraus ringsum«, sagte er, »und jetzt – ein Mann in der Mitte und eine Frau und unten – wartet – seltsame Buchstaben –«
     </p>
-    <p xml:id="eco_de_0000140_2150">
+    <p xml:id="eco_de_0000210_2150">
      »Zeig', zeig'!« baten Marianne und Lotti. Hans wies ihnen das eingegrabene Bild; aber er gab die Scheibe nicht aus den Händen, sondern sah sie immer mit ernsthaftem Gesicht an und drehte sie nach allen Seiten.
     </p>
-    <p xml:id="eco_de_0000140_2160">
+    <p xml:id="eco_de_0000210_2160">
      »Marianne, Lotti – ich glaube, wir haben etwas sehr, sehr Wichtiges gefunden, etwas ganz Uraltes – wahrscheinlich aus der Pfahlbauerzeit –«
     </p>
-    <p xml:id="eco_de_0000140_2170">
+    <p xml:id="eco_de_0000210_2170">
      Die Schwestern hörten erstaunt zu.
     </p>
-    <p xml:id="eco_de_0000140_2180">
+    <p xml:id="eco_de_0000210_2180">
      »Das war ein altes Volk, das in den Seen auf Pfählen lebte –«
     </p>
-    <p xml:id="eco_de_0000140_2190">
+    <p xml:id="eco_de_0000210_2190">
      »O«, sagte Lotti, »auf Pfählen? das war nicht angenehm!«
     </p>
-    <p xml:id="eco_de_0000140_2200">
+    <p xml:id="eco_de_0000210_2200">
      »Ach, Lotti, du bist noch schrecklich dumm! Es ist gut, wenn du jetzt dann auch einmal rechte Bücher liesest, damit du etwas lernst. Das vom Onkel Doktor, wo alles von den Pfahlbauern drin steht, ist prachtvoll. Also, Lotti, sie sassen natürlich nicht jeder auf einem Pfahl, sondern legten Bretter über die Pfähle und bauten ganze Häuser darauf. Und sie gingen auf die Jagd und brachten Bären und Auerochsen heim, und die Kinder band man an Stricke.«
     </p>
-    <p xml:id="eco_de_0000140_2210">
+    <p xml:id="eco_de_0000210_2210">
      »Warum?« fragte Lotti und hatte Mitleid mit den kleinen Pfahlbauerkindern.
     </p>
-    <p xml:id="eco_de_0000140_2220">
+    <p xml:id="eco_de_0000210_2220">
      »Natürlich damit sie nicht ins Wasser fielen. Und sie assen gedörrtes Obst und trugen grosse Ringe an den Ohren. Und sie glaubten nicht an Gott. Man weiss nicht recht, was für eine Religion sie hatten; vielleicht beteten sie Götzen an. Wisst ihr, was ich glaube –?«
     </p>
-    <p xml:id="eco_de_0000140_2230">
+    <p xml:id="eco_de_0000210_2230">
      Marianne und Lotti waren sehr gespannt.
     </p>
-    <p xml:id="eco_de_0000140_2240">
+    <p xml:id="eco_de_0000210_2240">
      »Ich glaube, die Platte da ist ein altes Götzenbild von den Pfahlbauern! Was könnte es anders sein –?«
     </p>
-    <p xml:id="eco_de_0000140_2250">
+    <p xml:id="eco_de_0000210_2250">
      »O!« riefen die Mädchen.
     </p>
-    <p xml:id="eco_de_0000140_2260">
+    <p xml:id="eco_de_0000210_2260">
      »Aber, du, Hans«, fragte dann Marianne, »wie ist denn das Götzenbild daher gekommen?«
     </p>
-    <p xml:id="eco_de_0000140_2270">
+    <p xml:id="eco_de_0000210_2270">
      »Ja, die Pfahlbauer sind später besiegt worden von andern Völkern oder sonst gestorben, ich weiss nicht recht, und ihre Sachen sind ins Wasser gefallen und in den Schlamm. Und jetzt gräbt man sie wieder aus und heisst sie Altertümer.«
     </p>
-    <p xml:id="eco_de_0000140_2280">
+    <p xml:id="eco_de_0000210_2280">
      Alle drei betrachteten noch einmal die Platte, und die beiden Mädchen fanden auch, dass das gewiss ein Götzenbild sei. Das war ja ein wundervoller Fund, viel schöner als alle Frösche und Eidechsen im Klaregg.
     </p>
-    <p xml:id="eco_de_0000140_2290">
+    <p xml:id="eco_de_0000210_2290">
      »Hans, was tun wir doch damit?« bestürmten Marianne und Lotti den Bruder, während er das Götzenbild in sein Taschentuch einwickelte.
     </p>
-    <p xml:id="eco_de_0000140_2300">
+    <p xml:id="eco_de_0000210_2300">
      »Ja, wenn wir es verkaufen würben, bekämen wir jedenfalls viel Geld dafür. Aber es ist viel feiner, wenn wir es schenken.«
     </p>
-    <p xml:id="eco_de_0000140_2310">
+    <p xml:id="eco_de_0000210_2310">
      Hans sah die Schwestern grossartig an.
     </p>
-    <p xml:id="eco_de_0000140_2320">
+    <p xml:id="eco_de_0000210_2320">
      »Ich hoffe, ihr versteht das. Wir schenken das Götzenbild der Stadt, und dann kommt es ins Museum, in einen grossen Saal, wo es eine Menge Pfahlbautenüberreste gibt. Wir waren ja mit Papa einmal dort, Marianne. Dann kommt die Platte in einen Glasschrank, und auf einem Zettel steht dabei: Geschenk von Hans, Marianne und Lotti Turnach.«
     </p>
-    <p xml:id="eco_de_0000140_2330">
+    <p xml:id="eco_de_0000210_2330">
      In einem Glasschrank im Museum und die Namen dabei –!
     </p>
-    <p xml:id="eco_de_0000140_2340">
+    <p xml:id="eco_de_0000210_2340">
      Die Mädchen wurden nun auch ganz aufgeregt.
     </p>
-    <p xml:id="eco_de_0000140_2350">
+    <p xml:id="eco_de_0000210_2350">
      »Und wenn wir im Winter an einem Sonntag ins Museum dürfen, dann gehen wir immer zuerst zu unserm Götzenbild und lesen, was auf dem Zettel steht!« rief Lotti und folgte mit Marianne dem Bruder, der, die Platte sorgfältig im Arm haltend, den Heimweg antrat.
     </p>
-    <p xml:id="eco_de_0000140_2360">
+    <p xml:id="eco_de_0000210_2360">
      Mama sass mit Grossmama, die für den Nachmittag gekommen war, vor dem Hause, und die alte Frau Völklein stand auch ein wenig dabei mit dem Strickzeug. Werner baute nebenan eine Mauer aus Sand und Steinen.
     </p>
-    <p xml:id="eco_de_0000140_2370">
+    <p xml:id="eco_de_0000210_2370">
      »Guten Tag, Grossmama, guten Tag, Frau Völklein! Mama, Mama! wir haben etwas furchtbar Seltenes gefunden, etwas sehr Wertvolles; Mama – da ist es im Taschentuch, damit es nicht zerbricht! Von den Pfahlbauern, Mama! es ist ein Götzenbild, und es kommt in einen Glaskasten; wir schenken es der Stadt …« so stürmten alle drei Kinder auf Mama los.
     </p>
-    <p xml:id="eco_de_0000140_2380">
+    <p xml:id="eco_de_0000210_2380">
      Grossmama hielt sich die Ohren zu; Frau Völklein lachte: »Nein, die Kinder, Frau Turnach, die Kinder –!«
     </p>
-    <p xml:id="eco_de_0000140_2390">
+    <p xml:id="eco_de_0000210_2390">
      »Nun ordentlich der Reihe nach, dass man euch versteht!« mahnte Mama, und während die Kinder noch einmal von vorn anfingen, nahm Grossmama behutsam das Götzenbild aus Hansens Taschentuch.
     </p>
-    <p xml:id="eco_de_0000140_2400">
+    <p xml:id="eco_de_0000210_2400">
      »Die Pfahlbauer beteten es an«, erklärte Lotti eifrig. »Und sie wohnten im Wasser und assen gedörrte Zwetschgen …«
     </p>
-    <p xml:id="eco_de_0000140_2410">
+    <p xml:id="eco_de_0000210_2410">
      »Das waren merkwürdige Leute!« sagte Grossmama. Frau Völklein aber nahm das Bild ebenfalls in Augenschein.
     </p>
-    <p xml:id="eco_de_0000140_2420">
+    <p xml:id="eco_de_0000210_2420">
      »Ach«, rief sie, »wie nett! wie mich das anheimelt! Nein, Kinder, wo habt ihr das her? Das ist eine Kuchenform – wissen Sie, Frau Turnach, für die flachen Honigkuchen, die zu unserer Kinderzeit auf Neujahr gebacken wurden. Der Vetter unserer Mutter war Zuckerbäcker und zeigte uns manchmal seine Formen –«
     </p>
-    <p xml:id="eco_de_0000140_2430">
+    <p xml:id="eco_de_0000210_2430">
      Sie drehte die Platte vergnügt um und um.
     </p>
-    <p xml:id="eco_de_0000140_2440">
+    <p xml:id="eco_de_0000210_2440">
      »Da – da unten haben wir auch eine Jahreszahl … achtzehnhundert – neun! Das ist alt, Kinder; das müsst ihr aufheben!«
     </p>
-    <p xml:id="eco_de_0000140_2450">
+    <p xml:id="eco_de_0000210_2450">
      Hans nahm der Frau Völklein die Platte wieder ab. Alt –! Wenn man gedacht hatte, das Ding sei viele tausend Jahre alt, und nun zählte es nicht einmal hundert! Und wenn man der festen Überzeugung gewesen war, es sei ein Götzenbild eines fremden Volkes der Urzeit, und man musste hören, dass es eine Kuchenform war, wie der Vetter von Frau Völkleins Mutter ganz viele gehabt hatte –!
     </p>
-    <p xml:id="eco_de_0000140_2460">
+    <p xml:id="eco_de_0000210_2460">
      Hans war schrecklich enttäuscht, und als Frau Völklein fortfuhr, der Grossmama von dem vortrefflichen und Kunstvollen Backwerk dieses Vetters zu erzählen, schlich er mit seinem Götzenbild um die Ecke. Lotti und Marianne folgten ihm mit langen Gesichtern zum See hinunter. Eine Weile sagte keines ein Wort.
     </p>
-    <p xml:id="eco_de_0000140_2470">
+    <p xml:id="eco_de_0000210_2470">
      »Jetzt wird es nichts mit dem Glasschrank und den Zetteln; gelt Hans?« fing Lotti endlich an.
     </p>
-    <p xml:id="eco_de_0000140_2480">
+    <p xml:id="eco_de_0000210_2480">
      »Natürlich nicht«, sagte Hans zornig. »Es ist alles aus!« Er legte die Platte auf die Mauer.
     </p>
-    <p xml:id="eco_de_0000140_2490">
+    <p xml:id="eco_de_0000210_2490">
      Marianne gab ihr einen Stoss. »Was tun wir nun damit? Kannst du sie noch ansehen? Ich nicht!«
     </p>
-    <p xml:id="eco_de_0000140_2500">
+    <p xml:id="eco_de_0000210_2500">
      »Nein, ich hasse sie!« erwiderte Hans, und Lotti fand nun, dass der Mann auf dem Bilde sehr unschön sei und dass die Frau ja gar keinen Kopf habe.
     </p>
-    <p xml:id="eco_de_0000140_2510">
+    <p xml:id="eco_de_0000210_2510">
      Plötzlich nahm Hans das Götzenbild und schlug es mit aller Macht an die Mauer; es zerbrach mit einem Krach in zwei Stücke. Lotti und Marianne erschraken einen Augenblick; aber dann fanden sie, dass dies das Richtige sei. Sie hoben die Stücke auf und warfen sie hin und noch einmal und noch einmal. Schliesslich standen sie vor einem Haufen Scherben.
     </p>
-    <p xml:id="eco_de_0000140_2520">
+    <p xml:id="eco_de_0000210_2520">
      »So«, sagte Hans etwas erleichtert, »nun müssen wir das versenken in den See.«
     </p>
-    <p xml:id="eco_de_0000140_2530">
+    <p xml:id="eco_de_0000210_2530">
      »Ich habe eine Pappschachtel; da tun wir's hinein!« schlug Marianne vor und lief zum Hause.
     </p>
-    <p xml:id="eco_de_0000140_2540">
+    <p xml:id="eco_de_0000210_2540">
      »Aber nicht die mit den roten Blumen!« rief Hans, »die passt nicht.«
     </p>
-    <p xml:id="eco_de_0000140_2550">
+    <p xml:id="eco_de_0000210_2550">
      Marianne kam zurück mit einer grauen Schachtel, und Lotti brachte eine schwarze Wollschnur zum Festbinden.
     </p>
-    <p xml:id="eco_de_0000140_2560">
+    <p xml:id="eco_de_0000210_2560">
      »Nicht wahr, schwarz muss sie sein, weil das eine traurige Geschichte ist?« sagte sie.
     </p>
-    <p xml:id="eco_de_0000140_2570">
+    <p xml:id="eco_de_0000210_2570">
      Nun stiegen die Kinder ins Schiff, und Hans ruderte hinaus bis da, wo es tief war. Dann nahm Marianne die Schachtel und warf sie ins Wasser. Sie sank langsam, und die Kinder sahen ihr ernsthaft nach, bis sie in der grünblauen Tiefe verschwand.
     </p>
-    <p xml:id="eco_de_0000140_2580">
+    <p xml:id="eco_de_0000210_2580">
      Am folgenden Abend kam Onkel Alfred in die Seeweid hinaus. Onkel Alfred war der Bruder von Mama, aber viel jünger als sie. Er studierte noch.
     </p>
-    <p xml:id="eco_de_0000140_2590">
+    <p xml:id="eco_de_0000210_2590">
      »Na, ihr Spatzen –« der Onkel nannte die Turnachkinder immer Spatzen, – »ihr habt ja scheint's einen merkwürdigen Fund getan! Wollt ihr die Form verkaufen? Der Herr Bannot sammelt doch alte Sachen. Da, seht einmal her, was er euch geben will dafür!«
     </p>
-    <p xml:id="eco_de_0000140_2600">
+    <p xml:id="eco_de_0000210_2600">
      Onkel Alfred zog aus seinem Geldbeutel ein Frankenstück und hielt es den Kindern hin. Er war sehr erstaunt, dass keines danach griff.
     </p>
-    <p xml:id="eco_de_0000140_2610">
+    <p xml:id="eco_de_0000210_2610">
      »Nun, Lotti, den dritten Teil davon bekommst du. Rechne das einmal aus!«
     </p>
-    <p xml:id="eco_de_0000140_2620">
+    <p xml:id="eco_de_0000210_2620">
      Da zog Lotti die Augenbrauen herauf, zwinkerte mit den Augen und fing an zu weinen. Sie konnte nicht helfen. Gerade hinausweinen musste sie. Marianne biss die Zähne auf die Lippen, und Hans rieb mit seinem Daumen die linke Hand. Eigentlich hatten sie ja das Götzenbild grossmütig der Stadt umsonst geben wollen. Aber da das nun doch nichts gewesen und der Franken jetzt so vor ihnen lag, reute sie schrecklich, was sie gestern getan.
     </p>
-    <p xml:id="eco_de_0000140_2630">
+    <p xml:id="eco_de_0000210_2630">
      Onkel Alfred sah vom einen zum andern.
     </p>
-    <p xml:id="eco_de_0000140_2640">
+    <p xml:id="eco_de_0000210_2640">
      »Ja, wenn ihr nicht wollt! Zu weinen brauchst du deswegen nicht, Lotti. Aber vielleicht darf ich das Stück wenigstens sehen?«
     </p>
-    <p xml:id="eco_de_0000140_2650">
+    <p xml:id="eco_de_0000210_2650">
      Lottis Tränen flossen stärker. Sie dachte an einen kleinen Wassereimer mit rotem Rand, den sie und Marianne schon lange gern gekauft hätten. Marianne dachte auch daran, und dem Hans fiel das Taschenmesser ein in dem kleinen Laden unten an der Schimmelgasse; zwanzig Rappen hatte er schon dazu in seiner Sparbüchse.
     </p>
-    <p xml:id="eco_de_0000140_2660">
+    <p xml:id="eco_de_0000210_2660">
      »Onkel«, begann endlich Marianne. »Wir – wir haben es nicht mehr. Wir haben gemeint, es sei ein Götzenbild von den Pfahlbauern, weisst du, und da hat Frau Völklein gesagt, es sei bloss eine Kuchenform. Und da sind wir bös geworden und haben es – haben es zerschlagen und –«
     </p>
-    <p xml:id="eco_de_0000140_2670">
+    <p xml:id="eco_de_0000210_2670">
      »Und haben es in den See geworfen!« beendigte Hans; denn es sah gerade aus, als ob Marianne auch noch wollte zu weinen anfangen.
     </p>
-    <p xml:id="eco_de_0000140_2680">
+    <p xml:id="eco_de_0000210_2680">
      Onkel Alfred lachte, dass er zuerst gar nicht sprechen konnte.
     </p>
-    <p xml:id="eco_de_0000140_2690">
+    <p xml:id="eco_de_0000210_2690">
      »Das ist wundervoll!« rief er endlich und schlug sich aufs Knie. »Das heisse ich radikal! Wenn man so alles, was einen ärgert, zusammenhauen und in den See werfen könnte – patsch, fertig –! Ihr seid Prachtsspatzen! Hahaha –«
     </p>
-    <p xml:id="eco_de_0000140_2700">
+    <p xml:id="eco_de_0000210_2700">
      Die Lustigkeit wirkte ansteckend. Lotti rieb sich mit dem Taschentuch die Augen trocken.
     </p>
-    <p xml:id="eco_de_0000140_2710">
+    <p xml:id="eco_de_0000210_2710">
      »Onkel«, sagte sie, »willst du die Stelle sehen, wo das Götzenbild im Wasser liegt? Dann können wir vielleicht noch ein bisschen herumfahren.«
     </p>
-    <p xml:id="eco_de_0000140_2720">
+    <p xml:id="eco_de_0000210_2720">
      »Natürlich will ich!« antwortete Onkel Alfred. Er steckte das Silberstück wieder ein, nahm aber für jedes Kind einen Zehner aus seinem Beutel.
     </p>
-    <p xml:id="eco_de_0000140_2730">
+    <p xml:id="eco_de_0000210_2730">
      »Den ganzen Franken geb' ich euch nicht, Spatzen; sonst verliert ja diese amüsante Geschichte ihren Hauptpunkt. Aber da – das steckt ein. Man nennt das Schmerzensgeld.«
     </p>
-    <p xml:id="eco_de_0000140_2740">
+    <p xml:id="eco_de_0000210_2740">
      Dann ging er mit den Kindern zum Schiff. Es war sehr schwer, die Stelle zu bestimmen, wo die Schachtel mit den Trümmern des Götzenbildes versteckt war. Ein Kind zeigte dahin, eines dorthin, und Marianne meinte einmal sogar, sie könne die Schachtel tief unten durch das blaugrüne Wasser sehen; aber dann war es bloss ein grosser Stein. Onkel Alfred musste beständig mahnen, dass nicht etwa eins der Kinder kopfüber hineinfalle.
     </p>
-    <p xml:id="eco_de_0000140_2750">
+    <p xml:id="eco_de_0000210_2750">
      Hans aber konnte die Pfahlbauergeschichte nicht so leicht vergessen. Er ging die nächsten zwei Tage ganz nachdenklich umher. Als er am Dienstag abend mit Marianne von der Schule heimkam und sie zur Abwechslung einmal den Weg durch die kleine Baumschule nahmen, blieb er plötzlich stehen.
     </p>
-    <p xml:id="eco_de_0000140_2760">
+    <p xml:id="eco_de_0000210_2760">
      »Siehst du, Marianne, das wäre grade ein guter Platz –« Er zeigte auf eine Stelle, wo der Boden locker war; man hatte da kürzlich einen jungen Kastanienbaum ausgegraben.
     </p>
-    <p xml:id="eco_de_0000140_2770">
+    <p xml:id="eco_de_0000210_2770">
      Marianne merkte, dass Hans wieder etwas im Sinne hatte; aber vor lauter Nachdenken konnte er noch nicht erklären, was.
     </p>
-    <p xml:id="eco_de_0000140_2780">
+    <p xml:id="eco_de_0000210_2780">
      »Das Loch muss nämlich sehr tief sein«, fuhr er fort.
     </p>
-    <p xml:id="eco_de_0000140_2790">
+    <p xml:id="eco_de_0000210_2790">
      »Tun wir einen Vogel begraben?« fragte Marianne. Kürzlich hatten sie eine tote junge Schwalbe gefunden und beerdigt.
     </p>
-    <p xml:id="eco_de_0000140_2800">
+    <p xml:id="eco_de_0000210_2800">
      »Nein, etwas ganz anderes. Es gibt – du darfst es aber niemand sagen als dem Lotti – wir graben Altertümer ein – das heisst, es sind noch keine; aber wenn wir das Loch recht tief machen, dann findet man die Sachen sehr lange nicht, vielleicht erst in zwei- oder dreitausend Jahren –«
     </p>
-    <p xml:id="eco_de_0000140_2810">
+    <p xml:id="eco_de_0000210_2810">
      »Was für Sachen?«
     </p>
-    <p xml:id="eco_de_0000140_2820">
+    <p xml:id="eco_de_0000210_2820">
      »Ja, das ist eben jetzt die Frage. Es müssen Waffen, Werkzeuge, Kleidungsstücke, Geschirre und Schmucksachen sein, damit das Volk, das später einmal hier lebt, genau weiss, was für Dinge man bei uns gehabt hat.«
     </p>
-    <p xml:id="eco_de_0000140_2830">
+    <p xml:id="eco_de_0000210_2830">
      »Aber wenn sie dann die Sachen finden, sind wir schon lang gestorben«, warf Marianne ein, der das andere mit dem Glasschrank, wo man am Sonntag hingegangen wäre, besser gefallen hatte.
     </p>
-    <p xml:id="eco_de_0000140_2840">
+    <p xml:id="eco_de_0000210_2840">
      »Ja, Marianne, man muss auch etwas für die Nachwelt tun. Das hat der Herr Altschmid einmal in der Schule gesagt. Denke, wie schön für die Leute, wenn sie die Sachen einmal finden.«
     </p>
-    <p xml:id="eco_de_0000140_2850">
+    <p xml:id="eco_de_0000210_2850">
      Marianne lief nun mit Hans, um eine Hacke zu holen und Lotti zu rufen. Dann berieten die Kinder lange, was man zum Eingraben hätte. Marianne gab ein Zinntöpfchen her und zwei blau geränderte Puppenteller. Hans brachte eine kleine Zange und sein Taschenmesser, an dem aber die Klinge abgebrochen war.
     </p>
-    <p xml:id="eco_de_0000140_2860">
+    <p xml:id="eco_de_0000210_2860">
      »Du«, sagte Marianne, »mein Zinntöpfchen ist dann aber ganz! An dem zerbrochenen Messer hat das spätere Volk gewiss keine Freude.«
     </p>
-    <p xml:id="eco_de_0000140_2870">
+    <p xml:id="eco_de_0000210_2870">
      »Wenn ich aber doch keine anderes habe! Und überhaupt, die ausgegrabenen Altertümer im Museum sind auch oft beschädigt; das macht gar nichts.«
     </p>
-    <p xml:id="eco_de_0000140_2880">
+    <p xml:id="eco_de_0000210_2880">
      »So, dann kann ich den auch geben«, meinte Lotti und zeigte einen Ring, den sie kürzlich von einem Schulkind gegen vier Fruchtbonbons eingetauscht hatte und aus dem der Stein verloren war. Dazu legte sie noch ein aus Perlen gestricktes Geldbeutelchen; es war sehr hübsch rosa, grün und schwarz; aber das Schloss ging nicht mehr zu.
     </p>
-    <p xml:id="eco_de_0000140_2890">
+    <p xml:id="eco_de_0000210_2890">
      Lange fand sich keine Waffe; denn das meiste Spielzeug der Kinder war ja in der Stadt geblieben. Endlich fiel dem Hans etwas ein. Er lief zu Balbine, die am offenen Küchenfenster für sich nähte.
     </p>
-    <p xml:id="eco_de_0000140_2900">
+    <p xml:id="eco_de_0000210_2900">
      »Balbine, wenn ich dir die hübsche runde Holzschachtel gebe, die ich von Grossmama habe, gibst du mir dann meine alte Patrontasche wieder, in der du deine Knöpfe und Haften aufhebst?«
     </p>
-    <p xml:id="eco_de_0000140_2910">
+    <p xml:id="eco_de_0000210_2910">
      »Freilich«, sagte Balbine und leerte den Inhalt der kleinen Patrontasche auf ein Papier. »Da mach' ich ja einen guten Tausch. Bring' mir aber die Schachtel heut abend noch!«
     </p>
-    <p xml:id="eco_de_0000140_2920">
+    <p xml:id="eco_de_0000210_2920">
      Hans versprach es und rannte mit der Patrontasche hinaus zu den Schwestern.
     </p>
-    <p xml:id="eco_de_0000140_2930">
+    <p xml:id="eco_de_0000210_2930">
      »Natürlich ein Gewehr oder ein Degen wäre besser«, sagte er. »Aber die Patrontasche geht auch. Lotti, als Kleidungsstück könntest du noch den braunen Lederhandschuh in meiner Schublade holen; Papa hat ihn mir geschenkt, weil er den andern verloren hat.«
     </p>
-    <p xml:id="eco_de_0000140_2940">
+    <p xml:id="eco_de_0000210_2940">
      Nun begannen sie das Loch tiefer zu graben; es war mühsam; denn die Erde war von vielen feinen Wurzeln durchzogen.
     </p>
-    <p xml:id="eco_de_0000140_2950">
+    <p xml:id="eco_de_0000210_2950">
      Auf einmal hörte man Werners Stimme.- »Marianne! Lotti! Marianne –!«
     </p>
-    <p xml:id="eco_de_0000140_2960">
+    <p xml:id="eco_de_0000210_2960">
      »Seid ganz still!« befahl Hans. »Wir können ihn nicht brauchen. Es ist ein Geheimnis, was wir da tun. Wenn man es erfährt, gräbt man uns am Ende die Sachen wieder aus.«
     </p>
-    <p xml:id="eco_de_0000140_2970">
+    <p xml:id="eco_de_0000210_2970">
      »Lotti –! Marianne –!« rief der kleine Werner wieder.
     </p>
-    <p xml:id="eco_de_0000140_2980">
+    <p xml:id="eco_de_0000210_2980">
      »Nein, das kann ich nicht hören«, sagte Marianne. »Er will so gern mit uns spielen, und Mama sagt auch immer, wir sollen ihn bei uns haben.«
     </p>
-    <p xml:id="eco_de_0000140_2990">
+    <p xml:id="eco_de_0000210_2990">
      Sie ging und holte den kleinen Werner.
     </p>
-    <p xml:id="eco_de_0000140_3000">
+    <p xml:id="eco_de_0000210_3000">
      Werner kam eilig daher gelaufen, so dass das Glöcklein, das er zum Spass um den Hals gebunden hatte, hell klingelte.
     </p>
-    <p xml:id="eco_de_0000140_3010">
+    <p xml:id="eco_de_0000210_3010">
      »Werner«, rief ihm Lotti zu, »wir machen Pfahlbautenaltertümer.«
     </p>
-    <p xml:id="eco_de_0000140_3020">
+    <p xml:id="eco_de_0000210_3020">
      »Ach, Lotti«, entgegnete Hans, »du sagst es immer falsch. Wir sind doch keine Pfahlbauer!«
     </p>
-    <p xml:id="eco_de_0000140_3030">
+    <p xml:id="eco_de_0000210_3030">
      Dem Werner hingegen gefiel das Wort sehr gut.
     </p>
-    <p xml:id="eco_de_0000140_3040">
+    <p xml:id="eco_de_0000210_3040">
      »Ich will auch Pfahlbauten machen!« rief er und versuchte in das Loch hinunterzusteigen.
     </p>
-    <p xml:id="eco_de_0000140_3050">
+    <p xml:id="eco_de_0000210_3050">
      »Halt, mein Sohn!« wehrte Hans. »Das geht nicht. Du kannst dahin stehen und zusehen. Zuerst aber musst du uns versprechen, dass du gar niemand ein Wort sagst. Das hier ist ein Geheimnis. Aber du bist noch so schrecklich klein und dumm und kannst nicht schweigen.«
     </p>
-    <p xml:id="eco_de_0000140_3060">
+    <p xml:id="eco_de_0000210_3060">
      »Gar nicht schrecklich klein!« verteidigte sich Werner. »Papa hat mich gemessen. Ich bin – so viel grösser!« Werner streckte seine flache Hand, so hoch er konnte.
     </p>
-    <p xml:id="eco_de_0000140_3070">
+    <p xml:id="eco_de_0000210_3070">
      Die Kinder lachten.
     </p>
-    <p xml:id="eco_de_0000140_3080">
+    <p xml:id="eco_de_0000210_3080">
      »Schweigen kann er eigentlich schon«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_3090">
+    <p xml:id="eco_de_0000210_3090">
      »Mama hat ihm meine Geburtstagspuppe gezeigt, und er hat nichts gesagt.«
     </p>
-    <p xml:id="eco_de_0000140_3100">
+    <p xml:id="eco_de_0000210_3100">
      »Weil man ihn gleich zu Bett legte und am andern Morgen der Geburtstag war!« erwiderte Hans.
     </p>
-    <p xml:id="eco_de_0000140_3110">
+    <p xml:id="eco_de_0000210_3110">
      Aber Marianne gab dem Kleinen einen Kuss: »Ja, ja, du bist ein lieber, kluger, grosser Bub!«
     </p>
-    <p xml:id="eco_de_0000140_3120">
+    <p xml:id="eco_de_0000210_3120">
      Nun sah Werner zu, wie die Arbeit weiterging. Hans holte bei der Scheune einige Dachziegel, die schon lange dort gelegen hatten, und formte eine Art Gruft, in die man die Sachen hineinlegte. Dann zog Hans eine Scherbe von einer Schiefertafel aus der Tasche und einen Nagel und ritzte die Jahreszahl und die Namen der Gegenstände ein.
     </p>
-    <p xml:id="eco_de_0000140_3130">
+    <p xml:id="eco_de_0000210_3130">
      »Es geht sehr schwer so«, sagte er. »Aber ein Blatt Papier würde vielleicht nicht halten.«
     </p>
-    <p xml:id="eco_de_0000140_3140">
+    <p xml:id="eco_de_0000210_3140">
      »Reden die Leute in 4000 Jahren auch deutsch?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_3150">
+    <p xml:id="eco_de_0000210_3150">
      Hans besann sich: »Nein, sie reden jedenfalls eine neue, andere Sprache; aber es macht nichts. Sie haben dann Gelehrte, und die können alle alten Sprachen.«
     </p>
-    <p xml:id="eco_de_0000140_3160">
+    <p xml:id="eco_de_0000210_3160">
      »O, und nun auch noch unsere Namen darunter!« bat Marianne.
     </p>
-    <p xml:id="eco_de_0000140_3170">
+    <p xml:id="eco_de_0000210_3170">
      »Du, und schreib' noch: Freundlichen Gruss. Das ist dann nett, wenn das neue Volk das liest«, sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_3180">
+    <p xml:id="eco_de_0000210_3180">
      Hans ritzte den freundlichen Gruss und die Namen ein.
     </p>
-    <p xml:id="eco_de_0000140_3190">
+    <p xml:id="eco_de_0000210_3190">
      »Hans, Marianne und Lotti Turnach«, buchstabierte er langsam während des Schreibens.
     </p>
-    <p xml:id="eco_de_0000140_3200">
+    <p xml:id="eco_de_0000210_3200">
      »Mich auch schreiben!« rief Werner, der mit grossem Vergnügen sah und hörte, was vorging.
     </p>
-    <p xml:id="eco_de_0000140_3210">
+    <p xml:id="eco_de_0000210_3210">
      »Dann musst du aber etwas dazu geben«, sagte Hans. »Gib dein Glöcklein!«
     </p>
-    <p xml:id="eco_de_0000140_3220">
+    <p xml:id="eco_de_0000210_3220">
      Aber Werner schüttelte sehr bestimmt den Kopf und hielt sein messingenes Glöcklein fest.
     </p>
-    <p xml:id="eco_de_0000140_3230">
+    <p xml:id="eco_de_0000210_3230">
      »Nicht? Ja, dann gehörst du also nicht dazu, und ich kann auch deinen Namen nicht daher schreiben.«
     </p>
-    <p xml:id="eco_de_0000140_3240">
+    <p xml:id="eco_de_0000210_3240">
      Nun wurden über die kleine Gruft noch zwei Ziegel gelegt. Ein Weilchen schauten die Kinder, ohne etwas zu sagen, hinunter und dachten an das Volk, das die Sachen ausgraben würde. Es war seltsam, daran zu denken. Endlich warfen sie Erde darauf, bis alles wieder aufgefüllt war. Marianne hob ein paar Unkrautbüschel mit der Erde aus, damit Hans sie über der Gruft einpflanze. So sah alles natürlich aus; niemand konnte ahnen, dass da drinnen etwas begraben liege.
     </p>
-    <p xml:id="eco_de_0000140_3250">
+    <p xml:id="eco_de_0000210_3250">
      Sehr befriedigt von ihrer Tat liefen die Kinder zum Hause zurück. Werner folgte langsam nach, und in seinem kleinen Kopfe dachte er sich aus, dass er einmal ganz allein »Pfahlbauten« machen wolle. Und so geschah es, dass er an jenem Sonntagmorgen die Zipfel der Butterhörnchen im Garten unter den Fliederbüschen vergrub. Warum es allerdings gerade das schöne Sonntagsgebäck sein musste, das hat kein Mensch jemals begriffen, der kleine Mann selbst wahrscheinlich am allerwenigsten.
     </p>
    </div>
@@ -1072,202 +1072,202 @@
     <head>
      Vom Rudern und Schwimmen.
     </head>
-    <p xml:id="eco_de_0000140_3260">
+    <p xml:id="eco_de_0000210_3260">
      Das Schönste in der Seeweid war natürlich das kleine Schiff, das in der Bucht an der Gartenmauer lag. Jeden Tag wurde mindestens eine Fahrt unternommen. Marianne und Lotti hatten allerdings recht gehabt: Hans konnte noch nicht so gut rudern wie Papa; immerhin wusste er schon ordentlich mit dem Schiff umzugehen, so dass Papa gleich am Anfang erklärt hatte, Hans dürfe dieses Jahr allein hinausfahren.
     </p>
-    <p xml:id="eco_de_0000140_3270">
+    <p xml:id="eco_de_0000210_3270">
      »Und wir mit, Papa!« hatten Marianne und Lotti gebeten.
     </p>
-    <p xml:id="eco_de_0000140_3280">
+    <p xml:id="eco_de_0000210_3280">
      »Ja, ihr mit. Es muss nur alles vernünftig geschehen.«
     </p>
-    <p xml:id="eco_de_0000140_3290">
+    <p xml:id="eco_de_0000210_3290">
      »Und«, sagte Mama, »an ein paar Gesetze werdet ihr euch zu halten haben. Einmal wirst du nicht denken, Hans, man lasse dich gleich über den ganzen See fahren. Ich will euch, wenn ich vom Garten hinaussehe, im Auge haben.«
     </p>
-    <p xml:id="eco_de_0000140_3300">
+    <p xml:id="eco_de_0000210_3300">
      »Natürlich«, stimmte Papa bei. »Ihr fahrt nicht weiter hinaus als – sagen wir einmal: als dreissig Ruderschläge vom Lande weggezählt.«
     </p>
-    <p xml:id="eco_de_0000140_3310">
+    <p xml:id="eco_de_0000210_3310">
      »Papa, das ist furchtbar wenig«, wendete Hans ein.
     </p>
-    <p xml:id="eco_de_0000140_3320">
+    <p xml:id="eco_de_0000210_3320">
      »Dreissig Ruderschläge vom Lande weg. Dann seeaufwärts bis –«
     </p>
-    <p xml:id="eco_de_0000140_3330">
+    <p xml:id="eco_de_0000210_3330">
      »Bis zum Färberschiff, Papa!« schlug Marianne vor.
     </p>
-    <p xml:id="eco_de_0000140_3340">
+    <p xml:id="eco_de_0000210_3340">
      »Gut, bis zum Färberschiff. Und abwärts bis zum Rittmergut. Verstanden, Hans?«
     </p>
-    <p xml:id="eco_de_0000140_3350">
+    <p xml:id="eco_de_0000210_3350">
      »Ja, Papa.«
     </p>
-    <p xml:id="eco_de_0000140_3360">
+    <p xml:id="eco_de_0000210_3360">
      »Selbstverständlich fahrt ihr nur bei ganz ruhigem See hinaus. Steigt ein Wind auf, während ihr draussen seid, so kommt ihr sofort herein und wartet nicht, bis man euch erst ruft.«
     </p>
-    <p xml:id="eco_de_0000140_3370">
+    <p xml:id="eco_de_0000210_3370">
      »Dürfen wir durch den Schilf fahren, wo er recht dicht ist?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_3380">
+    <p xml:id="eco_de_0000210_3380">
      »Jawohl!«, antwortete Mama. »Da kann nichts geschehen, als dass ihr stecken bleibt.«
     </p>
-    <p xml:id="eco_de_0000140_3390">
+    <p xml:id="eco_de_0000210_3390">
      »Dann steigen wir aus«, sagte Lotti. »Da wo der Schilf steht, geht mir das Wasser nie höher als bis ans Knie. Und dann stossen wir das Schiff los und steigen schnell wieder ein; gelt, Hans?«
     </p>
-    <p xml:id="eco_de_0000140_3400">
+    <p xml:id="eco_de_0000210_3400">
      Lotti sah dieses Abenteuer schon vor sich.
     </p>
-    <p xml:id="eco_de_0000140_3410">
+    <p xml:id="eco_de_0000210_3410">
      Das Wassergebiet zwischen dem Färberschiff und dem Rittmergarten, das Papa den Kindern zugewiesen hatte, war allerdings nicht sehr gross für Hansens Tatenlust. Aber die Schiffahrten gestalteten sich doch äusserst abwechslungsreich.
     </p>
-    <p xml:id="eco_de_0000140_3420">
+    <p xml:id="eco_de_0000210_3420">
      Schon allein das Wegrudern –! Das Schiff war meistens auf das Land heraufgezogen und mit der Kette an einen Pflock befestigt. Hans machte es los und schob es etwas ins Wasser; Marianne und Lotti stiegen ein; Hans fasste den Kiel und stiess das Schiff mit aller Kraft hinaus; im letzten Moment schwang er sich platt auf das Sitzbrett der Spitze.
     </p>
-    <p xml:id="eco_de_0000140_3430">
+    <p xml:id="eco_de_0000210_3430">
      Es begegnete oft, dass Hans ein bisschen mit dem Schiff ins Wasser hineinlief. Aber das schadete nichts.
     </p>
-    <p xml:id="eco_de_0000140_3440">
+    <p xml:id="eco_de_0000210_3440">
      »Ein Seebub hat bald trockene Füsse, bald nasse, wie's grade kommt«, sagte Jakob.
     </p>
-    <p xml:id="eco_de_0000140_3450">
+    <p xml:id="eco_de_0000210_3450">
      Die zweite Schwierigkeit war, aus der schmalen, auf beiden Seiten mit Mauern eingefassten Bucht herauszukommen. Hans musste mit den Stehrudern rückwärts fahren. Bald kam er zu stark links, bald zu weit rechts.
     </p>
-    <p xml:id="eco_de_0000140_3460">
+    <p xml:id="eco_de_0000210_3460">
      »Ui!« rief Marianne, »wir bekommen alle Augenblicke einen Puff!«
     </p>
-    <p xml:id="eco_de_0000140_3470">
+    <p xml:id="eco_de_0000210_3470">
      »Das ist lustig; das macht nichts!« meinte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_3480">
+    <p xml:id="eco_de_0000210_3480">
      »Euch nicht, aber dem Schiff!« sagte Hans. »Ich kann nicht recht rückwärts sehen; sagt mir die Richtung ein wenig!«
     </p>
-    <p xml:id="eco_de_0000140_3490">
+    <p xml:id="eco_de_0000210_3490">
      »Links – rechts! rückwärts! stopp –«, kommandierten die Schwestern.
     </p>
-    <p xml:id="eco_de_0000140_3500">
+    <p xml:id="eco_de_0000210_3500">
      »Stopp« hatten sie vom Kapitän des Neptun gelernt, als sie mit Grossmama einmal eine Dampfschiffahrt hatten machen dürfen.
     </p>
-    <p xml:id="eco_de_0000140_3510">
+    <p xml:id="eco_de_0000210_3510">
      Zuletzt kam man glücklich hinaus auf den freien See. Dann nahm Marianne die Sitzruder, die am Boden lagen, und hängte sie ein. Sie ruderte schon ganz schön mit Hans im Takte. Manchmal versuchte es auch Lotti, obgleich Hans nicht viel hielt auf ihr Geruder, wie er es nannte.
     </p>
-    <p xml:id="eco_de_0000140_3520">
+    <p xml:id="eco_de_0000210_3520">
      Eine besondere Freude hatten die Kinder, wenn Mama mit dem Schwesterlein und mit Werner an der Gartenmauer stand und zusah, wie die drei vorbeiruderten. Für Werner was es zwar zuerst immer ein Schmerz gewesen, nicht dabei zu sein. Er durfte nur mit, wenn ein Erwachsenes im Schiffe war. Nach und nach hatte er sich aber drein gefügt und schrie jedesmal lustig: »Hurra, hurra! ich darf dann mit Papa fahren!«
     </p>
-    <p xml:id="eco_de_0000140_3530">
+    <p xml:id="eco_de_0000210_3530">
      Er hatte eine kleine Trompete, auf der man ihn blasen liess, wenn die Kinder hereinkommen sollten. Dieses Mittel machte er sich bald zunutz und rief die Geschwister mit seinen Trompetenstössen heim, so oft es ihm einfiel. Natürlich zankten sie deswegen mit ihm.
     </p>
-    <p xml:id="eco_de_0000140_3540">
+    <p xml:id="eco_de_0000210_3540">
      »Also, siehst du, Werner«, erklärte ihm Hans, »wenn du wieder bläst, ohne dass man dich heisst, dann trauen wir dir nicht mehr und kommen auch nicht, wenn es gilt. Wer einmal lügt, dem glaubt man nicht und wenn er auch die Wahrheit spricht.«
     </p>
-    <p xml:id="eco_de_0000140_3550">
+    <p xml:id="eco_de_0000210_3550">
      »Ich hab' nicht gelügt«, verteidigte sich Werner. »Wenn ich im Garten spaziere und Trompete blase, weil es mir langweilig ist, dann hab' ich nicht gelügt!«
     </p>
-    <p xml:id="eco_de_0000140_3560">
+    <p xml:id="eco_de_0000210_3560">
      Die Kinder lachten über das possierliche »gelügt« und weil Wernerlein sich so schlau herauszureden versuchte.
     </p>
-    <p xml:id="eco_de_0000140_3570">
+    <p xml:id="eco_de_0000210_3570">
      Die Turnachkinder richteten ihre Fahrten womöglich auf die Zeit, da ein Dampfschiff vorbeifuhr. Hans wendete dann mit ein paar starken Ruderschlägen, so dass der Kiel die daherziehenden Wellen schnitt. Es war prächtig, wenn man so auf und ab geschaukelt wurde.
     </p>
-    <p xml:id="eco_de_0000140_3580">
+    <p xml:id="eco_de_0000210_3580">
      »Eigentlich fein ist's erst, wenn man recht nah beim Dampfschiff ist«, sagte Hans. »Da geht's hoch hinauf und dann hinunter, dass man fast meint, man versinke. Nächstes Jahr darf ich hoffentlich weiter hinaus. – Jetzt wollen wir zu den Steinen rudern, wo die jungen Fische sind.«
     </p>
-    <p xml:id="eco_de_0000140_3590">
+    <p xml:id="eco_de_0000210_3590">
      Die Steine waren grosse Blöcke, die überall längs den Ufermauern aufgeschüttet waren, damit die anschlagenden Wellen die Mauer nicht zerstörten. An der Ecke des Rittmergutes waren jetzt, am Anfang des Sommers, eine Unmenge von ganz kleinen Fischen zu sehen. Zu Hunderten und Hunderten schwammen sie da, so dicht ineinander, dass sie das Wasser verdunkelten. Fuhr man in sie hinein, so flohen sie nach allen Seiten, konnten aber in ihrem eigenen Gewimmel gar nicht schnell genug entkommen. Da schossen denn die einen sogar aus dem Wasser auf und in weitem Sprunge darüber hin. Es war, als ob kleine silberne Blitze aus dem grünblauen Wasser aufsprühten, um im nächsten Augenblick wieder zu versinken.
     </p>
-    <p xml:id="eco_de_0000140_3600">
+    <p xml:id="eco_de_0000210_3600">
      Am lustigsten aber war es, wenn man irgendwo an einer seichten Stelle auffuhr.
     </p>
-    <p xml:id="eco_de_0000140_3610">
+    <p xml:id="eco_de_0000210_3610">
      »Kann man da noch drüber oder nicht?« war jedesmal die wichtige Frage. Um sie zu lösen, fuhr man frisch drauf los, bis das Schiff auf den Kieseln des Grundes knirschte und man feststeckte. Dann griff Hans nach einem Sitzruder und begann zu stacheln, während Marianne mit dem andern hantierte. Lotti sass auf der Mittelbank und schrie: »Fest, Hans, fest –! Marianne, du tust falsch –! links – links –!«
     </p>
-    <p xml:id="eco_de_0000140_3620">
+    <p xml:id="eco_de_0000210_3620">
      Einmal wurden sie gar nicht mehr flott. Da hiess Hans Marianne und Lotti aussteigen, damit das Schiff leichter werde. Als sie die Schuhe und Strümpfe ausgezogen hatten und im Wasser standen, das ihnen nicht viel über die Knöchel ging, kam wirklich Hans mit einem tüchtigen Stosse los.
     </p>
-    <p xml:id="eco_de_0000140_3630">
+    <p xml:id="eco_de_0000210_3630">
      »Halt, halt!« riefen die Mädchen; »nimm uns doch auch mit!«
     </p>
-    <p xml:id="eco_de_0000140_3640">
+    <p xml:id="eco_de_0000210_3640">
      Aber Hans fuhr im Übermut davon, ganz weit weg. Da erhoben die Mädchen ein Geschrei. Ans Land konten sie nicht waten, weil dorthin der Grund wieder tiefer wurde.
     </p>
-    <p xml:id="eco_de_0000140_3650">
+    <p xml:id="eco_de_0000210_3650">
      Balbine, die eben im Gemüsegarten nach dem Erbsenbeete sah, kam ans Ufer gelaufen. Sie war nicht an einem See aufgewachsen und deshalb sehr misstrauisch gegen alles Schiffen und Rudern.
     </p>
-    <p xml:id="eco_de_0000140_3660">
+    <p xml:id="eco_de_0000210_3660">
      »Kinder, Kinder!« jammerte sie; »du liebe Güte! wie kommt ihr da hinaus! Ich rufe Sophie oder Jakob –«
     </p>
-    <p xml:id="eco_de_0000140_3670">
+    <p xml:id="eco_de_0000210_3670">
      Sie eilte zum Hause, ohne in der Bestürzung zu sehen, dass Hans in einem schönen Bogen eben wieder zu den ausgesetzten Schwestern zurückkehrte. Aber die Kinder schrien ihr nach: »Balbine, Balbine! Es war nur ein Spass. Er holt uns wieder!«
     </p>
-    <p xml:id="eco_de_0000140_3680">
+    <p xml:id="eco_de_0000210_3680">
      Balbine blieb stehen.
     </p>
-    <p xml:id="eco_de_0000140_3690">
+    <p xml:id="eco_de_0000210_3690">
      »Wartet ihr –!« brummte sie und drohte mit dem Finger. »Es wird noch gehen wie beim Werner und seiner Trompete: Wenn ihr einmal recht in der Klemme seid, hilft man euch auch nicht.«
     </p>
-    <p xml:id="eco_de_0000140_3700">
+    <p xml:id="eco_de_0000210_3700">
      »Ach, Balbine«, sagte Hans, der nahe herfuhr. »Wir kommen nicht in die Klemme! Willst du vielleicht ein wenig mitfahren?«
     </p>
-    <p xml:id="eco_de_0000140_3710">
+    <p xml:id="eco_de_0000210_3710">
      »Ich danke, ich danke höflich! Was mich betrifft, ich bleibe auf dem Lande und bewege mich auf meinen zwei Füssen; da weiss ich doch, woran ich bin. Dieses Wassergeschwampel ist mir höchst verdächtig.«
     </p>
-    <p xml:id="eco_de_0000140_3720">
+    <p xml:id="eco_de_0000210_3720">
      Damit ging Balbine zurück zu ihrem Erbsenbeet.
     </p>
-    <p xml:id="eco_de_0000140_3730">
+    <p xml:id="eco_de_0000210_3730">
      Einen wirklich grossartigen Charakter aber nahmen die Schiffahrten an, wenn Onkel Alfred oder Fritz Völklein dabei waren. Fritz Völklein war der Grossneffe von Frau Völklein. Er wohnte in der Nähe der Seeweid und kam sehr oft zu seiner Tante. Er war schon fünfzehn Jahre alt, stark und gewandt und ruderte ausgezeichnet. Auch hatte er etwas Vorsichtiges, Besonnenes. Mit ihm liess Frau Turnach die Kinder überall hinfahren, seeauf, seeab und querüber. Wenn sie noch so lange nicht heimkamen, sie ängstigte sich nicht.
     </p>
-    <p xml:id="eco_de_0000140_3740">
+    <p xml:id="eco_de_0000210_3740">
      Die Kinder kannten auch nichts Schöneres als mit Fritz Völklein zu fahren.
     </p>
-    <p xml:id="eco_de_0000140_3750">
+    <p xml:id="eco_de_0000210_3750">
      »Zuerst zum Färberschiff!« hiess es dann meistens. Das Färberschiff war ein plumper, viereckiger Kahn mit einem grossen Tisch in der Mitte und einem festen Dach. Das Schiff lag draussen auf dem See und war durch eine eiserne Kette gehalten, die am Grund befestigt war. Meistens sah das Wasser ringsum dunkelrot oder violett aus von den Garnstrangen, die hier ausgewaschen wurden. Wenn die Färber nicht da waren, konnte man in das komische Schiff hinübersteigen. Das war ein Hauptspass. Aber man durfte es nur tun, wenn Fritz Völklein oder Onkel Alfred dabei waren.
     </p>
-    <p xml:id="eco_de_0000140_3760">
+    <p xml:id="eco_de_0000210_3760">
      Manchmal brachte Onkel Alfred ein eigenes kleines Boot aus der Stadt mit. Dann wurde ein wundervolles Spiel gespielt. Das Färberschiff war Sankt Helena, weil es da draussen lag wie eine Insel im Meere. Hans war Kaiser Napoleon der Erste, den man auf die Insel Sankt Helena verbannt hatte mit seinem Gefolge, das aus Marianne und Lotti bestand. Fritz Völklein war der englische Feind und fuhr bewachend um die Insel. Wenn er ihr aber einmal den Rücken drehte und weiter hinausfuhr, kam Onkel Alfred als Anhänger Napoleons mit seinem Schoner daher, um Napoleon zu befreien. Es war sehr aufregend, bis der Kaiser und sein Gefolge in dem französischen Schoner geborgen waren. Denn der Kapitän der englischen Brigg nahm die Einschiffung wahr und schoss in grosser Eile herbei, um den Fluchtversuch zu vereiteln. Nun entstand eine wilde Jagd auf dem See. Napoleon selbst musste mitrudern. Die englische Brigg bemühte sich, zuvorzukommen und den Hafen zu versperren. Manchmal gelang es trotzdem, den Kaiser und sein Gefolge auf Frankreichs Boden zu setzen. Oft aber kam die englische Brigg dem französischen Schoner so nahe, dass der Kapitän die Kette hinüberwerfen konnte; das war das Zeichen, dass Napoleon gefangen war und mit seinem Gefolge wieder nach Sankt Helena zurück musste.
     </p>
-    <p xml:id="eco_de_0000140_3770">
+    <p xml:id="eco_de_0000210_3770">
      Schade war es, wenn mitten im Spiel Werner mit seiner Trompete auf der Gartenmauer erschien, und neben ihm Sophie, zum Zeichen, dass es ernst gelte und dass die Trompetenstösse als Ruf zum Abendessen zu nehmen seien.
     </p>
-    <p xml:id="eco_de_0000140_3780">
+    <p xml:id="eco_de_0000210_3780">
      Der Mai war dieses Jahr schön und warm gewesen. Am 27. nachmittags hatte das Seewasser schon 16 Grad gehabt, und so konnte jetzt mit dem Baden begonnen werden. An der Mauer des Obstgartens stand, in den See hinausgebaut, das nette alte Badhaus. Hans machte immer den Anfang und war schon im Wasser, wenn die Mädchen in ihren roten Anzügen auf der Treppe erschienen.
     </p>
-    <p xml:id="eco_de_0000140_3790">
+    <p xml:id="eco_de_0000210_3790">
      »Es ist prachtvoll!« schrie er. »Ganz warm! Kommt nur!«
     </p>
-    <p xml:id="eco_de_0000140_3800">
+    <p xml:id="eco_de_0000210_3800">
      Ganz warm –? nein – Lotti, die mit der Fusspitze hineintippte, fand es eher kalt. Sie blieb ein Weilchen auf der Stufe stehen; dann stieg sie langsam zur folgenden hinunter.
     </p>
-    <p xml:id="eco_de_0000140_3810">
+    <p xml:id="eco_de_0000210_3810">
      »Au –!« Sie zog die Achseln in die Höhe.
     </p>
-    <p xml:id="eco_de_0000140_3820">
+    <p xml:id="eco_de_0000210_3820">
      Nun kam aber Hans: »Wart, Lotti; ich will dir helfen. Ich weiss ein Mittel, da bist du im Augenblick im Wasser –«
     </p>
-    <p xml:id="eco_de_0000140_3830">
+    <p xml:id="eco_de_0000210_3830">
      Damit fing er an zu spritzen, dass Lotti über und über nass wurde und gar nicht mehr wusste, ob das Wasser warm oder kalt sei. Schreiend und pustend sprang sie hinunter und fand es alsbald auch prachtvoll. Sie lief auf Marianne zu, um sie zu fangen. Es war so komisch, wie man im Wasser gar nicht rasch gehen konnte. Die Kinder versuchten zu tauchen und übten sich im Schwimmen.
     </p>
-    <p xml:id="eco_de_0000140_3840">
+    <p xml:id="eco_de_0000210_3840">
      »Seekinder müssen schwimmen können wie die Enten!« sagte Papa immer.
     </p>
-    <p xml:id="eco_de_0000140_3850">
+    <p xml:id="eco_de_0000210_3850">
      Hans schwamm schon ziemlich gut. Marianne machte fünf oder sechs Züge; dann fing sie an zu zappeln, bis sie mit den Füssen an den Boden kam. Das war noch nicht das Richtige. Lotti wagte gar nicht recht, sich auf das Wasser zu legen.
     </p>
-    <p xml:id="eco_de_0000140_3860">
+    <p xml:id="eco_de_0000210_3860">
      »Ich hab' immer Angst, ich komme mit dem Kopf hinunter und könne dann nicht mehr atmen!« sagte sie.
     </p>
-    <p xml:id="eco_de_0000140_3870">
+    <p xml:id="eco_de_0000210_3870">
      Hans erinnerte Mama daran, dass er letztes Jahr eine Schwummel gehabt habe, mit der er ganz leicht schwimmen gelernt.
     </p>
-    <p xml:id="eco_de_0000140_3880">
+    <p xml:id="eco_de_0000210_3880">
      »Ja, Mama, bitte, mach' uns Schwummeln!« riefen Marianne und Lotti, und Werner, der das Wasser gar nicht liebte und immer mörderlich schrie, wenn Sophie ihn eintauchte, bettelte natürlich mit: »Mir auch eine Schwummel! ich will auch schwimmen!«
     </p>
-    <p xml:id="eco_de_0000140_3890">
+    <p xml:id="eco_de_0000210_3890">
      Zu einer Schwummel brauchte man von den Binsen, die da und dort im See wuchsen, wo er nicht tief war. Man band die leichten Stengel mit Bindfaden zu einem langen, geraden, stark armdicken Bündel zusammen, den man dann in der Mitte knickte und an beiden Enden durch eine Schnur verband. Zum Schwimmen legte man sich in das Dreieck hinein. Eine frische Schwummel trug einen so sicher, dass man damit hätte über den See schwimmen können. Nach und nach wurde sie gelb und welk und trug mit jedem Tage weniger gut. Aber während der Zeit hatte man gelernt, sich selber über Wasser zu halten und vorwärts zu kommen. Und wenn die Schwummel gar nichts mehr taugte, ging das Schwimmen ohne sie.
     </p>
-    <p xml:id="eco_de_0000140_3900">
+    <p xml:id="eco_de_0000210_3900">
      In der Nähe der Seeweid gab es nicht viele und keine grossen Binsen. Man musste sie weiter seeaufwärts holen. Mama versprach aber, dass die Kinder Schwummeln bekommen sollten.
     </p>
-    <p xml:id="eco_de_0000140_3910">
+    <p xml:id="eco_de_0000210_3910">
      »Nur müsst ihr noch eine Weile warten, bis sie hoch und dick gewachsen sind«, sagte sie. »Dann fährt Fritz Völklein oder Sophie einmal mit euch hinaus. Bis dahin zappeln Marianne und Lotti halt noch eine Weile im Wasser herum, so gut es geht.«
     </p>
    </div>
@@ -1275,217 +1275,217 @@
     <head>
      Der böse Mann
     </head>
-    <p xml:id="eco_de_0000140_3920">
+    <p xml:id="eco_de_0000210_3920">
      Der Schulweg, den die drei Turnachkinder zu machen hatten, war eine ganze kleine Reise, und sie erlebten da alles mögliche. Am Morgen freilich musste es schnell gehen. Hans, dessen Klasse viermal um sieben Uhr begann, hatte also meistens schon vor sechs aufzustehen. Das tat er auch pünktlich. Nicht ein einziges Mal war er von der Seeweid zu spät in die Schule gekommen. Marianne und Lotti mussten erst eine Stunde später fertig sein. Doch weil die zu zweit waren, ging das viel schwerer. Man lachte und schwatzte zusammen, und oft konnte man die Frühstücksmilch nur schnell noch stehend hinuntertrinken, was Mama nicht gut fand. Marianne war die Vernünftigere. Sie mahnte zuletzt immer:
     </p>
-    <p xml:id="eco_de_0000140_3930">
+    <p xml:id="eco_de_0000210_3930">
      »Vorwärts, Lotti! Wo hast du deinen Schultornister? So! und das Rechenbüchlein willst du gewiss da lassen! Nimm dein Neunuhrbrot! Du machst doch immer so langsam! Jetzt lauf' ich – ohne dich –!«
     </p>
-    <p xml:id="eco_de_0000140_3940">
+    <p xml:id="eco_de_0000210_3940">
      In die Nachmittagsschule kamen die Kinder meistens auf eine ganz feine und bequeme Art: Wenn es heiss war, liess sich Papa durch den Schiffmann Steppinger vom Kornplatz in die Seeweid zum Essen fahren, und der Steppinger nahm dann in seinem Schiff, das ein breites Verdeck hatte, die Kinder um halb zwei in die Stadt zurück. Auf dem See draussen wehte immer ein wenig frische Luft, Und es war herrlich, so im ruhigen, festen Takte der Ruder dahinzufahren. Man konnte, wenn man wollte, da auch noch schnell die Aufgaben überlesen; Marianne versuchte es hin und wieder. Aber Lotti, die an der Seite sass und die Hand in das helle Wasser tauchte, neckte die Schwester und spritzte sie ins Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_3950">
+    <p xml:id="eco_de_0000210_3950">
      »Das erfrischt dich!« sagte sie das eine Mal, und das andere Mal: »Es ist nur, damit du nicht einschläfst!«
     </p>
-    <p xml:id="eco_de_0000140_3960">
+    <p xml:id="eco_de_0000210_3960">
      Wenn es aber regnete, war der Schulweg auch wieder lustig. Schon das gab einen Spass, dass man den grossen Regenkragen überhing und die Kapuze über den Kopf sog.
     </p>
-    <p xml:id="eco_de_0000140_3970">
+    <p xml:id="eco_de_0000210_3970">
      »Nun sind wir zwei von den sieben Zwergen im Schneewittchen!« lachte dann Lotti und hüpfte herum wie ein übermütiges Bergmännchen. Aber Marianne war schon in ihren Überschuhen; die waren prächtig; man konnte mit ihnen durch alle Pfützen patschen und blieb doch trocken. So ging es munter unter den triefenden Birnbäumen hinauf und die nassen Wege entlang bis in die Stadt zum Hause der Grossmama, das an der Kronengasse ganz nah beim Schulhaus stand. Da wurde fest angeläutet, und alsbald streckte Friederike, Grossmamas Köchin, den Kopf zum Fenster hinaus.
     </p>
-    <p xml:id="eco_de_0000140_3980">
+    <p xml:id="eco_de_0000210_3980">
      »Guten Tag, Friederike, guten Tag!« riefen die Kinder hinauf. »Mama lässt Grossmama grüssen, und ob wir alle drei statt heimzugehen zu ihr zum Mittagessen kommen dürften, weil es so regne?«
     </p>
-    <p xml:id="eco_de_0000140_3990">
+    <p xml:id="eco_de_0000210_3990">
      »Ja wohl, ja wohl!« sagte Friederike, die wusste, dass Grossmama nie nein sagte. »Was befehlen denn die Herrschaften zu Mittag?«
     </p>
-    <p xml:id="eco_de_0000140_4000">
+    <p xml:id="eco_de_0000210_4000">
      Dann riefen die Kinder alles hinauf, was sie gerne assen, und es gab einen ellenlangen Speisezettel, wie Friederike sagte.
     </p>
-    <p xml:id="eco_de_0000140_4010">
+    <p xml:id="eco_de_0000210_4010">
      »Behüte, behüte!« wehrte sie zuletzt. »Da dürft ihr gar nicht in die Schule, sondern müsst beide heraufkommen und mir helfen, sonst werd' ich bis zwölf Uhr nicht fertig!«
     </p>
-    <p xml:id="eco_de_0000140_4020">
+    <p xml:id="eco_de_0000210_4020">
      Marianne und Lotti aber liefen vergnügt die Kronengasse hinauf. Friederike kochte wahrscheinlich nicht gerade das Bestellte; aber etwas Gutes gab es bei Grossmama immer.
     </p>
-    <p xml:id="eco_de_0000140_4030">
+    <p xml:id="eco_de_0000210_4030">
      Wenn man auf dem Hinweg zur Schule immer etwas eilen musste, so ging es auf der Heimkehr um so gemütlicher. Zuerst, durch die Gassen der Stadt, war man immer noch mit einer ganzen Reihe von Schulkindern zusammen; dann sagte eines an dieser Ecke Adieu, ein anderes an jener, und schliesslich blieben die Turnachkinder allein übrig in der breiten Strasse, die zur Stadt hinaus führte. Es standen da wenig Häuser mehr; zwischen ihnen lagen weite Gärten und unbebaute Plätze. Bei einem grossen Hofe blieb Lotti regelmässig stehen; es waren da eine Menge Hühner, gewöhnliche und ausländische mit seltsamen Büscheln auf dem Kopfe und Federgamaschen an den Beinen. Dazwischen stolzierte ein grosser Truthahn, der einen langen blutroten Lappen über dem Schnabel hin und her schwenkte und mit seinen weiss und bräunlichen Schwanzfedern ein Rad schlagen konnte. Lotti fürchtete sich ein wenig vor dem Truthahn und behauptete, er möge sie in ihrem buntkarrierten Kleid nicht ausstehen. Aber sie fand es doch sehr lustig, jedesmal ein paar Schritte in den Hof hineinzugehen, bis das Tier steif und mit ärgerlich aufgepusteten Federn auf sie zukam. Dann lief sie eilig davon.
     </p>
-    <p xml:id="eco_de_0000140_4040">
+    <p xml:id="eco_de_0000210_4040">
      Marianne hatte in der Nähe auch einen Bekannten, mit dem sie aber auf freundlicherem Fusse stand als Lotti mit ihrem Truthahn. Jeden tag hielt vor einer kleinen Wirtschaft ein Milchwagen mit einem alten Schimmel. Der Milchmann ass und trank in der Wirtschaft, und der Schimmel musste draussen warten. Er sah sehr müde aus und hängte traurig den Kopf. Einmal strich ihm Marianne behutsam über die Nase und zog den Rest von ihrem Neunuhrbrot aus der Tasche. Sie streckte es dem Pferde etwas ungeschickt hin; denn sie fürchtete sich vor den langen Zähnen. Da kam ein Dienstmädchen vorbei und zeigte ihr, wie sie das Brot auf die flache Hans legen müsse.
     </p>
-    <p xml:id="eco_de_0000140_4050">
+    <p xml:id="eco_de_0000210_4050">
      Als Marianne weiterging, sah der Schimmel ihr nach. Am nächsten Morgen dachte Marianne schon in der Schule an ihren neuen Freund und sparte fast das ganze Brot für ihn. Und nun bekam der Schimmel jeden Tag sein Frühstück, ein paarmal sogar einige Stücke Zucker, die Mama für ihn spendete. Er kannte Marianne und schnupperte nach ihrer Hand, wenn sie zu ihm kam.
     </p>
-    <p xml:id="eco_de_0000140_4060">
+    <p xml:id="eco_de_0000210_4060">
      Einmal war es zwischen elf und zwölf Uhr sehr heiss. Der arme Schimmel stand in der hellen Sonne am Gartenzaun angebunden; den Kopf hatte er tief zur Erde gesenkt. Marianne hatte grosses Mitleid mit ihrem Freund. Papa hatte kürzlich erzählt, dass die Pferde auch leiden unter der grossen Hitze.
     </p>
-    <p xml:id="eco_de_0000140_4070">
+    <p xml:id="eco_de_0000210_4070">
      »Wenn ich nur einen Schirm hätte!« dachte sie und zog ihre Schürze aus und hielt sie über den Kopf des Schimmels, damit er ein wenig Schatten habe. Zehn Schritte weiter hing eine prächtige dichte Linde aus einem Garten über die Strasse. Aber Marianne konnte doch nicht das Pferd mit dem Wagen bis dahin führen.
     </p>
-    <p xml:id="eco_de_0000140_4080">
+    <p xml:id="eco_de_0000210_4080">
      »Hoho –! was hat denn die kleine Jungfer mit meinem Schimmel zu schaffen?« rief plötzlich ein Mann aus dem offenen Fenster der Wirtschaft heraus.
     </p>
-    <p xml:id="eco_de_0000140_4090">
+    <p xml:id="eco_de_0000210_4090">
      Marianne erschrak; aber dann fasste sie sich ein Herz.
     </p>
-    <p xml:id="eco_de_0000140_4100">
+    <p xml:id="eco_de_0000210_4100">
      »Herr Bodenweiler«, sagte sie höflich – sie hatte hinten an dem Milchwagen gelesen, dass der Milchmann Samuel Bodenweiler heisse und von Walkhofen war – »Herr Bodenweiler, wollten Sie nicht so gut sein und das Pferd an den Schatten dort stellen? Die Sonne brennt ihm so auf den Kopf.«
     </p>
-    <p xml:id="eco_de_0000140_4110">
+    <p xml:id="eco_de_0000210_4110">
      Der Wirt sah nun auch heraus, lachte und sagte etwas zu dem Milchmann, was Marianne nicht verstand. Der schaute zuerst ärgerlich drein; aber dann kam er doch, um sein Pferd am Zaum zu nehmen.
     </p>
-    <p xml:id="eco_de_0000140_4120">
+    <p xml:id="eco_de_0000210_4120">
      »Meinetwegen!« sagte er und führte es unter die Linde.
     </p>
-    <p xml:id="eco_de_0000140_4130">
+    <p xml:id="eco_de_0000210_4130">
      Marianne hatte grosse Freude, als sie am nächsten heissen Tag ihren alten weissen Freund wieder unter dem Baume traf.
     </p>
-    <p xml:id="eco_de_0000140_4140">
+    <p xml:id="eco_de_0000210_4140">
      Wenn sich Lotti von ihrem Truthahn und Marianne von dem Schimmel getrennt hatten, fanden sie etwas weiter draussen den Hans gewöhnlich vor der Schmiede an der Neugasse oder sehr oft drinnen, wo das Feuer aufloderte und der Blasbalg brauste, wo das glühende Eisen im Wasser zischte und die Hammerschläge dröhnten. Das war alles so wild und schön anzusehen. Wenn Hans nur einmal hätte einen Hammer in die Hand nehmen dürfen, um zu versuchen, wie stark sein Arm sei! Er dachte an den Heldenknaben Siegfried, der in der Höhle des Zwerges sich sein Schwert selbst schmiedete. Wenn er nicht so ganz fest im Sinn gehabt hätte, Arzt zu werden wie Onkel Doktor, so wäre er am liebsten ein Schmied geworden. Lotti und Marianne standen meistens auch noch ein Weilchen vor dem sprühenden Feuer, bis es von dem nahen Kirchturm halb zwölf schlug oder gar drei Viertel. Dann fingen alle drei an zu laufen und kamen rasch hinaus, wo ein schmaler Fussweg abzweigte und an Kornfeldern vorbei zur Seeweid führte. »Die Kornfelder«, sagte Hans einmal, »sind unsere Uhr, nicht für den Tag, aber fürs Jahr. Sie zeigen genau, welche Zeit es ist.«
     </p>
-    <p xml:id="eco_de_0000140_4150">
+    <p xml:id="eco_de_0000210_4150">
      Er hatte recht. Im Frühling, wenn die Familie Turnach in die Seeweid zog, sahen die Kornäcker aus wie schöner, dichter Rasen. Dann wuchsen die Halme hoch und höher, und man sah die Ähren daran. Bald waren diese ganz lang und um und um mit graugrünen Staubbeuteln behängt. Zuerst standen die Ähren gerade auf; wenn sie aber anfingen sich zu neigen und gelber zu werden, dann wussten die Kinder, dass die Sommerferien kamen. War das Korn geschnitten, so dass man nur mehr Stoppeln und bald darauf die gepflügte braune Erde sah, so ging's wieder in die Schule. Dann eines Tages waren da auf einmal in langen Reihen Rüben gepflanzt. Die wuchsen auch rasch und sahen rötlich weiss hervor. Das hiess: Nun kommen die langen Abende, wo es kühl wird und man früher ins Zimmer muss. Und wenn die Rüben so gross waren, dass man sie zu Lampen aushöhlen konnte, dann gab es Herbstferien, und man zog aus der Seeweid zurück in die Stadt.
     </p>
-    <p xml:id="eco_de_0000140_4160">
+    <p xml:id="eco_de_0000210_4160">
      Auch die Wiesen wechselten mit jedem Monat ihr Aussehen. Am listigsten war's, wenn sie gemäht waren und das Heu in grossen Haufen lag. Dann konnte man quer über die untere Wiese laufen und auf die kürzeste Weise nach Hause kommen. Am Abend zwar eilte es den Kindern gar nicht so sehr. Sie warfen ihre Schultornister hin und rannten über die Heuhaufen weg. Sie machten Nester, Höhlen und Wälle und begruben einander in dem raschelnden Heu, das so schön nach Sommer roch. Der Knecht Jakob zankte manchmal, wenn die Kinder die schönen Haufen zerstörten. Dann holten sie Rechen und machten alles wieder in Ordnung, bis Sophie mit dem Schwesterlein im Wagen vor dem Hause erschien und hinüber rief: »Die drei Heuer sollen nun endlich heimkommen und ihre Milch trinken!«
     </p>
-    <p xml:id="eco_de_0000140_4170">
+    <p xml:id="eco_de_0000210_4170">
      Letztes Jahr waren die Turnachkinder wie alle Leute manchmal von der Landstrasse ab schräg über einen mit Unkraut bewachsenen Platz gegangen, um auf den unteren Wer zur Seeweid zu kommen. Jetzt war der Platz umzäunt, und man musste einen Umweg machen, der die Turnachkinder ärgerte. An dem Platze stand eine kleine alte Scheune, vor welcher oft ein Mann mit einem gelben strengen Gesicht und grauschwarzem Bart arbeitete. Hans hatte gesehen, dass er einmal einen Knaben, der über den Lattenzaun gestiegen war, böse geschüttelt und gezankt hatte. Seither hassten ihn die Turnachkinder und nannten ihn den bösen Mann.
     </p>
-    <p xml:id="eco_de_0000140_4180">
+    <p xml:id="eco_de_0000210_4180">
      An einem Abend standen Hans und Lotti an dem Zaun; der böse Mann war nicht zu sehen. Sie hatten grosse Lust, über den Platz zu laufen; aber sie wagten es doch nicht.
     </p>
-    <p xml:id="eco_de_0000140_4190">
+    <p xml:id="eco_de_0000210_4190">
      »Es würde ihm und seiner wüsten Wiese da gar nichts schaden«, brummte Hans; »aber er mag andern Leuten nur nichts gönnen.«
     </p>
-    <p xml:id="eco_de_0000140_4200">
+    <p xml:id="eco_de_0000210_4200">
      »Wenn ich ihn wieder sehe, so rufe ich: ›Sie sind ein böser Mann!‹ und springe fort!« sagte Lotti, die manchmal ein wenig unartig war.
     </p>
-    <p xml:id="eco_de_0000140_4210">
+    <p xml:id="eco_de_0000210_4210">
      Da nahm Hans aus seiner Heftmappe ein weisses Blatt und schrieb mit grosser Schrift darauf: »Sie sind ein böser Mann, weil Sie einen nicht mehr über den Platz gehen lassen.«
     </p>
-    <p xml:id="eco_de_0000140_4220">
+    <p xml:id="eco_de_0000210_4220">
      Er schob das Blatt, so weit er konnte, unter dem Lattenzaune durch und beschwerte es mit einem Stein; wenn der böse Mann aus der Scheune kam, konnte er das Blatt sehen.
     </p>
-    <p xml:id="eco_de_0000140_4230">
+    <p xml:id="eco_de_0000210_4230">
      Dann gingen Hans und Lotti heim. Als sie Marianne am Abend erzählten, was sie getan hatten, fand diese es nicht sehr nett. Hans hatte denn auch immer ein etwas schlechtes Gewissen, so oft er in den nächsten Tagen an das Blatt dachte.
     </p>
-    <p xml:id="eco_de_0000140_4240">
+    <p xml:id="eco_de_0000210_4240">
      Am Dienstag darauf war es schon in der letzten Schulstunde zwischen drei und vier Uhr ganz dunkel geworden; die Schüler in Hansens Klasse, die an der Wand sassen, konnten kaum mehr lesen. Als Hans auf die Strasse kam, sah er, dass ein Gewitter heranzog; man hörte schon ein fernes dumpfes Donnerrollen. Hans ging an Mariannens und Lottis Schulhaus vorbei und trieb die beiden Schwestern an, so rasch als möglich mit ihm nach Haus zu gehen. Die drei liefen und liefen und waren schon ziemlich weit draussen, als sie die ersten Tropfen spürten.
     </p>
-    <p xml:id="eco_de_0000140_4250">
+    <p xml:id="eco_de_0000210_4250">
      In der Nähe der Schmiede war ein kleiner Bäckerladen. Die Bäckersfrau stand eben vor der Türe, um an den Himmel zu sehen.
     </p>
-    <p xml:id="eco_de_0000140_4260">
+    <p xml:id="eco_de_0000210_4260">
      »Kinder, Kinder!« rief sie; »ihr kommt nimmer heim! Wartet lieber bei mir das Wetter ab!«
     </p>
-    <p xml:id="eco_de_0000140_4270">
+    <p xml:id="eco_de_0000210_4270">
      Lotti wäre gerne hinein zu der freundlichen Frau. Es roch da so gemütlich mach frischem Brot, und die Bäckerin hatte ihr einmal eine kleine Salzbretzel geschenkt. Aber Hans lief zu, und Lotti rannte hinterdrein, so schnell sie konnte in dem starken Wind, der zu blasen anfing.
     </p>
-    <p xml:id="eco_de_0000140_4280">
+    <p xml:id="eco_de_0000210_4280">
      Da fuhr ein greller Blitzstrahl über den schwarzen Himmel hin, und fast zu gleicher Zeit krachte der Donner ganz furchtbar. Lotti schrieb, und Hans fasste sie an der Hand, damit sie besser vorwärts komme; denn jetzt begann es auch zu regnen. Nein, das war mehr als Regen; das war, wie wenn es in Strömen vom Himmel heruntergösse! Und dazu Blitz auf Blitz und Donnerschlag auf Donnerschlag. Die Kinder waren wie betäubt und mussten gar nicht mehr, wohin sie liefen. Da – vor ihnen war etwas wie ein Haus und ein Dach. Schnell drauf zu! Sie drückten sich alle drei an die Wand. Es war kein rechter Schutz vor dem Regen; aber sie konnten doch wieder Atem schöpfen.
     </p>
-    <p xml:id="eco_de_0000140_4290">
+    <p xml:id="eco_de_0000210_4290">
      »Marianne, Lotti –!« sagte Hans, der sich den Regen aus den Augen gewischt und umhergesehen hatte, »wisst ihr, wo wir sind –? Das ist die Scheune des bösen Mannes! Wir können nicht da bleiben!«
     </p>
-    <p xml:id="eco_de_0000140_4300">
+    <p xml:id="eco_de_0000210_4300">
      Aber Lotti fing an zu weinen; sie wollte nicht wieder in den Gewittersturm hinaus.
     </p>
-    <p xml:id="eco_de_0000140_4310">
+    <p xml:id="eco_de_0000210_4310">
      »Lotti!« mahnte Hans, »denk' doch an das mit dem Blatt Papier. Der böse Mann weiss jedenfalls, dass wir es geschrieben haben. Wenn er uns jetzt da findet –«
     </p>
-    <p xml:id="eco_de_0000140_4320">
+    <p xml:id="eco_de_0000210_4320">
      Im selben Augenblick ging die Türe auf, an die die Kinder sich angelehnt hatten. Der böse Mann sah heraus und zog, ohne ein Wort zu sagen, die drei zur Türe herein und machte zu, ehe sie wussten, was ihnen geschah. Es war, wie wenn ein Riese sie in einen dunkeln Sack geschoben hätte. Lotti zitterte vor Angst und fasste Marianne am Arm. Dem Hans war auch gar nicht gut zu Mute.
     </p>
-    <p xml:id="eco_de_0000140_4330">
+    <p xml:id="eco_de_0000210_4330">
      »Wenn ich nur das nicht geschrieben hätte!« dachte er. Natürlich hatte der böse Mann sie da hereingeholt, um sie zu strafen. Vielleicht würde er sie schlagen, vielleicht einsperren bis in die Nacht …
     </p>
-    <p xml:id="eco_de_0000140_4340">
+    <p xml:id="eco_de_0000210_4340">
      Neben dem bösen Manne stand noch ein anderer mit einer Axt auf der Schulter. Die beiden Männer sprachen halblaut miteinander, und das war sehr unheimlich. Nach einer Weile machte der mit der Axt die Türe ein wenig auf; aber er hielt sie in der Hand; es war an kein Fliehen zu denken.
     </p>
-    <p xml:id="eco_de_0000140_4350">
+    <p xml:id="eco_de_0000210_4350">
      Jetzt ging der böse Mann nach hinten; es war so dunkel dort, dass man nicht sehen konnte, was er tat.
     </p>
-    <p xml:id="eco_de_0000140_4360">
+    <p xml:id="eco_de_0000210_4360">
      »Er holt gewiss einen Stock«, sagte sich Hans, und sein Herz klopfte stark.
     </p>
-    <p xml:id="eco_de_0000140_4370">
+    <p xml:id="eco_de_0000210_4370">
      Als aber der Mann auf Marianne und Lotti zuging, da trat Hans einen Schritt heraus und stellte sich vor die Schwestern.
     </p>
-    <p xml:id="eco_de_0000140_4380">
+    <p xml:id="eco_de_0000210_4380">
      »Ich will ihm sagen«, dachte er, »dass ich allein das Blatt geschrieben habe, und dass er Marianne und Lotti nichts tun darf. Lotti hat zwar auch unartig von ihm geredet; aber sie ist noch klein. Er soll mich allein schlagen –«
     </p>
-    <p xml:id="eco_de_0000140_4390">
+    <p xml:id="eco_de_0000210_4390">
      Doch der böse Mann hatte keinen Stock in der Hand.
     </p>
-    <p xml:id="eco_de_0000140_4400">
+    <p xml:id="eco_de_0000210_4400">
      »Mach' nur die Türe wieder auf, Göhringer!« rief er zu dem mit der Axt, und die Kinder sahen, dass er beide Hände voll Haselnüsse hatte.
     </p>
-    <p xml:id="eco_de_0000140_4410">
+    <p xml:id="eco_de_0000210_4410">
      »Da!« sagte er, indem er jedem einen Teil gab, »und nun lauft heim, der Regen hat fast aufgehört. Ihr seid ja tropfnass!«
     </p>
-    <p xml:id="eco_de_0000140_4420">
+    <p xml:id="eco_de_0000210_4420">
      Die Kinder waren so verwirrt, dass sie zu grüssen und zu danken vergassen. Ohne zu sprechen gingen sie auf dem Weg hintereinander her. Dann fing Lotti an:
     </p>
-    <p xml:id="eco_de_0000140_4430">
+    <p xml:id="eco_de_0000210_4430">
      »Siehst du, Hans! Nun war das ganz falsch! Er ist gar nicht böse. Mir hat er elf Haselnüsse gegeben. Wie viel hast du, Marianne? Und ich hab' solche Angst gehabt. Und du hast dich auch gefürchtet, Hans! Ich hab's ganz gut gemerkt!«
     </p>
-    <p xml:id="eco_de_0000140_4440">
+    <p xml:id="eco_de_0000210_4440">
      »Hans«, sagte Marianne, »wenn er nur den Zettel nicht gefunden hat! Das ist gewiss schrecklich, wenn man so etwas liest. Einmal hat Klara Wienig in der Schule der Rosa Schurmann geschrieben, sie möge mich nicht leiden, und das Briefchen habe ich gefunden, weil die Rosa Schurmann neben mir sitzt. Da war ich den ganzen Tag traurig.«
     </p>
-    <p xml:id="eco_de_0000140_4450">
+    <p xml:id="eco_de_0000210_4450">
      Hans gab keine Antwort; er schämte sich zu sehr. Am Abend aber erzählte er der Mama die ganze Geschichte. Wenn man etwas Dummes oder Böses gemacht hatte, war es doch immer am besten, mit Mama darüber zu sprechen. Sie tadelte einen manchmal streng und strafte auch etwa; aber nachher war einem wieder leichter.
     </p>
-    <p xml:id="eco_de_0000140_4460">
+    <p xml:id="eco_de_0000210_4460">
      »Unartig und auch recht dumm!« sagte Mama, als sie alles gehört hatte. »Es ist gut, dass du die Angst in der Scheune ausgestanden hast. Das hat dir gehört und auch dem Lotti. Natürlich war es nur das böse Gewissen, das dich quälte; das hat dir eingeflüstert, der Mann werde euch einsperren und schlagen. Sonst wärest du gar nicht auf den Gedanken gekommen, sondern hättest gleich gemerkt, das der Mann euch bloss herein holte wegen dem Unwetter. Was du auf das Papier geschrieben hast, war sehr ungezogen. Wie könnt ihr so schnell bereit sein, von einem Menschen zu sagen – er ist böse! oder: Ich hasse ihn! Jedenfalls habt ihr dem Manne Unrecht getan.«
     </p>
-    <p xml:id="eco_de_0000140_4470">
+    <p xml:id="eco_de_0000210_4470">
      »Aber es war nicht nett, dass er einen nicht mehr über den Platz gehen liess«, meinte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_4480">
+    <p xml:id="eco_de_0000210_4480">
      »Dafür wird er seine Gründe haben, Lotti. Und wer weiss, wie manchmal der Bube, den er jenesmal schüttelte, ihn geärgert hat!«
     </p>
-    <p xml:id="eco_de_0000140_4490">
+    <p xml:id="eco_de_0000210_4490">
      »Mama, wenn du wüsstest, was für ein böses Gesicht der Mann immer gemacht hat!« sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_4500">
+    <p xml:id="eco_de_0000210_4500">
      »Er ist vielleicht krank oder hat irgend eine Sorge. Nicht alle Leute haben es so gut wie ihr und mögen den ganzen Tag lachen. Ihr könnt nicht immer verstehen, warum einer ein ernsthaftes oder finsteres Gesicht macht; seid nur stets selber freundlich gegen jedermann und denkt freundlich von ihm.«
     </p>
-    <p xml:id="eco_de_0000140_4510">
+    <p xml:id="eco_de_0000210_4510">
      Am andern Abend und am darauf folgenden warteten die Turnachkinder lange vor der Scheune, um den Mann zu sehen. Am dritten stand er wirklich vor seiner Türe.
     </p>
-    <p xml:id="eco_de_0000140_4520">
+    <p xml:id="eco_de_0000210_4520">
      Hans ging auf ihn zu, etwas zaghaft; aber er hatte sich's fest vorgenommen.
     </p>
-    <p xml:id="eco_de_0000140_4530">
+    <p xml:id="eco_de_0000210_4530">
      »Guten Abend, Herr –!« Hans hustete ein wenig, weil er den Namen nicht wusste. »Guten Abend. Wir haben am Dienstag ganz vergessen zu danken für die Haselnüsse und auch, dass Sie uns haben unterstehen lassen.«
     </p>
-    <p xml:id="eco_de_0000140_4540">
+    <p xml:id="eco_de_0000210_4540">
      »Schon recht, schon recht!« sagte der Mann. »Das ist ja nicht der Rede wert.«
     </p>
-    <p xml:id="eco_de_0000140_4550">
+    <p xml:id="eco_de_0000210_4550">
      Hans war aber noch nicht fertig: »Und es tut mir sehr leid, wenn Sie etwa das Blatt gefunden haben, wo ich das – es war – ich –« Hans wurde sehr verlegen und kam nicht mehr weiter.
     </p>
-    <p xml:id="eco_de_0000140_4560">
+    <p xml:id="eco_de_0000210_4560">
      Der Mann verstand ihn auch offenbar nicht.
     </p>
-    <p xml:id="eco_de_0000140_4570">
+    <p xml:id="eco_de_0000210_4570">
      »Was willst du? Ein Blatt? Hast du eins verloren? Ich habe keins gefunden.« Damit nickte er den Kindern zu und wendete sich zur Scheune zurück.
     </p>
-    <p xml:id="eco_de_0000140_4580">
+    <p xml:id="eco_de_0000210_4580">
      Wie war Hans froh! Das fatale Blatt hatte ihm immer noch im Sinn gelegen.
     </p>
-    <p xml:id="eco_de_0000140_4590">
+    <p xml:id="eco_de_0000210_4590">
      »Nie, nie mehr tu' ich so etwas!« sagte er zu den Schwestern.
     </p>
-    <p xml:id="eco_de_0000140_4600">
+    <p xml:id="eco_de_0000210_4600">
      Als sie aber ein Dutzend Schritte gegangen waren, drehte sich das kecke, kleine Lotti noch einmal um und rief: »Die Haselnüsse waren sehr gut! Ich hatte gar keine taube und Hans auch nicht und Marianne bloss eine einzige!«
     </p>
-    <p xml:id="eco_de_0000140_4610">
+    <p xml:id="eco_de_0000210_4610">
      Da lachte der Mann ein wenig. Alle drei Kinder hatten deutlich gesehen, dass er gelacht hatte.
     </p>
-    <p xml:id="eco_de_0000140_4620">
+    <p xml:id="eco_de_0000210_4620">
      Er hiess nun bei den Turnachkindern der Haselnussmann, und jedesmal, wenn sie ihn bei der Scheune sahen, nickten die Mädchen, und Hans zog höflich seinen Hut ab.
     </p>
    </div>
@@ -1493,283 +1493,283 @@
     <head>
      Hans macht eine neue Bekanntschaft und sammelt alte Schuhe.
     </head>
-    <p xml:id="eco_de_0000140_4630">
+    <p xml:id="eco_de_0000210_4630">
      Bald darauf erlebte Hans wieder eine seltsame Geschichte auf dem Schulweg. Gegenüber der Schmiede standen an der Seitengasse eine Reihe aneinander gebauter Häuser. Eigentlich waren sie neu; aber sie sahen öde und unschön aus. Ringsum war kein Baum und kein Blumengärtlein. Aus den Fenstern hing unordentliche Wäsche, und die Frauen und Kinder, die zum Vorschein kamen, waren auch nicht sauber und nett anzusehen. Seit einer Woche bemerkte Hans vor dem zweiten Hause immer eine Anzahl Buben, die einander herumstiessen, bis einer die Türe aufriss und etwas hineinrief. Dann rannten alle schreiend und lachend davon.
     </p>
-    <p xml:id="eco_de_0000140_4640">
+    <p xml:id="eco_de_0000210_4640">
      »Da ist gewiss jemand drin, den sie ärgern wollen!« dachte Hans und war im Begriff, das seht ungezogen zu finden, als ihm der Haselnussmann einfiel. So arg wie diese Buben hatten er und Lotti es ja nicht gemacht; aber artig war es auch nicht gewesen.
     </p>
-    <p xml:id="eco_de_0000140_4650">
+    <p xml:id="eco_de_0000210_4650">
      Hans blieb stehen. Ob sie wohl gar nicht aufhören wollten? Da fuhren sie plötzlich zurück. Jemand tat von innen die Türe auf und kam heraus. Es war eine alte Frau mit einem Stocke, den sie böse gegen die Buben streckte. Die grauen Haare hingen ihr um das magere kleine Gesicht, das mit seiner langen gebogenen Nase ein wenig an einen Vogelkopf erinnerte. Es sah grade aus, als ob die Frau einen picken könnte. Sie hielt sich schlecht auf den Füssen und brauchte den Stock sonst jedenfalls, um sich darauf zu stützen. Hastig humpelte sie die Stufen vor der Türe hinunter, um den Buben nachzulaufen, die aber längst hinter der Hausecke verschwunden waren.
     </p>
-    <p xml:id="eco_de_0000140_4660">
+    <p xml:id="eco_de_0000210_4660">
      »Nun fällt sie –!« dachte Hans, und in demselben Augenblick war es auch geschehen. Die alte Frau lag auf der Erde.
     </p>
-    <p xml:id="eco_de_0000140_4670">
+    <p xml:id="eco_de_0000210_4670">
      Hans hielt einen Augenblick an, ob sie nicht von selber wieder aufstehe; sie sah gar so böse und hässlich aus. Aber dann sprang er hinzu. Man konnte sie doch nicht so liegen lassen. Er versuchte ihr aufzuhelfen; doch es ging gar nicht leicht. Er sah um sich; nein, so schlechte Buben, wie das waren! Dort an der Ecke guckten sie hervor und lachten, und keinem fiel es ein, zu kommen! Endlich brachte Hans die Frau doch auf die Füsse. Sie keuchte und hustete und schien gar nicht recht zu wissen, was vorging.
     </p>
-    <p xml:id="eco_de_0000140_4680">
+    <p xml:id="eco_de_0000210_4680">
      »Hat es Ihnen weh getan?« fragte Hans, indem er sich bemühte, freundlich in das Vogelgesicht zu sehen. Die Alte hinkte ohne Antwort schnaufend die Stufen hinauf und hielt sich fest an Hans; er musste mit in den engen Hausflur. Aber an der Stubentüre gab er der Frau den Stock, damit sie nun wieder allein gehen könne. Die Alte, als ob sie sich plötzlich besinne, sah Hans mit ihren schwarzen Äuglein, die in hundert Falten steckten, zornig an und hob den Stock, um ihn zu schlagen.
     </p>
-    <p xml:id="eco_de_0000140_4690">
+    <p xml:id="eco_de_0000210_4690">
      »Wart', du miserabler Kerl, nun haben wir dich!« rief sie.
     </p>
-    <p xml:id="eco_de_0000140_4700">
+    <p xml:id="eco_de_0000210_4700">
      Hans konnte ausweichen. Aber er wurde sehr böse. Das war doch zu arg, wenn man jemand half und dafür noch Schläge und Schimpfworte bekommen sollte.
     </p>
-    <p xml:id="eco_de_0000140_4710">
+    <p xml:id="eco_de_0000210_4710">
      »Grossmutter, Grossmutter, was ist –?« rief drinnen eine Stimme, und ein blasser junger Mann mit struppigem Kopf und ohne Halskragen sah aus der Türe.
     </p>
-    <p xml:id="eco_de_0000140_4720">
+    <p xml:id="eco_de_0000210_4720">
      »Ich habe ihr nichts getan!« sagte Hans und sah dem jungen Mann grade ins Gesicht; denn er hatte ein gutes Gewissen. »Die Buben draussen haben sie ausgelacht, und da ist sie gefallen, und ich habe ihr geholfen aufstehen, und –«
     </p>
-    <p xml:id="eco_de_0000140_4730">
+    <p xml:id="eco_de_0000210_4730">
      Hans wollte noch hinzufügen: »Und sie brauchte mich eigentlich nicht zu schimpfen.« Aber der junge Mann wandte sich erschrocken zu seiner Grossmutter und fragte sie mit vielen guten Worten, ob sie sich doch nicht verletzt habe. Er sprach sehr laut; die alte Frau schien schlecht zu hören.
     </p>
-    <p xml:id="eco_de_0000140_4740">
+    <p xml:id="eco_de_0000210_4740">
      Ein Schaden war ihr offenbar nicht geschehen. Sie schüttelte den Kopf und setzte sich in der Stube auf einen Stuhl. Da schalt sie vor sich hin, während sie ihre Schürze abrieb, die schmutzig geworden war.
     </p>
-    <p xml:id="eco_de_0000140_4750">
+    <p xml:id="eco_de_0000210_4750">
      Der junge Mann aber streckte Hans die Hand hin.
     </p>
-    <p xml:id="eco_de_0000140_4760">
+    <p xml:id="eco_de_0000210_4760">
      »Ich danke Ihnen recht viel mal, mein kleiner Herr, und verzeihen Sie doch! Das hat vorhin ja nicht Ihnen gegolten, sondern den Buben, die meine Grossmutter immer so plagen! Wollen Sie nicht eintreten und einen Augenblick Platz nehmen?«
     </p>
-    <p xml:id="eco_de_0000140_4770">
+    <p xml:id="eco_de_0000210_4770">
      Der junge Mann sprach mit einer fremdländischen Betonung. Er ging eilig zu einer Bank und schob einen Teller und allerlei Zeug auf die Seite. Am Fenster war ein Tritt; davor lagen auf einem niedrigen Tisch einige alte Schuhe und allerlei Werkzeug. Es sah unordentlich aus in der Stube und roch sehr schlecht nach angebrannten Kartoffeln, Leder und alten Kleidern. Hans wäre lieber nicht hereingekommen; aber der junge Mann war so höflich und hatte so traurige Augen und eingefallene Backen. Hans setzte sich etwas verlegen und drehte an seinem Hut.
     </p>
-    <p xml:id="eco_de_0000140_4780">
+    <p xml:id="eco_de_0000210_4780">
      »Wenn die Grossmutter nur nicht so wäre!« sagte der junge Mann leise. »Wir wohnen erst seit sechs Wochen hier, und schon sind alle Leute in der Nachbarschaft gegen die Grossmutter; sie wird gleich so zornig und zankt. Die Buben rufen ihr ›Hexe‹ nach –«
     </p>
-    <p xml:id="eco_de_0000140_4790">
+    <p xml:id="eco_de_0000210_4790">
      »Sie sieht auch so aus!« dachte Hans; aber dann fiel ihm ein, was Mama neulich vom Haselnussmann gesagt hatte.
     </p>
-    <p xml:id="eco_de_0000140_4800">
+    <p xml:id="eco_de_0000210_4800">
      »Vielleicht ist Ihre Grossmutter ein wenig krank«, sagte er zu dem jungen Mann, »oder sie hat Kummer!«
     </p>
-    <p xml:id="eco_de_0000140_4810">
+    <p xml:id="eco_de_0000210_4810">
      Der junge Mann sah Hans freundlich an.
     </p>
-    <p xml:id="eco_de_0000140_4820">
+    <p xml:id="eco_de_0000210_4820">
      »Das ist es eben! Viel Kummer und Unglück hat sie im Leben gehabt, und ein paarmal waren böse Menschen daran schuld. Jetzt will sie gar nimmer glauben, dass es auch noch gute Leute gibt – und wir hätten sie doch sehr nötig, die guten Leute, mein kleiner Herr. Ich bin Schuhmacher, und letzten Winter bin ich lang krank gewesen. Jetzt haben wir diese Wohnung genommen, weil sie billiger war. Aber ich bekomme fast keine Arbeit. Meine Grossmutter müsste eben freundlicher sein mit den Leuten. Keiner aus der Nachbarschaft bringt mir seine Schuhe. Und doch kann ich sagen, dass ich gut flicke und billig. – Das Leben ist sehr schwer, mein kleiner Herr. Sie wissen noch nicht wie schwer.«
     </p>
-    <p xml:id="eco_de_0000140_4830">
+    <p xml:id="eco_de_0000210_4830">
      Hans hatte grosses Mitleid. Vielleicht bekam der junge Mann nicht einmal genug zu essen. Und es war doch gewiss schrecklich, wenn man Geld verdienen wollte und die Leute gaben einem keine Arbeit.
     </p>
-    <p xml:id="eco_de_0000140_4840">
+    <p xml:id="eco_de_0000210_4840">
      Hans stand auf. Es trieb ihn heim, dass er das alles erzählen könne, und es ging ihm ein Gedanke im Kopf herum.
     </p>
-    <p xml:id="eco_de_0000140_4850">
+    <p xml:id="eco_de_0000210_4850">
      Er gab dem jungen Mann die Hand und ging auch zu der alten Frau hin, um Adieu zu sagen.
     </p>
-    <p xml:id="eco_de_0000140_4860">
+    <p xml:id="eco_de_0000210_4860">
      »Grossmutter!« sagte der junge Mann laut. »Der freundliche kleine Herr, der dir geholfen hat, will wieder gehen.«
     </p>
-    <p xml:id="eco_de_0000140_4870">
+    <p xml:id="eco_de_0000210_4870">
      Die alte Frau sah Hans an.
     </p>
-    <p xml:id="eco_de_0000140_4880">
+    <p xml:id="eco_de_0000210_4880">
      »So, so, der freundliche kleine Herr, der mir geholfen hat«, wiederholte sie.
     </p>
-    <p xml:id="eco_de_0000140_4890">
+    <p xml:id="eco_de_0000210_4890">
      »Mischa«, sagte sie dann, und ihre schwarzen Augen schauten nicht mehr böse drein, »Mischa, nimm mein Gebetbuch im Schrank unter dem gelben Halstuch. Es liegt ein Bild drin. Gib das dem kleinen Herrn.«
     </p>
-    <p xml:id="eco_de_0000140_4900">
+    <p xml:id="eco_de_0000210_4900">
      Mischa fand das Bild. Es war eine Frau darauf in blauem Kleid mit einem roten Mantel und starken Goldstrahlen um den Kopf. Ihre Hand hielt sie auf einem grossen Rad. Hans fand es nett, dass die Frau ihm etwas schenkte; er schüttelte ihr dankend die Hand, legte das Bild in seine Heftmappe und verliess dann den jungen Schuhmacher und seine Grossmutter.
     </p>
-    <p xml:id="eco_de_0000140_4910">
+    <p xml:id="eco_de_0000210_4910">
      Aber das Abenteuer dieses Vormittags war noch nicht zu Ende. Als Hans die Stufen vor der Haustüre hinuntersprang, pfiff und schrie es von der Strassenecke her, und zwei, drei – ein halbes Dutzend Buben schauten hervor.
     </p>
-    <p xml:id="eco_de_0000140_4920">
+    <p xml:id="eco_de_0000210_4920">
      »Etsch! etsch! hoho!« riefen sie durcheinander. »Seht mal den! das ist der Freund von der alten Zritschek, von der alten Hexe! das ist der Hexenfreund! Hoho, der Hexenfreund oder der Hexenlehrbub …«
     </p>
-    <p xml:id="eco_de_0000140_4930">
+    <p xml:id="eco_de_0000210_4930">
      Hans fand es entsetzlich, so verhöhnt zu werden, wo er doch den Buben gar nichts getan hatte. Sein Herz klopfte vor Zorn. Da flog ihm gar noch etwas an die Achsel. Es tat nicht weh; es war ein Grasbüschel mit Erde daran. Aber diese Schmach musste gerächt werden. Hans warf den Schulsack an einen Zaun und rannte zurück nach den Buben. Doch mit Hallo fuhren diese auseinander und verschwanden hinter den Häusern.
     </p>
-    <p xml:id="eco_de_0000140_4940">
+    <p xml:id="eco_de_0000210_4940">
      »Feig' sind sie auch noch!« dachte Hans ergrimmt. Er hatte keine Lust, einen zweiten Angriff abzuwarten, sondern nahm seinen Schulsack und lief heim.
     </p>
-    <p xml:id="eco_de_0000140_4950">
+    <p xml:id="eco_de_0000210_4950">
      Gerade kam er noch recht zum Mittagessen. Aber er wurde mit seiner Suppe gar nicht fertig, so viel hatte er zu erzählen. Marianne, Lotti und der kleine Werner horchten erstaunt, und auch Papa und Mama nahmen lebhaften Anteil.
     </p>
-    <p xml:id="eco_de_0000140_4960">
+    <p xml:id="eco_de_0000210_4960">
      »Weisst du, Papa«, unterbrach Hans sich selbst. »Das war eigentlich greulich. Dafür, dass ich der alten Frau aufgeholfen habe, hat sie mich geschimpft und mit dem Stock schlagen wollen. Nachher hat sie mir ja das Bild gegeben; aber dann kamen noch die Buben, die mich ausspotteten!«
     </p>
-    <p xml:id="eco_de_0000140_4970">
+    <p xml:id="eco_de_0000210_4970">
      »Ja, ja«, sagte Papa lachend. »In den Erzählungen, die ihr lest, werden die kleinen Wohltäter meistens gelobt und belohnt. Im Leben geht es aber oft anders. Daran muss man sich gewöhnen, Hans.«
     </p>
-    <p xml:id="eco_de_0000140_4980">
+    <p xml:id="eco_de_0000210_4980">
      Nach dem Essen hatten Marianne und Lotti hundert Fragen und wollten die ganze Geschichte noch einmal hören.
     </p>
-    <p xml:id="eco_de_0000140_4990">
+    <p xml:id="eco_de_0000210_4990">
      »Wie heisst er?« frug Lotti. »Mischa? Das ist aber ein komischer Name. Möchtest du Mischa heissen, Hans? Und die Frau mit den bösen Augen –! Sieh, Werner, so hat sie dreingesehen –« Lotti machte eine solch schreckliche Grimasse, dass der kleine Bruder sich fürchtete.
     </p>
-    <p xml:id="eco_de_0000140_5000">
+    <p xml:id="eco_de_0000210_5000">
      »Ach, Lotti!« sagte Hans, »du willst immer nur lachen. Wir haben jetzt anderes zu denken. Wir müssen zerrissene Schuhe und Stiefel sammeln, damit Mischa Arbeit bekommt. Mama erlaubt es; ich habe sie schon gefragt.«
     </p>
-    <p xml:id="eco_de_0000140_5010">
+    <p xml:id="eco_de_0000210_5010">
      »Ja, und dann nehmen wir unseren Wagen«, rief Lotti, »und fahren die Schuhe zu Frau Zri – wie heisst's? Zritschek! Du, Marianne, das klingt gerade, wie wenn man niesen muss!«
     </p>
-    <p xml:id="eco_de_0000140_5020">
+    <p xml:id="eco_de_0000210_5020">
      Die Kinder liefen mit einander zu Sophie, dass sie nach schadhaftem Schuhwerk sehe. Es war aber nicht viel vorhanden. Bloss Mariannes Sonntagstiefelchen konnten neue Absätze brauchen, und Papas Hausschuhe mussten geflickt werden.
     </p>
-    <p xml:id="eco_de_0000140_5030">
+    <p xml:id="eco_de_0000210_5030">
      »Wir wollen aber Mischa mehr bringen«, sagte Hans und ging mit den Schwestern zu Balbine in die Küche.
     </p>
-    <p xml:id="eco_de_0000140_5040">
+    <p xml:id="eco_de_0000210_5040">
      »Bitte, Balbine«, fragte Marianne, »sind nicht vielleicht deine Pantoffeln zerrissen?«
     </p>
-    <p xml:id="eco_de_0000140_5050">
+    <p xml:id="eco_de_0000210_5050">
      »Du liebe Güte! warum sollen denn jetzt meine Pantoffeln zerrissen sein!« wehrte sich Balbine. »Ich hab' nie zerrissene Pantoffeln!« und um das zu beweisen, zog sie den einen Hausschuh vom Fusse und zeigte die Sohle.
     </p>
-    <p xml:id="eco_de_0000140_5060">
+    <p xml:id="eco_de_0000210_5060">
      »O, o, ein Loch, ein Loch!« schrie Lotti, »Hier an der Seite ist ein Loch!«
     </p>
-    <p xml:id="eco_de_0000140_5070">
+    <p xml:id="eco_de_0000210_5070">
      »Ein Loch –?« erwiderte Balbine beleidigt. »Wo doch bloss das Leder etwas abgetreten ist? Da geh' ich noch mindestens zwei Wochen drauf.«
     </p>
-    <p xml:id="eco_de_0000140_5080">
+    <p xml:id="eco_de_0000210_5080">
      Aber die Kinder erklärten Balbine, warum sie durchaus Schuhe mit Löchern haben mussten, und liessen nicht nach mit Betteln. Hans erklärte sich bereit, einen Zehner an Balbines Ausgabe beizusteuern, und Marianne und Lotti wollten jede einen Fünfer geben.
     </p>
-    <p xml:id="eco_de_0000140_5090">
+    <p xml:id="eco_de_0000210_5090">
      »Meinetwegen also«, sagte Balbine. »Aber er soll vorläufig bloss einen Fleck draufsetzen und vernähen.«
     </p>
-    <p xml:id="eco_de_0000140_5100">
+    <p xml:id="eco_de_0000210_5100">
      Schliesslich bekamen sie von Frau Völklein noch ein Paar warme Schuhe, die neue Sohlen brauchten.
     </p>
-    <p xml:id="eco_de_0000140_5110">
+    <p xml:id="eco_de_0000210_5110">
      »Anziehen tu' ich die erst im Winter«, sagte die gute Frau. »Aber wenn's euch freut und wenn damit dem armen Schuhmacher ein wenig geholfen wird, dann nehmt sie nur mit.«
     </p>
-    <p xml:id="eco_de_0000140_5120">
+    <p xml:id="eco_de_0000210_5120">
      Am Nachmittag war keine Schule; so rückten denn Hans und Lotti gleich nach drei Uhr aus. Marianne wollte das nächste Mal mitgehen. Sie hatte für Grossmamas Geburtstag eine kleine Tasche fertig zu sticken.
     </p>
-    <p xml:id="eco_de_0000140_5130">
+    <p xml:id="eco_de_0000210_5130">
      Hans zog den Wagen, und Lotti ging eifrig plaudernd nebenher. Als sie von der Strasse in die Gasse einbogen, wo Mischa Zritschek wohnte, hielt Hans plötzlich an und sah aufmerksam nach den neuen Häusern.
     </p>
-    <p xml:id="eco_de_0000140_5140">
+    <p xml:id="eco_de_0000210_5140">
      »Lotti«, sagte er leise, »jetzt kannst du dann sehen, wie das heut' vormittag war. Dort stehen sie wieder! Aber wir gehen doch. Es wäre eine Schande, deswegen Mischa die Schuhe nicht zu bringen.«
     </p>
-    <p xml:id="eco_de_0000140_5150">
+    <p xml:id="eco_de_0000210_5150">
      »Ich fürchte mich nicht«, versicherte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_5160">
+    <p xml:id="eco_de_0000210_5160">
      »Hätten wir lieber den Wagen nicht mitgenommen«, sagte Hans. »Eines von uns muss jetzt draussen bleiben und ihn bewachen. Die Buben könnten ihn sonst nehmen.«
     </p>
-    <p xml:id="eco_de_0000140_5170">
+    <p xml:id="eco_de_0000210_5170">
      Lotti wollte nicht allein zu den Zritscheks hinein und übernahm es, den Wagen zu hüten.
     </p>
-    <p xml:id="eco_de_0000140_5180">
+    <p xml:id="eco_de_0000210_5180">
      »Ich bin schnell wieder da«, sagte Hans. »Wenn sie zu nah kommen, dann ruf' du.«
     </p>
-    <p xml:id="eco_de_0000140_5190">
+    <p xml:id="eco_de_0000210_5190">
      »Geh nur«, erwiderte Lotti und stellte sich mit der Wagendeichsel in der Hand tapfer an die Treppenstufen.
     </p>
-    <p xml:id="eco_de_0000140_5200">
+    <p xml:id="eco_de_0000210_5200">
      Aber die Buben, die sich wieder versteckt hatten, kamen näher, als Hans hineingegangen war. Sie fingen an hässlich zu lachen und zu rufen:
     </p>
-    <p xml:id="eco_de_0000140_5210">
+    <p xml:id="eco_de_0000210_5210">
      »Oho, das wird lustig! die will auch zur alten Zritschek, zur alten Hexe. Eine junge Hexe, haha! die kann gewiss noch nicht recht hexen!«
     </p>
-    <p xml:id="eco_de_0000140_5220">
+    <p xml:id="eco_de_0000210_5220">
      Nein, Hans hatte recht. Es war grässlich, so ausgespottet zu werden. Lotti bereute, dass nicht sie mit den Schuhen hineingegangen war. Nun entdeckten die Buben den Wagen und traten ganz nah hinzu. In einem Kreis stellten sie sich um Lotti herum. Lotti stand unbeweglich und sah die Buben an. Wenn nur einer von ihnen ein freundliches Gesicht gemacht hätte! Lotti war ein fröhliches Kind, das am liebsten lachte; sie konnte es nicht leiden, wenn jemand sie böse ansah. Da kam ihr plötzlich ein Gedanke. Sie fuhr mit der Hand in die Tasche. »Willst du den Bleistift?« fragte sie den grössten der Buben.
     </p>
-    <p xml:id="eco_de_0000140_5230">
+    <p xml:id="eco_de_0000210_5230">
      Er hatte rotbraunes Haar und eine zerrissene Jacke. Lotti hielt ihm einen Bleistift hin. Er war nicht mehr sehr lang, aber schön blau, und hatte hinten einen Metallknopf.
     </p>
-    <p xml:id="eco_de_0000140_5240">
+    <p xml:id="eco_de_0000210_5240">
      Der Bube drehte sich halb weg und machte ein verächtliches Gesicht; aber dann streckte er doch die Hand nach dem Bleistift aus:
     </p>
-    <p xml:id="eco_de_0000140_5250">
+    <p xml:id="eco_de_0000210_5250">
      »Gib her!«
     </p>
-    <p xml:id="eco_de_0000140_5260">
+    <p xml:id="eco_de_0000210_5260">
      Die andern Buben drängten sich noch näher, und ein ganz frecher gab Lottis Wagen einen Stoss:
     </p>
-    <p xml:id="eco_de_0000140_5270">
+    <p xml:id="eco_de_0000210_5270">
      »Eh, wie die gross tut! Was hast du denn weiter in deiner Tasche?«
     </p>
-    <p xml:id="eco_de_0000140_5280">
+    <p xml:id="eco_de_0000210_5280">
      »Sei du nicht so grob!« sagte der mit dem Bleistift und riss den Kameraden am Arm.
     </p>
-    <p xml:id="eco_de_0000140_5290">
+    <p xml:id="eco_de_0000210_5290">
      Derweil hatte Lotti noch etwas gefunden. Sie trug immer eine Sammlung von allerlei Dingen mit sich herum, die sie da und dort aufgehoben oder zusammengebettelt hatte und dann etwa wieder verschenkte.
     </p>
-    <p xml:id="eco_de_0000140_5300">
+    <p xml:id="eco_de_0000210_5300">
      »Da –« es war ein aus grünen Samtbändern geflochtenes Zöpfchen mit einer kleinen Schnalle, das sie einem der Buben hinstreckte, nicht dem ganz frechen, der vorhin dem Wagen einen Stoss gegeben hatte, sondern einem jüngern mit einer verschabten Lederschürze.
     </p>
-    <p xml:id="eco_de_0000140_5310">
+    <p xml:id="eco_de_0000210_5310">
      »Da! wenn du's nicht selber brauchst, kannst du's vielleicht deiner Schwester geben. Sie kann es als Armband tragen. Hast du eine Schwester?«
     </p>
-    <p xml:id="eco_de_0000140_5320">
+    <p xml:id="eco_de_0000210_5320">
      Der Kleine nickte.
     </p>
-    <p xml:id="eco_de_0000140_5330">
+    <p xml:id="eco_de_0000210_5330">
      »Ich auch; sie heisst Marianne; sie geht in die dritte Klasse und ich in die zweite. Hans ist schon gross; er geht in die fünfte. Jetzt ist er bei den Zritscheks drin. Ihr müsst aber die Frau nicht auslachen. Man darf alte Leute nicht verspotten und ihnen nachlaufen. Die Frau hat Hans ein Bild geschenkt mit einem Goldschein. Und er hat gesagt, wenn man länger bei ihr sei, so sei sie gar nicht so böse. Herr Mischa war krank, und jetzt möchte er Schuhe flicken …«
     </p>
-    <p xml:id="eco_de_0000140_5340">
+    <p xml:id="eco_de_0000210_5340">
      Lottis flinkes Mäulchen ging so fort, und die Buben standen um sie herum und hörten ihr zu.
     </p>
-    <p xml:id="eco_de_0000140_5350">
+    <p xml:id="eco_de_0000210_5350">
      Jetzt trat Hans aus dem Hause.
     </p>
-    <p xml:id="eco_de_0000140_5360">
+    <p xml:id="eco_de_0000210_5360">
      »Wollt ihr machen, dass ihr von meiner Schwester wegkommt!« rief er zornig und sprang die Stufen herunter.
     </p>
-    <p xml:id="eco_de_0000140_5370">
+    <p xml:id="eco_de_0000210_5370">
      Aber Lotti fasste ihn am Arm.
     </p>
-    <p xml:id="eco_de_0000140_5380">
+    <p xml:id="eco_de_0000210_5380">
      »Hans«, flüsterte sie rasch, »du musst keinen Streit anfangen. Sie sind nicht mehr so unartig. Sie haben mir nichts getan, und ich habe ihnen gesagt, sie sollen die alte Frau Zritschek nicht immer so plagen.«
     </p>
-    <p xml:id="eco_de_0000140_5390">
+    <p xml:id="eco_de_0000210_5390">
      »Also dann komm«, sagte Hans und nahm die Wagendeichsel in die Hand.
     </p>
-    <p xml:id="eco_de_0000140_5400">
+    <p xml:id="eco_de_0000210_5400">
      Aber die Buben gaben nicht recht Raum, sondern sprachen eifrig untereinander.
     </p>
-    <p xml:id="eco_de_0000140_5410">
+    <p xml:id="eco_de_0000210_5410">
      »Wir wollen der alten Zritschek morgen und übermorgen nicht nachrufen, wenn wir dreimal von da bis zur Kirche und wieder zurück mit euerem Wagen fahren dürfen«, erklärte der mit dem rotbraunen Haar und der zerrissenen Jacke.
     </p>
-    <p xml:id="eco_de_0000140_5420">
+    <p xml:id="eco_de_0000210_5420">
      Hans besann sich. Er gab seinen schönen neuen Wagen nicht gern diesen groben Buben. Aber Lotti drängte: »Ach, lass sie, Hans! Lass sie, bitte, fahren! Dann ist es doch morgen und übermorgen so nett für Frau Zritschek!«
     </p>
-    <p xml:id="eco_de_0000140_5430">
+    <p xml:id="eco_de_0000210_5430">
      Hans gab nach. Der kleinste von den Buben durfte aufsitzen. Der Grosse zog unter Hurrageschrei; Hans lief zur Sicherheit neben dem Wagen her, und hinterdrein rannten die andern. Lotti konnte natürlich nicht widerstehen, sondern galoppierte an der Seite des Buben, dem sie das grüne Armband geschenkt, ebenfalls zur Kirche hinüber. Hans gab noch ein paar Fahrten hinzu, so dass jeder Bub an die Reihe kam.
     </p>
-    <p xml:id="eco_de_0000140_5440">
+    <p xml:id="eco_de_0000210_5440">
      Die ganze Schar begleitete dann den Hans und das Lotti bis über den Bäckerladen hinaus.
     </p>
-    <p xml:id="eco_de_0000140_5450">
+    <p xml:id="eco_de_0000210_5450">
      »Also, nicht wahr, ihr haltet Wort?« sagte Hans zum Schlusse. »Bei uns in der Klasse sagen wir immer ›Auf Ehre‹ und dann gilt es für gemein, wenn einer das Wort nicht hält.«
     </p>
-    <p xml:id="eco_de_0000140_5460">
+    <p xml:id="eco_de_0000210_5460">
      »O, bei uns auch! was meinst du!« erwiderte der Rotbraune. »Erst letzthin haben wir einen durchgeprügelt; er hat versprochen, uns nicht zu verklagen, und hat dann in der Turnstunde dem Lehrer doch alles gesagt.«
     </p>
-    <p xml:id="eco_de_0000140_5470">
+    <p xml:id="eco_de_0000210_5470">
      Er sah sich in seiner Schar um.
     </p>
-    <p xml:id="eco_de_0000140_5480">
+    <p xml:id="eco_de_0000210_5480">
      »Ihr hört's jetzt: Wer nicht Wort hält, wird durchgehauen.«
     </p>
-    <p xml:id="eco_de_0000140_5490">
+    <p xml:id="eco_de_0000210_5490">
      Lotti gab jedem die Hand zum Abschied.
     </p>
-    <p xml:id="eco_de_0000140_5500">
+    <p xml:id="eco_de_0000210_5500">
      »Das ist noch gut gegangen!« sagte sie vergnügt, als sie mit Hans allein war. »Aber die Frau Zritschek und den Mischa hab' ich nun gar nicht gesehen.«
     </p>
-    <p xml:id="eco_de_0000140_5510">
+    <p xml:id="eco_de_0000210_5510">
      »Ja, das nächste Mal musst du mit hineinkommen. Der Mischa hat mir immer die Hand gedrückt und in einemfort gesagt: ›Ich werde es aufs allerbeste machen, mein kleiner Herr, aufs allerbeste‹. Und an dem Schuh von Papa hat er schon gleich die Stiche losgemacht, als ob er gar nicht warten könnte mit Anfangen. Weisst du, Lotti, Mama hat gesagt, wenn er ordentlich flicke, dann wolle sie ihm alles geben, weil der Schuhmacher Metzel so viel Arbeit habe und einen immer warten lasse. Sie will es auch Grossmama und anderen Leuten sagen.«
     </p>
-    <p xml:id="eco_de_0000140_5520">
+    <p xml:id="eco_de_0000210_5520">
      »Du«, sagte Lotti, »wir nehmen am Samstag, wenn wir die Schuhe abholen, den Wagen auch mit und lassen die Buben noch einmal fahren; dann sind sie vielleicht wieder ein paar Tage artig.«
     </p>
-    <p xml:id="eco_de_0000140_5530">
+    <p xml:id="eco_de_0000210_5530">
      Hans und Lotti taten so. Und es fügte sich weiter alles aufs beste. Nachdem die Buben die alte Frau Zritschek vier oder fünf Tage nicht mehr geplagt hatten, schämten sie sich doch, wieder anzufangen.
     </p>
-    <p xml:id="eco_de_0000140_5540">
+    <p xml:id="eco_de_0000210_5540">
      »Wir machen jetzt überhaupt ein neues Spiel«, erklärte der Rotbraune, »Räuber und Landjäger, oben beim Gerberwinkel mit den Buben aus der Hochgasse; da gehen wir nach der Schule immer gleich hinauf.«
     </p>
-    <p xml:id="eco_de_0000140_5550">
+    <p xml:id="eco_de_0000210_5550">
      So hatte die alte Frau Ruhe bekommen und sah weniger böse und zornig aus, besonders auch, weil Mischa jetzt arbeiten und Geld verdienen konnte. Lotti und Marianne machten natürlich auch Bekanntschaft mit den Zritscheks. Mischa nannte sie »die kleinen Fräulein« und war immer ungemein höflich gegen sie, was den beiden grossen Spass machte.
     </p>
    </div>
@@ -1777,202 +1777,202 @@
     <head>
      Lotti und die Rosenkäfer.
     </head>
-    <p xml:id="eco_de_0000140_5560">
+    <p xml:id="eco_de_0000210_5560">
      Lotti stand am Tisch in der Gartenlaube. Die Laube, deren Wände von lauter glatt geschnittenem Buchengebüsch gebildet waren, sah aus wie ein schönes, luftiges Zimmer. Eine Decke hatte das grüne Gemach nicht; oben schaute der blaue Himmel herein.
     </p>
-    <p xml:id="eco_de_0000140_5570">
+    <p xml:id="eco_de_0000210_5570">
      Es war ganz still in der Laube; nur von dem Wege, der zwischen den Johannisbeerbüschen zum hinteren Teil des Gartens führte, hörte man sprechen. Da ging Mama mit ihrer Freundin, Fräulein Striebert. Die Kinder hatten Fräulein Striebert sehr gern. Sie brachte jedesmal ein Päckchen Biskuit mit, die sie selbst gebacken hatte. Weil es Abend war und die Bäume schon breite Schatten warfen, hatte Fräulein Striebert ihren Hut auf den Tisch gelegt.
     </p>
-    <p xml:id="eco_de_0000140_5580">
+    <p xml:id="eco_de_0000210_5580">
      Lotti war zuerst damit beschäftigt gewesen, aus Buchenblättern, die sie mit Tannennadeln zusammensteckte, einen Kranz zu machen. Aber die Blätter rissen immer wieder aus. Sie schob den halbfertigen Kranz zurück und betrachtete Fräulein Strieberts Hut, der mit fünf blassroten Rosen geschmückt war. Lotti fuhr behutsam mit dem Finger über die feinen Blätter; dann drückte sie ihre Nase in eine der Blumen. Sie rochen gar nicht – und so schön wie die wirklichen Rosen waren sie auch nicht. Ringsum im Garten blühten die jetzt an Bäumchen und Büschen, weiss, gelblich, hell- und dunkelrot. Und in vielen sassen zwischen den Blumenblättern zwei, drei oder mehr goldgrün schimmernde Rosenkäferchen. Das sah sehr hübsch aus.
     </p>
-    <p xml:id="eco_de_0000140_5590">
+    <p xml:id="eco_de_0000210_5590">
      Plötzlich fiel Lotti etwas ein. Die Rosen von Fräulein Striebert sollten auch solche hübschen Käferchen haben. Lotti lief zum nächsten Rosenstrauch, der über und über voll von weissen duftenden Rosen stand, und sammelte von den niedlichen goldgrünen Tierchen, so viel sie erwischen konnte. Dann versuchte sie, die Rosen des Hutes damit zu besetzen. Aber den Käfern gefiel es nicht in den künstlichen Blumen; immer wieder krabbelten sie heraus; drei oder vier flogen sogar fort. Da wurde Lotti ärgerlich und hitzig, und es kam ihr wieder ein Gedanke – diesmal ein ganz schlimmer. Sie sprang ins Haus. In der Schublade der Kommode war ein Leimfläschchen; das nahm sie heraus, strich an jeden der kleinen Käfer etwas von der klebrigen Flüssigkeit und drückte ihn zwischen die Rosenkäfer. So, nun hielten sie fest.
     </p>
-    <p xml:id="eco_de_0000140_5600">
+    <p xml:id="eco_de_0000210_5600">
      Lotti war kein böses Kind. Ihr kleines Herz war sonst schnell gerührt, wenn sie jemand traurig sah, oder wenn man sie um etwas bat. Und die Tiere mochte sie ja so gern. Jetzt aber dachte sie gar nicht daran, dass diese kleinen, stummen Käfer, die nicht viel anders aussahen als sehr grosse Stecknadelköpfe, auch Geschöpfe seien, und dass man ihnen eine grosse Qual bereite, wenn man sie da festklebe.
     </p>
-    <p xml:id="eco_de_0000140_5610">
+    <p xml:id="eco_de_0000210_5610">
      So –! unter dieses Blatt auch noch eins! Nun waren alle angebracht.
     </p>
-    <p xml:id="eco_de_0000140_5620">
+    <p xml:id="eco_de_0000210_5620">
      »Lotti, Lotti!« schrie es von weitem. »Lotti, wo bist du denn!« Hansens Stimme tönte näher: »Lotti, ein ganz grosser Fisch ist hergeschwemmt worden! Wir werfen mit Harpunen nach ihm; wir machen eine Walfischjagd …«
     </p>
-    <p xml:id="eco_de_0000140_5630">
+    <p xml:id="eco_de_0000210_5630">
      Lotti rannte Hans entgegen und mit ihm zum See hinunter. Das war prachtvoll. Der Fisch war so lang wie ein Arm; er lag auf dem Rücken und bewegte sich mit dem Wasser her und wieder zurück. Hans und Marianne hatten von einer früheren Jagd her grosse eiserne Haken, die ihnen Jakob wie Angeln gebogen hatte.
     </p>
-    <p xml:id="eco_de_0000140_5640">
+    <p xml:id="eco_de_0000210_5640">
      »Lotti, da – deine Harpune!« rief Hans. »Sieh dass du gut zielst! Wenn er hinter den Schilf treibt, bekommen wir ihn nicht mehr, ausser wir nehmen das Schiff!«
     </p>
-    <p xml:id="eco_de_0000140_5650">
+    <p xml:id="eco_de_0000210_5650">
      »Das Schiff ist gar nicht da!« gab Marianne zurück. »Jakob ist über den See gefahren damit.«
     </p>
-    <p xml:id="eco_de_0000140_5660">
+    <p xml:id="eco_de_0000210_5660">
      »Jetzt –!« schrie sie und meinte schon, den Fisch angehakt zu haben. Aber es war nichts; die Wellen, die heute abend ziemlich stark waren, nahmen den Fisch wieder hinaus.
     </p>
-    <p xml:id="eco_de_0000140_5670">
+    <p xml:id="eco_de_0000210_5670">
      Hans rannte zur Scheune, um dort eine Stange zu holen. Marianne und Lotti zogen währenddessen Schuhe und Strümpfe aus, um ins Wasser zu waten; denn um jeden Preis musste man den Fisch bekommen.
     </p>
-    <p xml:id="eco_de_0000140_5680">
+    <p xml:id="eco_de_0000210_5680">
      Aber plötzlich machte Sophie der Jagd ein Ende, indem sie zum Abendessen rief.
     </p>
-    <p xml:id="eco_de_0000140_5690">
+    <p xml:id="eco_de_0000210_5690">
      »Sophie«, gab Hans zurück, »es ist jetzt gar nicht möglich, dass wir kommen! Man kann nicht so mitten drin aufhören!«
     </p>
-    <p xml:id="eco_de_0000140_5700">
+    <p xml:id="eco_de_0000210_5700">
      Doch Sophie hatte keinen Respekt vor diesem schwierigen Walfischfang.
     </p>
-    <p xml:id="eco_de_0000140_5710">
+    <p xml:id="eco_de_0000210_5710">
      »Ach, ihr habt jeden Abend etwas anderes. Da kann man nicht drauf achten! Kommt jetzt!«
     </p>
-    <p xml:id="eco_de_0000140_5720">
+    <p xml:id="eco_de_0000210_5720">
      Hans brummte ein wenig; aber dann packte er doch die Harpunen zusammen. Mama wollte, dass man Sophie folge.
     </p>
-    <p xml:id="eco_de_0000140_5730">
+    <p xml:id="eco_de_0000210_5730">
      »Du, es gibt Apfelreis!« sagte Lotti vergnügt zu Marianne, und die drei setzten sich an den Tisch unterm Birnbaum, wo Werner schon mit dem Löffel in der Hand wartete. Alle Kinder machten sich mit grossem Appetit über den Reis her.
     </p>
-    <p xml:id="eco_de_0000140_5740">
+    <p xml:id="eco_de_0000210_5740">
      »Hu, hu –!« jammerte Werner auf einmal und drückte seinen Kopf an Mariannes Schulter. »Ein Tier, ein Tier –! ich mag die bösen Fliegtiere nicht! Sie tun stechen –«
     </p>
-    <p xml:id="eco_de_0000140_5750">
+    <p xml:id="eco_de_0000210_5750">
      Es war ein kleiner brauner Nachtfalter, der um Werners Kopf schwirrte.
     </p>
-    <p xml:id="eco_de_0000140_5760">
+    <p xml:id="eco_de_0000210_5760">
      »O, Werner ist doch noch schrecklich dumm! Er fürchtet sich vor Schmetterlingen!«
     </p>
-    <p xml:id="eco_de_0000140_5770">
+    <p xml:id="eco_de_0000210_5770">
      Hans haschte nach dem Tier und hielt es Werner hin.
     </p>
-    <p xml:id="eco_de_0000140_5780">
+    <p xml:id="eco_de_0000210_5780">
      »Totmachen!« rief Werner und schlug mit dem Löffel nach dem Falter.
     </p>
-    <p xml:id="eco_de_0000140_5790">
+    <p xml:id="eco_de_0000210_5790">
      »Nein, nicht totmachen!« wehrte Marianne. »Warum denn? Wir lassen ihn wieder fliegen. Sieh, wie er sich freut, dass er frei ist. Flieg', flieg', ade, ade!«
     </p>
-    <p xml:id="eco_de_0000140_5800">
+    <p xml:id="eco_de_0000210_5800">
      »Ade, ade!« wiederholte Werner und klatschte in die Hände.
     </p>
-    <p xml:id="eco_de_0000140_5810">
+    <p xml:id="eco_de_0000210_5810">
      »Lotti, warum issest du denn deinen Reis nicht auf?« fragte Sophie, die herauskam.
     </p>
-    <p xml:id="eco_de_0000140_5820">
+    <p xml:id="eco_de_0000210_5820">
      Lotti hatte auf einmal, als Marianne von dem Schmetterling sprach, zu essen aufgehört. Sie sass unbeweglich vor ihrem Teller. Plötzlich schob sie ihn zurück.
     </p>
-    <p xml:id="eco_de_0000140_5830">
+    <p xml:id="eco_de_0000210_5830">
      »Ich kann nicht mehr, Sophie. Ich muss in den Garten hinüber und nach etwas sehen.«
     </p>
-    <p xml:id="eco_de_0000140_5840">
+    <p xml:id="eco_de_0000210_5840">
      »Wahrscheinlich hat sie ihre Puppe dort liegen lassen«, sagte Sophie, während sie abräumte.
     </p>
-    <p xml:id="eco_de_0000140_5850">
+    <p xml:id="eco_de_0000210_5850">
      Lotti rannte zur Buchenlaube und kam in einem Augenblick dieser zurück.
     </p>
-    <p xml:id="eco_de_0000140_5860">
+    <p xml:id="eco_de_0000210_5860">
      »Sophie, Sophie! ist Fräulein Striebert nicht mehr da?« fragte sie hastig.
     </p>
-    <p xml:id="eco_de_0000140_5870">
+    <p xml:id="eco_de_0000210_5870">
      »Ja, Kind, was willst du denn noch mit Fräulein Striebert? Längst ist sie fort. Sie war sogar etwas eilig. Ich hab' ihr noch die Tasche und die Jacke in die Droschke hinausgebracht.«
     </p>
-    <p xml:id="eco_de_0000140_5880">
+    <p xml:id="eco_de_0000210_5880">
      »Und ihren Hut? Hat sie ihn nicht angesehen, Sophie?«
     </p>
-    <p xml:id="eco_de_0000140_5890">
+    <p xml:id="eco_de_0000210_5890">
      »Angesehen? was wird sie ihn angesehen haben? Ich denke, sie kennt ihren Hut. Schnell aufgesetzt hat sie ihn und ist dann mit Mama zum Bahnhof gefahren.«
     </p>
-    <p xml:id="eco_de_0000140_5900">
+    <p xml:id="eco_de_0000210_5900">
      »Kommt Mama bald wieder?«
     </p>
-    <p xml:id="eco_de_0000140_5910">
+    <p xml:id="eco_de_0000210_5910">
      »Nein; ihr werdet längst im Bett sein und schlafen, wenn Mama wieder kommt.«
     </p>
-    <p xml:id="eco_de_0000140_5920">
+    <p xml:id="eco_de_0000210_5920">
      Das Schwesterlein auf Sophies Arm fing an zu weinen, und Sophie nahm Werner an der Hand, um die beiden Kleinen zu Bett zu bringen.
     </p>
-    <p xml:id="eco_de_0000140_5930">
+    <p xml:id="eco_de_0000210_5930">
      »Kommt«, schlug Hans den Schwestern vor, »wir gehen noch ein wenig auf der Seemauer hin und her.«
     </p>
-    <p xml:id="eco_de_0000140_5940">
+    <p xml:id="eco_de_0000210_5940">
      Marianne folgte ihm; Lotti blieb allein unter dem Birnbaum vor dem Hause stehen.
     </p>
-    <p xml:id="eco_de_0000140_5950">
+    <p xml:id="eco_de_0000210_5950">
      Es war dunkle Nacht. Marianne schlief fest; man konnte gut ihre regelmässigen Atemzüge hören. Lotti wachte noch. Von Zeit zu Zeit drehte sie sich und suchte eine kühle Stelle auf dem Kissen. Ihr Kopf war heiss; sie meinte eine ganze Ewigkeit da zu liegen. Öfter schon hatte sie nicht einschlafen können, z. B. in der ersten Nacht hier in der Seeweid und dann am Abend vor Weihnachten. Das war vor lauter Freude gewesen. Aber jetzt –! Immer musste Lotti an die Rosenkäfer denken. Ob das wohl sehr weh tat, so festgeklebt zu sein? Ob sie wohl gar nicht loskamen und dort auf Fräulein Strieberts Hut sterben mussten?
     </p>
-    <p xml:id="eco_de_0000140_5960">
+    <p xml:id="eco_de_0000210_5960">
      »Warum hab' ich es doch getan!« dachte Lotti und drückte, wie wenn sie selber Schmerz empfände, ihre kleine Faust an den Mund.
     </p>
-    <p xml:id="eco_de_0000140_5970">
+    <p xml:id="eco_de_0000210_5970">
      »Ich will die Augen fest zumachen; vielleicht kann ich dann doch einschlafen«, sagte sie sich und lag still, ohne sich zu drehen. Aber es war sonderbar. Die Augenlider machten gar nicht recht dunkel. Lotti sah lauter gelbe, grüne und rote Punkte; die kamen aus der Zimmerecke heraus, viele, viele und immer mehr, wie ein ganzer Wirbel von Punkten; sie drehten sich im Kreis, erst in der einen Richtung, dann in der andern; jetzt rückte der Kreis näher – Lotti fuhr sich über die Augen; da verschwanden die Punkte.
     </p>
-    <p xml:id="eco_de_0000140_5980">
+    <p xml:id="eco_de_0000210_5980">
      Nun blieb es eine Weile ruhig und dunkel. Plötzlich tauchte wieder ein Funke auf und wurde immer grösser, und Lotti erkannte mit Entsetzen, dass es ein Rosenkäfer war, ein riesengrosser Rosenkäfer mit langen Fühlhörnern und bösen Augen. Und hinter ihm kam noch einer hervor und wieder einer und jetzt ganz viele. Sie begannen alle mit den Flügeln zu surren und zu schwirren; es gab ein starkes Getöse. Mitten hinein aber hörte man eine Stimme. Es war der ganz grosse mit den langen Fühlhörnern, der mit einer schrecklichen, schnurrenden Stimme rief:
     </p>
-    <p xml:id="eco_de_0000140_5990">
+    <p xml:id="eco_de_0000210_5990">
      »Lotti Turnach, wir kommen, um die andern zu holen! Wo hast du sie? Es waren doch neun, die du weggetragen hast! Wo sind sie, Lotti Turnach –?«
     </p>
-    <p xml:id="eco_de_0000140_6000">
+    <p xml:id="eco_de_0000210_6000">
      Lotti war in einer Todesangst. Sie wollte rufen: »Ich will's nicht mehr tun! ich will's nicht mehr tun!« doch sie konnte sich nicht rühren und kein Wort sprechen. Der Hals war ihr wie zugeschnürt.
     </p>
-    <p xml:id="eco_de_0000140_6010">
+    <p xml:id="eco_de_0000210_6010">
      Der grösste Käfer mit den bösen Augen kam immer näher … Lotti tat einen lauten Schrei und erwachte. Die Käfer waren verschwunden; Mama beugte sich über Lotti. Mama war, wie sie es oft tat, vor dem Schlafengehen noch einmal in das Zimmer der Kinder gekommen.
     </p>
-    <p xml:id="eco_de_0000140_6020">
+    <p xml:id="eco_de_0000210_6020">
      »Hat dir schwer geträumt, Kind?« fragte sie und strich über Lottis Stirn. »Du hast ja schrecklich gestöhnt.«
     </p>
-    <p xml:id="eco_de_0000140_6030">
+    <p xml:id="eco_de_0000210_6030">
      Lotti tat einen tiefen Atemzug. Wie gut das war, Mama neben sich zu haben!
     </p>
-    <p xml:id="eco_de_0000140_6040">
+    <p xml:id="eco_de_0000210_6040">
      »O, Mama! die Käfer –!«
     </p>
-    <p xml:id="eco_de_0000140_6050">
+    <p xml:id="eco_de_0000210_6050">
      »Von Käfern hat dir geträumt? War das so arg? Nun sind sie ja aber weg, und du schläfst schnell wieder ein.«
     </p>
-    <p xml:id="eco_de_0000140_6060">
+    <p xml:id="eco_de_0000210_6060">
      »Nein, Mama, wenn ich schlafen will, dann kommen sie wieder!« Lotti setzte sich in ihrem Bett auf. »Ich muss dir etwas sagen, Mama.«
     </p>
-    <p xml:id="eco_de_0000140_6070">
+    <p xml:id="eco_de_0000210_6070">
      »Ja, Kind, wollen wir wirklich mitten in der Nacht da zusammen plaudern? Es ist nur gut, dass Marianne einen sehr festen Schlaf hat.«
     </p>
-    <p xml:id="eco_de_0000140_6080">
+    <p xml:id="eco_de_0000210_6080">
      »Mama, ich hab' heut' abend in der Laube – weisst du, auf dem Hut von Fräulein Striebert sind Rosen, und da hab' ich gedacht, es wäre hübsch, wenn da auch so Rosenkäfer drauf sässen, und da hab' ich – Mama, glaubst du, dass es für die Käfer arg ist, wenn man sie irgendwo festklebt?«
     </p>
-    <p xml:id="eco_de_0000140_6090">
+    <p xml:id="eco_de_0000210_6090">
      »Ja, Lotti, das glaub' ich sicher. Du hast das doch nicht getan!«
     </p>
-    <p xml:id="eco_de_0000140_6100">
+    <p xml:id="eco_de_0000210_6100">
      Lotti nickte kläglich mit dem Kopfe, und unter Schluchzen erzählte sie Mama die ganze Geschichte von den Rosenkäfern und das sie erst wieder an die Tierchen gedacht habe, als der braune Schmetterling um Werner herumgeschwirrt sei.
     </p>
-    <p xml:id="eco_de_0000140_6110">
+    <p xml:id="eco_de_0000210_6110">
      »Da bin ich in die Laube gegangen, Mama, um sie loszumachen; aber ihr wart schon fort –«
     </p>
-    <p xml:id="eco_de_0000140_6120">
+    <p xml:id="eco_de_0000210_6120">
      »Die armen, armen Käfer!« sagte Mama bekümmert. »Wie konntest du die Tierchen so plagen, Lotti! Ist dir denn nicht in den Sinn gekommen, wie grausam das ist? Nun quälen sie sich ab und können sich doch nicht losmachen! Woher hast du überhaupt ein Recht, so mit Gottes Geschöpfen umzugehen? Die Käfer wollen leben und sich freuen, und nun kommst du und bringst sie in solche Not!«
     </p>
-    <p xml:id="eco_de_0000140_6130">
+    <p xml:id="eco_de_0000210_6130">
      Lotti sah Mama flehentlich an.
     </p>
-    <p xml:id="eco_de_0000140_6140">
+    <p xml:id="eco_de_0000210_6140">
      »Ich will es nie, nie mehr tun!« sagte sie.
     </p>
-    <p xml:id="eco_de_0000140_6150">
+    <p xml:id="eco_de_0000210_6150">
      »Das hoff' ich, Kind!« antwortete Mama. »Es ist schlimm, dass du es einmal getan hast.«
     </p>
-    <p xml:id="eco_de_0000140_6160">
+    <p xml:id="eco_de_0000210_6160">
      »Wenn ich nur jetzt nicht mehr daran denken müsste und nicht wieder so schrecklich träume, Mama!«
     </p>
-    <p xml:id="eco_de_0000140_6170">
+    <p xml:id="eco_de_0000210_6170">
      »Ja, siehst du, weil du vorher nicht an die Käfer und ihre Qual, sondern nur an deinen Spass gedacht hast, musst du jetzt an sie denken. Und das ist gut; du wirft dann nicht so leicht wieder etwas Ähnliches tun.«
     </p>
-    <p xml:id="eco_de_0000140_6180">
+    <p xml:id="eco_de_0000210_6180">
      Als Mama hinausgegangen war, legte sich Lotti hin. Sie fühlte jetzt nicht mehr solche Angst und Unruhe, weil sie mit Mama hatte sprechen können. Aber noch lange hielten Reue und Betrübnis sie wach.
     </p>
-    <p xml:id="eco_de_0000140_6190">
+    <p xml:id="eco_de_0000210_6190">
      Am andern Abend erhielt Mama einen kleinen Brief von Fräulein Striebert.
     </p>
-    <p xml:id="eco_de_0000140_6200">
+    <p xml:id="eco_de_0000210_6200">
      »Ich bin gut zu Hause angekommen«, hiess es darin, »besser als die kleinen Reisegefährten auf meinem Hut! Das war wohl ein Einfall von einem der Kinder? Der kleine Missetäter hat meine Rosen schmücken wollen, und die armen Käfer mussten dabei herhalten! Eine Dame im Eisenbahnwagen hat mich aufmerksam gemacht, dass etwas auf meinem Hute herumkrieche. Eines der Tierchen hatte sich losgerissen, und da es unversehrt war, liessen wir es zum Waggonfenster hinausfliegen. Aber die andern hat der zähe Leim übel zugerichtet, und es war wohl das Beste, sie rasch zu töten. – Eigentlich nehme ich sicher an, es sei das Werk des kleinen Werner gewesen. Die andern Kinder wären ja doch zu vernünftig …«
     </p>
-    <p xml:id="eco_de_0000140_6210">
+    <p xml:id="eco_de_0000210_6210">
      Lotti wurde dunkelrot im Gesicht, als Mama die Stelle aus dem Briefe vorlas.
     </p>
    </div>
@@ -1980,340 +1980,340 @@
     <head>
      Es kommt Besuch in die Seeweid und führt sich schlecht auf.
     </head>
-    <p xml:id="eco_de_0000140_6220">
+    <p xml:id="eco_de_0000210_6220">
      Die Turnachkinder waren aus der Nachmittagschule heimgekommen und sassen im Kirschbaum an der Seemauer, Hans hoch oben rittlings, Marianne und Lotti nebeneinander auf einem der untern dicken Äste. Es war nicht leicht gewesen, hinaufzukommen. Hans allerdings war im Hui auf seinem Platze angelangt; aber Marianne und Lotti konnten nicht recht klettern.
     </p>
-    <p xml:id="eco_de_0000140_6230">
+    <p xml:id="eco_de_0000210_6230">
      »Es ist wirklich eine Schande!« hatte Hans hinunter gerufen. »Ihr müsst es jetzt dann ordentlich lernen. Man kann ja gar nichts anfangen mit euch.«
     </p>
-    <p xml:id="eco_de_0000140_6240">
+    <p xml:id="eco_de_0000210_6240">
      Lotti hatte den Stamm mit ihren kleinen Armen umschlungen und versucht, sich hinaufzuziehen; aber sie war mit den Füssen immer auf dem Boden geblieben.
     </p>
-    <p xml:id="eco_de_0000140_6250">
+    <p xml:id="eco_de_0000210_6250">
      »Steigt auf die Mauer und von da auf das Gartentor«, hatte Hans geraten. »Dann geht es am Ende; aber es ist keine rechte Art, um auf einen Baum zu kommen!«
     </p>
-    <p xml:id="eco_de_0000140_6260">
+    <p xml:id="eco_de_0000210_6260">
      Von dem hohen gemauerten Pfosten des Tores waren Marianne und Lotti denn auch glücklich auf den untersten Ast gelangt und von da auf den zweiten. Nun sassen sie vergnügt im Grünen; ringsum und über ihnen hingen die prächtigsten dunkelroten Kirschen. Herr Turnach hatte diesen Kirschbaum und den hintersten in der Allee von Frau Völklein, der die Seeweid gehörte, gemietet, so wie auch ein paar Birn- und Apfelbäume, eine Reihe Johannisbeerbüsche und den Haselstrauch in der Gartenecke. Heute durften die Kinder zum erstenmal Kirschen pflücken und essen nach Herzenslust.
     </p>
-    <p xml:id="eco_de_0000140_6270">
+    <p xml:id="eco_de_0000210_6270">
      »Hat's bei euch auch so viele?« rief Hans hinunter. »Ich mache die Augen zu, greife hinauf und habe gleich ein halbes Dutzend in der Hand.«
     </p>
-    <p xml:id="eco_de_0000140_6280">
+    <p xml:id="eco_de_0000210_6280">
      Lotti streckte ihren Kopf durch die Blätter.
     </p>
-    <p xml:id="eco_de_0000140_6290">
+    <p xml:id="eco_de_0000210_6290">
      »Da sieh!« Sie hatte an jeder Seite zwei oder drei Ohrhänger, so viel als ihre kleinen Ohren nur halten konnten, prachtvolle, dunkelrote Doppelkirschen.
     </p>
-    <p xml:id="eco_de_0000140_6300">
+    <p xml:id="eco_de_0000210_6300">
      Plötzlich rief Hans, der von seinem Aste auf einen noch höheren geklettert war:
     </p>
-    <p xml:id="eco_de_0000140_6310">
+    <p xml:id="eco_de_0000210_6310">
      »Marianne, Lotti! seht ihr nichts? dort oben an der Strasse –?«
     </p>
-    <p xml:id="eco_de_0000140_6320">
+    <p xml:id="eco_de_0000210_6320">
      Die beiden guckten um; aber sie konnten nicht so weit sehen.
     </p>
-    <p xml:id="eco_de_0000140_6330">
+    <p xml:id="eco_de_0000210_6330">
      »Hans, du solltest fragen: ›Schwester, siehst du nichts?‹ Dann rufe ich zurück: ›Eine Staubwolke – aber ach, es sind nur Schafe.‹ Dann ist es gerade wie im Blaubart«, sagte Lotti, die immer ihre Märchen im Kopfe hatte.
     </p>
-    <p xml:id="eco_de_0000140_6340">
+    <p xml:id="eco_de_0000210_6340">
      »Ach, Lotti«, erwiderte Marianne, »das passt aber jetzt gar nicht. Die Frau vom Blaubart war ja in Todesangst, weil der böse Mann sie umbringen wollte, und hoffte immer, dass ihre Brüder kommen und sie retten würden. Wir hier sind ganz zufrieden und wollen niemand.«
     </p>
-    <p xml:id="eco_de_0000140_6350">
+    <p xml:id="eco_de_0000210_6350">
      »Es ist ein Wagen!« rief Hans. »Er kommt zu uns herunter!«
     </p>
-    <p xml:id="eco_de_0000140_6360">
+    <p xml:id="eco_de_0000210_6360">
      »Hört«, sagte Marianne, »wir bleiben ruhig auf unserm Baum sitzen. Vielleicht kommt bloss Besuch zu Mama.«
     </p>
-    <p xml:id="eco_de_0000140_6370">
+    <p xml:id="eco_de_0000210_6370">
      Nun vernahm man vom Wege her schon ein lautes Rollen und Traben.
     </p>
-    <p xml:id="eco_de_0000140_6380">
+    <p xml:id="eco_de_0000210_6380">
      »Nein, nein, es ist nicht bloss Besuch für Mama!« meldete Hans wieder. »Es sind Kinder drin – Buben, glaub' ich.«
     </p>
-    <p xml:id="eco_de_0000140_6390">
+    <p xml:id="eco_de_0000210_6390">
      Er glitt rasch am Stamm herab, an den Schwestern vorbei. Im Nu war er auf dem Boden und rannte davon.
     </p>
-    <p xml:id="eco_de_0000140_6400">
+    <p xml:id="eco_de_0000210_6400">
      »Wir wollen doch auch gehen!« meinte Lotti und hängte sich an den untersten Ast. Die Füsse waren noch ein gutes Stück über der Erde; aber mutig liess sie los und – plumps! lag sie unten. Es tat nicht gerade wohl; doch sie stand rasch auf und lief Hans nach. Sie war zu neugierig, zu sehen, was alles aus dem Wagen steigen werde. Marianne liess nun die Kirschen auch, und die beiden kamen eben im rechten Moment auf den Platz vor dem Hause.
     </p>
-    <p xml:id="eco_de_0000140_6410">
+    <p xml:id="eco_de_0000210_6410">
      Zuerst stieg aus dem Wagen, der kribbelkrabbelvoll war, eine Dame in hellfarbigem Kleid, die auf Frau Turnach zueilte, um sie zu umarmen und zu küssen. Ihr folgte eine andere Dame, ebenfalls sehr schön angezogen. Hinterdrein aber kletterten mit grossem Geschrei ein, zwei, drei, vier kleine Buben heraus mit schwarzen Haaren und bräunlichen Gesichtern. Sie hatten weisse Kleider an und brennrote Halsschleifen und rannten wie kleine Ziegen, die man aus dem Stall gelassen, nach allen Seiten, bis vom Bock herunter ein seltsames Frauenwesen stieg, das die vier Bübchen zusammenzuholen versuchte.
     </p>
-    <p xml:id="eco_de_0000140_6420">
+    <p xml:id="eco_de_0000210_6420">
      Eine Negerin war das, eine wirkliche Negerin mit ganz schwarzem Gesicht, aus dem die Zähne und das Weisse der Augen wunderlich herausblitzten. Ihr schwarzes Haar war kraus wie Wolle und ihre Nase sehr breit. Sie trug ein gelb und weiss gestreiftes Kleid und in den Ohren grosse rote Ringe.
     </p>
-    <p xml:id="eco_de_0000140_6430">
+    <p xml:id="eco_de_0000210_6430">
      Die Turnachkinder standen starr. So etwas hatten sie noch nie gesehen.
     </p>
-    <p xml:id="eco_de_0000140_6440">
+    <p xml:id="eco_de_0000210_6440">
      »Sie ist aus Afrika«, flüsterte Hans, der in der Völkerkunde gut Bescheid wusste, den Schwestern zu, »oder aus Amerika, wo auch viele Neger leben. Die Neger sind ein sehr wildes Volk. Manche Stämme schlachten Menschen –«
     </p>
-    <p xml:id="eco_de_0000140_6450">
+    <p xml:id="eco_de_0000210_6450">
      »Und essen sie auf –?« fragte Lotti leise, als sie plötzlich einen Stoss bekam von einem der kleinen Buben. Offenbar wollte er auf diese Weise die Bekanntschaft einleiten. Lotti streckte ihm freundlich die Hans hin; da schossen auch die andern Buben auf die Turnachkinder ein, zupften sie und schrien durcheinander in einer fremden Sprache.
     </p>
-    <p xml:id="eco_de_0000140_6460">
+    <p xml:id="eco_de_0000210_6460">
      Marianne sah Mama an; aber diese war ganz in Anspruch genommen von den beiden Damen, die dem Hause zugingen. Nur schnell konnte sie den Kindern zurufen:
     </p>
-    <p xml:id="eco_de_0000140_6470">
+    <p xml:id="eco_de_0000210_6470">
      »Seid recht artig und vernünftig! Es ist die Frau von Papas Vetter Hermann aus Martinique mit ihren Buben und ihrer Schwester. Nehmt die vier ein wenig mit. Verstehen könnt ihr euch nicht, denn sie sprechen nur französisch; aber zeigt ihnen etwas, vielleicht die Kaninchen, bis Sophie den Tee gerichtet hat.«
     </p>
-    <p xml:id="eco_de_0000140_6480">
+    <p xml:id="eco_de_0000210_6480">
      Hans nahm an jede Hand einen der kleinen Vettern, und Marianne suchte die andern zwei einzufangen.
     </p>
-    <p xml:id="eco_de_0000140_6490">
+    <p xml:id="eco_de_0000210_6490">
      »Kommt, kommt!« rief sie.
     </p>
-    <p xml:id="eco_de_0000140_6500">
+    <p xml:id="eco_de_0000210_6500">
      »Ggommt, ggommmt!« machten die Bürschchen nach, liefen herzu und entwischten nach rechts und links in die Wiese, die schon wieder so hoch stand, dass man eigentlich nicht mehr hinein durfte.
     </p>
-    <p xml:id="eco_de_0000140_6510">
+    <p xml:id="eco_de_0000210_6510">
      Aber die kleinen Kobolde fuhren unbekümmert in dem Gras herum, warfen sich zu Boden und rissen lange Stengel aus, mit denen sie einander schlugen.
     </p>
-    <p xml:id="eco_de_0000140_6520">
+    <p xml:id="eco_de_0000210_6520">
      »Nicht, nicht –!« wehrte Hans.
     </p>
-    <p xml:id="eco_de_0000140_6530">
+    <p xml:id="eco_de_0000210_6530">
      »Niggt, niggt!« lachten die wilden Vetterchen, und die Negerin lachte auch, dass man alle ihre zweiunddreissig Zähne sah. Dann redete sie laut auf die kleinen Buben ein.
     </p>
-    <p xml:id="eco_de_0000140_6540">
+    <p xml:id="eco_de_0000210_6540">
      »Wie man nur eine so fremde Sprache so schnell sprechen kann!« dachten die Turnachkinder. Aus all dem Gerede verstanden sie nur, dass der grösste der Vettern Tatschi hiess, der zweite Muschi und die kleinen, welche Zwillinge waren, Tutu und Gogo.
     </p>
-    <p xml:id="eco_de_0000140_6550">
+    <p xml:id="eco_de_0000210_6550">
      »Haben wohl alle Leute auf Martinique solch komische Namen?« sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_6560">
+    <p xml:id="eco_de_0000210_6560">
      Übrigens konnte die Negerin rufen, so viel sie wollte; Tatschi, Muschi, Tutu und Gogo hörten nicht auf sie.
     </p>
-    <p xml:id="eco_de_0000140_6570">
+    <p xml:id="eco_de_0000210_6570">
      »Kommt, wir rennen drauf los; dann laufen sie uns gewiss nach!« schlug Hans vor.
     </p>
-    <p xml:id="eco_de_0000140_6580">
+    <p xml:id="eco_de_0000210_6580">
      Und richtig, hinter den drei Turnachkindern, die den Weg zur Scheune nahmen, sprangen auch die vier Vetterchen mit grossem Hallo.
     </p>
-    <p xml:id="eco_de_0000140_6590">
+    <p xml:id="eco_de_0000210_6590">
      Jakob stand mit der Heugabel im Futtergang, als die Horde hereinbrach, gefolgt von der Negerin.
     </p>
-    <p xml:id="eco_de_0000140_6600">
+    <p xml:id="eco_de_0000210_6600">
      »Herrschaft!« sagte er und liess vor Überraschung die Heugabel fallen. »Die ist ja schwarz wie –« er schluckte und sah unverwandt auf die Fremde.
     </p>
-    <p xml:id="eco_de_0000140_6610">
+    <p xml:id="eco_de_0000210_6610">
      »Du, Jakob«, sagte Lotti leise, »sie ist ganz freundlich; aber vielleicht ist sie doch eine Menschenfresserin!«
     </p>
-    <p xml:id="eco_de_0000140_6620">
+    <p xml:id="eco_de_0000210_6620">
      »Wir wollen's nicht hoffen!« meinte Jakob. »Zähne genug hätte sie allerdings! Herrschaft – was ist das für eine! Und woher kommen denn die vier Panduren da –?«
     </p>
-    <p xml:id="eco_de_0000140_6630">
+    <p xml:id="eco_de_0000210_6630">
      »Es sind unsere Vetterchen; aber wir können nicht mit ihnen reden«, erklärte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_6640">
+    <p xml:id="eco_de_0000210_6640">
      Inzwischen hatte Marianne die kleinen Gäste zu den Kaninchen geführt. Sie nahm ihren weissen Liebling mit dem blauen Band heraus und gab ihn dem Tutu auf den Arm. Der aber riss das Tier an den Ohren und packte es so fest um den Hals, dass es kaum mehr schnaufen konnte. Marianne wollte es dem Tutu wegnehmen; da rannte er schreiend davon und in die Hände seines Bruders Tatschi, der das arme Kaninchen so heftig in den Verschlag zurückwarf, dass Marianne aufschrie. Nun kam auch noch Muschi mit einem Stecken und stiess damit zwischen die Kaninchen. Tatschi aber klatschte in die Hände, indem er immer etwas wie »Schassee, schassee!«, rief.
     </p>
-    <p xml:id="eco_de_0000140_6650">
+    <p xml:id="eco_de_0000210_6650">
      Hans war empört. »Seid freundlich!« hatte Mama gesagt. Aber es war wirklich fast nicht möglich. Und die Negerin stand immer bloss da und lachte –!
     </p>
-    <p xml:id="eco_de_0000140_6660">
+    <p xml:id="eco_de_0000210_6660">
      Da legte sich Jakob ins Mittel.
     </p>
-    <p xml:id="eco_de_0000140_6670">
+    <p xml:id="eco_de_0000210_6670">
      »Halt, Musjeh, nix schassee hier!« sagte er, packte den bösen Muschi mit einem festen Griff und stellte ihn unter die Türe.
     </p>
-    <p xml:id="eco_de_0000140_6680">
+    <p xml:id="eco_de_0000210_6680">
      Der kleine Bub ballte die Fäuste; aber Jakob sah ihn gemütlich an, wie wenn er sagen wollte. »Du Tröpflein, du!«
     </p>
-    <p xml:id="eco_de_0000140_6690">
+    <p xml:id="eco_de_0000210_6690">
      Muschi lief hinaus; Tatschi, Tutu und Gogo liefen ihm nach, und das Vergnügen begann nun nebenan. Die kleinen Bursche entdeckten die Leiter, die, an der Mauer festgemacht, zum Heuboden führte. Einer hinter dem andern kletterte hinauf, und die Turnachkinder kamen auch nach. Nun ging da oben ein wilder Tumult an: man bewarf sich gegenseitig mit Heu und begrub einander darin. Die Turnachkinder machten mit, und es wäre so weit ganz lustig gewesen, wenn nicht die Vetterchen aus Martinique alle Augenblicke angefangen hätten, sich zu prügeln und zu stossen.
     </p>
-    <p xml:id="eco_de_0000140_6700">
+    <p xml:id="eco_de_0000210_6700">
      Auf einmal schienen sie genug von dem Heuboden zu haben, und man kletterte wieder die Leiter hinunter.
     </p>
-    <p xml:id="eco_de_0000140_6710">
+    <p xml:id="eco_de_0000210_6710">
      »Wir könnten ihnen jetzt noch den Hühnerhof zeigen«, sagte Hans zu Marianne. »Aber natürlich nur von aussen. Hinein lassen darf man die nicht.«
     </p>
-    <p xml:id="eco_de_0000140_6720">
+    <p xml:id="eco_de_0000210_6720">
      Als jedoch alle miteinander die Scheune verlassen wollten, ertönte vom Heuboden her ein entsetzliches Geschrei. Gogo war noch oben; er stand neben der Leiter und getraute sich offenbar nicht, sie wieder zu betreten. Ein paarmal fasste er die oberste Sprosse und streckte den Fuss aus, zog ihn aber immer wieder weinend zurück. Je mehr die Negerin und Muschi ihm zuredeten, desto lauter weinte er.
     </p>
-    <p xml:id="eco_de_0000140_6730">
+    <p xml:id="eco_de_0000210_6730">
      Hans kletterte hinauf, um zu helfen; aber der dumme Kleine war nun schon so ausser sich, dass er heulend weglief, sich ins Heu warf und mit den Füssen nach Hans schlug.
     </p>
-    <p xml:id="eco_de_0000140_6740">
+    <p xml:id="eco_de_0000210_6740">
      Es hätte noch wer weiss wie lang gehen können, wenn nicht Jakob hinter Hans heraufgekommen wäre und unversehens den zappelnden Gogo unter den Arm genommen hätte, um ihn hinunterzubringen.
     </p>
-    <p xml:id="eco_de_0000140_6750">
+    <p xml:id="eco_de_0000210_6750">
      »So«, sagte Jakob zu Hans, »jetzt macht aber, dass ihr mir zum Stall hinauskommt. Es wird einem ja ganz wirblig im Kopf.«
     </p>
-    <p xml:id="eco_de_0000140_6760">
+    <p xml:id="eco_de_0000210_6760">
      »Ja, sie sind grässlich«, erwiderte Hans. »Und man kann gar nichts zu ihnen sagen. Weisst du nicht vielleicht, wie das heisst: Seid nicht so unartig! Du hast doch gesagt, deine Schwester sei ein Jahr in Frankreich gewesen.«
     </p>
-    <p xml:id="eco_de_0000140_6770">
+    <p xml:id="eco_de_0000210_6770">
      »Ja«, sagte Jakob, »das ist schon sehr lange her. Du musst sehen, wie du mit ihnen zurecht kommst. Wenn sie's zu arg treiben, so hau' dem Grössten einmal eins auf. Das wird ungefähr in allen Sprachen das gleiche bedeuten. Die schwarze Person mit der wollenen Perücke ist scheint's nur zum Ansehen da. Die müsste mir anders hinter die Bürschlein her, potz Wetter!«
     </p>
-    <p xml:id="eco_de_0000140_6780">
+    <p xml:id="eco_de_0000210_6780">
      Als die ganze Schar gegen das Haus hinunter lief, stand Sophie da und rief zum Tee.
     </p>
-    <p xml:id="eco_de_0000140_6790">
+    <p xml:id="eco_de_0000210_6790">
      Die beiden Damen sassen schon bei Mama an dem grossen Tisch im Garten. Alle Kinder, die fremden wie die eigenen, wurden von den Damen gestreichelt und geküsst.
     </p>
-    <p xml:id="eco_de_0000140_6800">
+    <p xml:id="eco_de_0000210_6800">
      »So, Hans«, flüsterte Lotti schnell, die wusste, dass Hans die Zärtlichkeiten nicht liebte, »jetzt hast du auch einen Kuss bekommen.«
     </p>
-    <p xml:id="eco_de_0000140_6810">
+    <p xml:id="eco_de_0000210_6810">
      Hans konnte ihr in der Eile nur einen kleinen Puff geben.
     </p>
-    <p xml:id="eco_de_0000140_6820">
+    <p xml:id="eco_de_0000210_6820">
      Auf dem Tische stand neben dem Tee Butterbrot, Zwieback, Eingemachtes und der Rest von dem Hefekuchen, den Grossmama gestern gebracht hatte; Sophie hatte ihn schön in Scheiben geschnitten.
     </p>
-    <p xml:id="eco_de_0000140_6830">
+    <p xml:id="eco_de_0000210_6830">
      Nun war es ganz schrecklich zu sehen, wie die vier kleinen Buben sich benahmen, nicht viel besser als vorhin im Stall. Der eine wollte keinen Tee, der andere kein Butterbrot. Gogo goss sofort seine Tasse auf das Tischtuch aus. Tatschi langte über den ganzen Tisch nach dem Zwieback, nahm gleich drei Stücke und fing an mit den Brocken nach Marianne zu werfen. Tutu aber riss beständig die Serviette weg, die ihm die hinten stehende Negerin umbinden wollte, und beschmierte sich ganz mit dem Eingemachten.
     </p>
-    <p xml:id="eco_de_0000140_6840">
+    <p xml:id="eco_de_0000210_6840">
      »Mama«, fragte Marianne, die der Mutter eine leere Teetasse reichte, »heisst ›mong scheri‹ unartiger Bub?«
     </p>
-    <p xml:id="eco_de_0000140_6850">
+    <p xml:id="eco_de_0000210_6850">
      Sie hatte von dem, was Frau Hermann zu Tutu sagte, zwei Worte aufgeschnappt.
     </p>
-    <p xml:id="eco_de_0000140_6860">
+    <p xml:id="eco_de_0000210_6860">
      »Nein, das heisst ›mein Liebling‹«, antwortete Mama und lächelte ein wenig.
     </p>
-    <p xml:id="eco_de_0000140_6870">
+    <p xml:id="eco_de_0000210_6870">
      Marianne wunderte sich sehr. Aber Mama hatte weiter keine Zeit für sie. Es war gut, dass man sich mit Hans und Lotti durch allerlei Zeichen mit Mund und Augen etwas verständigen konnte über das Betragen der kleinen Vettern.
     </p>
-    <p xml:id="eco_de_0000140_6880">
+    <p xml:id="eco_de_0000210_6880">
      Werner war bei Balbine und dem Schwesterlein in der Buchenlaube geblieben. Man hätte am Teetisch nicht auch noch auf ihn acht geben können. Es ging sowieso zu wie im Kriege.
     </p>
-    <p xml:id="eco_de_0000140_6890">
+    <p xml:id="eco_de_0000210_6890">
      Endlich, nachdem der Zwieback, das Eingemachte und der Hefenkuchen aufgegessen waren, stürmten die vier kleinen Wilden wieder hinaus.
     </p>
-    <p xml:id="eco_de_0000140_6900">
+    <p xml:id="eco_de_0000210_6900">
      »Sophie, komm du mit«, sagte Hans an der Türe. »Wir können sie kaum im Zaum halten, und die Negerin tut gar nichts.«
     </p>
-    <p xml:id="eco_de_0000140_6910">
+    <p xml:id="eco_de_0000210_6910">
      Es war doppelt nötig, dass die Schutzmannschaft jetzt verstärkt wurde; denn Tatschi und Muschi waren zum See hinuntergerannt und hatten das Schiff entdeckt. Mit einem Jubelgeschrei sprangen sie hinein und griffen nach den Rudern.
     </p>
-    <p xml:id="eco_de_0000140_6920">
+    <p xml:id="eco_de_0000210_6920">
      »Man kann ihnen ja das Vergnügen machen und ein paar Züge hin- und herfahren hier, wo's nicht tief ist«, sagte Sophie.
     </p>
-    <p xml:id="eco_de_0000140_6930">
+    <p xml:id="eco_de_0000210_6930">
      Sie ordnete an, dass Marianne sich mit den Zwillingen auf die Bank setze, und bedeutete den Kleinen mit möglichst strengem Gesicht und aufgehobenem Finger, sie müssten sich ganz still halten.
     </p>
-    <p xml:id="eco_de_0000140_6940">
+    <p xml:id="eco_de_0000210_6940">
      Die Negerin blieb auf der Mauer zurück; sie schien kein Verlangen nach einer Kahnfahrt zu haben, und Lotti stand auch bei ihr. Es waren gerade genug Leute im Schiff.
     </p>
-    <p xml:id="eco_de_0000140_6950">
+    <p xml:id="eco_de_0000210_6950">
      Hans versuchte auf der zweiten Bank, den Tatschi zu bezähmen. Mit Muschi aber hatte Sophie einen schweren Stand; wie sie ihn auch zwingen wollte, sich zu setzen, immer wieder wollte er ihr das Ruder entreissen und sah sie mit seinen wilden Augen an. Sophie sagte gar nichts; aber sie war offenbar der Meinung Jakobs: Als es ihr zu arg wurde, gab sie dem Tatschi einen tüchtigen Klaps auf die Hand. Der stiess ein paar wütende Worte aus und riss dem Muschi den Stecken, den dieser aus der Scheune mitgenommen, weg. Sophie hatte sich gebückt, um das Ruder aufzunehmen, und sah also nicht, dass der schlimme Bursche zum Schlage gegen sie ausholte. Hans aber fuhr blitzschnell dazwischen und streckte den Arm aus, so dass der Stecken ihn traf. Au – es tat gehörig weh. Hans biss die Zähne zusammen; bevor er sich jedoch besinnen konnte, ob er diesen Tatschi nicht recht gehörig durchhauen wolle, war Marianne, die sonst so gutmütige Marianne, über die Bank gesprungen, um Tatschi zu packen und mit böser Stimme auf ihn einzureden:
     </p>
-    <p xml:id="eco_de_0000140_6960">
+    <p xml:id="eco_de_0000210_6960">
      »Du böser, unartiger Bub du! Warum hast du meinen Bruder so geschlagen? Und die Sophie hättest du beinahe an den Kopf getroffen!«
     </p>
-    <p xml:id="eco_de_0000140_6970">
+    <p xml:id="eco_de_0000210_6970">
      In ihrer Erregung vergass sie ganz, dass der kleine Vetter ja nichts verstand. Tatschi, der doch etwas erschrocken war über seine Missetat, sah Marianne verblüfft an und wand sich, um loszukommen. Aber Marianne hielt fest und schüttelte ihn wacker.
     </p>
-    <p xml:id="eco_de_0000140_6980">
+    <p xml:id="eco_de_0000210_6980">
      »Wart' nur, wir sagen es der Mama, dass sie es deiner Mama erzähle. Ihr seid überhaupt schrecklich; man sollte euch –«
     </p>
-    <p xml:id="eco_de_0000140_6990">
+    <p xml:id="eco_de_0000210_6990">
      Sie verstummte, weil von der Spitze des Schiffes ein fürchterlicher Schrei kam.
     </p>
-    <p xml:id="eco_de_0000140_7000">
+    <p xml:id="eco_de_0000210_7000">
      Gogo und Tutu, kaum dass Marianne sie gelassen, waren beide auf die Schiffkette losgefahren, die sie schon immer im Auge gehabt hatten. Jeder riss an der Kette; Gogo erklomm den Brettersitz in der Spitze des Schiffes; da vorn war ja die Kette angemacht; Tutu stieg nach, stiess ihn, und – kopfüber schossen die beiden ins Wasser.
     </p>
-    <p xml:id="eco_de_0000140_7010">
+    <p xml:id="eco_de_0000210_7010">
      Die Negerin brach in ein gellendes Jammergeschrei aus und lief herbei, Lotti ihr voraus geraden Wegs ins Wasser hinein. Aber schon hatte Sophie den Tutu erwischt, während Marianne den Gogo gefasst hatte und hielt, bis Hans half, ihn völlig herauszuziehen.
     </p>
-    <p xml:id="eco_de_0000140_7020">
+    <p xml:id="eco_de_0000210_7020">
      Die beiden kleinen Wichte schnappten, pusteten und spuckten, dass es fürchterlich war. Dann fingen sie wie auf Kommando zu brüllen an.
     </p>
-    <p xml:id="eco_de_0000140_7030">
+    <p xml:id="eco_de_0000210_7030">
      »Nun, Gottlob! sie haben den Atem wieder!« sagte Sophie. »Aber jetzt muss man sehen, wie man euch trocken bringt. Aussehen tut ihr schauderhaft.«
     </p>
-    <p xml:id="eco_de_0000140_7040">
+    <p xml:id="eco_de_0000210_7040">
      Ja, tropfnass waren die beiden Bübchen. Das Wasser lief ihnen aus den Haaren übers Gesicht, und bis weissen Kleidchen, die schon vorher im Stall und durch das Eingemachte ziemlich gelitten hatten, waren jetzt wie durch den Schmutz gezogen; denn das Wasser hatte so nah am Lande wenig Tiefe gehabt; die beiden waren schön auf den schlammigen Grund gekommen.
     </p>
-    <p xml:id="eco_de_0000140_7050">
+    <p xml:id="eco_de_0000210_7050">
      Die Negerin nahm den heulenden Gogo auf den Arm; Sophie zog den ebenfalls heulenden Tutu an der Hand hinter sich her. So ging's unter Gefolge der andern Kinder dem Hause zu.
     </p>
-    <p xml:id="eco_de_0000140_7060">
+    <p xml:id="eco_de_0000210_7060">
      Nun musste sich's gerade fügen, dass Frau Turnach mit den fremden Damen aus der Türe trat. Madame Hermann schrie laut auf und ihre Schwester auch. Frau Turnach wendete sich erschrocken zu Sophie.
     </p>
-    <p xml:id="eco_de_0000140_7070">
+    <p xml:id="eco_de_0000210_7070">
      »Frau Turnach«, sagte diese, »sie sind ein bisschen ins Wasser gefallen; aber es hat ihnen nichts getan. Wir ziehen sie schnell aus und reiben sie trocken.«
     </p>
-    <p xml:id="eco_de_0000140_7080">
+    <p xml:id="eco_de_0000210_7080">
      Unter vielem französischem und deutschem Reden und Wehklagen ging's dann in die Schlafstube. Tatschi, Muschi und die Turnachkinder liess man draussen.
     </p>
-    <p xml:id="eco_de_0000140_7090">
+    <p xml:id="eco_de_0000210_7090">
      Die fünf standen und schauten einander ziemlich feindselig an.
     </p>
-    <p xml:id="eco_de_0000140_7100">
+    <p xml:id="eco_de_0000210_7100">
      »Ich will das unzerreissbare Bilderbuch von Werner für sie holen«, sagte Marianne. »Herumführen tun wir sie nicht mehr; sonst gibt es wieder etwas.«
     </p>
-    <p xml:id="eco_de_0000140_7110">
+    <p xml:id="eco_de_0000210_7110">
      Tatschi und Muschi blätterten in dem Buche; die Turnachkinder sahen schweigend zu.
     </p>
-    <p xml:id="eco_de_0000140_7120">
+    <p xml:id="eco_de_0000210_7120">
      Nach einer Weile erhob sich drinnen ein neuer Lärm. Die Türe ging auf, und Tutu und Gogo wurden von Sophie, gegen die sie sich mit aller Kraft sträubten, hinausgeschoben.
     </p>
-    <p xml:id="eco_de_0000140_7130">
+    <p xml:id="eco_de_0000210_7130">
      Tatschi und Muschi lachten laut auf und klatschten in die Hände, als sie die kleinen Brüder sahen. Diese waren nämlich ganz verwandelt. Statt ihrer Höschen und Jacken hatten sie Röckchen an, die dem kleinen Werner gehörten, der eine das blaue, der andere das rote mit den weissen Punkten. Gogo trug zudem Werners neue Schuhe, während Tutu in Lottis braunen wie in kleinen Schiffen ging.
     </p>
-    <p xml:id="eco_de_0000140_7140">
+    <p xml:id="eco_de_0000210_7140">
      Die kleinen Bursche zerrten an den Röckchen und schrien auf die Negerin ein, während die Grossen lachten.
     </p>
-    <p xml:id="eco_de_0000140_7150">
+    <p xml:id="eco_de_0000210_7150">
      »Was sagen sie denn immer, Mama?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_7160">
+    <p xml:id="eco_de_0000210_7160">
      »Sie wollen ihre Höschen wieder haben. Sie sagen, sie seien keine kleinen Mädchen und wollen keine Röckchen tragen.«
     </p>
-    <p xml:id="eco_de_0000140_7170">
+    <p xml:id="eco_de_0000210_7170">
      Das fanden nun auch die Turnachkinder sehr komisch, und Tatschi und Muschi tanzten wie zwei Wilde um die »kleinen Mädchen«.
     </p>
-    <p xml:id="eco_de_0000140_7180">
+    <p xml:id="eco_de_0000210_7180">
      »Mama, Mama!« rief während dessen immer eine Stimme aus der hintern Stube. Es war Werner, den Balbine die ganze Zeit bei sich behalten hatte, der nun aber den Lärm hörte und sich nicht mehr halten liess. Mama öffnete die Türe.
     </p>
-    <p xml:id="eco_de_0000140_7190">
+    <p xml:id="eco_de_0000210_7190">
      Werners erster Blick fiel auf die zwei fremden kleinen Buben in dem blauen und dem roten Kleid. Das waren ja seine Röckchen! Er lief auf die beiden zu.
     </p>
-    <p xml:id="eco_de_0000140_7200">
+    <p xml:id="eco_de_0000210_7200">
      »Das – das gehört mir!« rief er böse und riss nun seinerseits an Tutus und Gogos Ärmel. So waren die drei Kerlchen ja eigentlich einer Meinung, nämlich dass die Kleider herunter sollten. Trotzdem schlug Tutu dem Werner auf die Hand, und dieser schlug wieder und traf auch den Gogo. Alle drei packten einander zeternd, und man hatte die grösste Mühe, sie aus einander zu lösen.
     </p>
-    <p xml:id="eco_de_0000140_7210">
+    <p xml:id="eco_de_0000210_7210">
      »Sie sollen nicht meine Röckchen haben!« schluchzte Werner. »Hu, hu –! ausziehen, ausziehen – die gehören mir!«
     </p>
-    <p xml:id="eco_de_0000140_7220">
+    <p xml:id="eco_de_0000210_7220">
      »O, was für einen unfreundlichen kleinen Buben hab' ich, der den Vetterchen nicht einmal seine Kleidchen leihen will!« mahnte Mama. »Sieh, die armen Bursche sind ins Wasser gefallen; so mussten wir ihnen etwas Trockenes anziehen. Morgen schicken sie dir alles wieder.«
     </p>
-    <p xml:id="eco_de_0000140_7230">
+    <p xml:id="eco_de_0000210_7230">
      Aber Werner liess sich nicht beruhigen, und Tutu mit Gogo schrien ebenfalls weiter. Es war ein solches Getümmel, dass einem Hören und Sehen verging und man es als eine wirkliche Erlösung empfand, als vom Wege her Räderrollen hörbar wurde.
     </p>
-    <p xml:id="eco_de_0000140_7240">
+    <p xml:id="eco_de_0000210_7240">
      »Der Wagen, der Wagen!«
     </p>
-    <p xml:id="eco_de_0000140_7250">
+    <p xml:id="eco_de_0000210_7250">
      Die Kinder liefen hinaus. Es ging an ein Suchen der Hüte, Tücher und Schirme, und eine gute Weile verstrich, bis endlich gross und klein eingepackt war. Tatschi und Muschi prügelten sich noch ein wenig um den Platz neben dem Kutscher.
     </p>
-    <p xml:id="eco_de_0000140_7260">
+    <p xml:id="eco_de_0000210_7260">
      Die Familie Turnach stand an dem Wagen; nur den kleinen Werner hatte Mama an der Haustüre hingestellt; dort konnte er weiter weinen, was er auch redlich tat, besonders als er sah, dass die kleinen Buben nun gar mit seinem blauen und seinem roten Röcklein davonfuhren.
     </p>
-    <p xml:id="eco_de_0000140_7270">
+    <p xml:id="eco_de_0000210_7270">
      »So! das wäre überstanden!« sagte Sophie. Mama lächelte und ging dann mit ihr ins Haus zurück; denn da gab es gehörig aufzuräumen.
     </p>
-    <p xml:id="eco_de_0000140_7280">
+    <p xml:id="eco_de_0000210_7280">
      »Holla, Hans!« tönte die frische Stimme von Fritz Völklein herunter. »Was war denn heute bei euch los? Das ging zu wie während der Zerstörung von Troja, Schlachtgetöse und Gebrüll ohne Ende!«
     </p>
-    <p xml:id="eco_de_0000140_7290">
+    <p xml:id="eco_de_0000210_7290">
      »Ja, es war ganz greulich!« rief Hans hinauf. »Komm noch ein wenig mit uns auf die Seemauer; dann erzählen wir dir.«
     </p>
-    <p xml:id="eco_de_0000140_7300">
+    <p xml:id="eco_de_0000210_7300">
      »Ja, Fritz, komm!« riefen auch die Mädchen. »Wenn du wüsstest, wie die getan haben! Ganz wie Wilde! Es sind eine Art Vetterchen von uns, und Mama sagt, sie seien eigentlich Weisse wie wir. Nur die Negerin stamme aus Afrika. Die hatte Zähne, Fritz! und Haar wie Wolle …«
     </p>
-    <p xml:id="eco_de_0000140_7310">
+    <p xml:id="eco_de_0000210_7310">
      Fritz Völklein setzte sich mit den Turnachkindern auf die Seemauer und hörte ihnen zu. Alle Augenblicke brach er in ein lautet Lachen aus.
     </p>
-    <p xml:id="eco_de_0000140_7320">
+    <p xml:id="eco_de_0000210_7320">
      »Nein, das war wirklich arg!« rief er. »Da seid ihr ja die reinsten Tugendhelden daneben! Nicht wahr, Lotti?«
     </p>
-    <p xml:id="eco_de_0000140_7330">
+    <p xml:id="eco_de_0000210_7330">
      Es war gut, dass man heute wegen der Unordnung, die die Gäste verursacht hatten, später zu Abend ass. Die Kinder hatten zu erzählen und zu erzählen, die das Halbachtuhr-Dampfschiff aus der Stadt daherrauschte.
     </p>
    </div>
@@ -2321,244 +2321,244 @@
     <head>
      Marianne als Pharaonentochter.
     </head>
-    <p xml:id="eco_de_0000140_7340">
+    <p xml:id="eco_de_0000210_7340">
      »Marianne, willst du das Schwesterlein ein wenig nehmen?« rief Sophie in den Garten hinaus. »Es will gar nicht ruhig bleiben, und ich sollte durchaus euere zwei Kleider noch fertig bügeln. Mama ist in der Küche, weil Balbine mit ihrer verbundenen Hand nicht allein zurecht kommt.«
     </p>
-    <p xml:id="eco_de_0000140_7350">
+    <p xml:id="eco_de_0000210_7350">
      Marianne hatte vorgehabt, mit ihrer Puppe einmal einen Spaziergang durch die Allee und zum Stalle hinauf zu machen; Ella kam so wenig hinaus. Aber eine lebendige Puppe war noch viel schöner. Marianne war stolz, wenn sie hin und wieder das Schwesterlein haben durfte. Man gab es ihr immer in ein leichtes, flaches Kissen gebunden, damit es ganz sicher sei auf Mariannes Arm. Das Schwesterlein war noch sehr klein und leicht. Mama sagte, es sollte eigentlich schwerer sein; es gedeihe nicht so gut wie die andern Kinder. Man hoffte, dass die Landluft ihm gut tue.
     </p>
-    <p xml:id="eco_de_0000140_7360">
+    <p xml:id="eco_de_0000210_7360">
      Marianne ging mit dem Schwesterlein durch den Garten und setzte sie vor das Portal. Sie wiegte das Schwesterlein sachte hin und her; es war jetzt ruhig und bewegte bloss seine winzigen Fingerchen, als ob es nach etwas greifen wollte. Marianne gab ihm ein Stöckchen; das packte es ganz fest.
     </p>
-    <p xml:id="eco_de_0000140_7370">
+    <p xml:id="eco_de_0000210_7370">
      »Du, du, du –« sagte Marianne mit leiser, freundlicher Stimme und zog an dem Stöckchen; dann verzog das Schwesterlein sei kleines Gesicht, als ob es lachen wollte.
     </p>
-    <p xml:id="eco_de_0000140_7380">
+    <p xml:id="eco_de_0000210_7380">
      Lotti stand unten am See. Er war jetzt niedrig. Man konnte trockenen Fusses bis zum Schilf hinausgehen.
     </p>
-    <p xml:id="eco_de_0000140_7390">
+    <p xml:id="eco_de_0000210_7390">
      »Du, wie der Schilf rasch hoch wird!« rief Lotti zu Marianne hinauf.
     </p>
-    <p xml:id="eco_de_0000140_7400">
+    <p xml:id="eco_de_0000210_7400">
      »Ja«, sagte Marianne. »Schön ist er. Und seit Sonntag, wo ich bei Grossmama war, mag ich ihn noch lieber als sonst. Ich muss jetzt immer, wenn ich unsern Schilf ansehe, an die Pharaonentochter denken.«
     </p>
-    <p xml:id="eco_de_0000140_7410">
+    <p xml:id="eco_de_0000210_7410">
      »An was musst du denken?« fragte Lotti und kam zu Marianne herauf.
     </p>
-    <p xml:id="eco_de_0000140_7420">
+    <p xml:id="eco_de_0000210_7420">
      »An die Pharaonentochter. Bei Grossmama hab' ich in einem schönen Buche ein Bild gesehen. Da steht die Tochter des Pharao im Schilf, und vor ihr liegt das Mosesknäblein in einem Körbchen im Wasser. Grossmama hat mir dann alles erzählt; es war in Ägypten. Dort hiessen sie den König Pharao.«
     </p>
-    <p xml:id="eco_de_0000140_7430">
+    <p xml:id="eco_de_0000210_7430">
      »Was hat die Tochter des Pharao im Schilf getan? Warum hat man das Büblein ins Wasser gelegt?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_7440">
+    <p xml:id="eco_de_0000210_7440">
      Nun erzählte Marianne dem Lotti die Geschichte von dem bösen Pharao, der nicht wollte, das es so viele Israeliten gebe im Land Ägypten, und der deshalb gebot, dass man alle kleinen Knaben dieses Volkes töte. Und von der Mutter des kleinen Moses, die ihr Kind gerne behalten hätte, und die es von ihrer Tochter in einem mit Pech verklebten Korbe in den Schilf legen liess, damit die Pharaonentochter, die da immer vorbeiging, sich des Knäbleins erbarme.
     </p>
-    <p xml:id="eco_de_0000140_7450">
+    <p xml:id="eco_de_0000210_7450">
      »Aber wenn die Prinzessin es zu sich genommen hat, dann hat die Mutter das Büblein ja doch nicht mehr gehabt!« wendete Lotti ein.
     </p>
-    <p xml:id="eco_de_0000140_7460">
+    <p xml:id="eco_de_0000210_7460">
      »Ja, dann kam eben das Schöne: Dann trat die grosse Schwester herzu und sagte, sie wüsste eine Pflegemutter für das kleine Büblein. Darüber war die Prinzessin froh und gebot dem Mädchen, das Knäblein zu der Frau zu tragen, und das war die eigene Mutter von dem kleinen Moses.«
     </p>
-    <p xml:id="eco_de_0000140_7470">
+    <p xml:id="eco_de_0000210_7470">
      »O!« sagte Lotti. »Die ist gewiss froh gewesen!«
     </p>
-    <p xml:id="eco_de_0000140_7480">
+    <p xml:id="eco_de_0000210_7480">
      »Ja. Und das Knäblein war nun unter dem Schutze der Prinzessin. Die Soldaten des Pharao durften ihm nichts mehr tun. Nachher wurde Moses ein Mann und führte die Israeliten weg aus Ägypten.«
     </p>
-    <p xml:id="eco_de_0000140_7490">
+    <p xml:id="eco_de_0000210_7490">
      »Das war aber nicht nett gegen die Prinzessin.«
     </p>
-    <p xml:id="eco_de_0000140_7500">
+    <p xml:id="eco_de_0000210_7500">
      »O, die hat vielleicht nicht mehr gelebt. Und dann musste Moses das tun. Gott hatte es ihm geboten.«
     </p>
-    <p xml:id="eco_de_0000140_7510">
+    <p xml:id="eco_de_0000210_7510">
      Marianne schwieg und sah wieder zu dem Schilf hinunter. Auf einmal stand sie auf mit dem Schwesterlein im Arm.
     </p>
-    <p xml:id="eco_de_0000140_7520">
+    <p xml:id="eco_de_0000210_7520">
      »Lotti!« sagte sie. »Wenn wir das mit der Pharaonentochter selber machen würden –! Wir haben den Schilf, und das Schwesterlein kann gut den kleinen Moses vorstellen. Du wärest die grosse Schwester und ich die Pharaonentochter.«
     </p>
-    <p xml:id="eco_de_0000140_7530">
+    <p xml:id="eco_de_0000210_7530">
      »O, meinst du, wir können das?« fragte Lotti voll Vergnügen.
     </p>
-    <p xml:id="eco_de_0000140_7540">
+    <p xml:id="eco_de_0000210_7540">
      »Natürlich. Die Hauptsache ist, dass wir einen niedrigen Korb haben. Lotti – hol' den Deckel von dem grossen Gemüsekorb! Aber in der Geschichte war er mit Pech verklebt, damit das Wasser nicht eindringe …«
     </p>
-    <p xml:id="eco_de_0000140_7550">
+    <p xml:id="eco_de_0000210_7550">
      »Wir können im Schilf eine Stelle an der Mauer wählen, wo es trocken ist«, schlug Lotti vor.
     </p>
-    <p xml:id="eco_de_0000140_7560">
+    <p xml:id="eco_de_0000210_7560">
      »Nein, dann ist es nicht genau. Weisst du – bring das braune Wachstuch vom Tischchen in der hintern Stube; das dürfen wir schon schnell haben. Und du als Schwester vom Mosesknäblein – du kannst ein weisses Tuch um den Kopf binden.«
     </p>
-    <p xml:id="eco_de_0000140_7570">
+    <p xml:id="eco_de_0000210_7570">
      »Dann seh' ich aber aus wie die alte Eierfrau«, warf Lotti ein.
     </p>
-    <p xml:id="eco_de_0000140_7580">
+    <p xml:id="eco_de_0000210_7580">
      »Nein, du musst nur den Knoten hinten machen – . Ich sollte einen Königsmantel haben – frag doch Sophie, ob wir für einen Augenblick den roten Vorhang aus ihrem Zimmer nehmen können, und deine bunte Halskette bring' auch mit!«
     </p>
-    <p xml:id="eco_de_0000140_7590">
+    <p xml:id="eco_de_0000210_7590">
      Lotti lief, und Marianne wartete mit dem Schwesterlein auf dem Schoss.
     </p>
-    <p xml:id="eco_de_0000140_7600">
+    <p xml:id="eco_de_0000210_7600">
      »Wie schade«, dachte sie, »dass es noch gar nichts versteht und man ihm nicht sagen kann, dass es jetzt dann den kleinen Moses darstellen darf.«
     </p>
-    <p xml:id="eco_de_0000140_7610">
+    <p xml:id="eco_de_0000210_7610">
      Lotti erschien ganz beladen. Sie hatte nichts vergessen.
     </p>
-    <p xml:id="eco_de_0000140_7620">
+    <p xml:id="eco_de_0000210_7620">
      »Sophie hat wissen wollen, zu was ich den roten Vorhang brauche. Aber ich hatte doch keine Zeit, ihr alles zu erzählen. Ich sagte, ich erkläre es ihr nachher.«
     </p>
-    <p xml:id="eco_de_0000140_7630">
+    <p xml:id="eco_de_0000210_7630">
      Marianne legte zur Probe das Schwesterlein sorgfältig in den Korbdeckel. Dann richteten sich die beiden Mädchen als Pharaonentochter und als Schwester des Moses her und berieten, was sie zu sprechen hätten. Hierauf trug Marianne das Schwesterlein zum Schilf hinunter. Sie ging behutsam und gab acht, dass sie nicht über die grossen Steine stolperte. Sie suchte mit Lotti einen Platz, wo das Wasser nicht höher war als Lottis Hand. Da legten sie den Korbdeckel hin, das Wachstuch darauf und dann das Schwesterlein in seinem Kissen. Das Kleine lag ganz behaglich und streckte sein Händchen nach dem nächsten Schilfblatte aus.
     </p>
-    <p xml:id="eco_de_0000140_7640">
+    <p xml:id="eco_de_0000210_7640">
      »Also, Lotti, jetzt geht es an. Du versteckst dich dort an der Ecke, und ich komme von da, wie wenn das die Strasse wäre, die am Nil entlang führt. Der Nil ist der Strom, der durch Ägypten fliesst. Gib acht, was ich sage, damit du merkst, wann du herauskommen musst.«
     </p>
-    <p xml:id="eco_de_0000140_7650">
+    <p xml:id="eco_de_0000210_7650">
      Lotti nickte und schlüpfte mit ihrem weissen Kopftuch in das dichte Schilfgebüsch. Die beiden meinten, ganz allein zu sein bei ihrem Spiel. Aber sie hatten einen Zuschauer. Oben über die Mauer guckte Hans hinunter. Er war als letzter aus der Schule heimgekommen und hatte die Schwestern gesucht.
     </p>
-    <p xml:id="eco_de_0000140_7660">
+    <p xml:id="eco_de_0000210_7660">
      Schon wollte er ihnen zurufen; aber er sah auf ein so wunderliches Treiben herab, dass er still blieb, um die beiden zu beobachten.
     </p>
-    <p xml:id="eco_de_0000140_7670">
+    <p xml:id="eco_de_0000210_7670">
      »Die Marianne – wie die aussieht!« dachte er. »Und das Lotti mit dem weissen Tuch um den Kopf! Mich nimmt wunder, was das eigentlich geben soll. Nein –! dort liegt ja das Schwesterlein!«
     </p>
-    <p xml:id="eco_de_0000140_7680">
+    <p xml:id="eco_de_0000210_7680">
      Marianne trat hervor:
     </p>
-    <p xml:id="eco_de_0000140_7690">
+    <p xml:id="eco_de_0000210_7690">
      »Es ist sehr heiss heute. Man geht gerne ein wenig am Wasser, da ist die Luft kühler …«
     </p>
-    <p xml:id="eco_de_0000140_7700">
+    <p xml:id="eco_de_0000210_7700">
      Marianne sprach langsam und mit anderer Stimme als sonst. Sie tat einen Schritt vor und sah nach links.
     </p>
-    <p xml:id="eco_de_0000140_7710">
+    <p xml:id="eco_de_0000210_7710">
      »Ach, was liegt doch da im Wasser! Ein Knäblein, glaube ich. Was für ein allerliebstes kleines Kind –! Ich möchte es gleich mit mir nehmen.«
     </p>
-    <p xml:id="eco_de_0000140_7720">
+    <p xml:id="eco_de_0000210_7720">
      Sie drehte sich zurück, als ob hinter ihr ein Gefolge von Hofdamen wäre.
     </p>
-    <p xml:id="eco_de_0000140_7730">
+    <p xml:id="eco_de_0000210_7730">
      »Kommt doch und seht das hübsche Knäblein! Es gehört gewiss einer Israelitenfrau …«
     </p>
-    <p xml:id="eco_de_0000140_7740">
+    <p xml:id="eco_de_0000210_7740">
      Hans hörte nicht weiter, sondern lief in grossen Sätzen zum Hause. Das war so nett, was sie da unten aufführten; das musste Mama auch hören.
     </p>
-    <p xml:id="eco_de_0000140_7750">
+    <p xml:id="eco_de_0000210_7750">
      »Mama«, sagte er, »weisst du, wo Marianne und Lotti mit dem Schwesterlein sind?«
     </p>
-    <p xml:id="eco_de_0000140_7760">
+    <p xml:id="eco_de_0000210_7760">
      »Am Gartentor, hat Sophie gesagt.«
     </p>
-    <p xml:id="eco_de_0000140_7770">
+    <p xml:id="eco_de_0000210_7770">
      »Ja, das meint ihr. Aber sie sind alle drei im Schilf unten. Das Schwesterlein liegt sogar im Wasser.«
     </p>
-    <p xml:id="eco_de_0000140_7780">
+    <p xml:id="eco_de_0000210_7780">
      »Was –? im Wasser –?« rief Mama erschrocken.
     </p>
-    <p xml:id="eco_de_0000140_7790">
+    <p xml:id="eco_de_0000210_7790">
      »Ja, aber es ist nicht gefährlich. Sie haben es gut in einen Korb eingepackt, und Marianne steht davor und hält eine Rede.«
     </p>
-    <p xml:id="eco_de_0000140_7800">
+    <p xml:id="eco_de_0000210_7800">
      Mama eilte in den Garten.
     </p>
-    <p xml:id="eco_de_0000140_7810">
+    <p xml:id="eco_de_0000210_7810">
      »Bitte, Mama«, sagte Hans, der ihr folgte, »stör' sie nicht. Sieh einmal hinunter. Du wirst gleich merken, was sie spielen. Herr Altschmid hat uns letzten Winter in der Religionsstunde die Geschichte von Moses erzählt.«
     </p>
-    <p xml:id="eco_de_0000140_7820">
+    <p xml:id="eco_de_0000210_7820">
      Mama beugte sich über die Mauer. Wirklich, es war ein anmutiges Bild: Da stand Marianne als Pharaonentochter in dem hohen Schilf. Über ihren Rücken fiel der rote Mantel; sie hatte ihre langen, dichten Haare aufgelöst und über die Stirn eine bunte Glasperlenschnur gebunden. Vor ihr lag das Mosesknäblein und sah mit grossen Augen zu Lotti auf, die an dem Korbe niete. Mama bemerkte, wie gut geborgen das Kind auf der Wachstuchdecke lag.
     </p>
-    <p xml:id="eco_de_0000140_7830">
+    <p xml:id="eco_de_0000210_7830">
      »Prinzessin,« sagte Lotti, »ich wüsste eine Frau, die das Knäblein pflegen würde, wenn Sie vielleicht nicht gut Zeit haben für so ein kleines Kind. Die Frau wohnt gar nicht weit von hier.«
     </p>
-    <p xml:id="eco_de_0000140_7840">
+    <p xml:id="eco_de_0000210_7840">
      »Aber ist es auch eine gute Frau, die das Knäblein lieb haben würde?« fragte die Pharaonentochter und beugte sich hinab zu dem Moseskind, um es zu streicheln.
     </p>
-    <p xml:id="eco_de_0000140_7850">
+    <p xml:id="eco_de_0000210_7850">
      »Ja, lieb haben wird die Frau es gewiss! Bringt mir das Büblein nur gleich her!« ertönte auf einmal eine Stimme von oben.
     </p>
-    <p xml:id="eco_de_0000140_7860">
+    <p xml:id="eco_de_0000210_7860">
      Die Mädchen schauten verblüfft auf. Da war Mama –!
     </p>
-    <p xml:id="eco_de_0000140_7870">
+    <p xml:id="eco_de_0000210_7870">
      »Ach, Mama! du machst mit? wie hübsch!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000140_7880">
+    <p xml:id="eco_de_0000210_7880">
      »Ja, Kinder – eigentlich sollte ich zanken! Was ist das nun wieder, das Schwesterlein so mir nichts dir nichts da hinunterzunehmen und ins Wasser zu legen –«
     </p>
-    <p xml:id="eco_de_0000140_7890">
+    <p xml:id="eco_de_0000210_7890">
      »Aber, Mama, es ist gar nicht mir nichts dir nichts!« erklärte Lotti. »Es ist, damit wir die schöne Geschichte spielen können. Wir haben alles ganz genau gemacht! Nur statt Lehm und Pech, mit dem die Schwester des Moses das Körbchen verklebt hat, haben wir das Wachstuch genommen. Sieh, das Kissen ist nicht ein bisschen nass geworden.«
     </p>
-    <p xml:id="eco_de_0000140_7900">
+    <p xml:id="eco_de_0000210_7900">
      »Wenn nun aber ein Dampfschiff vorbeigefahren wäre, hätten die Wellen über das Schwesterlein hinschlagen können.«
     </p>
-    <p xml:id="eco_de_0000140_7910">
+    <p xml:id="eco_de_0000210_7910">
      »Mama, das Zwölfuhrschiff ist schon vorbeigefahren, als ich Marianne den Mantel anheftete, und die ›Möve‹ kommt erst nach dem Essen. Wir haben gewiss an alles gedacht.«
     </p>
-    <p xml:id="eco_de_0000140_7920">
+    <p xml:id="eco_de_0000210_7920">
      »Ich will es glauben, Kind«, sagte Mama. »Aber es vergeht doch fast kein Tag ohne einen kleinen Schrecken. Ganz ruhig kann man nur sein, wenn man euch alle fünf um sich herum hat. Manchmal möcht' ich fast, die Seeweid wäre weniger weit und gross und läge nicht so hart am Wasser –«
     </p>
-    <p xml:id="eco_de_0000140_7930">
+    <p xml:id="eco_de_0000210_7930">
      »Mama«, fiel jetzt Hans entsetzt ein, »das wäre schrecklich! Dann wollte ich lieber, dass es gar keinen Sommer gäbe! Weisst du, Emil Kolb in unserer Klasse sagt auch immer, sie wohnen auf dem Land; aber sie haben nur einen ganz kleinen Garten, und wenn Emil zum See will, muss er lang durch die Stadt laufen. Ich glaube, auf der ganzen Welt gibt es nichts so Schönes wie die Seeweid! Fritz Völklein sagt es auch immer.«
     </p>
-    <p xml:id="eco_de_0000140_7940">
+    <p xml:id="eco_de_0000210_7940">
      Mama lächelte, und Marianne, die das Schwesterlein aufgenommen hatte und immer noch etwas betreten in ihrem roten Prinzessinnenmantel da stand, war von Herzen froh darüber. Mama war also nicht ungehalten.
     </p>
-    <p xml:id="eco_de_0000140_7950">
+    <p xml:id="eco_de_0000210_7950">
      »Was geht denn eigentlich da drinnen vor –?« hörte man jetzt vom See her rufen. Papas weisser Strohhut wurde zwischen dem Schilfe sichtbar.
     </p>
-    <p xml:id="eco_de_0000140_7960">
+    <p xml:id="eco_de_0000210_7960">
      Papa kam von der Stadt hergefahren. Er hatte seine Zeitung, die er oft im Schiffe las, zusammengelegt und nach dem Schilfplatze hingesehen.
     </p>
-    <p xml:id="eco_de_0000140_7970">
+    <p xml:id="eco_de_0000210_7970">
      »Steppinger«, hatte er gesagt, »rudern Sie doch noch ein paar Züge dort hin. Ich sehe bald etwas Weisses, bald etwas Rotes da sich bewegen –«
     </p>
-    <p xml:id="eco_de_0000140_7980">
+    <p xml:id="eco_de_0000210_7980">
      Seine Augen fielen überrascht auf Marianne.
     </p>
-    <p xml:id="eco_de_0000140_7990">
+    <p xml:id="eco_de_0000210_7990">
      »Ja – Marianne –«, rief er belustigt. »oder vielmehr nicht Marianne, sondern eine Zigeunerin wohl, die ein Kind raubt? oder – verzeih – die Königin mit dem Schneewittchen oder die Fee in –«
     </p>
-    <p xml:id="eco_de_0000140_8000">
+    <p xml:id="eco_de_0000210_8000">
      »Nein, Papa! nein, Papa! es ist etwas ganz anderes; etwas noch Schöneres«, riefen die Kinder und fingen an zu erzählen. Es war aber gut, dass Papa die Geschichte von dem Mosesknäblein im Nil schon wusste; denn es ging wieder einmal recht durcheinander.
     </p>
-    <p xml:id="eco_de_0000140_8010">
+    <p xml:id="eco_de_0000210_8010">
      »Du, Papa –«, unterbrach sich Lotti, »ich weiss etwas: Du könntest nun der Pharao sein und Herr Steppinger dein Krieger, und ihr würdet das Mosesknäblein ergreifen wollen, und Hans käme mit unserm Schiff und würde den kleinen Moses retten, und dann gäbe es eine Verfolgung –«
     </p>
-    <p xml:id="eco_de_0000140_8020">
+    <p xml:id="eco_de_0000210_8020">
      »Lotti, Lotti«, sagte Papa, indem er den Kopf schüttelte, »lass mich zuerst als einfacher Vater Turnach zu Mittag essen. Ich bin hungrig und müde. Das mit dem Pharao will ich mir dann überlegen.«
     </p>
-    <p xml:id="eco_de_0000140_8030">
+    <p xml:id="eco_de_0000210_8030">
      Nun kam auch Balbine mit ihrer verbundenen Hand ans Gartentor und meldete, dass die Suppe auf dem Tisch stehe. Marianne lief in aller Eile zu Sophie, um sie zu bitten, dass sie ihr den gelösten Zopf wieder flechte.
     </p>
-    <p xml:id="eco_de_0000140_8040">
+    <p xml:id="eco_de_0000210_8040">
      Bei Tisch sprachen die Kinder eifrig von der Mosesgeschichte, und am Abend, als sie mit Papa und Mama noch ein wenig am See sassen, begann Marianne wieder davon.
     </p>
-    <p xml:id="eco_de_0000140_8050">
+    <p xml:id="eco_de_0000210_8050">
      »Willst du uns am Sonntag mehr von Moses erzählen, Mama?« fragte sie.
     </p>
-    <p xml:id="eco_de_0000140_8060">
+    <p xml:id="eco_de_0000210_8060">
      Am Sonntag vormittag waren die Kinder immer eine Stunde mit Mama zusammen. Sie lehrte sie dann kleine Lieder und Gedichte, sprach ihnen von Jesus und erzählte ihnen anderes aus der biblischen Geschichte oder sonst von edeln, guten Menschen.
     </p>
-    <p xml:id="eco_de_0000140_8070">
+    <p xml:id="eco_de_0000210_8070">
      »Vielleicht erzählt euch Papa von Moses, und zwar gleich jetzt«, sagte Mama, »weil euere Gedanken doch immer noch bei der Geschichte sind. Es ist allerdings fast schon Schlafenszeit; aber machen wir heut eine Ausnahme! Der Abend ist so schön.«
     </p>
-    <p xml:id="eco_de_0000140_8080">
+    <p xml:id="eco_de_0000210_8080">
      Die Sonne war eben untergegangen. Der klare Himmel war im Westen golden rot, und dieselbe Glut leuchtete aus dem ruhigen Wasser zurück.
     </p>
-    <p xml:id="eco_de_0000140_8090">
+    <p xml:id="eco_de_0000210_8090">
      Da fing denn Papa an zu erzählen von Moses, wie er die Schafe hütete am Berg Horeb und wie er dann von Gott die grosse, schwere Aufgabe erhielt, das Volk der Israeliten aus Ägypten ins gelobte Land zu führen. Wie Moses zuerst Angst hatte und nicht wollte, dann aber doch sein Volk wegführte durch das rote Meer und in die Wüste, wo die Israeliten oft nichts zu essen und kein Wasser fanden, so dass sie gegen Moses murrten. Wie dann Moses manchmal selbst kleinmütig wurde, aber immer wieder in sich die Stimme Gottes hörte, die ihn ermahnte, standhaft und treu zu bleiben. Wie er den Israeliten verbot, Götzen aus Stein oder Gold anzubeten, und sie lehrte, dass nur ein Gott sei, von dem man kein Bild machen könne. Wie endlich Moses, nachdem er mit seinem Volke viele Jahre in der Wüste geblieben war, als alter, müder Mann vom Berge Nebo aus das schöne gelobte Land noch sah und da oben auf der Berghöhe starb, ohne das Land zu betreten.
     </p>
-    <p xml:id="eco_de_0000140_8100">
+    <p xml:id="eco_de_0000210_8100">
      »Das war traurig für Moses«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_8110">
+    <p xml:id="eco_de_0000210_8110">
      »Ja, das war schwer«, antwortete Papa. »Oft erreichen die Menschen ihr Ziel nicht. Aber wenn sie unermüdlich, tapfer und treu waren, dann fühlen sie doch Gottes Segen und können getrost sterben.«
     </p>
-    <p xml:id="eco_de_0000140_8120">
+    <p xml:id="eco_de_0000210_8120">
      Die Kinder waren ganz andächtig geworden. Es war so schön, Papa zuzuhören, während es ringsum immer dunkler wurde. Sie konnten noch nicht alles verstehen, was Moses getan und gelitten hatte; aber sie fühlten, wie viel grosse und geheimnisvolle Dinge es gebe im Leben der Menschen.
     </p>
-    <p xml:id="eco_de_0000140_8130">
+    <p xml:id="eco_de_0000210_8130">
      Noch eine Weile blieben alle still sitzen, bis der Mond aufgegangen war und sein Schein wie eine silberne Brücke auf dem dunkeln Wasser schimmerte.
     </p>
    </div>
@@ -2566,559 +2566,559 @@
     <head>
      Der Seesturm
     </head>
-    <p xml:id="eco_de_0000140_8140">
+    <p xml:id="eco_de_0000210_8140">
      An einem heissen Mittwochnachmittag waren die Kinder unten am See. Marianne und Lotti gingen im feuchten Kies auf und ab, um nach Muscheln zu suchen, die der See etwa herschwemmte. Oft lagen viele zwischen den Steinen. Sie waren sehr hübsch, wie kleine ovale Schüsseln, aussen bräunlich, innen mattglänzend, ähnlich dem Perlmutter. Wenn bis Kinder eine unbeschädigte Muschel fanden, steckten sie sie ein. Man konnte beim Malen bis Farben darin anreiben und mischen. Oft errichteten bis Mädchen mit den Muscheln auch eine Geschirrhandlung. Sie stellten bis gleichgrossen zu Stössen in einander, immer ein halbes Dutzend. Dann setzte sich Marianne dazu, und Lotti kam, um einzukaufen. Oder sie gingen beide in die Küche hausieren zu Balbine, welche Teller und Schüsseln brauchte, aber ein scharfes Auge hatte und den feinsten Schaden an dem Geschirr entdeckte. Auch handelte sie lange, bis sie die Ware um den billigsten Preis bekam.
     </p>
-    <p xml:id="eco_de_0000140_8150">
+    <p xml:id="eco_de_0000210_8150">
      Heute fanden Marianne und Lotti fast keine schönen Muscheln.
     </p>
-    <p xml:id="eco_de_0000140_8160">
+    <p xml:id="eco_de_0000210_8160">
      »Kommt doch lieber zu mir!« rief Hans. »Seht, wie das fein geht!«
     </p>
-    <p xml:id="eco_de_0000140_8170">
+    <p xml:id="eco_de_0000210_8170">
      Hans liess Steine tanzen. Das war eine Lieblingsbeschäftigung von ihm. Und heute brauchte er nicht einmal lange im Uferkies nach flachen Steinen zu suchen; er hatte eine alte Schiefertafel zerschlagen und warf nun die kleinen Scherben in kräftigem Schwunge auf den See hinaus, so dass sie, nachdem sie aufgeschlagen, wieder in die Höhe Schnellten und in schönem Bogen über das Wasser schossen, um wieder aufzuprallen und vielleicht noch einen und noch einen Sprung zu tun.
     </p>
-    <p xml:id="eco_de_0000140_8180">
+    <p xml:id="eco_de_0000210_8180">
      Marianne und Lotti fingen nun auch an zu werfen. Leicht war es nicht.
     </p>
-    <p xml:id="eco_de_0000140_8190">
+    <p xml:id="eco_de_0000210_8190">
      »Mir wollen sie gar nicht tanzen, Hans!« sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_8200">
+    <p xml:id="eco_de_0000210_8200">
      »Du gibst dir aber auch keine rechte Mühe. Du wirfst bloss drauf los. Sieh, so –«
     </p>
-    <p xml:id="eco_de_0000140_8210">
+    <p xml:id="eco_de_0000210_8210">
      Hans stellte sich übers Wasser gebeugt, das Schieferstück zwischen den Fingern haltend, und warf. Im Eifer tat er allerdings einen festen Schritt ins Wasser hinein, so dass es ihm über die Schuhe lief. Aber fein war's.
     </p>
-    <p xml:id="eco_de_0000140_8220">
+    <p xml:id="eco_de_0000210_8220">
      »Ein – zwei – drei – viermal!« schrie er und holte eine neue Scherbe.
     </p>
-    <p xml:id="eco_de_0000140_8230">
+    <p xml:id="eco_de_0000210_8230">
      »Meine ist jetzt auch dreimal gesprungen!« rief Marianne triumphierend.
     </p>
-    <p xml:id="eco_de_0000140_8240">
+    <p xml:id="eco_de_0000210_8240">
      Lotti versuchte von neuem ihre Kunst und brachte es wenigstens auf einen Sprung.
     </p>
-    <p xml:id="eco_de_0000140_8250">
+    <p xml:id="eco_de_0000210_8250">
      »Aber grässlich heiss ist es!« sagte Hans, nachdem er wieder einen Meisterwurf getan hatte. Und auf einmal fanden Marianne und Lotti auch, man könne es vor Hitze nicht mehr aushalten.
     </p>
-    <p xml:id="eco_de_0000140_8260">
+    <p xml:id="eco_de_0000210_8260">
      Sie stiegen auf die Seemauer und setzten sich unter den Apfelbaum.
     </p>
-    <p xml:id="eco_de_0000140_8270">
+    <p xml:id="eco_de_0000210_8270">
      »Puh – puh!« machte Lotti und fächelte sich Luft zu mit einem grossem Ampferblatt.
     </p>
-    <p xml:id="eco_de_0000140_8280">
+    <p xml:id="eco_de_0000210_8280">
      »Auf dem See wäre es, glaub' ich, kühler«, meinte Hans. »Kommt, wir fahren ein wenig hinaus.«
     </p>
-    <p xml:id="eco_de_0000140_8290">
+    <p xml:id="eco_de_0000210_8290">
      Die Kinder liefen zum Schiff und fuhren weg. Viel frischer war es auch nicht da draussen. Aber die Sonne schien nicht mehr so stark; der Himmel umzog sich etwas.
     </p>
-    <p xml:id="eco_de_0000140_8300">
+    <p xml:id="eco_de_0000210_8300">
      »Ich weiss, wohin wir fahren«, sagte Hans, während er gegen das Färberschiff ruderte. »Wenn man ums Klaregg herum ist, kommt man etwas weiter oben zu einem Platz, wo eine ganze Menge hohe, dicke Binsen stehen. Die holen wir; dann macht uns Mama vielleicht heut' abend noch Schwummeln!«
     </p>
-    <p xml:id="eco_de_0000140_8310">
+    <p xml:id="eco_de_0000210_8310">
      »Aber, Hans, wir dürfen ja gar nicht so weit wegfahren!« warf Marianne ein. »Du weisst, was Papa und Mama gesagt haben.«
     </p>
-    <p xml:id="eco_de_0000140_8320">
+    <p xml:id="eco_de_0000210_8320">
      »Ach, das war vor etwa sieben Wochen! Jetzt kann ich doch schon wieder viel besser rudern. Mama hat es selbst gefunden, als sie vorgestern mit uns fuhr. Und es ging noch dazu ein wenig Wind. Ich komme jetzt sehr rasch vorwärts, und das Drehen geht auch ganz leicht. Seht einmal –«
     </p>
-    <p xml:id="eco_de_0000140_8330">
+    <p xml:id="eco_de_0000210_8330">
      Hans stemmte mit dem einen Ruder, während er mit dem andern ein paar tüchtige Züge tat; das Schiff drehte sich schnell und sicher herum.
     </p>
-    <p xml:id="eco_de_0000140_8340">
+    <p xml:id="eco_de_0000210_8340">
      »Da, Lotti, ich will sehen, wann du das einmal kannst!« sagte er zufrieden und ruderte in gerader Richtung weiter.
     </p>
-    <p xml:id="eco_de_0000140_8350">
+    <p xml:id="eco_de_0000210_8350">
      »Ich glaube auch«, sagte Lotti, »dass wir schon weiter hinausfahren dürfen, um die Binsen zu holen; das ist doch etwas Nützliches. Mama findet es gewiss gut, wenn wir eine rechte Ladung heimbringen. Marianne, dann haben wir morgen schon Schwummeln!«
     </p>
-    <p xml:id="eco_de_0000140_8360">
+    <p xml:id="eco_de_0000210_8360">
      Marianne lockte es gewaltig, und sie machte sich's in ihrem Sinn ebenfalls zurecht, dass Mama nichts dagegen habe, wenn man jetzt die Binsen hole.
     </p>
-    <p xml:id="eco_de_0000140_8370">
+    <p xml:id="eco_de_0000210_8370">
      Es war ein ziemlicher Weg bis zum Klaregg, und als Hans endlich um die Spitze der Halbinsel herumgelenkt hatte, ging es noch ein gutes Stück seeaufwärts. Endlich entdeckten die Kinder die mit Binsen bewachsene Stelle. Ein ganzer kleiner Wald von langen schönen Stengeln stand da.
     </p>
-    <p xml:id="eco_de_0000140_8380">
+    <p xml:id="eco_de_0000210_8380">
      »Nun müsst ihr mir genau folgen«, erklärte Hans, indem er die Ruder einzog. »Auf den Schiffen muss strenger Gehorsam sein, sagt Fritz Völklein immer, weil es sonst leicht etwas Dummes gibt.«
     </p>
-    <p xml:id="eco_de_0000140_8390">
+    <p xml:id="eco_de_0000210_8390">
      »Ja, gelt, und jetzt bist du froh, dass du befehlen kannst!« sagte Marianne. Aber sie tat, was Hans anordnete; denn er war doch der Älteste. Sie setzte sich ganz auf eine Seite des Schiffes, und damit dieses still stehe, hielt sie einen Büschel Binsen gefasst. Hans bückte sich an der andern Seite hinaus und zog behutsam einen Stengel nach dem andern aus dem Seegrund. Wenn er sie nicht schön gerade heraufzog, so brachen sie ab und waren zu kurz. Lotti musste ihm die Binsen abnehmen und auf den Boden des Schiffes legen.
     </p>
-    <p xml:id="eco_de_0000140_8400">
+    <p xml:id="eco_de_0000210_8400">
      »Mehr hinüber, Marianne!« rief Hans von Zeit zu Zeit.
     </p>
-    <p xml:id="eco_de_0000140_8410">
+    <p xml:id="eco_de_0000210_8410">
      »Mach' dich etwas schwerer!«
     </p>
-    <p xml:id="eco_de_0000140_8420">
+    <p xml:id="eco_de_0000210_8420">
      Wenn er dann mit einem Ruck wieder eine Binse losbrachte, schwankte das Schiff und Lotti schrie ein wenig. Doch wussten Hans und Marianne rasch auszugleichen und das Gleichgewicht wieder herzustellen.
     </p>
-    <p xml:id="eco_de_0000140_8430">
+    <p xml:id="eco_de_0000210_8430">
      Nach einer Weile lag auf dem Schiffboden ein ganzer Haufen langer dicker Binsen; unten, wo sie im Wasser gesteckt hatten, waren sie gelblich, oben dunkelgrün und trugen kurze bräunliche Blütenbüschel.
     </p>
-    <p xml:id="eco_de_0000140_8440">
+    <p xml:id="eco_de_0000210_8440">
      »Noch etwa ein Dutzend, dann gibt es wohl drei Schwummeln«, meinte Hans.
     </p>
-    <p xml:id="eco_de_0000140_8450">
+    <p xml:id="eco_de_0000210_8450">
      »Wie gut«, sagte Lotti. »Jetzt ist es gar nicht mehr so heiss. Es geht ein schöner Wind.«
     </p>
-    <p xml:id="eco_de_0000140_8460">
+    <p xml:id="eco_de_0000210_8460">
      Sie sah zu, wie das Wasser in gekräuselten Wellen durch die Binsen strich.
     </p>
-    <p xml:id="eco_de_0000140_8470">
+    <p xml:id="eco_de_0000210_8470">
      Marianne schaute auf.
     </p>
-    <p xml:id="eco_de_0000140_8480">
+    <p xml:id="eco_de_0000210_8480">
      »Hans, dort hinter dem Kreuzberg kommt es ganz dunkel herauf! Wir wollen heimfahren!«
     </p>
-    <p xml:id="eco_de_0000140_8490">
+    <p xml:id="eco_de_0000210_8490">
      »Noch die zwei – und die drei dicken dort –« Es reute Hans, die schönsten zurückzulassen.
     </p>
-    <p xml:id="eco_de_0000140_8500">
+    <p xml:id="eco_de_0000210_8500">
      Endlich richtete er sich auf. Marianne und Lotti wussten kaum mehr, wohin sie die Füsse stellen sollten; alles lag voll Binsen.
     </p>
-    <p xml:id="eco_de_0000140_8510">
+    <p xml:id="eco_de_0000210_8510">
      »Das Schiff ist schwerer jetzt«, sagte Hans und begann angestrengt zu rudern. »Es ist dumm, dass man gerade gestern die Sitzruder zum Anstreichen getragen hat, sonst hättest du helfen können, Marianne.«
     </p>
-    <p xml:id="eco_de_0000140_8520">
+    <p xml:id="eco_de_0000210_8520">
      »Ja, und der Wind bläst uns entgegen! Die Wellen werden immer stärker. Hans, warum fährst du denn so weit hinaus –?« Marianne machte ein besorgtes Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_8530">
+    <p xml:id="eco_de_0000210_8530">
      Hans antwortete nicht. Er hatte alle Mühe, die Richtung zu behalten. Immer wieder drehte sich das Schiff, so dass die Wellen von der Seite anschlugen.
     </p>
-    <p xml:id="eco_de_0000140_8540">
+    <p xml:id="eco_de_0000210_8540">
      »Wenn wir nur schon beim Klaregg wären!« sagte Lotti. »Man meint, wir kommen gar nicht vorwärts, Hans.«
     </p>
-    <p xml:id="eco_de_0000140_8550">
+    <p xml:id="eco_de_0000210_8550">
      »So komm du an die Ruder! Vielleicht geht es dann besser!« erwiderte Hans zornig.
     </p>
-    <p xml:id="eco_de_0000140_8560">
+    <p xml:id="eco_de_0000210_8560">
      »Ach, fang' nicht an zu streiten jetzt!« wehrte Marianne. »Ich glaube, es war nicht recht, dass wir da hinausfuhren!«
     </p>
-    <p xml:id="eco_de_0000140_8570">
+    <p xml:id="eco_de_0000210_8570">
      »Ich glaube es auch!« sagte Lotti. Hans biss sich auf die Lippe; es sah aus, als ob er dasselbe dächte.
     </p>
-    <p xml:id="eco_de_0000140_8580">
+    <p xml:id="eco_de_0000210_8580">
      Der Wind wurde heftiger; die Wellen wurde immer höher und stürzten mit lautem Brausen daher. Der See hatte eine unheimlich dunkle Farbe. Auf jeder Welle flog eine weisse Schaumkrone daher und spritzte ihren Gischt in das schwankende Schiff. Marianne und Lotti wurden ganz nass; sie sassen still und ängstlich auf der mittlern Bank.
     </p>
-    <p xml:id="eco_de_0000140_8590">
+    <p xml:id="eco_de_0000210_8590">
      »Marianne, glaubst du auch, der liebe Gott schicke den Sturm, weil wir ungehorsam gewesen sind –?« fragte Lotti leise.
     </p>
-    <p xml:id="eco_de_0000140_8600">
+    <p xml:id="eco_de_0000210_8600">
      Da kam wieder eine mächtige Welle: ein ganzer Wasserstrahl ging über die Spitze des Schiffes und riss einen Teil der Binsen, die dort lagen, weg. Lotti wollte sie halten.
     </p>
-    <p xml:id="eco_de_0000140_8610">
+    <p xml:id="eco_de_0000210_8610">
      »Nein, nein – Lotti, lass! Vielleicht sollen wir keine Binsen haben!« rief Marianne. »Ich kann sie auch gar nicht mehr sehen – ich wollte, wir hätten keine ausgerissen, keine einzige –«
     </p>
-    <p xml:id="eco_de_0000140_8620">
+    <p xml:id="eco_de_0000210_8620">
      Marianne nahm, so viel sie von den Binsen am Boden fassen konnte, und warf sie hinaus.
     </p>
-    <p xml:id="eco_de_0000140_8630">
+    <p xml:id="eco_de_0000210_8630">
      Lotti sah nach Hans. Er wehrte mit keinem Wort.
     </p>
-    <p xml:id="eco_de_0000140_8640">
+    <p xml:id="eco_de_0000210_8640">
      »Ja, ja«, sagte sie. »Wir wollen sie hergeben. Vielleicht lässt der liebe Gott dann den Sturm aufhören!«
     </p>
-    <p xml:id="eco_de_0000140_8650">
+    <p xml:id="eco_de_0000210_8650">
      Sie griff auch nach den Binsen und warf sie hinaus. Die langen grünen Stengel wurden von den Wellen fortgerissen.
     </p>
-    <p xml:id="eco_de_0000140_8660">
+    <p xml:id="eco_de_0000210_8660">
      Aber der Sturm legte sich nicht; in heulenden Stössen fuhr er über den See weg. Der Himmel war mit schweren, dunkeln Wolken bedeckt.
     </p>
-    <p xml:id="eco_de_0000140_8670">
+    <p xml:id="eco_de_0000210_8670">
      Auf einmal riss ein Windstoss dem Hans den Hug vom Kopfe. Hans liess beide Ruder los und griff nach dem Hut.
     </p>
-    <p xml:id="eco_de_0000140_8680">
+    <p xml:id="eco_de_0000210_8680">
      Hui –! wie die Wellen das Schiff herumdrehten, als ob sie zeigen wollten, dass sie es doch noch rascher konnten als Hans.
     </p>
-    <p xml:id="eco_de_0000140_8690">
+    <p xml:id="eco_de_0000210_8690">
      Hans wäre beinahe ins Wasser gestürzt; den Hut erwischte er nicht. Als er sich aufrichtete, riss der Wind das Schiff noch einmal herum, und Hansens Hand wurde zwischen das Ruder und den Rand des Schiffes gequetscht.
     </p>
-    <p xml:id="eco_de_0000140_8700">
+    <p xml:id="eco_de_0000210_8700">
      »Ah –!« stöhnte Hans; doch fasste er das Ruder. Aber Lotti sah, dass das Blut über des Bruders Hand floss, und fing laut an zu weinen.
     </p>
-    <p xml:id="eco_de_0000140_8710">
+    <p xml:id="eco_de_0000210_8710">
      Nach ein paar Zügen hörte Hans wieder auf.
     </p>
-    <p xml:id="eco_de_0000140_8720">
+    <p xml:id="eco_de_0000210_8720">
      »Ich – ich kann nicht mehr! Es gibt solche Stiche –«
     </p>
-    <p xml:id="eco_de_0000140_8730">
+    <p xml:id="eco_de_0000210_8730">
      Er sank ganz vernichtet hin und überliess das Schiff den Wellen.
     </p>
-    <p xml:id="eco_de_0000140_8740">
+    <p xml:id="eco_de_0000210_8740">
      Marianne wollte aufstehen; aber das Schiff schwankte so stark, dass sie sich erschrocken wieder setzte. Auch wusste sie ja mit dem Stehruder gar nicht recht umzugehen.
     </p>
-    <p xml:id="eco_de_0000140_8750">
+    <p xml:id="eco_de_0000210_8750">
      »Marianne – Hans –« schluchzte Lotti. »Wir wollen beten, dass der liebe Gott uns hilft. Hans, sag' ein Gebet – eins, wo etwas vom Sturm drin vorkommt!«
     </p>
-    <p xml:id="eco_de_0000140_8760">
+    <p xml:id="eco_de_0000210_8760">
      Aber vor Schmerz und Angst fiel dem Hans gar kein Gebet ein.
     </p>
-    <p xml:id="eco_de_0000140_8770">
+    <p xml:id="eco_de_0000210_8770">
      Da fing Marianne mit zitternder Stimme an:
     </p>
-    <p xml:id="eco_de_0000140_8780">
+    <p xml:id="eco_de_0000210_8780">
      »Befiehl du deine Wege Und was dein Herze kränkt Der allertreusten Pflege –«
     </p>
-    <p xml:id="eco_de_0000140_8790">
+    <p xml:id="eco_de_0000210_8790">
      »Da ist ja nichts vom Sturm!« unterbrach Lotti.
     </p>
-    <p xml:id="eco_de_0000140_8800">
+    <p xml:id="eco_de_0000210_8800">
      »Sei doch still, Lotti!« rief Hans. »Es kommt schon –«
     </p>
-    <p xml:id="eco_de_0000140_8810">
+    <p xml:id="eco_de_0000210_8810">
      »Der allertreusten Pflege Des, der den Himmel lenkt. Der Wolken, Luft und Winden gibt Wege, Lauf und Bahn, Der wird auch Wege finden, Da dein Fuss gehen kann …«
     </p>
-    <p xml:id="eco_de_0000140_8820">
+    <p xml:id="eco_de_0000210_8820">
      Der Sturm heulte, und die Wellen brausten mit Getöse daher.
     </p>
-    <p xml:id="eco_de_0000140_8830">
+    <p xml:id="eco_de_0000210_8830">
      »Lauter, Marianne, lauter!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000140_8840">
+    <p xml:id="eco_de_0000210_8840">
      Und Marianne fing noch einmal an, so laut sie konnte:
     </p>
-    <p xml:id="eco_de_0000140_8850">
+    <p xml:id="eco_de_0000210_8850">
      »Der Wolken, Luft und Winden Gibt Wege, Lauf und Bahn …«
     </p>
-    <p xml:id="eco_de_0000140_8860">
+    <p xml:id="eco_de_0000210_8860">
      Das Schiff aber trieb in dem wilden Wasser immer weiter in den See hinaus.
     </p>
-    <p xml:id="eco_de_0000140_8870">
+    <p xml:id="eco_de_0000210_8870">
      »Sophie!« Balbine steckte ihren Kopf in die Stube, wo Sophie nähte. Frau Turnach war ausgegangen. Im Korbwagen lag das Schwesterlein und schlief. Werner sass am Boden und ordnete die Knöpfe, die Sophie ihm aus ihrer Schachtel auf den Teppich geschüttet hatte; die schwarzen tat er zusammen, dann die weissen und die bunten.
     </p>
-    <p xml:id="eco_de_0000140_8880">
+    <p xml:id="eco_de_0000210_8880">
      »Sophie, wo sind denn die Kinder? Es stürmt draussen, dass es einem fast den Atem nimmt!«
     </p>
-    <p xml:id="eco_de_0000140_8890">
+    <p xml:id="eco_de_0000210_8890">
      »Sie sind im Stall bei den Kaninchen, glaub' ich«, sagte Sophie und nähte ruhig weiter.
     </p>
-    <p xml:id="eco_de_0000140_8900">
+    <p xml:id="eco_de_0000210_8900">
      »Nein, im Stall sind sie nicht. Ich hab' gerade den Jakob gefragt. Er ist mit einem zerbrochenen Rad zum Wagner gegangen. Und Frau Völklein weiss auch nichts von ihnen. Ich meine, du solltest doch einmal hinausgehen.«
     </p>
-    <p xml:id="eco_de_0000140_8910">
+    <p xml:id="eco_de_0000210_8910">
      Sophie stand auf, und Balbine setzte sich an ihren Platz zu den Kleinen.
     </p>
-    <p xml:id="eco_de_0000140_8920">
+    <p xml:id="eco_de_0000210_8920">
      »Wo können sie wohl sein?« dachte Sophie. »Im Badhaus vielleicht. Hans hat einmal behauptet, es sei dort am allerschönsten, wenn die Wellen heranbrausen und an der Holzwand heraufschlagen.«
     </p>
-    <p xml:id="eco_de_0000140_8930">
+    <p xml:id="eco_de_0000210_8930">
      Sophie lief über den Hof und am Landungsplatz vorbei.
     </p>
-    <p xml:id="eco_de_0000140_8940">
+    <p xml:id="eco_de_0000210_8940">
      Was war das –? Das Schiff war ja nicht da –! Den Jakob hatte Balbine eben weggehen sehen – Fritz Völklein war oben bei seiner Grosstante. Wer hatte das Schiff –! Sie Kinder –? Um Gotteswillen, die Kinder werden doch nicht bei dem Sturm –
     </p>
-    <p xml:id="eco_de_0000140_8950">
+    <p xml:id="eco_de_0000210_8950">
      Sophie lief hinaus an die Mauerecke, wo man einen Ausblick über den See hatte. Kein Schiff war zu sehen.
     </p>
-    <p xml:id="eco_de_0000140_8960">
+    <p xml:id="eco_de_0000210_8960">
      Sie rannte ins Haus zurück und die Treppe hinauf zu Frau Völklein.
     </p>
-    <p xml:id="eco_de_0000140_8970">
+    <p xml:id="eco_de_0000210_8970">
      »Holla, Sophie! Sie fahren ja daher wie der Sturmwind draussen!« lachte Fritz Völklein, der auf dem Vorplatz an einem Schemel für die Tante herumzimmerte.
     </p>
-    <p xml:id="eco_de_0000140_8980">
+    <p xml:id="eco_de_0000210_8980">
      »Fritz, die Kinder – sie sind nicht da, und das Schiff ist auch fort! Sie sind – Gott, o Gott, wenn sie in dem Sturm –«
     </p>
-    <p xml:id="eco_de_0000140_8990">
+    <p xml:id="eco_de_0000210_8990">
      Fritz sprang auf.
     </p>
-    <p xml:id="eco_de_0000140_9000">
+    <p xml:id="eco_de_0000210_9000">
      »Tante«, rief er ins Zimmer hinein, »die Turnachkinder sind auf dem See draussen! Man muss nach ihnen sehen! Ich laufe zum alten Lienhard, dass er mir sein Schiff gebe –«
     </p>
-    <p xml:id="eco_de_0000140_9010">
+    <p xml:id="eco_de_0000210_9010">
      In ein paar Sätzen war Fritz unten.
     </p>
-    <p xml:id="eco_de_0000140_9020">
+    <p xml:id="eco_de_0000210_9020">
      Frau Völklein sah ihm nach.
     </p>
-    <p xml:id="eco_de_0000140_9030">
+    <p xml:id="eco_de_0000210_9030">
      »Er ist ein braver, braver Bursch«, sagte sie. »Aber bei einem solchen Sturm ist es schlimm hinausfahren! Hilf Gott, dass das gut geht …«
     </p>
-    <p xml:id="eco_de_0000140_9040">
+    <p xml:id="eco_de_0000210_9040">
      Fritz Völklein rannte durch den Sturm den Weg hinauf und dann rechts den Hecken entlang. Dass Sophie hinter ihm drein lief, merkte er gar nicht.
     </p>
-    <p xml:id="eco_de_0000140_9050">
+    <p xml:id="eco_de_0000210_9050">
      Der alte Lienhard sah zum Fenster hinaus nach dem Unwetter.
     </p>
-    <p xml:id="eco_de_0000140_9060">
+    <p xml:id="eco_de_0000210_9060">
      »Herr Lienhard!« rief Fritz Völklein atemlos, »Herr Lienhard, kann ich Ihr Schiff haben? Die Turnachkinder sind draussen!«
     </p>
-    <p xml:id="eco_de_0000140_9070">
+    <p xml:id="eco_de_0000210_9070">
      »Die Turnachkinder –? Ja, sind denn die noch nicht zurück? Es hat gerade halb vier Uhr geschlagen, da sah ich sie gegen das Klaregg hinausfahren.«
     </p>
-    <p xml:id="eco_de_0000140_9080">
+    <p xml:id="eco_de_0000210_9080">
      Nun wusste Fritz Völklein doch, welche Richtung er zu nehmen hatte.
     </p>
-    <p xml:id="eco_de_0000140_9090">
+    <p xml:id="eco_de_0000210_9090">
      »Da –«, der alte Lienhard warf den kleinen Schlüssel zur Schiffkette hinunter.
     </p>
-    <p xml:id="eco_de_0000140_9100">
+    <p xml:id="eco_de_0000210_9100">
      Als Fritz Völklein zum Schiff kam, stand Sophie da.
     </p>
-    <p xml:id="eco_de_0000140_9110">
+    <p xml:id="eco_de_0000210_9110">
      »Ich fahre mit, Fritz! Ich halt' es nicht aus vor Angst! Und dann – zwei kommen doch weiter als eins –«
     </p>
-    <p xml:id="eco_de_0000140_9120">
+    <p xml:id="eco_de_0000210_9120">
      Sophie sprang ins Schiff und hängte die Sitzruder ein. Sie war jung und kräftig und ruderte gut.
     </p>
-    <p xml:id="eco_de_0000140_9130">
+    <p xml:id="eco_de_0000210_9130">
      »Also denn –«, sagte Fritz, warf die Kette ins Schiff und stiess los.
     </p>
-    <p xml:id="eco_de_0000140_9140">
+    <p xml:id="eco_de_0000210_9140">
      Wild schleuderten die Wellen das Schiff an die Mauern; mit Mühe kam Fritz hinaus. Dann ruderten die beiden mit Anstrengung ihrer ganzen Kraft drauf los. Auf und nieder ging es über die mächtigen Wellen, und der Sturm heulte und pfiff ohne Unterlass …
     </p>
-    <p xml:id="eco_de_0000140_9150">
+    <p xml:id="eco_de_0000210_9150">
      »Noch vor zehn Jahren wäre ich selber hinausgefahren«, sagte der alte, fast achtzigjährige Lienhard vor sich hin, während er dem Schiffe nachsah. »Aber wenn man die Gicht in allen Knochen hat –! Ein Gewitter gibt's nicht. Es wäre besser. Dann würde der Sturm sich legen. Aber so wird er noch eine Weile fortblasen und, scheint mir, eher noch stärker werden.«
     </p>
-    <p xml:id="eco_de_0000140_9160">
+    <p xml:id="eco_de_0000210_9160">
      Er legte die Hand über die Augen.
     </p>
-    <p xml:id="eco_de_0000140_9170">
+    <p xml:id="eco_de_0000210_9170">
      »Wenn sie nur gut ums Klaregg kommen! Dort haut es einen immer am stärksten herum.«
     </p>
-    <p xml:id="eco_de_0000140_9180">
+    <p xml:id="eco_de_0000210_9180">
      In der Seeweid standen Frau Völklein und Balbine auch am Fenster und sahen in Angst und Spannung hinaus.
     </p>
-    <p xml:id="eco_de_0000140_9190">
+    <p xml:id="eco_de_0000210_9190">
      »Frau Turnach wird jeden Augenblick heimkommen«, sagte Balbine. »Sie ist bei ihrer Mutter, die krank liegt. Frau Völklein, was sag' ich nun, wenn Frau Turnach frägt, wo die Kinder sind –!«
     </p>
-    <p xml:id="eco_de_0000140_9200">
+    <p xml:id="eco_de_0000210_9200">
      Frau Völklein seufzte, während sie den kleinen Werner streichelte, der ihr zeigte, wie schön er die Knöpfe geordnet habe.
     </p>
-    <p xml:id="eco_de_0000140_9210">
+    <p xml:id="eco_de_0000210_9210">
      Grossmama in der Stadt fühlte sich besser; sie wollte Frau Turnach nicht fortlassen bei dem Sturm, der sich erhoben hatte; doch diese hatte keine Ruhe mehr.
     </p>
-    <p xml:id="eco_de_0000140_9220">
+    <p xml:id="eco_de_0000210_9220">
      »Gerade bei solchem Wetter ist es gut, wenn ich zu Hause bin«, sagte sie. »Wenn alle fünf in der Stube sein müssen, so wird Sophie kaum mit ihnen fertig.«
     </p>
-    <p xml:id="eco_de_0000140_9230">
+    <p xml:id="eco_de_0000210_9230">
      Draussen war es sehr hässlich. Hoch wirbelte der Staub auf, und aus jeder Gasse fuhr ein tückischer Windstoss den Vorübereilenden entgegen.
     </p>
-    <p xml:id="eco_de_0000140_9240">
+    <p xml:id="eco_de_0000210_9240">
      »Wenn nur Sophie die Fenster gut zugemacht hat und oben in Hansens Stübchen nach den Läden sieht«, dachte Frau Turnach, während sie so eilig ging, als sie konnte. »Ob Hans wohl daran denkt, seine Bücher frisch einzubinden in das braune Papier, das ich ihm gegeben habe? Es ist immer gut, wenn er etwas Bestimmtes zu tun hat. Marianne wird mit Werner spielen. Sie versteht so nett mit ihm umzugehen …«
     </p>
-    <p xml:id="eco_de_0000140_9250">
+    <p xml:id="eco_de_0000210_9250">
      Von Zeit zu Zeit musste Frau Turnach stillstehen, so stark blies der Wind. Als sie von der Strasse in den Seeweg bog, war dieser bestreut mit losgerissenen Blättern und Zweigen. Der Wind rauschte und tobte in den alten Bäumen, als ob sie aus der Erde heraus müssten.
     </p>
-    <p xml:id="eco_de_0000140_9260">
+    <p xml:id="eco_de_0000210_9260">
      »Wie gut, jetzt daheim zu sein!« dachte Frau Turnach, indem sie die Haustüre aufmachte.
     </p>
-    <p xml:id="eco_de_0000140_9270">
+    <p xml:id="eco_de_0000210_9270">
      »Guten Abend, Kinder!« rief sie gegen die Wohnstube hin.
     </p>
-    <p xml:id="eco_de_0000140_9280">
+    <p xml:id="eco_de_0000210_9280">
      Sie wunderte sich, dass es so still war. Da hörte sie oben bei Frau Völklein Werners Stimme.
     </p>
-    <p xml:id="eco_de_0000140_9290">
+    <p xml:id="eco_de_0000210_9290">
      »Mama, Mama!«
     </p>
-    <p xml:id="eco_de_0000140_9300">
+    <p xml:id="eco_de_0000210_9300">
      Mit raschen Füssen trabte Werner die Treppe herunter.
     </p>
-    <p xml:id="eco_de_0000140_9310">
+    <p xml:id="eco_de_0000210_9310">
      »Mama, Fritz Völklein holt den Hans und die Marianne und Lotti. Sie sind draussen auf dem See, und Sophie ist mit Fritz, und ich hab' nicht mitdürfen! Hast du mir etwas mitgebracht?«
     </p>
-    <p xml:id="eco_de_0000140_9320">
+    <p xml:id="eco_de_0000210_9320">
      Frau Turnach sah entsetzt hinauf; ihre Augen fielen auf die ängstlichen Gesichter von Frau Völklein und Balbine, und sie erschrak noch mehr.
     </p>
-    <p xml:id="eco_de_0000140_9330">
+    <p xml:id="eco_de_0000210_9330">
      »Balbine! was ist geschehen – wo sind die Kinder –?«
     </p>
-    <p xml:id="eco_de_0000140_9340">
+    <p xml:id="eco_de_0000210_9340">
      »Noch ist nichts geschehen, Frau Turnach!« Frau Völklein suchte ihrer Stimme einen festen Klang zu geben. »Die Kinder sind hinausgefahren und nicht zurückgekommen. Aber Fritz holt sie – Fritz und Sophie werden sie bringen; der liebe Gott wird ihnen helfen, Frau Turnach.« So tröstete die gute alte Frau, während Frau Turnach blass und wortlos am Treppengeländer stand.
     </p>
-    <p xml:id="eco_de_0000140_9350">
+    <p xml:id="eco_de_0000210_9350">
      Nach einem Augenblick aber raffte sie sich zusammen und eilte hinaus. Sie musste zum See; sie musste nach ihren Kindern sehen! Balbine und Frau Völklein gingen ihr nach. Grite hatte übernommen, bei den Kindern zu bleiben. Draussen an der Seemauer stürmte es furchtbar; man konnte kaum stehen. Der Wind heulte, und die Wellen bäumten sich laut tosend auf und spritzten ihren weissen Schaum über den Garten hin.
     </p>
-    <p xml:id="eco_de_0000140_9360">
+    <p xml:id="eco_de_0000210_9360">
      »Um Gottes willen!« jammerte Balbine leise zu Frau Völklein. »Es wird immer ärger –!«
     </p>
-    <p xml:id="eco_de_0000140_9370">
+    <p xml:id="eco_de_0000210_9370">
      Sie trat mit der alten Frau hinter das Badhaus, um etwas Schutz zu haben. Frau Turnach aber blieb am Rande der Mauer stehen. Sie sah unverwandt hinaus auf den See, als ob sie mit dem angstvollen treuen Blick ihrer Augen die Kinder durch das tosende Wasser herführen könnte …
     </p>
-    <p xml:id="eco_de_0000140_9380">
+    <p xml:id="eco_de_0000210_9380">
      Und während sie so hinausspähte, ruderten Fritz Völklein und Sophie schon hinter dem Klaregg heran, das Schiff nachschleppend, in dem die Turnachkinder sassen, glücklich gerettet.
     </p>
-    <p xml:id="eco_de_0000140_9390">
+    <p xml:id="eco_de_0000210_9390">
      Glücklich gerettet, nachdem sie weinend auf den wilden See hinausgetrieben worden waren und sich von Gott und Menschen verlassen geglaubt hatten. Hans zuerst hatte das Schiff auftauchen sehen. Es war näher und näher gekommen –
     </p>
-    <p xml:id="eco_de_0000140_9400">
+    <p xml:id="eco_de_0000210_9400">
      »Fritz, Fritz –!« hatten die Kinder gerufen. »Fritz und Sophie kommen uns zu Hülfe –«
     </p>
-    <p xml:id="eco_de_0000140_9410">
+    <p xml:id="eco_de_0000210_9410">
      Es war ein schweres Stück Arbeit gewesen, dem Schiff der Kinder nahe zu kommen.
     </p>
-    <p xml:id="eco_de_0000140_9420">
+    <p xml:id="eco_de_0000210_9420">
      »Achtung, Hans –!« hatte Fritz geschrien und das Seil, das er mitgenommen, hinübergeworfen. Der Wurf misslang.
     </p>
-    <p xml:id="eco_de_0000140_9430">
+    <p xml:id="eco_de_0000210_9430">
      Hans erhob sich, um beim zweiten Wurf das Seil zu erhaschen.
     </p>
-    <p xml:id="eco_de_0000140_9440">
+    <p xml:id="eco_de_0000210_9440">
      »Sitzen bleiben!« schrie Fritz mit strenger Stimme. »Willst noch hinausgeschleudert werden! Knie an den Boden!«
     </p>
-    <p xml:id="eco_de_0000140_9450">
+    <p xml:id="eco_de_0000210_9450">
      Noch einmal fiel das Seil ins Wasser. Sophie stemmte mit aller Kraft die Ruder gegen die Wellen, um ihr Schiff dem andern möglichst nahe zu bringen.
     </p>
-    <p xml:id="eco_de_0000140_9460">
+    <p xml:id="eco_de_0000210_9460">
      »Hans – nimm dich zusammen! Bist doch sonst nicht so ungeschickt!« Fritz war fast böse.
     </p>
-    <p xml:id="eco_de_0000140_9470">
+    <p xml:id="eco_de_0000210_9470">
      »Er hat die Hand zerquetscht!« schrien Marianne und Lotti hinüber.
     </p>
-    <p xml:id="eco_de_0000140_9480">
+    <p xml:id="eco_de_0000210_9480">
      Das dritte Mal ging es. Marianne hatte das Seil erwischt und kroch zur Spitze des Schiffes, um es dort durch den Ring zu ziehen und fest zu machen. Sie zitterte so vor Schrecken und Aufregung, dass sie kaum damit zu stande kam.
     </p>
-    <p xml:id="eco_de_0000140_9490">
+    <p xml:id="eco_de_0000210_9490">
      »Wirf mir euere Kette herüber, Marianne!« rief Fritz, indem er das Schiff der Turnachkinder näher heranzog.
     </p>
-    <p xml:id="eco_de_0000140_9500">
+    <p xml:id="eco_de_0000210_9500">
      Er fing die Kette auf und hängte sie ein. Mühsam ging es nun vorwärts. Das angebundene Schiff wurde auf und ab, hin und her geschleudert; jeden Augenblick glaubte man, dass es umschlage.
     </p>
-    <p xml:id="eco_de_0000140_9510">
+    <p xml:id="eco_de_0000210_9510">
      »Lotti, Marianne, Hans!« rief Sophie hinüber, »seid nur getrost! wir kommen schon durch!«
     </p>
-    <p xml:id="eco_de_0000140_9520">
+    <p xml:id="eco_de_0000210_9520">
      Sie hätte am liebsten, wenn es möglich gewesen wäre, die Kinder zu sich herübergenommen. Sie sahen so verängstigt und verweint aus. Aber es galt, fest am Ruder zu bleiben. Die beiden Schiffe waren schwer durch die Wellen zu bringen.
     </p>
-    <p xml:id="eco_de_0000140_9530">
+    <p xml:id="eco_de_0000210_9530">
      »Frau Turnach wird längst zu Hause sein – mein Gott! und welche Angst ausstehen!« sagte Sophie zu Fritz Völklein. »Wenn wir ums Klaregg biegen, so können sie uns kommen sehen. Aber dann geht es noch lange, die sie erkennen, dass wir alle drei Kinder glücklich bringen.«
     </p>
-    <p xml:id="eco_de_0000140_9540">
+    <p xml:id="eco_de_0000210_9540">
      Fritz Völklein dachte einen Augenblick nach. Dann rief er, ohne die Ruder loszulassen, hinter sich:
     </p>
-    <p xml:id="eco_de_0000140_9550">
+    <p xml:id="eco_de_0000210_9550">
      »Hans! Hat deine Mama in dem griechischen Sagenbuch die Geschichte vom Theseus gelesen?«
     </p>
-    <p xml:id="eco_de_0000140_9560">
+    <p xml:id="eco_de_0000210_9560">
      Sophie wunderte sich, wie Fritz jetzt zwischen alles hinein an die Griechen denken konnte.
     </p>
-    <p xml:id="eco_de_0000140_9570">
+    <p xml:id="eco_de_0000210_9570">
      »Ja!« rief Hans. »Letzten Winter hat sie uns das Buch vorgelesen.«
     </p>
-    <p xml:id="eco_de_0000140_9580">
+    <p xml:id="eco_de_0000210_9580">
      »Dann weiss sie also, dass ein weisses Segel oder eine weisse Flagge Gutes bedeutet! Im Schiff muss von gestern eine Stange liegen. Seht, dass ihr Mariannes und Lottis Schürzen dran bindet; sie sind ja weiss –!«
     </p>
-    <p xml:id="eco_de_0000140_9590">
+    <p xml:id="eco_de_0000210_9590">
      »Sie haben braune Punkte!« schrie Lotti hinüber.
     </p>
-    <p xml:id="eco_de_0000140_9600">
+    <p xml:id="eco_de_0000210_9600">
      »Schadet nichts! Lehnt die Stange an die Ruderbank und haltet sie fest, so gut ihr könnt! Es muss eine weisse Flagge flattern, so wie wir ums Klaregg kommen – wegen euerer Mama! Aber dass ihr mir am Boden bleibt –!« schloss Fritz streng.
     </p>
-    <p xml:id="eco_de_0000140_9610">
+    <p xml:id="eco_de_0000210_9610">
      Es war nicht leicht zu tun, was Fritz befohlen hatte. Hans konnte seine geschwollene, blutende Hand nicht mehr bewegen und also kaum helfen. Lotti hatte einen Bindfaden in der Tasche; aber jeder Windstoss drohte, Schürzen und Schnur mit sich fortzureissen.
     </p>
-    <p xml:id="eco_de_0000140_9620">
+    <p xml:id="eco_de_0000210_9620">
      Doch als man in weitem Bogen ums Klaregg fuhr, flatterte die weisse Fahne über dem Schiff. Jedes der Kinder wollte halten. Es war, als sei man nun schon fast bei Mama, da man ihr dies Zeichen geben konnte …
     </p>
-    <p xml:id="eco_de_0000140_9630">
+    <p xml:id="eco_de_0000210_9630">
      Frau Turnach stand an derselben Stelle, fort und fort hinausspähend.
     </p>
-    <p xml:id="eco_de_0000140_9640">
+    <p xml:id="eco_de_0000210_9640">
      Da –! Weit draussen vor dem Klaregg tauchte etwas auf – ein Schiff!
     </p>
-    <p xml:id="eco_de_0000140_9650">
+    <p xml:id="eco_de_0000210_9650">
      »Balbine! ein Schiff!« Frau Turnach fasste Balbines Arm.
     </p>
-    <p xml:id="eco_de_0000140_9660">
+    <p xml:id="eco_de_0000210_9660">
      »Und ein zweites dahinter –« rief Frau Völklein. »Frau Turnach, sie sind's!«
     </p>
-    <p xml:id="eco_de_0000140_9670">
+    <p xml:id="eco_de_0000210_9670">
      Aber Balbine schüttelte ängstlich den Kopf.
     </p>
-    <p xml:id="eco_de_0000140_9680">
+    <p xml:id="eco_de_0000210_9680">
      »Das Schiff bringen sie – Gott! Gott! ob aber die Kinder drin sind –« sagte sie leise zu Frau Völklein, während Frau Turnach wieder auf die Mauer hinaustrat.
     </p>
-    <p xml:id="eco_de_0000140_9690">
+    <p xml:id="eco_de_0000210_9690">
      Sie schien sich dieselbe Frage zu stellen; denn mit bangen Augen schaute sie nach den Schiffen.
     </p>
-    <p xml:id="eco_de_0000140_9700">
+    <p xml:id="eco_de_0000210_9700">
      Auf einmal sah man etwas Helles flattern – eine weisse Flagge, die hin und her geschwenkt wurde.
     </p>
-    <p xml:id="eco_de_0000140_9710">
+    <p xml:id="eco_de_0000210_9710">
      Und Frau Turnach verstand den braven Fritz Völklein.
     </p>
-    <p xml:id="eco_de_0000140_9720">
+    <p xml:id="eco_de_0000210_9720">
      »Balbine –! Frau Völklein –! Das ist ein Zeichen, das Fritz uns gibt! Sie bringen die Kinder – der gute Gott hat sie mir beschützt –«
     </p>
-    <p xml:id="eco_de_0000140_9730">
+    <p xml:id="eco_de_0000210_9730">
      Und jetzt erst, als Frau Turnach aus ihrer furchtbaren Angst erlöst war, fühlte sie ihre Knie zittern und setzte sich auf Frau Völkleins Mahnen auf die Bank neben dem Badhause.
     </p>
-    <p xml:id="eco_de_0000140_9740">
+    <p xml:id="eco_de_0000210_9740">
      Zwanzig lange Minuten vergingen noch, bis die Schiffe anlangten. Es schien, als ob sie kaum vorwärts kämen durch den Wind und die grimmigen Wellen. Aber treulich flatterte das weisse Fähnlein im zweiten Schiffe, und allmählich rückten sie doch näher. Man konnte erkennen, wie fest Fritz ausgriff und wie Sophie ihre ganze Kraft einsetzte; jetzt unterschied man die Köpfe der Kinder im hinteren Schiff.
     </p>
-    <p xml:id="eco_de_0000140_9750">
+    <p xml:id="eco_de_0000210_9750">
      »Mama! Mama!« hörte man rufen, und die weisse Flagge winkte stärker.
     </p>
-    <p xml:id="eco_de_0000140_9760">
+    <p xml:id="eco_de_0000210_9760">
      »Sitzen bleiben!« schrie Fritz noch einmal und zum letzten Male; denn nun lenkte er hinein in die Hafenbucht.
     </p>
-    <p xml:id="eco_de_0000140_9770">
+    <p xml:id="eco_de_0000210_9770">
      »Achtung, Sophie!« kommandierte er. »Die Mauer –«
     </p>
-    <p xml:id="eco_de_0000140_9780">
+    <p xml:id="eco_de_0000210_9780">
      Endlich, endlich waren sie am Lande. Fritz sprang mit drei Sätzen an Sophie vorbei und als erster ans Ufer.
     </p>
-    <p xml:id="eco_de_0000140_9790">
+    <p xml:id="eco_de_0000210_9790">
      »Gott sei Lob und Dank! Fritz, das war brav – brav, Sophie!« rief Frau Völklein.
     </p>
-    <p xml:id="eco_de_0000140_9800">
+    <p xml:id="eco_de_0000210_9800">
      Frau Turnach drückte Fritz die Hand; sie konnte nicht sprechen. Fritz sprang auch gleich wieder zurück, um das Schiff mit den Kindern heranzuziehen.
     </p>
-    <p xml:id="eco_de_0000140_9810">
+    <p xml:id="eco_de_0000210_9810">
      »Dürfen wir jetzt aufstehen, Fritz?« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000140_9820">
+    <p xml:id="eco_de_0000210_9820">
      »Ja, jetzt dürft ihr aufstehen!« Und Fritz half einem nach dem andern herüber. Blass und zerzaust stürmten die Kinder in Mamas Arme.
     </p>
-    <p xml:id="eco_de_0000140_9830">
+    <p xml:id="eco_de_0000210_9830">
      »Mama, Mama! Es war furchtbar! Wir haben gedacht, wir müssten untergehen! Hans hat sich die Hand zerquetscht, und die Binsen haben wir ins Wasser geworfen, damit der liebe Gott mit dem Sturm aufhöre. Aber es wurde immer ärger, und dann hat Marianne gebetet …«
     </p>
-    <p xml:id="eco_de_0000140_9840">
+    <p xml:id="eco_de_0000210_9840">
      Erst als die Kinder sahen, wie die Tränen über Mamas Gesicht liefen, merkten sie, dass auch sie in Angst und Schrecken gewesen war.
     </p>
-    <p xml:id="eco_de_0000140_9850">
+    <p xml:id="eco_de_0000210_9850">
      »Mama, Mama! bitte, wein' nicht! Wir wollen es nie, nie mehr tun –!« rief Lotti, während Marianne anfing mitzuweinen.
     </p>
-    <p xml:id="eco_de_0000140_9860">
+    <p xml:id="eco_de_0000210_9860">
      Und Sophie, der Frau Völklein die nassen Haare aus dem Gesicht strich, war auch in Tränen ausgebrochen.
     </p>
-    <p xml:id="eco_de_0000140_9870">
+    <p xml:id="eco_de_0000210_9870">
      »Ach Gott, ach Gott! wie bin ich froh! wie bin ich froh!« wiederholte sie immer, indem sie laut schluchzte.
     </p>
-    <p xml:id="eco_de_0000140_9880">
+    <p xml:id="eco_de_0000210_9880">
      Dazu hob Balbine einen grossen Jammer an über Hansens blutende und geschwollene Hand. Und um dem Tumult noch grösser zu machen, erschien auch Grite, Frau Völkleins Magd, mit Werner, der auf Sophie und auf Fritz Völklein lossprang, warum sie ihn nicht mitgenommen.
     </p>
-    <p xml:id="eco_de_0000140_9890">
+    <p xml:id="eco_de_0000210_9890">
      Fritz fasste den Kleinen und hielt ihn in die Luft.
     </p>
-    <p xml:id="eco_de_0000140_9900">
+    <p xml:id="eco_de_0000210_9900">
      »Ja, Wernermann, das war wirklich unrecht, dich zu Haus zu lassen. Das nächste Mal, wenn ich draussen bin und mir nicht zu helfen weiss, dann kommst du mit dem Schiff und holst mich!«
     </p>
-    <p xml:id="eco_de_0000140_9910">
+    <p xml:id="eco_de_0000210_9910">
      Der Kleine jubelte laut auf.
     </p>
-    <p xml:id="eco_de_0000140_9920">
+    <p xml:id="eco_de_0000210_9920">
      So war ein grosses Durcheinander von Freuen und Weinen am Landungsplatz; erst als Fritz fragte:
     </p>
-    <p xml:id="eco_de_0000140_9930">
+    <p xml:id="eco_de_0000210_9930">
      »Grite, haben Sie mir nicht noch ein wenig Kaffee aufgehoben?« dachte man daran, von dem wilden See und dem Sturm weg in das sichere Haus zu gehen.
     </p>
-    <p xml:id="eco_de_0000140_9940">
+    <p xml:id="eco_de_0000210_9940">
      Gestraft wurden die Turnachkinder weiter nicht. Sie hatten genug Angst und Not ausgestanden und dachten an diesen Tag gewiss auf alle Zeiten hinaus. Sie konnten gar nicht aufhören, von dem Schrecken zu erzählen und sich selbst anzuklagen, als Papa spät abends heimkam.
     </p>
-    <p xml:id="eco_de_0000140_9950">
+    <p xml:id="eco_de_0000210_9950">
      Hans fühlte starke Schmerzen in seiner Hand und wurde unten im Zimmer gebettet, damit man ihm Überschläge machen konnte. Marianne und Lotti schliefen auch nicht gut. Lotti fuhr alle Augenblicke auf:
     </p>
-    <p xml:id="eco_de_0000140_9960">
+    <p xml:id="eco_de_0000210_9960">
      »Mama –! ich hab' gemeint, ich fahre wieder im Sturm –«
     </p>
-    <p xml:id="eco_de_0000140_9970">
+    <p xml:id="eco_de_0000210_9970">
      Und Marianne rief einmal laut: »Wirf doch alle hinaus, Lotti, alle, alle –«
     </p>
-    <p xml:id="eco_de_0000140_9980">
+    <p xml:id="eco_de_0000210_9980">
      Hans trug noch mehrere Tage die Hand in der Schlinge. Wenn sie ihn aber in der Schule ausfragten, gab er nicht gerne Bericht. Ein Abenteuer war es wohl gewesen; doch hatte er keine Heldenrolle darin spielen können, sondern hatte sich geduckt und gedemütigt müssen mit den Mädchen ans Land ziehen lassen.
     </p>
    </div>
@@ -3126,511 +3126,511 @@
     <head>
      Ferien.
     </head>
-    <p xml:id="eco_de_0000140_9990">
+    <p xml:id="eco_de_0000210_9990">
      »Seht ihr, wie gut unsere Jahruhr geht? Das Korn wird gelb, und in acht Tagen haben wir Ferien!« sagte Marianne an einem Montag auf dem Schulweg.
     </p>
-    <p xml:id="eco_de_0000140_10000">
+    <p xml:id="eco_de_0000210_10000">
      »Ferien, Hans, Ferien!« rief Lotti. »Ich freu' mich schrecklich! So freu' ich mich, Marianne –« und Lotti fasste die Schwester so fest um den Hals, dass Marianne kaum mehr atmen konnte.
     </p>
-    <p xml:id="eco_de_0000140_10010">
+    <p xml:id="eco_de_0000210_10010">
      Die Turnachkinder lernten gut in der Schule und hatten Lehrer und Lehrerin gern. Manchmal stritten sie sogar: Hans meinte, sein Herr Altschmid wisse und mache alles am besten, während Marianne Fräulein Heller lobte und Lotti behauptete, ihre Lehrerin sei die allernetteste.
     </p>
-    <p xml:id="eco_de_0000140_10020">
+    <p xml:id="eco_de_0000210_10020">
      »Gestern«, erzählte Lotti, »in der zweiten Stunde hab' ich auf einmal lachen müssen. Das ist schrecklich! Man weiss gar nicht warum, und man muss immer weiter lachen! Hihihi! immer weiter, wenn man gar nicht will! Also dann wurde Fräulein Matthias zuerst ein wenig böse und sagte streng: ›Lotti Turnach, kannst du nicht aufhören zu lachen?‹ ›Nein, Fräulein Matthias‹, hab' ich gesagt, ›ich will schon immer; aber ich kann nicht!‹ Da hat Fräulein Matthias auch ein wenig lachen müssen, nur so in einer Ecke vom Mund, aber man hat's doch gesehen, und hat gesagt, ›Also, nun darf Lotti Turnach lachen, bis sie zu Ende ist!‹ Da sahen mich alle Kinder an und lachten auch. ›So‹, sagte dann Fräulein Matthias, ›nun bist du, glaub' ich, fertig! Nun geh schnell an die Wandtafel und schreib' den folgenden Satz: Der Wald ist grün.‹ Da musst' ich auf einmal gar nicht mehr lachen, sondern immer denken, ob Wald ein t hat oder ein d.«
     </p>
-    <p xml:id="eco_de_0000140_10030">
+    <p xml:id="eco_de_0000210_10030">
      »Natürlich hast du ein t gemacht!« neckte Hans.
     </p>
-    <p xml:id="eco_de_0000140_10040">
+    <p xml:id="eco_de_0000210_10040">
      »Nein, eben nicht! Gar keinen Fehler hab' ich gemacht. Fräulein Matthias hat gesagt: ›Gut, Lotti Turnach! Siehst du, du bist ja ein ganz vernünftiges Kind; manchmal würde man es zwar fast nicht glauben‹ und hat mich freundlich angesehen. Da hab' ich fleissig weiter geschrieben in meinem Heft, bis die Stunde aus gewesen ist.«
     </p>
-    <p xml:id="eco_de_0000140_10050">
+    <p xml:id="eco_de_0000210_10050">
      »Bei uns geht's nicht so fein zu!« sagte Hans. »Manchmal lässt uns Herr Altschmid auch ein bisschen laut tun. Aber wenn er an sein Pult kommt und ruft: ›Ihr Wetterskerle, wollt ihr augenblicklich still sein!‹ dann lacht keiner mehr. er hat eine Stimme und kann Augen machen –! Aber das mögen wir gern.«
     </p>
-    <p xml:id="eco_de_0000140_10060">
+    <p xml:id="eco_de_0000210_10060">
      »Wetterskerle – das ist fast ein wenig grob«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_10070">
+    <p xml:id="eco_de_0000210_10070">
      »O, bewahre! Das passt gerade für uns, hat Onkel Alfred gesagt.«
     </p>
-    <p xml:id="eco_de_0000140_10080">
+    <p xml:id="eco_de_0000210_10080">
      Also die Turnachkinder gingen gerne in die Schule. Aber die Ferien waren noch schöner, über alle Massen schön! Fast schien es, als wolle die letzte Woche kein Ende nehmen; schliesslich wurde es doch Freitag nachmittag.
     </p>
-    <p xml:id="eco_de_0000140_10090">
+    <p xml:id="eco_de_0000210_10090">
      »Herr Steppinger«, sagte Lotti, als die Kinder um halb zwei in das Schiff stiegen, »nun fahren wir zum letztenmal mit Ihnen in die Stadt, und dann vier Wochen nicht mehr. Vier Wochen sind eine ganze Ewigkeit, nicht?«
     </p>
-    <p xml:id="eco_de_0000140_10100">
+    <p xml:id="eco_de_0000210_10100">
      »Wenn man jung ist, meint man es«, sagte der alte Steppinger gutmütig und griff in seiner ruhigen Weise nach den Rudern.
     </p>
-    <p xml:id="eco_de_0000140_10110">
+    <p xml:id="eco_de_0000210_10110">
      Am Montag morgen begann denn also die Ewigkeit, die nun mit lauter schönen und lustigen Dingen ausgefüllt werden konnte. Es war schon so behaglich, länger im Bett zu bleiben und mit halbgeschlossenen Augen durch das offene Fenster hinauszublinzeln in die grünen Zweige, die im frischen Winde schwankten.
     </p>
-    <p xml:id="eco_de_0000140_10120">
+    <p xml:id="eco_de_0000210_10120">
      »Tiu, tiu«, sang die Amsel auf der Silberpappel.
     </p>
-    <p xml:id="eco_de_0000140_10130">
+    <p xml:id="eco_de_0000210_10130">
      »Ruf du nur«, dachte Marianne. »Du weisst natürlich nicht, dass wir Ferien haben und liegen bleiben können.«
     </p>
-    <p xml:id="eco_de_0000140_10140">
+    <p xml:id="eco_de_0000210_10140">
      Aber nach einer Weile sprang sie doch aus dem Bette und trippelte zu Lotti hinüber.
     </p>
-    <p xml:id="eco_de_0000140_10150">
+    <p xml:id="eco_de_0000210_10150">
      Lotti schlief noch fest. Ja, wenn man recht zuhörte, schnarchte sie ein wenig.
     </p>
-    <p xml:id="eco_de_0000140_10160">
+    <p xml:id="eco_de_0000210_10160">
      »Schnurr, schnurr, schnurr«, machte Marianne leise und dann immer lauter, bis Lotti sich drehte und versuchte, die Augen aufzutun.
     </p>
-    <p xml:id="eco_de_0000140_10170">
+    <p xml:id="eco_de_0000210_10170">
      »Lotti, Lotti! Es ist höchste Zeit, in die Schule zu gehen.«
     </p>
-    <p xml:id="eco_de_0000140_10180">
+    <p xml:id="eco_de_0000210_10180">
      Lotti fuhr in die Höhe; aber dann fiel's ihr ein: »Es ist gar nicht wahr, du –! Wir haben ja Ferien!« und sie steckte sich wohlig noch einmal unter die Decke.
     </p>
-    <p xml:id="eco_de_0000140_10190">
+    <p xml:id="eco_de_0000210_10190">
      »Faulpelz, Faulpelz!« sagte Marianne. Sie wusch sich, zog sich an und lief dann hinüber ins hintere Zimmer:
     </p>
-    <p xml:id="eco_de_0000140_10200">
+    <p xml:id="eco_de_0000210_10200">
      »Sophie, nun helf' ich dir bei den Kleinen!«
     </p>
-    <p xml:id="eco_de_0000140_10210">
+    <p xml:id="eco_de_0000210_10210">
      »Gut«, sagte Sophie, »wasch mir einmal da den Werner und kämme ihn schön!«
     </p>
-    <p xml:id="eco_de_0000140_10220">
+    <p xml:id="eco_de_0000210_10220">
      Das war ein ziemliches Stück Arbeit; denn Werner liebte weder Wasser noch Kamm. Er sträubte sich beim Wasche und machte Grimassen, und man merkte, jetzt ging gleich das Weinen an.
     </p>
-    <p xml:id="eco_de_0000140_10230">
+    <p xml:id="eco_de_0000210_10230">
      Aber dann begann Marianne selber.
     </p>
-    <p xml:id="eco_de_0000140_10240">
+    <p xml:id="eco_de_0000210_10240">
      »Huhu – o, das schreckliche kalte Wasser! Der arme Werner! Huhu – jetzt wird die Nase ganz nass, und jetzt geht der böse Schwamm rings um den Hals und nun noch über die Arme – huhu –«
     </p>
-    <p xml:id="eco_de_0000140_10250">
+    <p xml:id="eco_de_0000210_10250">
      Werner schnitt ein arges Gesicht; aber er weinte nicht; er musste doch hören, was Marianne alles sagte und wie sie »Huhu« machte.
     </p>
-    <p xml:id="eco_de_0000140_10260">
+    <p xml:id="eco_de_0000210_10260">
      Und weil Werner nun kein Heulpeter gewesen war, erzählte ihm Marianne die lustige Geschichte von den fünf Fingern. Erst bekamen die Finger Gesichter mit Mariannes Blaustift: Zwei Punkte, in die Mitte ein Häkchen und unten einen Strich – so, das waren Augen, Nase und Mund. Nein, wie Werner lachte, wenn die bläulichen Gesichter sich beugten und auf einander losredeten! Der Daumen war eine dicke Bäuerin. Sie hatte vier Knechte, die wollten nicht mehr so früh melken und so viel mähen und so spät noch Holz hacken, sondern lieber Speck essen und Most trinken. Zuletzt nahm der Zeigfinger, der Joggel, eine grosse Wurst und lief davon und die andern Knechte und die Bäuerin hintendrein. O, wie die Finger zappelten und sich streckten, um vorwärts zu kommen, und wie die Bäuerin, weil sie so kurz und dick war, immer die letzte blieb! Nun ging es einen hohen Berg hinauf über Werners Bett und plumps! hinten hinunter. Da lagen sie alle in einem tiefen Graben.
     </p>
-    <p xml:id="eco_de_0000140_10270">
+    <p xml:id="eco_de_0000210_10270">
      »Hans!« schrie Werner, als der grosse Bruder hineintrat. »Nun sind sie ertrunken!«
     </p>
-    <p xml:id="eco_de_0000140_10280">
+    <p xml:id="eco_de_0000210_10280">
      »Guten Morgen, Wernermann! Wer denn ist ertrunken?« »Der Joggel, der Käpper, der Melcher, der Dieter und die alte Frau Vrene«, erzählte Werner, stolz, dass er die Namen alle im Sinn hatte.
     </p>
-    <p xml:id="eco_de_0000140_10290">
+    <p xml:id="eco_de_0000210_10290">
      »Was für eine nette Gesellschaft! Schade, dass sie ertrunken sind, sonst hätten sie mit zum Frühstück kommen können.«
     </p>
-    <p xml:id="eco_de_0000140_10300">
+    <p xml:id="eco_de_0000210_10300">
      »Sie kommen doch, sie kommen doch! Siehst du, dort laufen sie!« rief Werner, als Marianne hinausging. Er fand es prächtig, nun auch einmal dem grossen Bruder, der ihn so oft neckte, etwas vorzumachen.
     </p>
-    <p xml:id="eco_de_0000140_10310">
+    <p xml:id="eco_de_0000210_10310">
      Nach einer Weile sassen alle Kinder beisammen zum Frühstück unter dem grossen, alten Birnbaum. Der runde Tisch ging rings um den dicken Stamm. Wer einem gerade gegenüber sass, den sah man nicht; das war immer ein Spass. Und heute hatte man so schön Zeit, zu schwatzen und zu lachen und den Vögeln zuzusehen, die umherflatterten. Der alte Birnbaum wollte auch mittun: Patsch, warf er eine seiner kleinen, grünen Birnen dem Hans in die Tasse, dass die Milch weit aufspritzte, und gleich nachher prallte dem Lotti ein Birnchen auf den Kopf.
     </p>
-    <p xml:id="eco_de_0000140_10320">
+    <p xml:id="eco_de_0000210_10320">
      »Au!« schrie sie zu dem Birnbaum hinauf. »Du bist aber ein Grober!«
     </p>
-    <p xml:id="eco_de_0000140_10330">
+    <p xml:id="eco_de_0000210_10330">
      Alle guckten erwartungsvoll, ob der Birnbaum noch weiteres im Sinn habe. Dann fingen sie an, die unreifen kleinen Birnen vom Boden aufzulesen, und eröffneten ein lustiges Bombardement gegen einander. Sophie hatte nur zu tun, die Tassen und den Milchtopf in Sicherheit zu bringen.
     </p>
-    <p xml:id="eco_de_0000140_10340">
+    <p xml:id="eco_de_0000210_10340">
      »Was habt ihr nun eigentlich für den Vormittag im Sinn?« fragte Mama, als das Kampfspiel zu Ende war.
     </p>
-    <p xml:id="eco_de_0000140_10350">
+    <p xml:id="eco_de_0000210_10350">
      »Mama«, sagte Lotti, »wir haben ausgemacht, dass wir einmal gar nichts tun wollen. Wir setzten uns bloss an den See und freuen uns, dass wir Ferien haben.«
     </p>
-    <p xml:id="eco_de_0000140_10360">
+    <p xml:id="eco_de_0000210_10360">
      »So; dann nehmt aber den Werner mit. Beim Nichtstun kann er ja helfen.«
     </p>
-    <p xml:id="eco_de_0000140_10370">
+    <p xml:id="eco_de_0000210_10370">
      Die vier Kinder liefen zur Seemauer und setzten sich neben einander auf den sonnigen Stein.
     </p>
-    <p xml:id="eco_de_0000140_10380">
+    <p xml:id="eco_de_0000210_10380">
      »Jetzt sind wir Lazzaroni«, sagte Hans und steckte sich ein Stöckchen zwischen die Zähne, als ob er rauche.
     </p>
-    <p xml:id="eco_de_0000140_10390">
+    <p xml:id="eco_de_0000210_10390">
      »Was ist das?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_10400">
+    <p xml:id="eco_de_0000210_10400">
      »Das sind Italiener. Sie liegen bloss herum und gähnen und essen Makkaroni.«
     </p>
-    <p xml:id="eco_de_0000140_10410">
+    <p xml:id="eco_de_0000210_10410">
      »Müssen sie nicht in die Schule?«
     </p>
-    <p xml:id="eco_de_0000140_10420">
+    <p xml:id="eco_de_0000210_10420">
      »Nein. Es sind grosse Leute. In ihrem Lande ist es heiss, und da arbeitet man nicht so.«
     </p>
-    <p xml:id="eco_de_0000140_10430">
+    <p xml:id="eco_de_0000210_10430">
      »Bekommen sie die Makkaroni umsonst?«
     </p>
-    <p xml:id="eco_de_0000140_10440">
+    <p xml:id="eco_de_0000210_10440">
      Das wusste Hans selber nicht recht.
     </p>
-    <p xml:id="eco_de_0000140_10450">
+    <p xml:id="eco_de_0000210_10450">
      »Ach, Lotti«, sagte er, »du frägst immer noch etwas und noch etwas!« Er legte sich der Länge nach hin, mit den Händen unter dem Kopf.
     </p>
-    <p xml:id="eco_de_0000140_10460">
+    <p xml:id="eco_de_0000210_10460">
      »Fische, ganz viel Fische –« rief Werner, der so weit an den Rand hinausrutschte, als Marianne ihn liess.
     </p>
-    <p xml:id="eco_de_0000140_10470">
+    <p xml:id="eco_de_0000210_10470">
      Marianne hatte ein Stück Brot in der Tasche und fing an, grosse Brocken hinunterzuwerfen. Die Fische schossen von allen Seiten darauf zu und stiessen an dem Brot herum, wohl dreissig oder vierzig, nicht viel länger als ein Finger, mit blaugrünem Rücken und silberschimmernder Seite.
     </p>
-    <p xml:id="eco_de_0000140_10480">
+    <p xml:id="eco_de_0000210_10480">
      »Das sind bloss Bläulinge«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_10490">
+    <p xml:id="eco_de_0000210_10490">
      Aber unter den schwänzelnden Bläulingen schwamm langsam ein etwas grösserer Fisch mit dunkeln Strichen hin und her. Wenn das Brot sank, tat er einen Schnapp und verschluckte das ganze Stück. Dann schossen die kleinen Fische erschrocken davon. Es war ein Rechling. Aber der kleine Werner war anderer Meinung.
     </p>
-    <p xml:id="eco_de_0000140_10500">
+    <p xml:id="eco_de_0000210_10500">
      »Das ist ein – Hecht!« erklärte er. Kürzlich hatte er beim alten Lienhard einen Hecht gesehen.
     </p>
-    <p xml:id="eco_de_0000140_10510">
+    <p xml:id="eco_de_0000210_10510">
      »Nein, Werner –«, Hans machte ein ganz ernsthaftes Gesicht, »das ist ein Walfisch. Wenn der heraufkommt und mit seiner Nase anfängt zu blasen, dann geht ein grosser Wasserstrom über uns weg und schwemmt uns in den See hinaus.«
     </p>
-    <p xml:id="eco_de_0000140_10520">
+    <p xml:id="eco_de_0000210_10520">
      »O!« sagte Werner und machte grosse Augen. Er konnte nicht recht begreifen, das der Fisch da so etwas Schreckliches anstelle; aber es gab viel Dinge, die sein kleiner Kopf noch nicht begreifen konnte.
     </p>
-    <p xml:id="eco_de_0000140_10530">
+    <p xml:id="eco_de_0000210_10530">
      Hans und Lotti lachten. Marianne legte den Arm um den Kleinen.
     </p>
-    <p xml:id="eco_de_0000140_10540">
+    <p xml:id="eco_de_0000210_10540">
      »Nein, nein!« sagte sie. »Hans, warum gibst du ihm doch solche Sachen an!«
     </p>
-    <p xml:id="eco_de_0000140_10550">
+    <p xml:id="eco_de_0000210_10550">
      »Ja, er sollte nun nach und nach klüger werden und nicht alles glauben«, meinte Hans.
     </p>
-    <p xml:id="eco_de_0000140_10560">
+    <p xml:id="eco_de_0000210_10560">
      Der kleine Werner war übrigens nicht gekränkt. Es war gar zu schön, dass die Grossen einmal nicht in die Schule liefen, sondern bei ihm blieben.
     </p>
-    <p xml:id="eco_de_0000140_10570">
+    <p xml:id="eco_de_0000210_10570">
      »Dort ist ein Dampfschiff!« sagte er nach einer Weile und deutete hinaus.
     </p>
-    <p xml:id="eco_de_0000140_10580">
+    <p xml:id="eco_de_0000210_10580">
      Diesmal war nichts dagegen einzuwenden. Es war wirklich ein Dampfschiff, das daher kam in stolzem, geradem Zuge und mit einem langen Rauchstreifen, der wie ein dunkles Band nachflatterte.
     </p>
-    <p xml:id="eco_de_0000140_10590">
+    <p xml:id="eco_de_0000210_10590">
      »Das ist das Halbzehnuhrschiff!« sagte Marianne. »Jetzt hätten wir eine Singstunde gehabt und wären mitten in der Rechnenstunde.«
     </p>
-    <p xml:id="eco_de_0000140_10600">
+    <p xml:id="eco_de_0000210_10600">
      Lotti machte ein nachdenkliches Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_10610">
+    <p xml:id="eco_de_0000210_10610">
      »So, jetzt sind bereits anderthalb Stunden von unsern Ferien herum –«
     </p>
-    <p xml:id="eco_de_0000140_10620">
+    <p xml:id="eco_de_0000210_10620">
      Die Kinder sahen einander an und standen wie auf ein Zeichen auf, um zum Haus zurückzulaufen. Werner zottelte hintendrein.
     </p>
-    <p xml:id="eco_de_0000140_10630">
+    <p xml:id="eco_de_0000210_10630">
      »Mama, Mama!« riefen sie. »Nun sind anderthalb Stunden von unsern Ferien herum, und wir haben noch nichts angefangen!«
     </p>
-    <p xml:id="eco_de_0000140_10640">
+    <p xml:id="eco_de_0000210_10640">
      »Ich dachte schon«, sagte Mama, »das es euch bald entleiden werde, bloss so zu faulenzen –«
     </p>
-    <p xml:id="eco_de_0000140_10650">
+    <p xml:id="eco_de_0000210_10650">
      »Wie die Lazzaroni!« fiel Lotti ein. »Wenn wir bis zum Mittagessen nichts tun, bekommen wir dann Makkaroni –?« Lotti sah Mama schelmisch an.
     </p>
-    <p xml:id="eco_de_0000140_10660">
+    <p xml:id="eco_de_0000210_10660">
      »Nein, mein Kind. Bei uns bekommen Leute, die gar nichts tun, auch nichts zu essen!« sagte Mama.
     </p>
-    <p xml:id="eco_de_0000140_10670">
+    <p xml:id="eco_de_0000210_10670">
      Hans und Marianne aber fingen an, ernsthaft zu beraten, was man jetzt Schönes unternehmen könnte.
     </p>
-    <p xml:id="eco_de_0000140_10680">
+    <p xml:id="eco_de_0000210_10680">
      »Ich weiss –« sagte Hans. »Wir gehen in den Stall hinauf! Jakob will schon lang den Verschlag für die Kaninchen ausbessern. – Ich helf' ihm, und ihr nehmt die Kaninchen hinaus und lasst sie grasen. Aber ihr müsst acht geben, dass sie euch nicht fortspringen.«
     </p>
-    <p xml:id="eco_de_0000140_10690">
+    <p xml:id="eco_de_0000210_10690">
      »Ja, ja!« riefen Marianne und Lotti, »das ist lustig!«
     </p>
-    <p xml:id="eco_de_0000140_10700">
+    <p xml:id="eco_de_0000210_10700">
      Alle drei rannten zum Gartentor hinaus gerade auf Frau Völkleins Grite los.
     </p>
-    <p xml:id="eco_de_0000140_10710">
+    <p xml:id="eco_de_0000210_10710">
      »Hui –!« machte diese. »Es ist gut, wenn man fest auf den Füssen steht, sonst rennen einen die Turnachkinder um! Zum Jakob wollt ihr –? Ja, der ist heut' den ganzen Tag in den Kartoffeln.«
     </p>
-    <p xml:id="eco_de_0000140_10720">
+    <p xml:id="eco_de_0000210_10720">
      Damit ging Grite ins Haus.
     </p>
-    <p xml:id="eco_de_0000140_10730">
+    <p xml:id="eco_de_0000210_10730">
      »Hans! jetzt fällt mir etwas Nettes ein!« sagte Lotti. »Wir fahren mit dem Wagen zu Mischa. Mama hat Schuhe zum Sohlen, und den Werner nehmen wir mit. Frau Zritschek hat schon immer gesagt, sie möchte gern einmal unsern kleinen Bruder sehen.«
     </p>
-    <p xml:id="eco_de_0000140_10740">
+    <p xml:id="eco_de_0000210_10740">
      »Zu Mischa fahren! Zu Mischa fahren!« rief Werner. »Sophie, ich muss die schöne rote Schürze anziehen!« Der kleine Mann lief eifrig hinein.
     </p>
-    <p xml:id="eco_de_0000140_10750">
+    <p xml:id="eco_de_0000210_10750">
      Aber da hatte Mama auch noch ein Wort zu sagen.
     </p>
-    <p xml:id="eco_de_0000140_10760">
+    <p xml:id="eco_de_0000210_10760">
      »Halt, nicht so hitzig, mein Bub! Zu Mischa könnt ihr morgen und gleich Lottis Stiefel holen, die er heute flickt.«
     </p>
-    <p xml:id="eco_de_0000140_10770">
+    <p xml:id="eco_de_0000210_10770">
      Nun machte Marianne einen Vorschlag:
     </p>
-    <p xml:id="eco_de_0000140_10780">
+    <p xml:id="eco_de_0000210_10780">
      »Lotti, hinter der Scheune zwischen den Steinen haben wir doch so feines Moos gesehen und gesagt, wir wollten einen Puppengarten machen auf dem grossen Gläserbrett, weisst du, mit Sandwegen und kleinen Bäumen.«
     </p>
-    <p xml:id="eco_de_0000140_10790">
+    <p xml:id="eco_de_0000210_10790">
      »Wie fein!« rief Lotti und hüpfte auf einem Bein vor Vergnügen.
     </p>
-    <p xml:id="eco_de_0000140_10800">
+    <p xml:id="eco_de_0000210_10800">
      »Ja, und ich schnitze Gartenbänke und vielleicht eine Schaukel«, stimmte Hans bei. »Aber das geht doch am besten auf dem langen Tisch neben der Türe. Das können wir machen, wenn es einmal regnet.«
     </p>
-    <p xml:id="eco_de_0000140_10810">
+    <p xml:id="eco_de_0000210_10810">
      Derweil stand die liebe Sonne am klaren Himmel und lachte die Kinder aus und dachte: wenn sie nun nicht bald sich entschliessen, so wird der schöne Vormittag noch herumgehen, ohne dass etwas geschieht. Warten kann ich nicht; ich muss meinen Weg machen.
     </p>
-    <p xml:id="eco_de_0000140_10820">
+    <p xml:id="eco_de_0000210_10820">
      Da kam Sophie mit einem Bündel in der Hand.
     </p>
-    <p xml:id="eco_de_0000140_10830">
+    <p xml:id="eco_de_0000210_10830">
      »Wie wär's, wenn ihr heut' gleich mit einer rechten und nützlichen Arbeit anfangen würdet? Da – euere Puppenwäsche wollt ihr doch im Herbst nicht schmutzig wieder in die Stadt nehmen –? Heut' würde sie schön trocknen an der Sonne.«
     </p>
-    <p xml:id="eco_de_0000140_10840">
+    <p xml:id="eco_de_0000210_10840">
      Lotti sprang auf Sophie zu:
     </p>
-    <p xml:id="eco_de_0000140_10850">
+    <p xml:id="eco_de_0000210_10850">
      »Ja, ja! Sophie wir halten grosse Wäsche! Das wird furchtbar nett! Ich hab' mich den ganzen Winter darauf gefreut. Sophie, du weisst doch immer die gescheitesten Sachen!«
     </p>
-    <p xml:id="eco_de_0000140_10860">
+    <p xml:id="eco_de_0000210_10860">
      Marianne klatschte auch in die Hände.
     </p>
-    <p xml:id="eco_de_0000140_10870">
+    <p xml:id="eco_de_0000210_10870">
      »Komm, Lotti, zu Frau Völklein hinauf! Sie leiht uns vielleicht wie letztes Jahr die zwei Kübelchen und den kleinen Zuber.«
     </p>
-    <p xml:id="eco_de_0000140_10880">
+    <p xml:id="eco_de_0000210_10880">
      »Guten Morgen, ihr Jüngferlein!« sagte Frau Völklein, als die beiden Mädchen höflich ihre Bitte vorbrachten. »Natürlich sollt ihr die Sachen haben. Es wird alles ein wenig rinnen, weil es lang im Trocknen gestanden hat. Aber das macht im Sande draussen nichts.«
     </p>
-    <p xml:id="eco_de_0000140_10890">
+    <p xml:id="eco_de_0000210_10890">
      Die freundliche alte Frau holte aus der Kammer, wo sie allerlei Gerät und Spielzeug aus früherer Zeit aufbewahrte, die Holzgefässe, dazu einen kleinen Wasserschöpfer und ein niedriges Bänkchen, auf das man den Zuber stellen konnte. Dann fand sich noch ein Seifenschüsselchen.
     </p>
-    <p xml:id="eco_de_0000140_10900">
+    <p xml:id="eco_de_0000210_10900">
      »Die kleinen Bügeleisen und das Brettchen braucht ihr heut' noch nicht«, sagte Frau Völklein.
     </p>
-    <p xml:id="eco_de_0000140_10910">
+    <p xml:id="eco_de_0000210_10910">
      Lotti stiess Marianne vor Vergnügen in die Seite.
     </p>
-    <p xml:id="eco_de_0000140_10920">
+    <p xml:id="eco_de_0000210_10920">
      Sie schleppten alles hinunter und stellten es an den See.
     </p>
-    <p xml:id="eco_de_0000140_10930">
+    <p xml:id="eco_de_0000210_10930">
      »Hans«, sagte Marianne etwas gnädig; denn bei einer Wäsche waren doch die Mädchen die Hauptpersonen, »du kannst schon auch mitmachen. Du kannst Wasser schöpfen und nachher die Schnur anbinden, wenn wir aufhängen, und Stützen stecken.«
     </p>
-    <p xml:id="eco_de_0000140_10940">
+    <p xml:id="eco_de_0000210_10940">
      Hans besann sich, ob das nicht doch unter seiner Würde sei. Da tönte ein lustiges Pfeifen den Weg herunter. Es war Fritz Völklein, der auch Ferien hatte.
     </p>
-    <p xml:id="eco_de_0000140_10950">
+    <p xml:id="eco_de_0000210_10950">
      »Das ist ein Tag, Kinder! Das ist ein erster Ferientag –!« Er schwenkte die Mütze zum blauen Himmel hinauf und ging dann stracks zum See:
     </p>
-    <p xml:id="eco_de_0000140_10960">
+    <p xml:id="eco_de_0000210_10960">
      »Rasch ins Schiff und die Ruder eingehängt! Es treibt einen mit alter Macht aufs Wasser.«
     </p>
-    <p xml:id="eco_de_0000140_10970">
+    <p xml:id="eco_de_0000210_10970">
      »Fritz«, sagte Lotti, »wir haben grosse Wäsche; wir können nicht mitfahren.«
     </p>
-    <p xml:id="eco_de_0000140_10980">
+    <p xml:id="eco_de_0000210_10980">
      »So! dann müssen wir halt sehen, wie es ohne euch geht. Es ist zwar fatal, Lotti. Wenn du nicht mitruderst, kommt man nicht vom Fleck –«
     </p>
-    <p xml:id="eco_de_0000140_10990">
+    <p xml:id="eco_de_0000210_10990">
      Fritz hatte höchste Zeit, mit einem Seitensprung sich zu retten; denn Lotti ging mit dem vollen Schöpfer auf den Spötter zu.
     </p>
-    <p xml:id="eco_de_0000140_11000">
+    <p xml:id="eco_de_0000210_11000">
      »Du, Fritz –«, sagte Hans; ihm ging etwas durch den Kopf; »wenn wir – wenn Mama uns – weisst du, seit dem Sturm –«
     </p>
-    <p xml:id="eco_de_0000140_11010">
+    <p xml:id="eco_de_0000210_11010">
      »Wo ich euch arme Tröpfe habe holen müssen!« Fritz schlenkerte den Arm, als ob sein Ärmel jetzt noch nass wäre.
     </p>
-    <p xml:id="eco_de_0000140_11020">
+    <p xml:id="eco_de_0000210_11020">
      »Ja, seither haben wir von den Schwummeln gar nicht mehr gesprochen. Aber heut – geh du einmal in den Garten und frag' unsere Mama, ob wir Binsen holen dürfen und ob sie uns dann Schwummeln mache.«
     </p>
-    <p xml:id="eco_de_0000140_11030">
+    <p xml:id="eco_de_0000210_11030">
      »Zu deiner Mama geh' ich schon; ich will ihr auch guten Tag sagen. Aber du begleitest mich und frägst selber. Was hast du denn auf einmal, dass du deine Mama fürchtest? Mit ihr kann man doch über alles reden. Sie ist so freundlich.«
     </p>
-    <p xml:id="eco_de_0000140_11040">
+    <p xml:id="eco_de_0000210_11040">
      Fritz selbst hatte keine Mutter mehr.
     </p>
-    <p xml:id="eco_de_0000140_11050">
+    <p xml:id="eco_de_0000210_11050">
      Es war auch nicht eigentlich, dass Hans sich fürchtete. Er schämte sich bloss noch immer, dass er ungehorsam gewesen war, und mochte nicht gerne Mama an jenen schlimmen Nachmittag erinnern. Nun ging er aber doch mit Fritz in den Garten.
     </p>
-    <p xml:id="eco_de_0000140_11060">
+    <p xml:id="eco_de_0000210_11060">
      Währenddessen waren Marianne und Lotti schon in voller Tätigkeit. Marianne hatte in der Küche ein Stückchen Seife gekommen und zwei Tücher zum Vorbinden über die Kleider. Lotti schöpfte eifrig die Kübel voll Wasser und legte die Bettücher und Kissenüberzüge hinein.
     </p>
-    <p xml:id="eco_de_0000140_11070">
+    <p xml:id="eco_de_0000210_11070">
      »Wir müssen sortieren, Marianne!« rief sie voll Vergnügen. »Wir müssen die grossen Stücke in den Zuber tun und die feinern Sachen extra. Es gibt furchtbar viel Arbeit«
     </p>
-    <p xml:id="eco_de_0000140_11080">
+    <p xml:id="eco_de_0000210_11080">
      Nun erschien auch der kleine Werner strahlend. Sophie hatte ihm eine lange Wachstuchschürze umgebunden.
     </p>
-    <p xml:id="eco_de_0000140_11090">
+    <p xml:id="eco_de_0000210_11090">
      »Sophie hat gesagt, ich dürfe auch waschen!« rief er.
     </p>
-    <p xml:id="eco_de_0000140_11100">
+    <p xml:id="eco_de_0000210_11100">
      »Ja, ja, du sollst uns helfen«, sagte Marianne. »Du musst das Waschknechtlein sein. Waschknechtlein, geh einmal hinein: Ich glaube, die Ella hat noch eine ganz schmutzige Schürze an. Oder bring' die Ella und das Julchen gleich mit; sie können beim Einseifen ein wenig helfen.«
     </p>
-    <p xml:id="eco_de_0000140_11110">
+    <p xml:id="eco_de_0000210_11110">
      Werner lief und holte die Puppenkinder. Es setzte sie an den kleinen Kübel und ermahnte sie, sich nicht nass zu machen. Er selbst war allerdings schon nach fünf Minuten triefend.
     </p>
-    <p xml:id="eco_de_0000140_11120">
+    <p xml:id="eco_de_0000210_11120">
      Hans hatte seine Bitte im Garten, wo Mama mit einer Näharbeit beim Schwesterlein lag, vorgebracht, und Mama hatte Ja gesagt. Nur eine kleine Ermahnung hatte sie gegeben.
     </p>
-    <p xml:id="eco_de_0000140_11130">
+    <p xml:id="eco_de_0000210_11130">
      »Du hast doch sehr gut gewusst, Hans, dass es nicht recht war, so weit hinauszufahren. Dein Gewissen hat dir's gesagt; aber du hast getan, als ob du's nicht hörtest. Wir könnten euch ja das Rudern und auch anderes einfach verbieten; aber wir möchten euch so viel Freiheit als möglich lassen. Wir möchten, dass ihr lernt, euch selbst gebieten und gehorchen. Wer das nicht kann, aus dem wird nie im Leben etwas Tüchtiges. – Geh jetzt mit Fritz, und seid vergnügt an dem schönen Morgen!«
     </p>
-    <p xml:id="eco_de_0000140_11140">
+    <p xml:id="eco_de_0000210_11140">
      Bald darauf ruderten die beiden an der Gartenmauer vorbei.
     </p>
-    <p xml:id="eco_de_0000140_11150">
+    <p xml:id="eco_de_0000210_11150">
      »Auf Wiedersehen, Frau Turnach! auf Wiedersehen, Mama!« riefen sie hinauf.
     </p>
-    <p xml:id="eco_de_0000140_11160">
+    <p xml:id="eco_de_0000210_11160">
      Der See schimmerte in hellem Blau. Ein leichter Ostwind strich drüber hin. Der Himmel war wolkenlos, und fern im Duft standen die Schneeberge.
     </p>
-    <p xml:id="eco_de_0000140_11170">
+    <p xml:id="eco_de_0000210_11170">
      Fritz hatte den Hans an die Stehruder gelassen und gab ihm guten Rat, wie er das Schiff ohne starke Stösse und doch rasch vorwärts bringen könne.
     </p>
-    <p xml:id="eco_de_0000140_11180">
+    <p xml:id="eco_de_0000210_11180">
      »Komm«, sagte er, »jetzt fahren wir einmal durch den Schilf. Wir nehmen uns fest vor, nicht stecken zu bleiben! Hast du dir's vorgenommen –? Dann los –! Eins, zwei – eins, zwei –«
     </p>
-    <p xml:id="eco_de_0000140_11190">
+    <p xml:id="eco_de_0000210_11190">
      Er lenkte das Schiff auf die dichteste Stelle. Hui! wie die Halme knackten und rauschten.
     </p>
-    <p xml:id="eco_de_0000140_11200">
+    <p xml:id="eco_de_0000210_11200">
      »Eins, zwei – fest dran, Hans!« schrie Fritz und griff mächtig aus mit seinem Ruder. Hans arbeitete, dass ihm der Schweiss auf die Stirne trat. Die Ruder schlugen auf den Schilf und erreichten kaum mehr das Wasser –
     </p>
-    <p xml:id="eco_de_0000140_11210">
+    <p xml:id="eco_de_0000210_11210">
      »Stramm, Hans! wir haben's uns vorgenommen –«
     </p>
-    <p xml:id="eco_de_0000140_11220">
+    <p xml:id="eco_de_0000210_11220">
      Noch drei, vier gewaltige Schläge, und mit einem Schuss flog das Schiff wieder ins freie Wasser hinaus.
     </p>
-    <p xml:id="eco_de_0000140_11230">
+    <p xml:id="eco_de_0000210_11230">
      Die beiden verschnauften einen Augenblick.
     </p>
-    <p xml:id="eco_de_0000140_11240">
+    <p xml:id="eco_de_0000210_11240">
      »Siehst du, das ist hübsch«, sagte Fritz, »wenn man etwas durchsetzt, was einem zuerst fast nicht möglich schien. Manchmal bei einer besonders schweren Mathematikaufgabe geht's mir so. Ich denke: Jetzt grad –! und zwing' und zwinge, bis ich durchkomme.«
     </p>
-    <p xml:id="eco_de_0000140_11250">
+    <p xml:id="eco_de_0000210_11250">
      »Durch den dichten Schilf rudern tu' ich lieber, als eine schwere Rechnung machen«, meinte Hans.
     </p>
-    <p xml:id="eco_de_0000140_11260">
+    <p xml:id="eco_de_0000210_11260">
      »Ja, du bist nicht dumm! Das andere muss aber auch sein, wenigstens, wenn man aufs Polytechnikum will.«
     </p>
-    <p xml:id="eco_de_0000140_11270">
+    <p xml:id="eco_de_0000210_11270">
      Fritz griff wieder zum Ruder, und jetzt fuhren sie gemächlich zum Klaregg und dort nahe ans Ufer. Es war ganz still da draussen; man hörte bloss einen Buchfinken schlagen. Die Sonne schien durch die alten Weidenbüsche; die Kiesel am Ufer waren blank wie frisch gewaschen. Da sahen die beiden Knaben etwas Schönes. Im Grase, nah am Wasser, lag zusammengeringelt eine glänzende Schlange. Sie sonnte sich da, und als sie ein Geräusch hörte, hob sie bloss ein wenig den Kopf und sah nach den Anfahrenden.
     </p>
-    <p xml:id="eco_de_0000140_11280">
+    <p xml:id="eco_de_0000210_11280">
      »Es ist eine Ringelnatter!« flüsterte Fritz. Hans wurde ganz aufgeregt.
     </p>
-    <p xml:id="eco_de_0000140_11290">
+    <p xml:id="eco_de_0000210_11290">
      »O! eine Ringelnatter! So nah hab' ich noch keine gesehen! Fritz, wenn wir sie bekämen –«
     </p>
-    <p xml:id="eco_de_0000140_11300">
+    <p xml:id="eco_de_0000210_11300">
      Doch als die beiden Miene machten, aus dem Schiff zu springen, schoss die Schlange auf und geradenwegs ins Wasser hinein. In schönen, grossen Wellenlinien, den Kopf bald hochhebend, bald senkend, schwamm sie dahin. Man sah deutlich die schwarzen Flecken auf dem Rücken. Auf einmal bog sie seitwärts, und bevor die Knaben ihr Schiff wenden konnten, war die Schlange verschwunden.
     </p>
-    <p xml:id="eco_de_0000140_11310">
+    <p xml:id="eco_de_0000210_11310">
      »Wie schade!« rief Hans. »Wir hätten sie vielleicht fangen können. Giftig sind die Ringelnattern ja nicht. Man kann sie ruhig anfassen.«
     </p>
-    <p xml:id="eco_de_0000140_11320">
+    <p xml:id="eco_de_0000210_11320">
      »Wenn sie stillhalten!« lachte Fritz. »Weisst du, am schönsten sind die Tiere doch in der Freiheit. Wie rasch und stolz ist sie geschwommen! Dies Frühjahr war ich in einer Menagerie; da lagen die Schlangen so lahm und langweilig herum; man wusste die längste Zeit nicht, ob sie tot oder lebendig seien.«
     </p>
-    <p xml:id="eco_de_0000140_11330">
+    <p xml:id="eco_de_0000210_11330">
      Fritz zog seine Uhr heraus.
     </p>
-    <p xml:id="eco_de_0000140_11340">
+    <p xml:id="eco_de_0000210_11340">
      »Jetzt muss gleich der ›Schwan‹ kommen. Ich will dir einmal zeigen, wie ich in die Rückwellen fahre. Aber das machst du mir dann erst in zwei oder drei Jahren nach!«
     </p>
-    <p xml:id="eco_de_0000140_11350">
+    <p xml:id="eco_de_0000210_11350">
      In der Tat sah man von ferne das Dampfschiff herkommen. Fritz stellte sich an die Stehruder und fuhr zu, immer auf das Dampfschiff los.
     </p>
-    <p xml:id="eco_de_0000140_11360">
+    <p xml:id="eco_de_0000210_11360">
      »Es sieht gerade aus, als wollte er in den ›Schwan‹ hineinfahren!« dachte Hans.
     </p>
-    <p xml:id="eco_de_0000140_11370">
+    <p xml:id="eco_de_0000210_11370">
      Nun kamen sie ganz hart vor das Dampfschiff. Der Kapitän in der Spitze des Schiffes sah nach den beiden.
     </p>
-    <p xml:id="eco_de_0000140_11380">
+    <p xml:id="eco_de_0000210_11380">
      »Die fahren nah heran!« sagte ein Mann, der hinzu trat.
     </p>
-    <p xml:id="eco_de_0000140_11390">
+    <p xml:id="eco_de_0000210_11390">
      Aber der Kapitän nickte gemütlich.
     </p>
-    <p xml:id="eco_de_0000140_11400">
+    <p xml:id="eco_de_0000210_11400">
      »Da ist keine Gefahr. Der am Stehruder weiss, was er tut. Das sind zwei wackere Seebuben.« Er lachte und legte die Hand an die Mütze.
     </p>
-    <p xml:id="eco_de_0000140_11410">
+    <p xml:id="eco_de_0000210_11410">
      Jetzt brauste das Rad an den beiden vorbei. Wie das stampfte und toste und spritzte! Fest hielt Fritz sein Ruder, und mit einem gut berechneten Schlag lenkte er scharf hinter den »Schwan« in die brausenden, schaumweissen Rückwellen. Hoch auf tanzte das kleine Schiff und senkte sich. Aber Fritz hatte es in der Gewalt, so dass der Kiel die Wellen schnitt.
     </p>
-    <p xml:id="eco_de_0000140_11420">
+    <p xml:id="eco_de_0000210_11420">
      Einige Fremde, die auf dem Hinterdeck sassen, riefen einander zu und hatten ihre Freude an den kühnen jungen Ruderern. Ein alter Herr mit weissem Haar warf ihnen einen Strauss zu. Als sie ihn aus dem aufgeregten, wirbelnden Wasser auffischten, war es ein Büschel Alpenrosen.
     </p>
-    <p xml:id="eco_de_0000140_11430">
+    <p xml:id="eco_de_0000210_11430">
      »Das ist aber nett von dem Herrn!« sagte Hans. »Die hälfte der Blumen bringen wir der Mama und die andern deiner Tante. Heute erleben wir lauter hübsche Sachen!«
     </p>
-    <p xml:id="eco_de_0000140_11440">
+    <p xml:id="eco_de_0000210_11440">
      »Ja, und die Hauptsache vergessen wir noch! Wir haben höchste Zeit, jetzt zu den Binsen zu fahren!«
     </p>
-    <p xml:id="eco_de_0000140_11450">
+    <p xml:id="eco_de_0000210_11450">
      Als Fritz und Hans mit einer schweren Ladung langer, dicker Binsen heimkehrten, war es gerade Mittag. Mariannes und Lottis Wäsche flatterte lustig im Ostwind.
     </p>
-    <p xml:id="eco_de_0000140_11460">
+    <p xml:id="eco_de_0000210_11460">
      Beim Essen bekam Papa wieder eine Menge Geschichten zu hören, von der Wäsche und wie Werner in den Zuber gefallen sei, und von der Ringelnatter, dem Dampfschiff und den Alpenrosen. Sophie trug ab, und die Kinder wussten immer noch etwas und noch etwas, bis Papa sie lachend hinausschickte, weil er doch seine Mittagsruhe haben wollte.
     </p>
-    <p xml:id="eco_de_0000140_11470">
+    <p xml:id="eco_de_0000210_11470">
      »Ja, Papa, wir gehen«, sagte Lotti. »Wir wissen auch schon wieder etwas Nettes. Wir machen Seifenblasen von unserer übrigen Seife. Jakob hat uns vorhin aus Stohhalmen Röhrchen zurechtgeschnitten.«
     </p>
-    <p xml:id="eco_de_0000140_11480">
+    <p xml:id="eco_de_0000210_11480">
      Die Kinder setzten sich mit ihren Strohpfeifen und dem Schüsselchen voll Seifenschaum an den See und bliesen grosse grün, rot und blau schillernde Seifenblasen in die Luft. Manche platzten gleich; manche stiegen in die Höhe und trieben als glänzende Kugeln über den See hinaus.
     </p>
-    <p xml:id="eco_de_0000140_11490">
+    <p xml:id="eco_de_0000210_11490">
      Der Seifenschaum war noch nicht aufgebraucht, als die Kinder unterbrochen wurden durch einen sehr possierlichen Auftritt.
     </p>
-    <p xml:id="eco_de_0000140_11500">
+    <p xml:id="eco_de_0000210_11500">
      Vom Hühnerhofe her kam langsam die schwarz und weiss gesprenkelte Henne geschritten mit ihrer Kinderschar. Es waren eigentlich nur Pflegekinder. Weil die schwarz-weisse Henne gut brütete, hatte ihr Frau Völklein sieben Enteneier ins Nest gelegt, und über denen hatte die Henne treulich und geduldig gesessen, bis vor ein paar Tagen sieben allerliebste winzige Entlein ausgeschlüpft waren, gelbflaumig, mit grossen Köpfen und breiten Patschfüsschen. Heute machte die schwarz-weisse Henne den ersten Ausgang mit ihren Kleinen. Vergnügt wuselten und stolperten die Entlein um die Pflegemutter herum mit einem komischen Gepip; schnattern konnten sie noch nicht recht.
     </p>
-    <p xml:id="eco_de_0000140_11510">
+    <p xml:id="eco_de_0000210_11510">
      Als die schwarz-weisse Henne die Turnachkinder sah, lenkte sie zu ihnen hin. Sie sollten auch sehen, wie nett und sauber die Kleinen waren. Aber der Stolz der Henne verwandelte sich unversehens in Angst und Schrecken.
     </p>
-    <p xml:id="eco_de_0000140_11520">
+    <p xml:id="eco_de_0000210_11520">
      Das vorderste, keckste Entlein streckte seinen Kopf, als ob es etwas schnupperte; dann fing es an, gegen den See zu laufen, so rasch es nur konnte, und seine sechs Geschwister watschelten ihm nach. Die zwei hintersten purzelten in der Hans über die grossen Ufersteine; aber sie erhoben sich wieder und liefen zu, immer zu. Es war gerade, als ob sie alle müssten. Jetzt stand das erste am Wasser. Es reckte sich und hob die winzigen Flügel, die noch nichts waren als zwei gelbwollene Zipfelchen, und plumps! war das Entlein im Wasser!
     </p>
-    <p xml:id="eco_de_0000140_11530">
+    <p xml:id="eco_de_0000210_11530">
      Die schwarz-weisse Henne war mit gesträubten Federn nachgelaufen, um die Kleinen aufzuhalten. Aber es half nichts; schon plumpste das zweite und jetzt das dritte ins Wasser. Mit entsetztem Gegacker rannte die Henne am Ufer hin und her. Das war ja grässlich! Die tollkühnen Kleinen mussten ja ertrinken! In der Verzweiflung tat die schwarz-weisse Henne einen kleinen Schritt ins Wasser; aber sie zuckte wieder zurück. Die kalte Nässe war ihr zu schrecklich.
     </p>
-    <p xml:id="eco_de_0000140_11540">
+    <p xml:id="eco_de_0000210_11540">
      Nun platschte vor den Augen der unglücklichen Pflegemutter auch das siebente und letzte Entlein hinein.
     </p>
-    <p xml:id="eco_de_0000140_11550">
+    <p xml:id="eco_de_0000210_11550">
      Die Turnachkinder waren alle herzugesprungen, um das lustige Schauspiel in der Nähe zu sehen.
     </p>
-    <p xml:id="eco_de_0000140_11560">
+    <p xml:id="eco_de_0000210_11560">
      »Nein, Hans –« rief Marianne. »Sie können wahrhaftig alle schon schwimmen. Sieh, wie sie artig und fest rudern mit ihren kurzen Beinchen!«
     </p>
-    <p xml:id="eco_de_0000140_11570">
+    <p xml:id="eco_de_0000210_11570">
      »Ja, Lotti«, sagte Hans, »die sind anders dran hingegangen als du!«
     </p>
-    <p xml:id="eco_de_0000140_11580">
+    <p xml:id="eco_de_0000210_11580">
      »O, o! Jetzt schwimmen sie zum Schilf!« rief Werner und klatschte vor Entzücken und Erstaunen in die Hände.
     </p>
-    <p xml:id="eco_de_0000140_11590">
+    <p xml:id="eco_de_0000210_11590">
      Die schwarz-weisse Henne lief mit klagendem Gegacker um die Turnachkinder herum. Sie hatte vielleicht gemeint, nun komme Hülfe. Aber die Kinder lachten bloss.
     </p>
-    <p xml:id="eco_de_0000140_11600">
+    <p xml:id="eco_de_0000210_11600">
      »Ach, du«, sagte Hans zu der bekümmerten Henne. »Tu du nicht so dumm! Du siehst ja, dass ihnen nichts geschieht. Könntest eher stolz sein, dass die so famos schwimmen.«
     </p>
-    <p xml:id="eco_de_0000140_11610">
+    <p xml:id="eco_de_0000210_11610">
      »Ohne Schwummeln –!« fügte Lotti hinzu. »Du, Hans, wir könnten die schwarz-weisse Henne Balbine heissen, weil Balbine auch nichts vom Schwimmen und Rudern wissen will.«
     </p>
-    <p xml:id="eco_de_0000140_11620">
+    <p xml:id="eco_de_0000210_11620">
      »Oder Tante Ängstlich!« schlug Marianne vor. »Dann wird Balbine nicht böse.«
     </p>
-    <p xml:id="eco_de_0000140_11630">
+    <p xml:id="eco_de_0000210_11630">
      »Ja, Tante Ängstlich passt gut«, stimmte Hans bei. »Also hörst du«, wandte er sich wieder zu der Henne, »du heissest jetzt Tante Ängstlich.«
     </p>
-    <p xml:id="eco_de_0000140_11640">
+    <p xml:id="eco_de_0000210_11640">
      Die Henne schlug aufgeregt mit den Flügeln. Sie machte sich nichts aus dem Namen; wenn nur die Kleinen wieder auf dem Trockenen gewesen wären.
     </p>
-    <p xml:id="eco_de_0000140_11650">
+    <p xml:id="eco_de_0000210_11650">
      »Aber Balbine muss wenigstens kommen und sehen«, erklärte Lotti. »Für sie ist das gerade sehr merkwürdig.«
     </p>
-    <p xml:id="eco_de_0000140_11660">
+    <p xml:id="eco_de_0000210_11660">
      Sie rannte in die Küche und ruhte nicht, bis Balbine vom Abspülen weg zum See kam, um die geschickten Entlein und die Tante Ängstlich zu sehen, die am Ufer warten musste, ob es ihren waghalsigen Pfleglingen endlich beliebe, aus dem greulichen Wasser herauszukommen.
     </p>
-    <p xml:id="eco_de_0000140_11670">
+    <p xml:id="eco_de_0000210_11670">
      Nachmittags gab es eine fröhliche Schwummelfabrikation; alle Kinder halfen mit. Um fünf Uhr konnte man die Schwummeln schon beim Baden benützen, und Lotti schwamm darauf so mutig wie eine junge Ente.
     </p>
    </div>
@@ -3638,394 +3638,394 @@
     <head>
      Wie es in den Ferien bei Regenwetter geht.
     </head>
-    <p xml:id="eco_de_0000140_11680">
+    <p xml:id="eco_de_0000210_11680">
      Am zweiten Ferientag hatten Marianne und Lotti zu bügeln; Hans half Jakob beim Kaninchenstall. Am Nachmittag unternahm man die Fahrt zu Mischa. Das Vergnügen wurde zwar zuerst etwas gestört; denn der kleine Werner, als er die alte Frau Zritschek mit der Hakennase sah und die Hand geben sollte, fing an zu weinen und steckte den Kopf hinter Marianne:
     </p>
-    <p xml:id="eco_de_0000140_11690">
+    <p xml:id="eco_de_0000210_11690">
      »Ich – ich will die Frau nicht sehen –! ich – ich will heim –«
     </p>
-    <p xml:id="eco_de_0000140_11700">
+    <p xml:id="eco_de_0000210_11700">
      Marianne versuchte umsonst, ihn zu beruhigen.
     </p>
-    <p xml:id="eco_de_0000140_11710">
+    <p xml:id="eco_de_0000210_11710">
      »Es ist schrecklich!« sagte Hans leise zu Lotti. »Man hat nur Schande mit ihm. Hätten wir ihn doch nicht mitgenommen!«
     </p>
-    <p xml:id="eco_de_0000140_11720">
+    <p xml:id="eco_de_0000210_11720">
      Da fing Mischa an, auf sein Sohlleder zu klopfen und dazu mit seiner sanften Stimme zu sprechen:
     </p>
-    <p xml:id="eco_de_0000140_11730">
+    <p xml:id="eco_de_0000210_11730">
      »Wenn der ganz kleine Herr mir helfen will die Nägel einschlagen –? So – immer so –«
     </p>
-    <p xml:id="eco_de_0000140_11740">
+    <p xml:id="eco_de_0000210_11740">
      Werner horchte auf. Dann ging er zwei Schritte auf Mischa zu, der ihm freundlich den Hammer hinstreckte.
     </p>
-    <p xml:id="eco_de_0000140_11750">
+    <p xml:id="eco_de_0000210_11750">
      Jetzt war das Spiel gewonnen. Werner begann munter zu hämmern und war gar nicht mehr von Mischa wegzubringen. Als Marianne ihn endlich an der Hand nahm, erklärte er: »Morgen komm' ich wieder!« und gab der Frau Zritschek einen zutraulichen Patsch zum Abschied. –
     </p>
-    <p xml:id="eco_de_0000140_11760">
+    <p xml:id="eco_de_0000210_11760">
      Für den Mittwoch war das Klaregg in Aussicht genommen. Aber in der Nacht schlug das Wetter plötzlich um. Hans hörte beim Erwachen ein starkes Rauschen. Er sah hinaus: Es regnete, was es konnte. Die Blätter des Birnbaums trieften. Der Himmel war grau, der See grau.
     </p>
-    <p xml:id="eco_de_0000140_11770">
+    <p xml:id="eco_de_0000210_11770">
      Hans kam aber doch lustig pfeifend die Treppe herunter. Er dachte an den Garten, den sie nun auf Mamas grossem Gläserbrett anlegen wollten. Als jedoch die Kinder beim Frühstück lebhaft von dem Garten sprachen, kam Mama hinzu:
     </p>
-    <p xml:id="eco_de_0000140_11780">
+    <p xml:id="eco_de_0000210_11780">
      »Wie wär's, Marianne und Lotti, wenn ihr zuerst einmal etwa eine Stunde fleissig stricktet? Hans kann mir zwei Stränge Wolle abwickeln und nachher die kleine Mappe leimen, die ich längst gern hätte.«
     </p>
-    <p xml:id="eco_de_0000140_11790">
+    <p xml:id="eco_de_0000210_11790">
      Hans brachte sofort den Haspel:
     </p>
-    <p xml:id="eco_de_0000140_11800">
+    <p xml:id="eco_de_0000210_11800">
      »Bitte, bitte, die Wolle, Mama, damit ich nachher bald das Moos holen kann –!«
     </p>
-    <p xml:id="eco_de_0000140_11810">
+    <p xml:id="eco_de_0000210_11810">
      Lotti seufzte ein wenig. Sie hatte für Werner einen Strumpf in Arbeit, der gar nicht vom Fleck wollte. Es war ein Glück, dass wenigstens das Garn zweifarbig war; immer kam nach einem weissen Ringel wieder ein blauer. Aber es dauerte fruchtbar lang, bis so ein Streifen fertig war. An einer einzigen Masche gab es vier Dinge zu tun, wie Grossmama sie gelehrt hatte: Einstechen, Umschlagen, Herausziehen und Fallenlassen. Und eine Masche war so wenig.
     </p>
-    <p xml:id="eco_de_0000140_11820">
+    <p xml:id="eco_de_0000210_11820">
      »Marianne, kann ein grosser Mensch wohl ausrechnen, wie viele Maschen ein Strumpf hat?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_11830">
+    <p xml:id="eco_de_0000210_11830">
      Marianne zuckte nur mit den Achseln; sie war gerade am Abnehmen; da musste man aufpassen.
     </p>
-    <p xml:id="eco_de_0000140_11840">
+    <p xml:id="eco_de_0000210_11840">
      Lotti wickelte das Garn ein wenig auf, um zu sehen, wie weit das Blau noch gehe. Dann schüttelte sie ihren Knäuel. Zu allerinnerst steckte ein Schächtelchen mit einem Geldstück. Grossmama hatte das so gewickelt. Lotti hätte gern gewusst, ob ein Fünfer oder ein Zehner drin sei; es klapperte ziemlich stark.
     </p>
-    <p xml:id="eco_de_0000140_11850">
+    <p xml:id="eco_de_0000210_11850">
      »Ja, Lotti, auf die Art kommt es nicht heraus!« sagte Sophie, als sie durchs Zimmer ging. »Am vernünftigsten ist, du strickst nacheinander fort und schaust den Knäuel gar nicht an. Wieviel Gänge hast du denn auf?«
     </p>
-    <p xml:id="eco_de_0000140_11860">
+    <p xml:id="eco_de_0000210_11860">
      »Sechs«, antwortete Lotti etwas kläglich.
     </p>
-    <p xml:id="eco_de_0000140_11870">
+    <p xml:id="eco_de_0000210_11870">
      »Siehst du, da musst du schon fest dran sein, sonst laufen dir Hans und Marianne davon!«
     </p>
-    <p xml:id="eco_de_0000140_11880">
+    <p xml:id="eco_de_0000210_11880">
      Da setzte sich Lotti auf ihrem Stuhl zurecht und fing eifrig an, in die Maschen zu stechen. Es wäre doch schrecklich gewesen, wenn sie nicht hätte mit den andern im Kapuzenkragen durch den Regen zur Scheune hinaufrennen können, wo zwischen den Steinen das Moos wuchs.
     </p>
-    <p xml:id="eco_de_0000140_11890">
+    <p xml:id="eco_de_0000210_11890">
      Die Turnachkinder arbeiteten den ganzen Tag an ihrem Garten. Am Abend war er fertig und so schön, dass jedermann kommen musste, um ihn zu besichtigen. Frau Völklein und Grite wurden besonders heruntergeholt. Auch Jakob wurde gebeten. Er erklärte zwar, er gehe nicht gern in eine rechte Stube mit seinen Stallstiefeln.
     </p>
-    <p xml:id="eco_de_0000140_11900">
+    <p xml:id="eco_de_0000210_11900">
      »Du musst sie nur fest abputzen«, rief Lotti, welche nicht nachgab.
     </p>
-    <p xml:id="eco_de_0000140_11910">
+    <p xml:id="eco_de_0000210_11910">
      Als er dann wirklich im Zimmer vor dem Garten stand, konnte er seiner Verwunderung zuerst gar keinen Ausdruck geben.
     </p>
-    <p xml:id="eco_de_0000140_11920">
+    <p xml:id="eco_de_0000210_11920">
      »Aber nein, aber nein!« sagte er, den Kopf schüttelnd. »Man würde es nicht glauben! So etwas Künstliches! nein, nein –!«
     </p>
-    <p xml:id="eco_de_0000140_11930">
+    <p xml:id="eco_de_0000210_11930">
      Der Garten war auch geradezu grossartig. Das ganze grosse Brett war mit sammetfeinem dunkelgrünem Moos bedeckt, das den Rasen vorstellte. Nach allen Richtungen schlängelten sich die sandbestreuten Wege. In der Mitte hatte Hans von Erde einen Hügel gebildet und gleichfalls mit Moos bedeckt. Auf dem Hügel aber hatte er einen niedlichen Pavillon gebaut aus feingespaltenem Schindelholz. Der Pavillon war von zarten grünen Ranken umsponnen. An den Wegen und in den Rasenplätzen waren buschige Zweige als Bäume eingepflanzt und als Sträuchergruppen verwendet. Davor sah man Bänkchen, auf denen Mariannes und Lottis Papierpüppchen sassen. An einer Seite war ein freier Sandplatz; da stand eine Schaukel und eine Wippe, ebenfalls aus Holz geschnitzt. Hinten im Garten befand sich Lottis kleiner Pumpbrunnen. In der andern Ecke aber hatte Marianne einen dichten Grasbüschel so geschickt gebunden, dass er wie eine Trauerweide über einen kleinen Steinblock fiel, der ein Denkmal vorstellte.
     </p>
-    <p xml:id="eco_de_0000140_11940">
+    <p xml:id="eco_de_0000210_11940">
      Diesen Teil des Gartens nannte Frau Völklein romantisch und über alle Massen schön und setzte sich mit ihrem Strickzeug daneben, um den Anblick recht zu geniessen.
     </p>
-    <p xml:id="eco_de_0000140_11950">
+    <p xml:id="eco_de_0000210_11950">
      Als am andern Morgen das Wetter auch noch trüb und nass war, erklärte Mama, dass nun die allerhöchste Zeit sei, einmal an die Tanten zu schreiben.
     </p>
-    <p xml:id="eco_de_0000140_11960">
+    <p xml:id="eco_de_0000210_11960">
      »Aber sauber. Erst ein Entwurf und dann ordentlich abschreiben.«
     </p>
-    <p xml:id="eco_de_0000140_11970">
+    <p xml:id="eco_de_0000210_11970">
      »Muss ich auch, Mama?« fragte Lotti. »Wir haben noch gar nicht alle Worte gehabt.«
     </p>
-    <p xml:id="eco_de_0000140_11980">
+    <p xml:id="eco_de_0000210_11980">
      »Ja, Lotti, probier's auch. Die Tante Emma weiss ganz gut, was ein Kind in der zweiten Klasse kann.«
     </p>
-    <p xml:id="eco_de_0000140_11990">
+    <p xml:id="eco_de_0000210_11990">
      Die Kinder sassen alle drei um den Tisch. Marianne und Lotti nagten an den Bleistiften. Ein Brief, das war wie eine Aufgabe in der Schule. Hans ging flink dran und hatte schon neun Linien, während die Schwestern noch nicht über »Meine liebe Tante« hinaus waren.
     </p>
-    <p xml:id="eco_de_0000140_12000">
+    <p xml:id="eco_de_0000210_12000">
      »Grässlich«, sagte Hans, als er aufsah. »Ihr fangt ja gar nicht an!«
     </p>
-    <p xml:id="eco_de_0000140_12010">
+    <p xml:id="eco_de_0000210_12010">
      »Ach du!« erwiderte Marianne. »Tu du nicht so stolz! Du bist auch ein Jahr und zwei Monate älter als ich. Wenn ich nur einen Anfang hätte, dann könnte ich gut weiterfahren.«
     </p>
-    <p xml:id="eco_de_0000140_12020">
+    <p xml:id="eco_de_0000210_12020">
      »Gib dein Blatt; ich helf' dir!« sagte Hans, und Marianne reichte ihm das Blatt herüber.
     </p>
-    <p xml:id="eco_de_0000140_12030">
+    <p xml:id="eco_de_0000210_12030">
      Aber sie wurde böse, als sie es wieder erhielt und darauf las: »Meine liebe Tante, ich möchte Dir einen Brief schreiben; aber ich weiss keinen Anfang. Weisst Du vielleicht einen?«
     </p>
-    <p xml:id="eco_de_0000140_12040">
+    <p xml:id="eco_de_0000210_12040">
      Gerade kam Mama, und Marianne wollte über Hans klagen; doch Mama lachte.
     </p>
-    <p xml:id="eco_de_0000140_12050">
+    <p xml:id="eco_de_0000210_12050">
      »Marianne, man muss Spass verstehen.«
     </p>
-    <p xml:id="eco_de_0000140_12060">
+    <p xml:id="eco_de_0000210_12060">
      »Hörst du!« triumphierte Hans. »Man soll überhaupt nicht lang einen Anfang suchen, hat Herr Altschmid gesagt, sondern frisch drangehen, wie wenn man ins Wasser springt. Siehst du, so –«
     </p>
-    <p xml:id="eco_de_0000140_12070">
+    <p xml:id="eco_de_0000210_12070">
      Damit stand Hans schon auf dem Stuhl und hielt die Arme hoch über dem Kopf wie ein Schwimmer.
     </p>
-    <p xml:id="eco_de_0000140_12080">
+    <p xml:id="eco_de_0000210_12080">
      »So, jetzt hab' ich dir wieder einen Anfang gezeigt!«
     </p>
-    <p xml:id="eco_de_0000140_12090">
+    <p xml:id="eco_de_0000210_12090">
      Währenddessen war Lotti ein Gedanke gekommen:
     </p>
-    <p xml:id="eco_de_0000140_12100">
+    <p xml:id="eco_de_0000210_12100">
      »Mama, kann ich gleich anfangen: ›Liebe Tante, gestern haben wir einen schönen Garten gemacht‹?«
     </p>
-    <p xml:id="eco_de_0000140_12110">
+    <p xml:id="eco_de_0000210_12110">
      »Natürlich!«
     </p>
-    <p xml:id="eco_de_0000140_12120">
+    <p xml:id="eco_de_0000210_12120">
      Da schrieb Lotti vergnügt, und Marianne nahm sich auch zusammen und erzählte von der Puppenwäsche und dass das Schwesterlein nicht ganz wohl gewesen sei und dass sie einen dicken, schönen Frosch im Aquarium hätten, der Alexius heisse. Als ihr Brief fertig war, sagte Mama sogar, er sei recht nett.
     </p>
-    <p xml:id="eco_de_0000140_12130">
+    <p xml:id="eco_de_0000210_12130">
      »Und jetzt dürfen wir nach dem Essen malen, Mama?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_12140">
+    <p xml:id="eco_de_0000210_12140">
      »Aber wir haben gar keine Bilderbogen!« meinte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_12150">
+    <p xml:id="eco_de_0000210_12150">
      »Dann zeichnet ihr euch selber etwas und malt es«, schlug Mama vor.
     </p>
-    <p xml:id="eco_de_0000140_12160">
+    <p xml:id="eco_de_0000210_12160">
      Nun konnten die Kinder kaum warten bis nach Tisch. Sie holten Wassergläser und ihre Malkästchen, und Mama gab jedem aus ihrem alten Zeichnungsbuch zwei schöne Blätter.
     </p>
-    <p xml:id="eco_de_0000140_12170">
+    <p xml:id="eco_de_0000210_12170">
      Dann fingen die drei an zu arbeiten, dass es eine Freude war. Keines stöhnte, keines nagte am Bleistift oder fragte um einen Anfang.
     </p>
-    <p xml:id="eco_de_0000140_12180">
+    <p xml:id="eco_de_0000210_12180">
      Es war ganz still im Zimmer. Man hörte nur den kleinen Werner, der am Boden aus Bauhölzchen einen Turm errichtete, ihn mit grossem Gepolter zusammenwarf und wieder aufbaute.
     </p>
-    <p xml:id="eco_de_0000140_12190">
+    <p xml:id="eco_de_0000210_12190">
      »Zum Glück lässt er uns in Ruhe«, sagte Hans, während er den Pinsel ausschwenkte, so dass das Wasser ganz gelb wurde. »Ich habe noch viel zu tun. Immer fällt einem wieder etwas ein, was her muss.«
     </p>
-    <p xml:id="eco_de_0000140_12200">
+    <p xml:id="eco_de_0000210_12200">
      »Weiss –?« sprach Marianne vor sich hin, »weiss kann man auf weissem Papier nicht malen. Das muss ich leer lassen und ringsum ein wenig grau oder blau malen. So –«
     </p>
-    <p xml:id="eco_de_0000140_12210">
+    <p xml:id="eco_de_0000210_12210">
      Lotti hätte gern gewusst, was das Weisse auf Mariannes Bild bedeute; aber sie hatte keine Zeit, hinüberzusehen. Ihr lief gerade die blaue Farbe in die rote nebenan. Sie wischte und wischte. Plötzlich aber entstand das schönste Violett, und Lotti strich erfreut mit dieser neuen Farbe das ganze Kleid an, das sie in Arbeit hatte.
     </p>
-    <p xml:id="eco_de_0000140_12220">
+    <p xml:id="eco_de_0000210_12220">
      Endlich hielt Marianne ihr Bild vor sich hin.
     </p>
-    <p xml:id="eco_de_0000140_12230">
+    <p xml:id="eco_de_0000210_12230">
      »Fertig!« sagte sie und stand auf, um Lottis Gemälde zu sehen.
     </p>
-    <p xml:id="eco_de_0000140_12240">
+    <p xml:id="eco_de_0000210_12240">
      Dieses stellte eine Obstfrau vor in grünem Kleid. Sie sass unter einem Schirm; vor sich hatte sie einen grossen Korb mit gelben und einen mit roten Äpfeln. Bei den Körben stand ein Mädchen mit einem Schultornister und einem gelben Hute. Das Kleid des Mädchens war violett.
     </p>
-    <p xml:id="eco_de_0000140_12250">
+    <p xml:id="eco_de_0000210_12250">
      Auf Mariannes Blatt war ein Weihnachtsbaum zu sehen mit vielen Lichtern, die einen runden, gelben Schein warfen. Alle Zweige hingen voll bunter Kugeln und Sterne und brauner Lebkuchen. Der Tisch nebenan war mit einem weissen Tuch gedeckt und mit Geschenken beladen; obenan sass eine rosa gekleidete Puppe.
     </p>
-    <p xml:id="eco_de_0000140_12260">
+    <p xml:id="eco_de_0000210_12260">
      »So, jetzt könnt ihr mein Bild ansehen!« rief Hans. »Es ist aus der deutschen Sage. Es ist Barbarossa, wie er im Kyffhäuserberg schläft.«
     </p>
-    <p xml:id="eco_de_0000140_12270">
+    <p xml:id="eco_de_0000210_12270">
      Marianne und Lotti bewunderten Hansens Kunstwerk. Auf einem Throne sass Kaiser Barbarossa mit purpurnem Mantel und goldener Krone. Hans besass in seiner Malschachtel ein Näpfchen Gold.
     </p>
-    <p xml:id="eco_de_0000140_12280">
+    <p xml:id="eco_de_0000210_12280">
      »Ihr müsst den Bart des Kaisers besonders ansehen!« ermahnte Hans. »Er ist durch den Tisch gewachsen. Seht, da reicht er bis zum Boden. Das war schwer zu machen! Hier ist Barbarossas Zwerg –« Hans deutete auf ein graubraunes Wesen, das neben dem Throne stand.
     </p>
-    <p xml:id="eco_de_0000140_12290">
+    <p xml:id="eco_de_0000210_12290">
      »Wie schad'! da sind dir schwarze Flecken hingekommen«, sagte Lotti, indem sie auf die Seiten des Bildes zeigte.
     </p>
-    <p xml:id="eco_de_0000140_12300">
+    <p xml:id="eco_de_0000210_12300">
      »Flecken –?« Hans war empört. »Das sind doch keine Flecken! Das sind ja die Raben, die um den Kyffhäuser fliegen. So lange sie fliegen, muss der Kaiser verzaubert schlafen.«
     </p>
-    <p xml:id="eco_de_0000140_12310">
+    <p xml:id="eco_de_0000210_12310">
      Hans griff nach seinem Pinsel und malte die Flügel der Raben etwas länger.
     </p>
-    <p xml:id="eco_de_0000140_12320">
+    <p xml:id="eco_de_0000210_12320">
      »Wer jetzt nicht sieht, dass es Raben sind –!«
     </p>
-    <p xml:id="eco_de_0000140_12330">
+    <p xml:id="eco_de_0000210_12330">
      Da ging die Türe auf und Onkel Alfred trat ein.
     </p>
-    <p xml:id="eco_de_0000140_12340">
+    <p xml:id="eco_de_0000210_12340">
      »Guten Tag, Spatzen! Was ist denn da los? Kunstausstellung? Zeigt her – wundervoll! Famos, Lotti! Das ist wohl eine Strassenszene in Peking? In der Mitte der violette Chinese ist sehr gut –«
     </p>
-    <p xml:id="eco_de_0000140_12350">
+    <p xml:id="eco_de_0000210_12350">
      Onkel Alfred betrachtete Lottis Bild mit ernsthaftem Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_12360">
+    <p xml:id="eco_de_0000210_12360">
      Aber Lotti traute dem Gesicht nicht.
     </p>
-    <p xml:id="eco_de_0000140_12370">
+    <p xml:id="eco_de_0000210_12370">
      »Ach, Onkel, du lachst einen immer aus! Es ist gar nicht in Peking –«
     </p>
-    <p xml:id="eco_de_0000140_12380">
+    <p xml:id="eco_de_0000210_12380">
      »Was auslachen! – Ich lache nicht. Ich schäme mich. Nie brächte ich solche Kompositionen zustande! Luise!« rief er ins andere Zimmer hinüber. »Luise, glückliche Mutter dieser Wunderkinder! Du weisst wohl gar nicht, was du besitzest!«
     </p>
-    <p xml:id="eco_de_0000140_12390">
+    <p xml:id="eco_de_0000210_12390">
      Man hörte Mama drüben lachen.
     </p>
-    <p xml:id="eco_de_0000140_12400">
+    <p xml:id="eco_de_0000210_12400">
      »Lauter junge Talente«, fuhr Onkel Alfred fort, »die man ermutigen, die man in irgend einer Weise fördern muss! Halt – eine Idee – eine prachtvolle Idee –«
     </p>
-    <p xml:id="eco_de_0000140_12410">
+    <p xml:id="eco_de_0000210_12410">
      Er griff in die Tasche. Die Kinder sahen ihn erwartungsvoll an. Etwas Lustiges gab es immer, wenn Onkel Alfred so anfing.
     </p>
-    <p xml:id="eco_de_0000140_12420">
+    <p xml:id="eco_de_0000210_12420">
      »Kinder, das schickt euch Grossmama –« Er hielt ein Päckchen Schokolade in die Höhe. »Ihr werdet es verschmähen, diese Schokolade so ohne allen Witz und Sinn zu verzehren. Ihr werdet einstimmen, wenn ich einen Wettbewerb vorschlage, einen Wettbewerb mit Preisen –«
     </p>
-    <p xml:id="eco_de_0000140_12430">
+    <p xml:id="eco_de_0000210_12430">
      »Ja, einen Wettbewerb, Onkel!« rief Lotti, überzeugt, dass ein Wettbewerb etwas Schönes sei.
     </p>
-    <p xml:id="eco_de_0000140_12440">
+    <p xml:id="eco_de_0000210_12440">
      Und so war es auch: Die Kinder mussten sich noch einmal zum Zeichnen und Malen hinsetzen, und der Onkel wollte ihnen allen die gleiche Aufgabe stellen.
     </p>
-    <p xml:id="eco_de_0000140_12450">
+    <p xml:id="eco_de_0000210_12450">
      »Eine Aufgabe –«, Onkel Alfred sann nach. »Ach, die gibt sich ja hier von selbst: Ihr seid Seekinder; ihr zeichnet den See.«
     </p>
-    <p xml:id="eco_de_0000140_12460">
+    <p xml:id="eco_de_0000210_12460">
      »Soll ein Dampfschiff drauf sein? Und kleine Schiffe? Oder eine Badeanstalt? Darf man auch vom Land etwas zeichnen? Oder, Onkel, etwas, das früher am See war –?« So riefen alle drei Kinder durcheinander. Der Onkel streckte abwehrend die Hände aus.
     </p>
-    <p xml:id="eco_de_0000140_12470">
+    <p xml:id="eco_de_0000210_12470">
      »Silentium! Das heisst auf Deutsch: Spatzen, haltet euere Schnäbel! Alles dürft ihr zeichnen, was auf, in, über, unter und an dem See ist. Es herrscht völlige Freiheit. Nun die Preise –« Er machte das Päckchen auf.
     </p>
-    <p xml:id="eco_de_0000140_12480">
+    <p xml:id="eco_de_0000210_12480">
      »Drei, sechs, acht, zwölf – zwölf Tafeln. Das beste Bild erhält den ersten Preis, bestehend aus fünf Tafeln; als zweiten Preis setzen wir drei Tafeln. Das dritte Bild erhält eine Ehrenerwähnung.«
     </p>
-    <p xml:id="eco_de_0000140_12490">
+    <p xml:id="eco_de_0000210_12490">
      »Wie viel Schokolade ist das?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_12500">
+    <p xml:id="eco_de_0000210_12500">
      »Ja, das ist eigentlich keine Schokolade, bloss Lob. Doch wir können ja eine Ausnahme machen. Also zwei Tafeln zur Ehrenerwähnung.«
     </p>
-    <p xml:id="eco_de_0000140_12510">
+    <p xml:id="eco_de_0000210_12510">
      »Und die letzten zwei Tafeln?« fragte Marianne. Werner stand neben ihr und hörte zu. Er verstand bloss, dass es sich um Schokolade handelte.
     </p>
-    <p xml:id="eco_de_0000140_12520">
+    <p xml:id="eco_de_0000210_12520">
      »Bitte, mir auch, Onkel Alfred!« rief er.
     </p>
-    <p xml:id="eco_de_0000140_12530">
+    <p xml:id="eco_de_0000210_12530">
      »Ja, was meinst du, Werner! Wir gekommen sie nicht nur so –! Wir müssen zeichnen dafür«, erklärte Hans.
     </p>
-    <p xml:id="eco_de_0000140_12540">
+    <p xml:id="eco_de_0000210_12540">
      »Ich will auch zeichnen«, sagte Werner.
     </p>
-    <p xml:id="eco_de_0000140_12550">
+    <p xml:id="eco_de_0000210_12550">
      Die Kinder lachten.
     </p>
-    <p xml:id="eco_de_0000140_12560">
+    <p xml:id="eco_de_0000210_12560">
      Aber Onkel Alfred riss ein Blatt aus seinem Notizbuch.
     </p>
-    <p xml:id="eco_de_0000140_12570">
+    <p xml:id="eco_de_0000210_12570">
      »Warum nicht? Warum diesen strebsamen Jüngling ausschliessen? Kinder, es wird grossartig. Vier Bewerber! Ich sehe, dass ich auch noch etwas tun muss –« Er sog den Geldbeutel heraus.
     </p>
-    <p xml:id="eco_de_0000140_12580">
+    <p xml:id="eco_de_0000210_12580">
      »Hier lege ich zum ersten Preis einen Zehner, zum zweiten einen Fünfer –«
     </p>
-    <p xml:id="eco_de_0000140_12590">
+    <p xml:id="eco_de_0000210_12590">
      »Und zur Ehrenerwähnung?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_12600">
+    <p xml:id="eco_de_0000210_12600">
      »Die scheint dir sehr am Herzen zu liegen, Lotti. Zur Ehrenerwähnung – einen Zweier. Aber den hab' ich nicht! Lotti, lauf in die Küche zu Balbine, ob sie mir einen Zweier leihe.«
     </p>
-    <p xml:id="eco_de_0000140_12610">
+    <p xml:id="eco_de_0000210_12610">
      Marianne und Hans liefen hinter Lotti drein.
     </p>
-    <p xml:id="eco_de_0000140_12620">
+    <p xml:id="eco_de_0000210_12620">
      »Da«, riefen sie, als sie wieder hereinkamen. »Balbine will den Zweier schenken. Sie sagte, sie sei auch sehr für Kunst!«
     </p>
-    <p xml:id="eco_de_0000140_12630">
+    <p xml:id="eco_de_0000210_12630">
      »Schön, sehr schön von Balbine! Nun vorwärts, Kinder! Ich habe mit eurer Mama etwas zu besprechen und lasse euch. Arbeitet mit Begeisterung, guckt einander nicht auf die Blätter und leckt nicht am Pinsel! In einer halben Stunde sollt ihr fertig sein. Dann legt ihr die Blätter hin und geht hinaus. Ich darf natürlich nicht wissen, von wem jedes Blatt ist.«
     </p>
-    <p xml:id="eco_de_0000140_12640">
+    <p xml:id="eco_de_0000210_12640">
      Onkel Alfred verliess die Kinder. Wieder wurde es sehr still im Zimmer. Man hörte die Fliegen summen am Fenster.
     </p>
-    <p xml:id="eco_de_0000140_12650">
+    <p xml:id="eco_de_0000210_12650">
      Nach einer halben Stunde klopfte Hans an Mamas Türe.
     </p>
-    <p xml:id="eco_de_0000140_12660">
+    <p xml:id="eco_de_0000210_12660">
      »Wir sind fertig, Onkel! Wir bleiben in der Küche, bis du uns rufst.«
     </p>
-    <p xml:id="eco_de_0000140_12670">
+    <p xml:id="eco_de_0000210_12670">
      Die Kinder standen um Balbine herum, die Kartoffeln schälte und sich erzählen liess, was gemalt worden war. Sie sagte, sie hätte als Kind auch gerne zeichnen wollen; aber sie habe immer Brot austragen und Gänse hüten müssen.
     </p>
-    <p xml:id="eco_de_0000140_12680">
+    <p xml:id="eco_de_0000210_12680">
      Lotti ging ein paarmal an die Wohnzimmertüre, um zu horchen.
     </p>
-    <p xml:id="eco_de_0000140_12690">
+    <p xml:id="eco_de_0000210_12690">
      »Marianne«, flüsterte sie, »es ist ganz feierlich. Man bekommt fast Herzklopfen.«
     </p>
-    <p xml:id="eco_de_0000140_12700">
+    <p xml:id="eco_de_0000210_12700">
      Da machte Onkel Alfred die Türe auf und rief die Kinder herein.
     </p>
-    <p xml:id="eco_de_0000140_12710">
+    <p xml:id="eco_de_0000210_12710">
      »Bitte, Balbine«, sagte er, zur Küche gewendet, »wollen Sie nicht auch eintreten? Ich habe mit Freuden gehört, dass Sie warmen Anteil an der Kunst nehmen.«
     </p>
-    <p xml:id="eco_de_0000140_12720">
+    <p xml:id="eco_de_0000210_12720">
      Balbine rieb sich die Hände ab und band die bessere Schürze um.
     </p>
-    <p xml:id="eco_de_0000140_12730">
+    <p xml:id="eco_de_0000210_12730">
      Mama stand am Tisch vor den vier Bildern. Das vom Wernermann konnte man zwar wirklich nicht ein Bild nennen. Es war bloss ein Gekritzel und eine Reihe von Nullen mit angesetzten Strichen. Werner behauptete, das seien Soldaten.
     </p>
-    <p xml:id="eco_de_0000140_12740">
+    <p xml:id="eco_de_0000210_12740">
      Hans zeigte Balbine sein Bild und erklärte es. Er hatte eine Pfahlbaueransiedlung dargestellt. – In der Mitte sah man auf Pfählen eine braune Holzhütte und eine Treppe, die ins Wasser führte. Ein Mann zog sein Netz heraus; eine Frau mit roter Halskette und blauem Rock stand daneben. Von links fuhr ein Kahn mit Männern herbei, die einen erlegten Hirsch brachten; man konnte das grosse Geweih erkennen.
     </p>
-    <p xml:id="eco_de_0000140_12750">
+    <p xml:id="eco_de_0000210_12750">
      »Ich glaube, Hans, du bekommst den ersten Preis«, sagte Marianne, die das Blatt auch betrachtete.
     </p>
-    <p xml:id="eco_de_0000140_12760">
+    <p xml:id="eco_de_0000210_12760">
      Auf Lottis Bild war ein Dampfschiff zu sehen mit rot-weisser Flagge, vielen Fenstern und einem sehr langen Kamin. Dahinter fuhr ein grosses Steinschiff und hart daneben ein Boot mit dreieckigem Segel. Und wo Lotti sonst noch Platz gefunden, da hatte sie kleine bunte Schiffchen angebracht mit Fähnchen und Rudersleuten und Damen.
     </p>
-    <p xml:id="eco_de_0000140_12770">
+    <p xml:id="eco_de_0000210_12770">
      Mariannes Bild war einfacher: Links eine graue Mauer, drüber ein Apfelbaum – gerade wie's draussen in Wirklichkeit war. Da stand auch im Wasser der grüne Schilf; jenseits erhob sich der Berg, und dahinter war der Himmel ein wenig rotgelb. Auch auf dem Wasser war ein rotgelber Schein. Auf der Mauer sassen vier Kinder; man sah sie bloss von hinten; aber man konnte sie alle erkennen: Hans an seiner blauen Mütze, Marianne am langen Zopf, Lotti am kurzen braunen Haar, und den kleinen Werner an seiner weiss und blau gestreiften Schürze.
     </p>
-    <p xml:id="eco_de_0000140_12780">
+    <p xml:id="eco_de_0000210_12780">
      Nun stellte sich Onkel Alfred an den Tisch und hielt eine kleine Rede von Kunst und von einem Maler, der Raffael geheissen habe. Dann räusperte er sich und sah auf die Bilder.
     </p>
-    <p xml:id="eco_de_0000140_12790">
+    <p xml:id="eco_de_0000210_12790">
      »Jetzt kommt's!« flüsterte Lotti und kniff Hans in den Arm, so dass er sie gerne gepufft hätte, wenn der Augenblick nicht so spannend gewesen wäre.
     </p>
-    <p xml:id="eco_de_0000140_12800">
+    <p xml:id="eco_de_0000210_12800">
      »Das Preisgericht«, fuhr Onkel Alfred fort, »das Preisgericht, bestehend aus der Mutter und dem Onkel dieser jungen Künstler, hat entschieden, dass der erste Preis, also die fünf Schokoladetafeln und der Zehner dem Bilde ›Abend auf der Seemauer‹ zufällt –«
     </p>
-    <p xml:id="eco_de_0000140_12810">
+    <p xml:id="eco_de_0000210_12810">
      Alle blickten Marianne an. Sie wurde rot vor Überraschung und Freude. Auch Hans hatte rote Backen bekommen vor lauter Erstaunen, dass sein Bild nicht als das beste erklärt wurde.
     </p>
-    <p xml:id="eco_de_0000140_12820">
+    <p xml:id="eco_de_0000210_12820">
      »Den zweiten Preis, bestehend aus drei Tafeln und einem Fünfer, erhält –«
     </p>
-    <p xml:id="eco_de_0000140_12830">
+    <p xml:id="eco_de_0000210_12830">
      Es wurde Hans ganz beklommen zu Mut.
     </p>
-    <p xml:id="eco_de_0000140_12840">
+    <p xml:id="eco_de_0000210_12840">
      »Erhält das Gemälde ›Pfahlbauer, von der Jagd heimkehrend‹ –«
     </p>
-    <p xml:id="eco_de_0000140_12850">
+    <p xml:id="eco_de_0000210_12850">
      Hans atmete auf; er hätte sich doch zu arg schämen müssen, wenn sein Bild zuletzt gekommen wäre.
     </p>
-    <p xml:id="eco_de_0000140_12860">
+    <p xml:id="eco_de_0000210_12860">
      »Das dritte Bild, das wir ›Fröhliche Schiffahrt‹ nennen wollen –«
     </p>
-    <p xml:id="eco_de_0000140_12870">
+    <p xml:id="eco_de_0000210_12870">
      »Das bin ich, Onkel!«, rief Lotti. »Ich hab' immer gedacht, dass ich die Ehrenerwähnung bekomme!«
     </p>
-    <p xml:id="eco_de_0000140_12880">
+    <p xml:id="eco_de_0000210_12880">
      »Silentium!« mahnte der Onkel. »Lotti, du hast noch keinen Begriff von parlamentarischem Anstand –«
     </p>
-    <p xml:id="eco_de_0000140_12890">
+    <p xml:id="eco_de_0000210_12890">
      Aber nun drangen die Kinder auf den Onkel ein, um ihre Preise in Empfang zu nehmen. Und da auch Papa eintrat, dem man alles zeigen und erzählen musste, gab es einen grossen Tumult, in welchem man eine Weile den kleinen Werner gar nicht geachtete, der immerfort schrie:
     </p>
-    <p xml:id="eco_de_0000140_12900">
+    <p xml:id="eco_de_0000210_12900">
      »Onkel, Onkel! Ich hab' auch ein Bild gemacht! Ich hab' Soldaten gemacht!«
     </p>
-    <p xml:id="eco_de_0000140_12910">
+    <p xml:id="eco_de_0000210_12910">
      Schliesslich packte er den Onkel am Rockzipfel; das half.
     </p>
-    <p xml:id="eco_de_0000140_12920">
+    <p xml:id="eco_de_0000210_12920">
      Der Onkel griff an die Stirne, als ob er sehr erschrocken wäre über seine Vergesslichkeit.
     </p>
-    <p xml:id="eco_de_0000140_12930">
+    <p xml:id="eco_de_0000210_12930">
      »Werner –! Wie ist's möglich! Wie konnt' ich dich übersehen –! Gewiss, auch in dir steckt ein Künstler! Dein Bild ist so wunderbar, dass es ausser allem Wettbewerb steht!« Er nahm den Kleinen und hielt ihn hoch in die Luft.
     </p>
-    <p xml:id="eco_de_0000140_12940">
+    <p xml:id="eco_de_0000210_12940">
      »Jedenfalls erhältst du den Rest der Schokolade und einen Kuss! – So, Kinder, seid ihr alle zufrieden? Es war eine furchtbar verantwortungsvolle Aufgabe!«
     </p>
-    <p xml:id="eco_de_0000140_12950">
+    <p xml:id="eco_de_0000210_12950">
      Als Balbine endlich mit dem Essen fertig war – sie hatte sich bei der Gemäldeausstellung und der Preisverteilung etwas verspätet – setzte man sich vergnügt zu Tisch. Papa hatte alle drei Bilder hübsch gefunden; aber der Marianne klopfte er für ihr Blatt mit der Seemauer besonders freundlich auf die Schulter. –
     </p>
-    <p xml:id="eco_de_0000140_12960">
+    <p xml:id="eco_de_0000210_12960">
      Balbine behandelte Marianne, seitdem diese so ausgezeichnet worden war, fast mit ein wenig Respekt.
     </p>
-    <p xml:id="eco_de_0000140_12970">
+    <p xml:id="eco_de_0000210_12970">
      »Lotti«, sagte sie oft, wenn mittags der Tisch gedeckt werden sollte, »tu du's! Marianne hat andere Talente.«
     </p>
    </div>
@@ -4033,448 +4033,448 @@
     <head>
      Indianerleben.
     </head>
-    <p xml:id="eco_de_0000140_12980">
+    <p xml:id="eco_de_0000210_12980">
      Schon am Anfang der Ferien hatten Hans, Marianne und Lotti davon gesprochen, im Schilf eine Indianerhütte zu bauen. Aber dann fiel ihnen ein, dass sie damit warten wollten, bis die Doktorskinder von Larstetten kämen.
     </p>
-    <p xml:id="eco_de_0000140_12990">
+    <p xml:id="eco_de_0000210_12990">
      »Mit ihnen muss man doch lauter Spiele am See machen«, sagte Hans. »Man bringt sie ja nie vom Wasser weg. Otto will sowieso dies Jahr schwimmen und rudern lernen.«
     </p>
-    <p xml:id="eco_de_0000140_13000">
+    <p xml:id="eco_de_0000210_13000">
      Otto war der Vetter und Trudi das Cousinchen der Turnachkinder. Die Ferien in Larstetten begannen später, und erst am Montag der dritten Ferienwoche langten die kleinen Gäste an, begleitet von Tante Doktor. Hans, Marianne und Lotti durften sie mit Mama am Bahnhof abholen. Das war schon sehr nett. In der grossen Halle, wo es pfiff, toste und rauchte und die Leute hin und her eilten, kam es den Turnachkindern fast vor, als ob sie selber auf Reisen gingen.
     </p>
-    <p xml:id="eco_de_0000140_13010">
+    <p xml:id="eco_de_0000210_13010">
      Als Otto mit der Tasche und Trudi mit den Schirmen zwischen den grossen Leuten hindurch auf die Turnachkinder zukamen, lachten sich alle Fünfe an und schüttelten sich die Hand, wussten aber im ersten Augenblick gar nichts zu reden; denn sie hatten sich lange nicht gesehen. Nur dem Trudi, das neben Lotti vorausging, fiel gleich etwas ein.
     </p>
-    <p xml:id="eco_de_0000140_13020">
+    <p xml:id="eco_de_0000210_13020">
      »Mama«, rief sie zurück, »Lotti hat kurze Haare! Darf ich auch kurze Haare haben?«
     </p>
-    <p xml:id="eco_de_0000140_13030">
+    <p xml:id="eco_de_0000210_13030">
      Die Mütter lachten. Es war eine bekannte Sache, dass Trudi alles haben und tun wollte wie Lotti. Die beiden waren fast gleich alt und liebten einander zärtlich. Man behauptete auch, sie glichen sich.
     </p>
-    <p xml:id="eco_de_0000140_13040">
+    <p xml:id="eco_de_0000210_13040">
      »Dann wird man euch gar nicht mehr von einander kennen!« sagte Tante Doktor. »Aber meinetwegen, weil's so heisser Sommer ist!«
     </p>
-    <p xml:id="eco_de_0000140_13050">
+    <p xml:id="eco_de_0000210_13050">
      »Unser Haarschneider wohnt nicht weit von Mischa«, fing Lotti an. »Aber von Mischa wisst ihr ja noch nichts! Also auf dem Schulweg –«
     </p>
-    <p xml:id="eco_de_0000140_13060">
+    <p xml:id="eco_de_0000210_13060">
      »Nein, den Seesturm müssen wir zu allererst erzählen –«
     </p>
-    <p xml:id="eco_de_0000140_13070">
+    <p xml:id="eco_de_0000210_13070">
      »Oder das von den Vetterchen aus Martinique, von Tatschi und Muschi –«
     </p>
-    <p xml:id="eco_de_0000140_13080">
+    <p xml:id="eco_de_0000210_13080">
      So tönte es jetzt auf einmal lebhaft durcheinander, und den Doktorskindern fiel auch alles Mögliche ein. Als man aber dem Fluss entlang gegen den See kam, ging Otto, ein fester blonder Bub im Alter zwischen Hans und Marianne, immer rascher und sah nur noch gerade aus.
     </p>
-    <p xml:id="eco_de_0000140_13090">
+    <p xml:id="eco_de_0000210_13090">
      »Hans,« sagte er, »wenn dir doch gleich ein Dampfschiff sehen würden! Ich freue mich so schrecklich auf den See. Ich habe die letzte Woche gar nicht mehr gut rechnen können in der Schule, weil ich immer an euere Seeweid habe denken müssen.«
     </p>
-    <p xml:id="eco_de_0000140_13100">
+    <p xml:id="eco_de_0000210_13100">
      Die beiden Vettern liefen voraus. Zum Glück steuerte gerade der »Delphin« mit starkem Rauschen und Wellenschlagen hinaus. Otto stand entzückt und unbeweglich. Auch ein schwer beladenes Steinschiff kam heran, das drei Männer mit ihren Stachelstangen zum Hafen lenkten.
     </p>
-    <p xml:id="eco_de_0000140_13110">
+    <p xml:id="eco_de_0000210_13110">
      Die andern sassen schon lang in Steppingers Schiff, das die ganze Gesellschaft in die Seeweid hinausbringen sollte. Man musste Otto dreimal rufen und ihn endlich am Arm nehmen.
     </p>
-    <p xml:id="eco_de_0000140_13120">
+    <p xml:id="eco_de_0000210_13120">
      »Mama«, sagte er mit einem tiefen Atemzug, »es ist traurig und eine furchtbare Schande, dass Larstetten keinen See hat. Wenn ich einmal –«
     </p>
-    <p xml:id="eco_de_0000140_13130">
+    <p xml:id="eco_de_0000210_13130">
      »Wenn du einmal ein berühmter Ingenieur bist, gräbst du den Larstettern einen grossen See zwischen dem Weissberg und dem Bassenkopf; dann errichtet man dir ein Denkmal auf dem Marktplatz«, sagte seine Mama.
     </p>
-    <p xml:id="eco_de_0000140_13140">
+    <p xml:id="eco_de_0000210_13140">
      Otto schaute sie an, ob das ernst gemeint sei. Aber Mama hatte ihn nur necken wollen. Da lachte er denn mit den andern und dachte nicht mehr an die schlechte Lage von Larstetten, sondern an die schöne Seeweid, wo er zwei Wochen verbringen durfte.
     </p>
-    <p xml:id="eco_de_0000140_13150">
+    <p xml:id="eco_de_0000210_13150">
      Schon am zweiten Morgen ging das Indianerspiel an. Es war kaum halb sieben Uhr, als die drei Mädchen durch ein lautes Klopfen geweckt wurden. Marianne lief ans Fenster.
     </p>
-    <p xml:id="eco_de_0000140_13160">
+    <p xml:id="eco_de_0000210_13160">
      »Lotti! Trudi! Es sind die Buben! Sie arbeiten schon im Schilf –«
     </p>
-    <p xml:id="eco_de_0000140_13170">
+    <p xml:id="eco_de_0000210_13170">
      Trudi besann sich noch ein wenig. Es war so hübsch, da zu liegen in dem ungewohnten und doch traulichen Zimmer mit den weissen, dicken Blumen an der Tapete. Als sie aber sah, dass Lotti schon zum Waschtisch ging, machte sie sich auch auf.
     </p>
-    <p xml:id="eco_de_0000140_13180">
+    <p xml:id="eco_de_0000210_13180">
      Sowie sie angekleidet waren, liefen die drei hinaus und stiegen auf die Mauer.
     </p>
-    <p xml:id="eco_de_0000140_13190">
+    <p xml:id="eco_de_0000210_13190">
      »Sollen wir kommen und euch helfen?« riefen sie hinunter.
     </p>
-    <p xml:id="eco_de_0000140_13200">
+    <p xml:id="eco_de_0000210_13200">
      »Ja, natürlich!« schrie Hans. »Die Pfähle zum Wigwam haben wir eingerammelt. Nun werden Latten darangenagelt und mit Schilf bedeckt. Das Dach wird am schwierigsten zu machen sein …«
     </p>
-    <p xml:id="eco_de_0000140_13210">
+    <p xml:id="eco_de_0000210_13210">
      Als er hörte, dass die Mädchen an der Mauer entlang zum Schilfe kamen, rief er:
     </p>
-    <p xml:id="eco_de_0000140_13220">
+    <p xml:id="eco_de_0000210_13220">
      »Gebt acht, dass ihr keinen breiten Weg tretet! Wenn die Mingos nahen, um uns zu überfallen, sollen sie keinen Zugang finden.«
     </p>
-    <p xml:id="eco_de_0000140_13230">
+    <p xml:id="eco_de_0000210_13230">
      Trudi sah Lotti fragend an.
     </p>
-    <p xml:id="eco_de_0000140_13240">
+    <p xml:id="eco_de_0000210_13240">
      »Die Mingos sind ein feindlicher Stamm«, erklärte diese. »Wir sind Delawaren; das sind sehr edle Indianer.«
     </p>
-    <p xml:id="eco_de_0000140_13250">
+    <p xml:id="eco_de_0000210_13250">
      Trudi guckte sich um. Sie standen in einem ganzen Walde hoher Schilfhalme auf einem kleinen freien Platz. Hinter ihnen ragte die Gartenmauer auf; an drei Seiten waren sie von Schilf und See umgeben.
     </p>
-    <p xml:id="eco_de_0000140_13260">
+    <p xml:id="eco_de_0000210_13260">
      »Nun könnt ihr Schilf brechen«, ordnete Hans an. »Aber recht lange Halme!«
     </p>
-    <p xml:id="eco_de_0000140_13270">
+    <p xml:id="eco_de_0000210_13270">
      Trudi brachte zuerst nichts Ordentliches zu stande. Doch Marianne zeigte ihr, wie die Halme an der Knotenstelle, wo ein Blatt angewachsen war, sich leicht knicken liessen. Da wurde Trudi sehr eifrig. Nur wenn sich ein recht langer Stengel fand mit besonders schöner rotbrauner Blütenrispe, spielten Lotti und Trudi ein wenig damit, schlichen hinter Hans und Otto und wedelten ihnen mit den langen Halmen um die Ohren.
     </p>
-    <p xml:id="eco_de_0000140_13280">
+    <p xml:id="eco_de_0000210_13280">
      Hans schüttelte dann bloss den Kopf.
     </p>
-    <p xml:id="eco_de_0000140_13290">
+    <p xml:id="eco_de_0000210_13290">
      »Das ist natürlich wieder einmal Lotti. Man kann sie fast nicht brauchen bei einer wichtigen Arbeit. Sie will immer nur lachen.«
     </p>
-    <p xml:id="eco_de_0000140_13300">
+    <p xml:id="eco_de_0000210_13300">
      »Trudi ist nicht viel besser!« sagte Otto. »Jetzt, glaub' ich, haben wir genug Latten; jetzt kommt der Schilf drüber –«
     </p>
-    <p xml:id="eco_de_0000140_13310">
+    <p xml:id="eco_de_0000210_13310">
      Marianne war schon mit einem Knäuel starkem altem Strickgarn zur Hand. Während sie aber mit Hans und Otto beriet, wie der Schilf zu befestigen sei, ertönte Sophies Stimme:
     </p>
-    <p xml:id="eco_de_0000140_13320">
+    <p xml:id="eco_de_0000210_13320">
      »Wo seid ihr denn alle –? Zum Frühstück! Die Milch steht schon seit einer Viertelstunde auf dem Tisch!«
     </p>
-    <p xml:id="eco_de_0000140_13330">
+    <p xml:id="eco_de_0000210_13330">
      »O, jetzt haben wir gewiss nicht Zeit!« antworteten Hans und Marianne.
     </p>
-    <p xml:id="eco_de_0000140_13340">
+    <p xml:id="eco_de_0000210_13340">
      Otto aber, der immer einen guten Appetit hatte und das bräunliche Roggenbrot bei Tante Turnach sehr liebte, rief:
     </p>
-    <p xml:id="eco_de_0000140_13350">
+    <p xml:id="eco_de_0000210_13350">
      »Doch, doch! wir kommen! – Weisst du, Hans, wir müssen ja auch hinauf wegen den Waffen und den Federbüschen, und unsere Namen wollen wir ausmachen.«
     </p>
-    <p xml:id="eco_de_0000140_13360">
+    <p xml:id="eco_de_0000210_13360">
      Beim Frühstück unter dem Birnbaum erhob sich schon ein echtes Indianergeschrei. Alle sprachen zu gleicher Zeit, und Werner lief von einem zum andern und schrie mit.
     </p>
-    <p xml:id="eco_de_0000140_13370">
+    <p xml:id="eco_de_0000210_13370">
      »Ich heisse Chingachgook!« rief Otto. »Bitte, Hans, lass mich Chingachgook heissen! Ich habe schon die ganze Nacht davon geträumt. Chingachgook oder die Grosse Schlange!«
     </p>
-    <p xml:id="eco_de_0000140_13380">
+    <p xml:id="eco_de_0000210_13380">
      »Also ja, wenn du es so furchtbar gern willst und schon davon geträumt hast!« sagte Hans. Er musste sich ein wenig zusammennehmen; denn er hätte selbst gern Chingachgook geheissen. »Dann wähle ich für mich Schwarze Feder; es passt zu meinem Kopfschmuck.«
     </p>
-    <p xml:id="eco_de_0000140_13390">
+    <p xml:id="eco_de_0000210_13390">
      »Otto, ich will auch Grosse Schlange heissen!« bat Werner und zog Otto, da er nicht hörte, am Arm.
     </p>
-    <p xml:id="eco_de_0000140_13400">
+    <p xml:id="eco_de_0000210_13400">
      Otto und Hans lachten laut auf.
     </p>
-    <p xml:id="eco_de_0000140_13410">
+    <p xml:id="eco_de_0000210_13410">
      »Ja, du wärest eine schöne Grosse Schlange!« sagten sie.
     </p>
-    <p xml:id="eco_de_0000140_13420">
+    <p xml:id="eco_de_0000210_13420">
      »Du kannst höchstens die Kleine Blindschleiche sein, wenn du überhaupt mitmachen darfst!«
     </p>
-    <p xml:id="eco_de_0000140_13430">
+    <p xml:id="eco_de_0000210_13430">
      Werner lief zu Marianne, um ihr seinen neuen Namen mitzuteilen. Aber diese hatte mit ihrem eigenen zu tun.
     </p>
-    <p xml:id="eco_de_0000140_13440">
+    <p xml:id="eco_de_0000210_13440">
      »Hans«, wandte sie sich zum Bruder, »mir gefällt Wildtaube so gut! Mama hat uns einmal eine Zigeunergeschichte erzählt; da hiess das Mädchen Wildtaube. Eine Indianerin kann gewiss auch –«
     </p>
-    <p xml:id="eco_de_0000140_13450">
+    <p xml:id="eco_de_0000210_13450">
      Weiter verstand man Marianne nicht. Lotti machte einen zu argen Lärm.
     </p>
-    <p xml:id="eco_de_0000140_13460">
+    <p xml:id="eco_de_0000210_13460">
      »Wah-ta-wah, Wah-ta-wah!« schrie sie beständig. »Im Lederstrumpf kommt eine Wah-ta-wah vor, und die bin jetzt ich!«
     </p>
-    <p xml:id="eco_de_0000140_13470">
+    <p xml:id="eco_de_0000210_13470">
      »Lotti, du solltest eigentlich Schnatterente heissen!« sagte Hans.
     </p>
-    <p xml:id="eco_de_0000140_13480">
+    <p xml:id="eco_de_0000210_13480">
      Nun versuchte auch Trudi zu Wort zu kommen:
     </p>
-    <p xml:id="eco_de_0000140_13490">
+    <p xml:id="eco_de_0000210_13490">
      »Und ich? Ich habe' noch keinen Namen!«
     </p>
-    <p xml:id="eco_de_0000140_13500">
+    <p xml:id="eco_de_0000210_13500">
      »Weisst was, Trudi? Nimm du Junge Schildkröte! Eine Schildkröte würde etwa so rasch wie du an die Schulaufgaben gehen!« zog Bruder Otto sie auf.
     </p>
-    <p xml:id="eco_de_0000140_13510">
+    <p xml:id="eco_de_0000210_13510">
      »Ja! Heiss' du Junge Schildkröte!« rief Lotti. »Schildkröten sind nett. Onkel Alfred hatte letztes Jahr eine.«
     </p>
-    <p xml:id="eco_de_0000140_13520">
+    <p xml:id="eco_de_0000210_13520">
      Mit den neuen Namen liefen dann alle die Treppe hinauf zur Bodenkammer, wo die Turnachkinder in einer alten Kiste eine Federnsammlung hatten.
     </p>
-    <p xml:id="eco_de_0000140_13530">
+    <p xml:id="eco_de_0000210_13530">
      Marianne besass schöne bläulichgraue Taubenfedern. Sie steckte sich den Zopf hoch auf und befestigte die Federn in dem Knoten. Lotti und Trudi banden sich Bänder über die kurzen Haare, um ihrem Federschmucke Halt zu geben. Lotti hatte einen ganzen Büschel Perlhuhnfedern und ein paar breite weiss und braun gestreifte. Die waren von ihrem Bekannten, von dem zornigen Truthahn an der Langstrasse. Lotti hatte dort einmal der Magd, die eine schwere Schüssel trug, die Hoftüre aufgemacht und dafür nachher die Federn erhalten.
     </p>
-    <p xml:id="eco_de_0000140_13540">
+    <p xml:id="eco_de_0000210_13540">
      »Du, Marianne, wenn der Truthahn wüsste, dass ich jetzt seine Federn mir auf den Kopf stecke, der würde erst recht wild!« lachte Lotti, während Marianne auch Werners Kopf schmückte.
     </p>
-    <p xml:id="eco_de_0000140_13550">
+    <p xml:id="eco_de_0000210_13550">
      Jetzt traten Hans und Otto aus ihrer Ecke vor die Mädchen. Die beiden gewährten einen wirklich überwältigenden Anblick, schrecklich und schön zugleich. Hans hatte schon eine Woche zuvor mit Draht, Schnüren und allerlei Gefieder hantiert, so dass er und Vetter Otto die kunstvoll verfertigten kronen- oder hahnenkammartigen Gebilde nur aufzusetzen brauchten. Auf Hansens Kopf sträubten sich eine Reihe grosser schwarzer Rabenfedern, an beiden Seiten verziert mit bunten Hühnerfedern. Otto trug zwei weiss-graue Flügel; zwischen ihnen schaute ein Büschel roter Federn heraus, die Hans aus Sophiens altem Flederwisch erbeutet hatte.
     </p>
-    <p xml:id="eco_de_0000140_13560">
+    <p xml:id="eco_de_0000210_13560">
      »Ihr seid noch schöner als wir!« sagte Trudi anerkennend.
     </p>
-    <p xml:id="eco_de_0000140_13570">
+    <p xml:id="eco_de_0000210_13570">
      »Das muss auch sein«, antwortete Hans. »Wir sind Häuptlinge. Ihr als Frauen brauchtet, genau genommen, überhaupt keinen Federnschmuck. Jetzt kommt noch das Tätowieren.«
     </p>
-    <p xml:id="eco_de_0000140_13580">
+    <p xml:id="eco_de_0000210_13580">
      »Was ist das?« fragte Lotti, während sie den andern die Treppen hinunter folgte.
     </p>
-    <p xml:id="eco_de_0000140_13590">
+    <p xml:id="eco_de_0000210_13590">
      »Das ist eine Sitte der Indianer«, erklärte Marianne. »Sie stechen und schneiden sich in die Haut mit Dornen und Muscheln und reiben dann Farbe hinein.«
     </p>
-    <p xml:id="eco_de_0000140_13600">
+    <p xml:id="eco_de_0000210_13600">
      »Aber das tut weh!« meinte Trudi etwas ängstlich.
     </p>
-    <p xml:id="eco_de_0000140_13610">
+    <p xml:id="eco_de_0000210_13610">
      »Ach, weisst du, wir machen es bloss mit dem Pinsel!« tröstete Marianne. Sie lief zu ihrem Schränkchen und holte die Farbenschachtel.
     </p>
-    <p xml:id="eco_de_0000140_13620">
+    <p xml:id="eco_de_0000210_13620">
      Hans stand schon vor dem Spiegel und malte sich mit braunroter Farbe allerlei seltsame Zacken und Bogen auf sein Gesicht. Otto bekam eine dunkelgrüne Schlange quer über die Stirne und auf jede Backe einen Stern, Marianne etwas, das eine Taube darstellen sollte und links und rechts eine Sonne. Trudi und Lotti verzierten sich mit gelben und blauen Schneckenlinien und Halbmonden.
     </p>
-    <p xml:id="eco_de_0000140_13630">
+    <p xml:id="eco_de_0000210_13630">
      Werner lachte so über das wunderbare Aussehen all der Gesichter, dass er gar nicht stillhalten konnte, während ihm Marianne zwei kleine violette Blindschleichen auf seine dicken Backen malte.
     </p>
-    <p xml:id="eco_de_0000140_13640">
+    <p xml:id="eco_de_0000210_13640">
      Mama und Sophie entsetzten sich, als sie die wilden Indianer mit den tätowierten Gesichtern und den starrenden Federbüschen sahen.
     </p>
-    <p xml:id="eco_de_0000140_13650">
+    <p xml:id="eco_de_0000210_13650">
      »Macht jetzt nur, dass ihr in euern Schilf kommt«, sagte Mama. »Ihr passt wirklich kaum zu kultivierten Leuten. Marianne, gib auf Werner acht!«
     </p>
-    <p xml:id="eco_de_0000140_13660">
+    <p xml:id="eco_de_0000210_13660">
      Drunten ging es mit Eifer an die Vollendung der Hütte oder des Wigwam, wie Hans sagte. Über den Dachfirst breitete er das Rehfell, das sonst vor seinem Bett lag.
     </p>
-    <p xml:id="eco_de_0000140_13670">
+    <p xml:id="eco_de_0000210_13670">
      Lotti und Trudi beschäftigten sich hauptsächlich damit, durch den engen Eingang hin und her zu schlüpfen, und der kleine Werner kroch ihnen nach und verlor beständig seinen Kopfschmuck.
     </p>
-    <p xml:id="eco_de_0000140_13680">
+    <p xml:id="eco_de_0000210_13680">
      Als der Wigwam endlich fertig war, griffen Chingachgook und die Schwarze Feder zu ihren Jagdgewehren – es waren Stöcke, die man an Schnüren über die Schulter werfen konnte – und verabredeten, dass sie zuerst zur Biberinsel – so wurde heut' das Färberschiff genannt – fahren und nachher auf die Jagd ziehen wollten. Die Frauen sollten inzwischen den Platz vor dem Wigwam säubern und für Hausgerät und Geschirr sorgen.
     </p>
-    <p xml:id="eco_de_0000140_13690">
+    <p xml:id="eco_de_0000210_13690">
      Die beiden Häuptlinge entfernten sich, indem sie nach Indianerart hinter einander schlichen und umherspähten, ob von keiner Seite Gefahr drohe. –
     </p>
-    <p xml:id="eco_de_0000140_13700">
+    <p xml:id="eco_de_0000210_13700">
      »Tische und Stühle können wir nicht machen«, sagte Marianne, »und das wäre auch gar nicht indianisch. Aber wir holen Heu bei Jakob und häufen es in den Ecken zu Ruhebänken auf. Das Geschirr muss auch ganz grob sein, Lotti –«
     </p>
-    <p xml:id="eco_de_0000140_13710">
+    <p xml:id="eco_de_0000210_13710">
      »Ich heisse ja Wah-ta-wah!«
     </p>
-    <p xml:id="eco_de_0000140_13720">
+    <p xml:id="eco_de_0000210_13720">
      »Also, Wah-ta-wah – im Waschhaus sind Blumentopfuntersätze; die putzen wir; dann können es unsere Teller sein.«
     </p>
-    <p xml:id="eco_de_0000140_13730">
+    <p xml:id="eco_de_0000210_13730">
      Die Delawarenfrauen gingen mit der Kleinen Blindschleiche das Geschirr holen und dann zum Stall hinauf.
     </p>
-    <p xml:id="eco_de_0000140_13740">
+    <p xml:id="eco_de_0000210_13740">
      Jakob sah sie kommen und machte schnell die Türe zu, als ob er sich fürchte.
     </p>
-    <p xml:id="eco_de_0000140_13750">
+    <p xml:id="eco_de_0000210_13750">
      »Nein«, rief er durch die Spalte, »das ist ja noch ärger als die Negerin damals! Solch ein Gesindel –«
     </p>
-    <p xml:id="eco_de_0000140_13760">
+    <p xml:id="eco_de_0000210_13760">
      »Wir sind kein Gesindel!« rief Marianne und drückte gegen die Türe. »Wir sind Delawarenfrauen. Die Delawaren sind ein sehr edler Stamm. Unsere Häuptlinge sind auf die Jagd gezogen. Wir sollen Heu haben für den Wigwam.«
     </p>
-    <p xml:id="eco_de_0000140_13770">
+    <p xml:id="eco_de_0000210_13770">
      Endlich liess Jakob sich erbitten, und jede Delawarenfrau durfte einen Armvoll Heu nehmen. Dafür wurde Jakob eingeladen, sich später das Delawarenlager im Schilfe anzusehen.
     </p>
-    <p xml:id="eco_de_0000140_13780">
+    <p xml:id="eco_de_0000210_13780">
      Der Wigwam wurde bestmöglich eingerichtet und das Geschirr mit Seesand gescheuert.
     </p>
-    <p xml:id="eco_de_0000140_13790">
+    <p xml:id="eco_de_0000210_13790">
      Plötzlich hörte man Schritte auf der Mauer. Lotti guckte hinauf.
     </p>
-    <p xml:id="eco_de_0000140_13800">
+    <p xml:id="eco_de_0000210_13800">
      »Es ist Fritz Völklein! – Guten Morgen, Fritz!« rief sie.
     </p>
-    <p xml:id="eco_de_0000140_13810">
+    <p xml:id="eco_de_0000210_13810">
      Aber Fritz tat gar nicht, als ob das sein Name wäre. Er hatte, als er vorhin wegen Fischen bei Lienhards gewesen war, Hans und Otto getroffen, und es machte ihm Spass, ein wenig mitzuspielen.
     </p>
-    <p xml:id="eco_de_0000140_13820">
+    <p xml:id="eco_de_0000210_13820">
      »Der Lederstrumpf grüsst die Delawarenfrauen«, sagte er und sah ernsthaft auf die vier herunter, die vor ihrem Wigwam standen. »Warum haben die Häuptlinge die Frauen allein gelassen? Mingos schleichen umher und werden das Lager überfallen, wenn die Männer sorglos sind.«
     </p>
-    <p xml:id="eco_de_0000140_13830">
+    <p xml:id="eco_de_0000210_13830">
      Trudi fasste Lotti am Arm. Das klang so seltsam und fast etwas unheimlich.
     </p>
-    <p xml:id="eco_de_0000140_13840">
+    <p xml:id="eco_de_0000210_13840">
      Marianne aber fand es prachtvoll, dass Fritz so redete, so echt indianisch. Sie bemühte sich, im richtigen Ton zu antworten.
     </p>
-    <p xml:id="eco_de_0000140_13850">
+    <p xml:id="eco_de_0000210_13850">
      »Die Wildtaube grüsse den Lederstrumpf«, rief sie hinauf. »Die Schwarze Feder ist mit Chingachgook auf die Jagd gegangen. Wir warten, ob sie Beute heimbringen.«
     </p>
-    <p xml:id="eco_de_0000140_13860">
+    <p xml:id="eco_de_0000210_13860">
      »Die Jagdgründe sind nicht mehr wie ehedem«, gab Lederstrumpf zur Antwort. »Blassgesichter durchstreifen sie in Scharen. Ich fürchte, die Delawarenmänner kehren leer zurück. Wollen die Frauen drei von diesen Fischen haben, so sollen sie sprechen.«
     </p>
-    <p xml:id="eco_de_0000140_13870">
+    <p xml:id="eco_de_0000210_13870">
      Dabei schwenkte Lederstrumpf drei Fische, durch deren Kiemen er eine Schnur gezogen hatte.
     </p>
-    <p xml:id="eco_de_0000140_13880">
+    <p xml:id="eco_de_0000210_13880">
      »O, Fritz! bitte, ja – wirf sie uns herunter!« rief Lotti. In ihrer Lebhaftigkeit vergass sie, auf indianische Weise zu sprechen. Sie packte Trudi.
     </p>
-    <p xml:id="eco_de_0000140_13890">
+    <p xml:id="eco_de_0000210_13890">
      »Trudi, denk' doch, Fische –! Vielleicht machen wir ein Feuer und braten sie –«
     </p>
-    <p xml:id="eco_de_0000140_13900">
+    <p xml:id="eco_de_0000210_13900">
      Aber Lederstrumpf schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000140_13910">
+    <p xml:id="eco_de_0000210_13910">
      »Es sind schöne Fische«, sagte er. »Wenn ich sie zu den Blassgesichtern bringe, kaufen diese sie gerne. Die Delawarenfrauen sollen sich besinnen, was sie für die Fische geben wollen.«
     </p>
-    <p xml:id="eco_de_0000140_13920">
+    <p xml:id="eco_de_0000210_13920">
      Die Delawarenfrauen sahen sich verlegen an. Was konnte man dafür bieten –?
     </p>
-    <p xml:id="eco_de_0000140_13930">
+    <p xml:id="eco_de_0000210_13930">
      »Die Delawaren wohnen am grossen See«, hub Lederstrumpf wieder an. »Das Ufer ist reich an Muscheln. Für dreimal acht Muscheln sollen die Frauen die Fische erhalten. Wenn die Sonne auf jenen Stein im Wasser scheint, kehrt Lederstrumpf zurück; dann sollen die Muscheln hier auf der Mauerecke liegen.«
     </p>
-    <p xml:id="eco_de_0000140_13940">
+    <p xml:id="eco_de_0000210_13940">
      Lederstrumpf sprang von der Mauer hinunter und verschwand.
     </p>
-    <p xml:id="eco_de_0000140_13950">
+    <p xml:id="eco_de_0000210_13950">
      »Wenn die Sonne auf jenen Stein im Wasser scheint – das ist, glaub' ich, ganz bald!« rief Marianne aufgeregt.
     </p>
-    <p xml:id="eco_de_0000140_13960">
+    <p xml:id="eco_de_0000210_13960">
      Es fiel ihr ein, dass sie zum Glück einen Vorrat von dreizehn Muscheln hatten. Also noch elf –! Barfuss patschten nun die Wildtaube, Wah- ta-wah und die Junge Schildkröte am Ufer entlang. Die Blindschleiche sass auf einem Stein und hielt die Muscheln.
     </p>
-    <p xml:id="eco_de_0000140_13970">
+    <p xml:id="eco_de_0000210_13970">
      »Da – und da –!« rief die Junge Schildkröte. Aber die Wildtaube nahm ihr die aufgehobenen Muscheln aus der Hand und warf sie in den See zurück.
     </p>
-    <p xml:id="eco_de_0000140_13980">
+    <p xml:id="eco_de_0000210_13980">
      »Zerbrochene gelten beim Tausche nicht«, sagte sie ernsthaft. »Lederstrumpf wird die Fische nur für schöne Muscheln geben.«
     </p>
-    <p xml:id="eco_de_0000140_13990">
+    <p xml:id="eco_de_0000210_13990">
      Endlich waren elf Stück beisammen, und als die Delawarenfrauen zurückkehrten, stand Lederstrumpf wieder auf der Mauer und bot die Fische herunter.
     </p>
-    <p xml:id="eco_de_0000140_14000">
+    <p xml:id="eco_de_0000210_14000">
      »Die Wildtaube sage den Männern«, rief er, »dass Lederstrumpf ihr Freund ist. Er wird, wenn die Sonne im Westen steht, kommen und mit ihnen am Feuer sitzen.«
     </p>
-    <p xml:id="eco_de_0000140_14010">
+    <p xml:id="eco_de_0000210_14010">
      Lederstrumpf war kaum fort, als es im Schilfe knackte und die Schwarze Feder mit Chingachgook erschien. Sie hatten grosse Abenteuer erlebt; aber auch die Frauen hatten zu erzählen und zeigten ihre Fische. Lederstrumpf hatte recht gehabt: die Jagd war nicht gut gewesen. Aber die beiden Männer brachten wenigstens Kartoffeln, die sie unter vielen Gefahren von den Feldern eines Blassgesichtes – dieses Blassgesicht war die gute grau Völklein – erbeutet hatten. Sie hatten zudem Speere und hölzerne Schilde verfertigt auch für die Frauen.
     </p>
-    <p xml:id="eco_de_0000140_14020">
+    <p xml:id="eco_de_0000210_14020">
      Der Ruf zum Mittagessen unterbrach das Treiben im Delawarenlager. Mama hatte aber erlaubt, dass die Kinder als Indianer an den Tisch kamen. Schade nur, dass Papa auf einer Geschäftsreise war und sie nicht sehen konnte.
     </p>
-    <p xml:id="eco_de_0000140_14030">
+    <p xml:id="eco_de_0000210_14030">
      Die grosse Frage war nun, ob man am Nachmittag wirklich ein Feuer machen dürfe, um die Fische und Kartoffeln zu braten. Ein Feuer im Freien war so etwas Wundervolles, und es gehörte doch zum Indianerleben. Wie Mama hörte, dass Fritz als Lederstrumpf im Lager der Delawaren erscheinen werde, gab sie die Erlaubnis.
     </p>
-    <p xml:id="eco_de_0000140_14040">
+    <p xml:id="eco_de_0000210_14040">
      »Die Kleine Blindschleiche aber bleibt bei mir«, sagte sie, »und sieht sich die Sache von der Mauer aus an.«
     </p>
-    <p xml:id="eco_de_0000140_14050">
+    <p xml:id="eco_de_0000210_14050">
      Am Nachmittag, als »die Sonne im Westen stand«, brannte denn wirklich ein hellen Feuer; von dem der bläuliche Rauch aufstieg. Die Delawaren hatten am Ufer Holz gesammelt, das, vom See angeschwemmt und von der Sonne getrocknet, da lag. Sie hatten Steine zusammengetragen, aus denen Lederstrumpf einen Herd baute, und die Wildtaube hatte ein paar lange, gerade Haselruten geholt, die man zuspitzte, um die Fische daran zu stecken. Die Fischbraterei war über alle Massen schön. Jedes wollte den Spiess halten und langsam über dem Feuer drehen, damit der Fisch von allen Seiten gleichmässig geröstet würde. Die Kartoffeln legte man in die heisse Asche.
     </p>
-    <p xml:id="eco_de_0000140_14060">
+    <p xml:id="eco_de_0000210_14060">
      Nun tauchte Jakobs Gesicht über der Gartenmauer auf. Er lobte den Wigwam und den Feuerherd.
     </p>
-    <p xml:id="eco_de_0000140_14070">
+    <p xml:id="eco_de_0000210_14070">
      »Komm herunter!« rief die Schwarze Feder. »Du musst Blassgesicht heissen oder Europäer, was du lieber willst.«
     </p>
-    <p xml:id="eco_de_0000140_14080">
+    <p xml:id="eco_de_0000210_14080">
      Jakob entschied sich für »Europäer«; »Blassgesicht«, sagte er, komme ihm zu kränklich vor.
     </p>
-    <p xml:id="eco_de_0000140_14090">
+    <p xml:id="eco_de_0000210_14090">
      Gerade waren die Fische fertig und wurden in den Untersätzen, die die Wildtaube schön mit Blättern belegt hatte, aufgetragen.
     </p>
-    <p xml:id="eco_de_0000140_14100">
+    <p xml:id="eco_de_0000210_14100">
      Jakob bekam auch einen Teller. Er schüttelte zwar den Kopf und sagte, er habe seiner Lebtage noch nie nachmittags um vier Uhr Fisch und Kartoffeln gegessen. Aber sein Sträuben half ihm nichts; er musste mithalten.
     </p>
-    <p xml:id="eco_de_0000140_14110">
+    <p xml:id="eco_de_0000210_14110">
      Das Mahl schmeckte den Delawaren ausgezeichnet.
     </p>
-    <p xml:id="eco_de_0000140_14120">
+    <p xml:id="eco_de_0000210_14120">
      »Europäer, du findest den Fisch doch auch gut?« fragte Wah-ta-wah.
     </p>
-    <p xml:id="eco_de_0000140_14130">
+    <p xml:id="eco_de_0000210_14130">
      »Er ist eigen. Er schmeckt ein wenig nach verbranntem Haar. Aber wenn man sich daran gewöhnt, ist er nicht übel.«'
     </p>
-    <p xml:id="eco_de_0000140_14140">
+    <p xml:id="eco_de_0000210_14140">
      Nach beendetem Essen bedankte sich der Europäer Jakob und ging wieder an seine Arbeit. Lederstrumpf ging mit.
     </p>
-    <p xml:id="eco_de_0000140_14150">
+    <p xml:id="eco_de_0000210_14150">
      Die Delawarenfrauen räumten ab, während die Schwarze Feder und Chingachgook am verglimmenden Feuer sassen. Plötzlich wurden sie aus ihrer Ruhe aufgescheucht durch ein Geräusch, das vom See her kam. Die Schwarze Feder spähte durch den Schilf.
     </p>
-    <p xml:id="eco_de_0000140_14160">
+    <p xml:id="eco_de_0000210_14160">
      »Es ist ein Kanoe!« flüsterte er. »Es sind vielleicht Mingos! Chingachgook, wir müssen uns auf einen Überfall gefasst machen –!«
     </p>
-    <p xml:id="eco_de_0000140_14170">
+    <p xml:id="eco_de_0000210_14170">
      Sie griffen zu den Waffen und benachrichtigten die Frauen. Chingachgook löschte die Glut des Herdfeuers, damit der Rauch sie nicht verrate.
     </p>
-    <p xml:id="eco_de_0000140_14180">
+    <p xml:id="eco_de_0000210_14180">
      Aber das Kanoe kam näher. Man vernahm Stimmen, ein lautes, kriegerisches: »He! Holla –!« Dann hörte man leise sprechen; das feindliche Kanoe suchte offenbar einen Weg durch den Schilf.
     </p>
-    <p xml:id="eco_de_0000140_14190">
+    <p xml:id="eco_de_0000210_14190">
      Die Delawaren gaben keinen Laut. Die Wildtaube langte nach Schild und Speer und reichte auch Wah-ta-wah und der Jungen Schildkröte Waffen.
     </p>
-    <p xml:id="eco_de_0000140_14200">
+    <p xml:id="eco_de_0000210_14200">
      Jetzt hörte man das Kanoe ganz nah; die Ruder streiften schon den Schilf.
     </p>
-    <p xml:id="eco_de_0000140_14210">
+    <p xml:id="eco_de_0000210_14210">
      »Alle zurück in den Wigwam –!« flüsterte die Schwarze Feder, und rasch schlüpfte eins nach dem andern in die Schilfhütte. Die Schwarze Feder legte das Brett, das als Türe diente, hinter sich an. Es war ganz dunkel im Wigwam. Von draussen hörte man das Knacken des Schilfs …
     </p>
-    <p xml:id="eco_de_0000140_14220">
+    <p xml:id="eco_de_0000210_14220">
      »Fahr' rechts, wo's weniger dicht ist –!« schrie eine Stimme.
     </p>
-    <p xml:id="eco_de_0000140_14230">
+    <p xml:id="eco_de_0000210_14230">
      »Könnten wir nicht weglaufen?« flüsterte die Junge Schildkröte.
     </p>
-    <p xml:id="eco_de_0000140_14240">
+    <p xml:id="eco_de_0000210_14240">
      »Nein!« sagte die Wildtaube, die neben ihr kauerte. »Hinter uns ist die Mauer; um die obere Ecke kann man nicht herum; da ist das Wasser zu tief. Und an der untern sind sie.«
     </p>
-    <p xml:id="eco_de_0000140_14250">
+    <p xml:id="eco_de_0000210_14250">
      Die Schwarze Feder spähte durch eine Spalte hinaus.
     </p>
-    <p xml:id="eco_de_0000140_14260">
+    <p xml:id="eco_de_0000210_14260">
      »Jetzt haben sie die Stelle gefunden, wo man landen kann!« rief er leise und aufgeregt.
     </p>
-    <p xml:id="eco_de_0000140_14270">
+    <p xml:id="eco_de_0000210_14270">
      Da begann die Junge Schildkröte plötzlich zu schluchzen: »Ich will hinaus –! Ich fürchte mich! Ich will zur Tante –«
     </p>
-    <p xml:id="eco_de_0000140_14280">
+    <p xml:id="eco_de_0000210_14280">
      »Still!« flüsterte Chingachgook empört. »Wie kannst du sagen ›zur Tante‹, wo wir Delawaren sind –«
     </p>
-    <p xml:id="eco_de_0000140_14290">
+    <p xml:id="eco_de_0000210_14290">
      »Ich will kein Delaware mehr sein – ich will hinaus –«
     </p>
-    <p xml:id="eco_de_0000140_14300">
+    <p xml:id="eco_de_0000210_14300">
      Chingachgook rückte hinüber, um die feige Schildkröte zum Schweigen zu bringen.
     </p>
-    <p xml:id="eco_de_0000140_14310">
+    <p xml:id="eco_de_0000210_14310">
      »Jetzt –!« schrie auf einmal die Schwarze Feder, die unverwandt hinausgesehen hatte. »Sie sind aufgefahren! Jetzt brechen wir los –«
     </p>
-    <p xml:id="eco_de_0000140_14320">
+    <p xml:id="eco_de_0000210_14320">
      Polternd flog die Türe hin. Mit hochgeschwungenem Speer und Schild stürmte die Schwarze Feder hervor, hinter ihm Chingachgook. Unter fürchterlichem Kampfgeschrei drangen sie gegen das Schiff. Die Delawarenfrauen folgten. Der Jungen Schildkröte kam der Mut wieder; sie lief hinter Wah-ta-wah tapfer gegen den Feind.
     </p>
-    <p xml:id="eco_de_0000140_14330">
+    <p xml:id="eco_de_0000210_14330">
      In dem Schiffe waren drei grosse Bursche, von denen einer am Ruder stand. Sie wussten gar nicht wie ihnen geschah, als plötzlich diese seltsame federngeschmückte und buntbemalte Schar auf sie eindrang. Die zwei Bursche vorn machten Miene auszusteigen; doch die Schwarze Feder und Chingachgook begannen, mit ihren langen Speeren auf das Wasser zu schlagen, so dass die Bursche über und über bespritzt wurden. Die Delawarenfrauen halfen wacher.
     </p>
-    <p xml:id="eco_de_0000140_14340">
+    <p xml:id="eco_de_0000210_14340">
      Die Bursche versuchten, Gleiches mit Gleichem zu vergelten, und es entstand ein wildes Streiten, halb See-, halb Landgefecht. Aber da die Bursche keine Sitzruder hatten und die Stehruder festgemacht waren, dauerte ihre Gegenwehr nicht lange. Unter Schimpfen und Lachen stiessen sie vom Land ab und ruderten davon.
     </p>
-    <p xml:id="eco_de_0000140_14350">
+    <p xml:id="eco_de_0000210_14350">
      Es war ein glänzender Sieg der Delawaren. Sie trieften zwar vor Nässe, und ihr Federschmuck hatte bedeutend gelitten; aber jubelnd priesen sie ihre Heldentat, während sie dem wegfahrenden Schiffe nachsahen. Dann liefen sie in übermütigen Sprüngen an der Mauer entlang zum Garten hinauf. In ihrer Siegerfreude hatten sie das Bedürfnis, jemand die Geschichte zu erzählen.
     </p>
-    <p xml:id="eco_de_0000140_14360">
+    <p xml:id="eco_de_0000210_14360">
      Mama sass unter dem Birnbaum und hörte staunend von dem Überfall der Mingos, von ihrem schmählichen Rückzuge und auch, dass die Junge Schildkröte auf einmal angefangen habe zu weinen.
     </p>
-    <p xml:id="eco_de_0000140_14370">
+    <p xml:id="eco_de_0000210_14370">
      »Ja, so gar wilde Spiele, wie ihr sie treibt, ist Trudi vielleicht doch nicht gewöhnt.«
     </p>
-    <p xml:id="eco_de_0000140_14380">
+    <p xml:id="eco_de_0000210_14380">
      Frau Turnach legte den Arm um ihre kleine Nichte.
     </p>
-    <p xml:id="eco_de_0000140_14390">
+    <p xml:id="eco_de_0000210_14390">
      »Einen Kuss geb' ich dir dann nachher, mein Kind, wenn deine Bäcklein wieder rot sind statt grün und blau.«
     </p>
-    <p xml:id="eco_de_0000140_14400">
+    <p xml:id="eco_de_0000210_14400">
      Die Junge Schildkröte sah wirklich bedenklich aus. Ihre Tränen waren in das Tätowierte gelaufen und hatten da ganz wunderliche Wolken und Striemen gebildet. Aber auch die Gesichter der andern Delawaren zeigten die Spuren des nassen Kampfes.
     </p>
-    <p xml:id="eco_de_0000140_14410">
+    <p xml:id="eco_de_0000210_14410">
      »Es wird das beste sein, ihr geht jetzt alle baden und erscheint dann als gesittete Europäer wieder. Otto und Hans fangen an, und ihr Mädchen kommt nach.«
     </p>
-    <p xml:id="eco_de_0000140_14420">
+    <p xml:id="eco_de_0000210_14420">
      »Ja, ja!« rief Otto. »Und ich darf wieder deine Schwummel haben, Hans. Das ist etwas Feines! Mit der könnte ich über den ganzen See schwimmen!«
     </p>
-    <p xml:id="eco_de_0000140_14430">
+    <p xml:id="eco_de_0000210_14430">
      Es gab nun ein sehr lustiges Baden. Sogar Trudi wagte, sich auf die Schwummel zu legen, und strampelte mit Armen und Beinen, um vorwärts zu kommen.
     </p>
-    <p xml:id="eco_de_0000140_14440">
+    <p xml:id="eco_de_0000210_14440">
      »Ui –!« rief Marianne, »du machst ein Gespritze, wie wenn die Mingos noch da wären und du sie bekämpfen müsstest!«
     </p>
-    <p xml:id="eco_de_0000140_14450">
+    <p xml:id="eco_de_0000210_14450">
      Noch den ganzen Abend und bis zum Einschlafen sprachen und lachten die Kinder über den ereignisreichen Indianertag, den sie verbracht hatten.
     </p>
    </div>
@@ -4482,325 +4482,325 @@
     <head>
      Kindergesellschaften.
     </head>
-    <p xml:id="eco_de_0000140_14460">
+    <p xml:id="eco_de_0000210_14460">
      Jeden Tag gab es nun eine neue Lustbarkeit im Garten, im Stall, beim Rudern und auf der Seemauer. Man hatte gar nicht Zeit, alle Pläne auszuführen, die beim Frühstück unterm alten Birnbaum entworfen wurden. Wenn Otto im Wasser war, sagte er, er möchte den ganzen Tag schwimmen; wenn sie im Schiff fuhren, wollte er nicht wieder vom Ruder weg, und im Klaregg gefiel es ihm und Trudi auch über alle Massen gut. Es war wunderschön, da Entdeckungsreisen zu machen und zu erforschen, was alles krabbelte und schwamm im »Roten Meer«, im »Käfertümpel«, im »Schwarzen Loch« im »Bosporus« und wie die Gewässer des Klaregg alle hiessen bei den Turnachkindern.
     </p>
-    <p xml:id="eco_de_0000140_14470">
+    <p xml:id="eco_de_0000210_14470">
      Am Ende der vorletzten Ferienwoche sprach man viel von den drei Kindergesellschaften, die nun stattfinden sollten. Die Turnachkinder durften jedes Jahr ihre Schulklasse in die Seeweid einladen.
     </p>
-    <p xml:id="eco_de_0000140_14480">
+    <p xml:id="eco_de_0000210_14480">
      Zuerst kam Mariannes Klasse dran. Das Einladen machte sich einfach: Marianne ging in die Stadt zu vier oder fünf Freundinnen, und diese übernahmen es, den andern, die nicht verreist waren, mitzuteilen, dass übermorgen Gesellschaft in der Seeweid sei.
     </p>
-    <p xml:id="eco_de_0000140_14490">
+    <p xml:id="eco_de_0000210_14490">
      »Es kommen etwa zwanzig oder dreiundzwanzig«, meldete Marianne, als sie zurückkehrte. »Von dreien weiss man es noch nicht recht. Sie freuen sich glaub' ich alle furchtbar!«
     </p>
-    <p xml:id="eco_de_0000140_14500">
+    <p xml:id="eco_de_0000210_14500">
      »Rechnen wir dreiundzwanzig«, sagte Mama. »Und ihr seid fünf. Wir müssen Frau Völklein um Tassen bitten und um ihre zwei grossen Gugelhopfformen. Ihr könnt auch gleich zur Bäckerin hinaufgehen und die Zimmetsterne und Mandelbretzeln bestellen.«
     </p>
-    <p xml:id="eco_de_0000140_14510">
+    <p xml:id="eco_de_0000210_14510">
      Am Montag um zwei Uhr langten die Mädchen an, zweiundzwanzig an der Zahl, alle in hellen Kleidern, mit frisch geflochtenen Zöpfen und fröhlichen Gesichtern. Viele wohnten in der Stadt in engen Gassen, und die Seeweid kam ihnen wie ein Wunderland vor.
     </p>
-    <p xml:id="eco_de_0000140_14520">
+    <p xml:id="eco_de_0000210_14520">
      »Marianne, ich hab' mich am meisten auf euere Kaninchen gefreut!« sagte eine. »Können wir nicht gleich zu den Kaninchen gehen –?«
     </p>
-    <p xml:id="eco_de_0000140_14530">
+    <p xml:id="eco_de_0000210_14530">
      »Nein, Marianne! zuerst zum Schilf, wo ihr Indianer gespielt habt!« riefen ein paar andere.
     </p>
-    <p xml:id="eco_de_0000140_14540">
+    <p xml:id="eco_de_0000210_14540">
      Alle liefen dann hinter Marianne zum Schilf hinunter, wo der Wigwam und der Feuerherd noch zu sehen waren.
     </p>
-    <p xml:id="eco_de_0000140_14550">
+    <p xml:id="eco_de_0000210_14550">
      Einige Mädchen fingen an, sich Büschel von den schönen bräunlichroten Schilfblüten zu brechen.
     </p>
-    <p xml:id="eco_de_0000140_14560">
+    <p xml:id="eco_de_0000210_14560">
      »Sie halten den ganzen Winter!« sagte Lotti, die mit Trudi natürlich mitten unter der Schar war.
     </p>
-    <p xml:id="eco_de_0000140_14570">
+    <p xml:id="eco_de_0000210_14570">
      Berta Strobel und noch ein paar Kecke versuchten, auf den einzeln aufragenden Steinen in den See hinauszugehen. Sie stiessen sich, so dass sie ins Wasser patschten.
     </p>
-    <p xml:id="eco_de_0000140_14580">
+    <p xml:id="eco_de_0000210_14580">
      »Das schadet nichts,« beruhigte Marianne. »Bei uns in der Seeweid wird man immer nass!«
     </p>
-    <p xml:id="eco_de_0000140_14590">
+    <p xml:id="eco_de_0000210_14590">
      Vom Schilf ging's zum Aquarium, in welchem gerade wieder Alexius sich aufhielt. Er sass behäbig auf dem Tuffstein in der Mitte des Glases und liess sich ruhig von Lotti herausnehmen, die ihn der Lisa Peter hinstreckte. Lisa aber schrie laut auf, und alle wichen zurück.
     </p>
-    <p xml:id="eco_de_0000140_14600">
+    <p xml:id="eco_de_0000210_14600">
      »O, wie ihr tut –!« sagte Marianne. »Er ist doch so zahm und nett!« Sie setzte ihn auf ihre hochgehaltene Hand.
     </p>
-    <p xml:id="eco_de_0000140_14610">
+    <p xml:id="eco_de_0000210_14610">
      Berta Strobel trat einen Schritt vor. Alexius dachte wohl, dass sie Freundschaft mit ihm schliessen wolle, und hüpfte in geschicktem Sprung auf ihre Schulter.
     </p>
-    <p xml:id="eco_de_0000140_14620">
+    <p xml:id="eco_de_0000210_14620">
      Jetzt natürlich neues Geschrei unter den Mädchen. Marianne konnte den erstaunten Alexius gerade noch zurück ins Aquarium retten.
     </p>
-    <p xml:id="eco_de_0000140_14630">
+    <p xml:id="eco_de_0000210_14630">
      Otto und Hans hatten von ferne zugesehen.
     </p>
-    <p xml:id="eco_de_0000140_14640">
+    <p xml:id="eco_de_0000210_14640">
      »Du, wie die schreien –!« sagte Otto.
     </p>
-    <p xml:id="eco_de_0000140_14650">
+    <p xml:id="eco_de_0000210_14650">
      »Wenn viele Mädchen beisammen sind, ist immer so ein Gequietsche«, bemerkte Hans.
     </p>
-    <p xml:id="eco_de_0000140_14660">
+    <p xml:id="eco_de_0000210_14660">
      Das »Gequietsche« setzte sich fort, als Mariannes Klasse in den Garten kam und da begann, »Begegnenfangens« zu spielen. Das war ungeheuer lustig: es ging immer um die Beete und Boskette herum. Umkehren durfte man nicht. Wenn man dem Fänger begegnete, war man gefangen. Manchmal konnte man mit knapper Not noch um eine Ecke entwischen.
     </p>
-    <p xml:id="eco_de_0000140_14670">
+    <p xml:id="eco_de_0000210_14670">
      »Macht doch auch mit!« schrie Lotti, die gerade am Fliederbusch, wo die Knaben standen, vorbei rannte.
     </p>
-    <p xml:id="eco_de_0000140_14680">
+    <p xml:id="eco_de_0000210_14680">
      »Ihr seid uns zu viel Mädel!« sagte Otto. »Wir fahren lieber auf den See hinaus.«
     </p>
-    <p xml:id="eco_de_0000140_14690">
+    <p xml:id="eco_de_0000210_14690">
      Als es dann aber zum Tee in die Buchenlaube ging, wo drei aneinander gestellte Tische gedeckt waren, und die drei Kuchen verlockend in der Mitte prangten, machten sich Hans und Otto doch herbei. Die Mädchen räumten ihnen die Plätze an den beiden Enden der Tafel ein. Hans hiess der obere und Otto der untere Tischpräsident. Es wurde geschwatzt und gelacht, dazu viel Tee getrunken und eine unglaubliche Zahl von Butterbroten und Gugelhopfstücken gegessen.
     </p>
-    <p xml:id="eco_de_0000140_14700">
+    <p xml:id="eco_de_0000210_14700">
      »Lotti«, sagte Hans leise zur Schwester, die neben ihm sass, »gib acht, jetzt halte ich einen Toast –«
     </p>
-    <p xml:id="eco_de_0000140_14710">
+    <p xml:id="eco_de_0000210_14710">
      »Was hältst du?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_14720">
+    <p xml:id="eco_de_0000210_14720">
      Aber Hans stand auf und schlug mit dem Messer an seine Teetasse.
     </p>
-    <p xml:id="eco_de_0000140_14730">
+    <p xml:id="eco_de_0000210_14730">
      »Liebe Gäste!« sprach er laut. »Es freut uns sehr, dass ihr in die Seeweid gekommen seid, und wir wünschen, dass es euch recht gut bei uns gefalle. Wir heissen euch fröhlich willkommen. Ich trinke auf das Wohl von Mariannes Freundinnen. Sie sollen leben hoch – hoch – hoch!«
     </p>
-    <p xml:id="eco_de_0000140_14740">
+    <p xml:id="eco_de_0000210_14740">
      »Hoch – hoch – hoch!« schrie die ganze Gesellschaft mit, die Eingeladenen wie die Gastgeber.
     </p>
-    <p xml:id="eco_de_0000140_14750">
+    <p xml:id="eco_de_0000210_14750">
      »Das war wieder einmal fein von Hans«, dachte Otto. »Der weiss immer, wie man es macht!«
     </p>
-    <p xml:id="eco_de_0000140_14760">
+    <p xml:id="eco_de_0000210_14760">
      Aber an der linken Ecke, wo Lili Rabus sass, die Geschickteste in Mariannes Klasse, gab es ein Geflüster, und auf einmal stand Lili Rabus auch auf mit erhobener Teetasse:
     </p>
-    <p xml:id="eco_de_0000140_14770">
+    <p xml:id="eco_de_0000210_14770">
      »Wir sind alle schrecklich gern in die Seeweid gekommen. Es ist nirgends so schön und so lustig wie da, und nirgends gibt es einen so guten Gugelhopf. Frau Turnach und alle Turnachkinder und die Doktorskinder und die ganze Seeweid, sie sollen leben hoch – hoch – hoch!«
     </p>
-    <p xml:id="eco_de_0000140_14780">
+    <p xml:id="eco_de_0000210_14780">
      »Hoch – hurra – hoch!« ertönte es wieder jubelnd um den ganzen Tisch. Lili Rabus stiess mit Hans an, und nun folgte ein allgemeines Anstossen. Es war ein Wunder, dass dabei alle Teetassen ganz blieben.
     </p>
-    <p xml:id="eco_de_0000140_14790">
+    <p xml:id="eco_de_0000210_14790">
      »Jetzt zeigen wir euch die Tante Ängstlich und die Kaninchen!« schlug Lotti vor.
     </p>
-    <p xml:id="eco_de_0000140_14800">
+    <p xml:id="eco_de_0000210_14800">
      Wie ein Schwarm Vögel fuhr die ganze Schar auf und zum Hühnerstall hin. Tante Ängstlich kümmerte sich nicht mehr viel um ihre kecken Pflegeentlein, die schon ziemlich gross geworden waren und eben an einem Stück Fleisch herumrissen. Sie sass wieder auf Eiern und blinzelte wichtig mit den Augen, als die Kinder kamen.
     </p>
-    <p xml:id="eco_de_0000140_14810">
+    <p xml:id="eco_de_0000210_14810">
      »Sie denkt gewiss, sie wolle ihre neuen Jungen jetzt dann lieber gar nicht zum See führen, damit sie nicht wieder so einen Schrecken erlebt!« meinte Martha König.
     </p>
-    <p xml:id="eco_de_0000140_14820">
+    <p xml:id="eco_de_0000210_14820">
      »Diesmal werden es rechte Hühnchen«, sagte Marianne. »An denen wird sie Freude haben.«
     </p>
-    <p xml:id="eco_de_0000140_14830">
+    <p xml:id="eco_de_0000210_14830">
      Im Kaninchenverschlag waren neben den neun grossen Tieren sieben junge. Alle, die grossen wie die kleinen, mussten sich's gefallen lassen, auf den Arm genommen zu werden; aber die Mädchen taten das so sanft und manierlich, dass Jakob freundlich nickte.
     </p>
-    <p xml:id="eco_de_0000140_14840">
+    <p xml:id="eco_de_0000210_14840">
      »Das ist etwas anderes als die vier Panduren, die ihr mir damals in den Stall gebracht habt,« sagte er.
     </p>
-    <p xml:id="eco_de_0000140_14850">
+    <p xml:id="eco_de_0000210_14850">
      Und weil Mariannes Mitschülerinnen also keine Panduren waren, sondern bei allem Übermut artige Mädchen, durften sie sich in Stall und Scheune herumtreiben, so viel sie wollten.
     </p>
-    <p xml:id="eco_de_0000140_14860">
+    <p xml:id="eco_de_0000210_14860">
      Nebenan stand ein halbabgeladener Heuwagen. Berta Strobel kletterte die Leiter hinauf zum Heuboden, wo damals der kleine Vetter so gebrüllt und gestrampelt hatte. Lotti stand im Nu neben ihr:
     </p>
-    <p xml:id="eco_de_0000140_14870">
+    <p xml:id="eco_de_0000210_14870">
      »Wagst du es, da hinunterzuspringen?«
     </p>
-    <p xml:id="eco_de_0000140_14880">
+    <p xml:id="eco_de_0000210_14880">
      »Ja, wenn du auch springst«, sagte Berta Strobel.
     </p>
-    <p xml:id="eco_de_0000140_14890">
+    <p xml:id="eco_de_0000210_14890">
      Im selben Moment flogen die beiden und lagen lachend in dem rauschenden Heu des Wagens. Nun kletterte alles nach. Mutig wagten die einen den Sprung; zaghaft standen die andern und schauten hinunter. Aber schliesslich merkten auch sie, wie gefahrlos und wie lustig es war, hinabzuspringen, sich aus dem weichen Heu herauszuwälzen und wieder die Leiter hinaufzuklettern.
     </p>
-    <p xml:id="eco_de_0000140_14900">
+    <p xml:id="eco_de_0000210_14900">
      Plumps – plumps –! ging's in einem fort. Manche fassten sich an der Hand und flogen zu zwei. Es war ein Prachtsvergnügen. Schliesslich waren alle ganz ausser Atem und sahen mit ihren wirren Haaren voll Heu aus wie die Wetterhexen.
     </p>
-    <p xml:id="eco_de_0000140_14910">
+    <p xml:id="eco_de_0000210_14910">
      »Nun machen wir uns draussen zurecht und ruhen aus!« schlug Lili Rabus vor.
     </p>
-    <p xml:id="eco_de_0000140_14920">
+    <p xml:id="eco_de_0000210_14920">
      Aber als sie auf die schattige, frischgemähte Baumwiese kamen, dachten sie nicht mehr ans Ruhen, sondern begannen gleich, Spiele zu machen: »Vogel flieg aus«, »Kapitän«, »Fürchtet ihr den schwarzen Mann nicht –?« und »Kommt, wir woll'n spazieren gehn; 's ist doch wohl kein Bär im Wald!« Werner war auch herbei gelaufen. Lili Rabus, die kleine Kinder sehr gern hatte, aber zu Hause allein war, nahm ihn unter ihren Schutz; er lief immer an ihrer Hand mit, wenn sie zu springen hatte.
     </p>
-    <p xml:id="eco_de_0000140_14930">
+    <p xml:id="eco_de_0000210_14930">
      Am Abend kam die Pflaumenlese. Mama ging mit den Kindern durch die Allee zu den zwei letzten Bäumen, die schon ganz reife, süsse Pflaumen trugen. Wenn man nur ein wenig an den Stamm stiess, fielen die Pflaumen auf den Grasboden, plumps – plumps –!
     </p>
-    <p xml:id="eco_de_0000140_14940">
+    <p xml:id="eco_de_0000210_14940">
      »Gerade wie wir vorhin!« rief Berta Strobel und stellte sich dicht unter den Baum, so dass die Pflaumen sie auf den Kopf und die Schultern trafen.
     </p>
-    <p xml:id="eco_de_0000140_14950">
+    <p xml:id="eco_de_0000210_14950">
      Die Kinder jauchzten und sammelten in ihre Körbchen, die sie auf Mariannes Ermahnung alle von zu Haus mitgenommen hatten. Hans und Otto kletterten in die Bäume hinauf, um noch die einzelnen Äste zu schüttelt. Der Pflaumenregen wollte gar kein Ende nehmen. Mama gab acht, dass alle Körbchen ungefähr gleichmässig gefüllt wurden, und legte in jedes vier Zimmetsterne und vier Mandelbretzeln. Die Mädchen trugen ihren Vorrat zur Seemauer, wo sie sich in einer Reihe hinsetzten, gerade über dem Schilf. Jedes konnte nun essen und behalten, so viel es wollte. Die meisten hatten Schwestern und Brüder daheim und freuten sich, etwas mitbringen zu können.
     </p>
-    <p xml:id="eco_de_0000140_14960">
+    <p xml:id="eco_de_0000210_14960">
      »Du, Marianne«, sagte Lisa Peter, »es ist zu nett, so auf der Mauer zu sitzen und über den See wegzusehen! Um unsern Garten stehen rings lauter Häuser. – O, da kommt auch ein Dampfschiff –!«
     </p>
-    <p xml:id="eco_de_0000140_14970">
+    <p xml:id="eco_de_0000210_14970">
      »Das ist das Siebenuhrschiff!« bemerkte Trudi, die sich in den Dampfschiffen schon auskannte.
     </p>
-    <p xml:id="eco_de_0000140_14980">
+    <p xml:id="eco_de_0000210_14980">
      »Das Siebenuhrschiff –!« Lili Rabus stand auf. »Viertel nach sieben sollte ich ja zu Hause sein! Ich dachte, es wäre kaum sechs Uhr!«
     </p>
-    <p xml:id="eco_de_0000140_14990">
+    <p xml:id="eco_de_0000210_14990">
      »Ja, wenn es nur erst zwei Uhr wäre!« riefen die Mädchen, während sie gingen, ihre Hüte zu holen und Frau Turnach zu danken. Marianne, Lotti und Trudi begleiteten die Mädchen bis zur Landstrasse. Dann ging es an ein Händeschütteln und Winken, und immer tönte es den Dreien noch nach:
     </p>
-    <p xml:id="eco_de_0000140_15000">
+    <p xml:id="eco_de_0000210_15000">
      »Adieu, adieu! Das war lustig! Das war schön!«
     </p>
-    <p xml:id="eco_de_0000140_15010">
+    <p xml:id="eco_de_0000210_15010">
      Lottis Kindergesellschaft verlief ähnlich und ebenso vergnügt. Nur gab es da ein grosses allgemeines Baden.
     </p>
-    <p xml:id="eco_de_0000140_15020">
+    <p xml:id="eco_de_0000210_15020">
      »Sie wollen durchaus ihre Badeanzüge mitbringen, Mama!« berichtete Lotti.
     </p>
-    <p xml:id="eco_de_0000140_15030">
+    <p xml:id="eco_de_0000210_15030">
      »Aber die haben doch nicht alle Platz im Badhaus!« warf Marianne ein.
     </p>
-    <p xml:id="eco_de_0000140_15040">
+    <p xml:id="eco_de_0000210_15040">
      »Ja, da hab' ich mir schon ausgedacht. Wir errichten zwei Zelte nebenan. Nicht wahr, Mama, Sophie darf uns grosse Tücher geben, und Hans und Otto machen das Gerüst.«
     </p>
-    <p xml:id="eco_de_0000140_15050">
+    <p xml:id="eco_de_0000210_15050">
      »Was es doch bei uns immer gibt!« sagte Sophie. »Letzte Woche eine Indianerhütte, nun zwei Badezelte! Nächstens baut ihr einen chinesischen Glockenturm –!«
     </p>
-    <p xml:id="eco_de_0000140_15060">
+    <p xml:id="eco_de_0000210_15060">
      »Ja, da haben wir keine Glocken dazu,« erwiderte Lotti lachend.
     </p>
-    <p xml:id="eco_de_0000140_15070">
+    <p xml:id="eco_de_0000210_15070">
      Die »Baderei«, wie Hans sich ausdrückte, ging natürlich unter Lärm und Getümmel vor sich. Die Kinder plätscherten und spritzten, was sie konnten.
     </p>
-    <p xml:id="eco_de_0000140_15080">
+    <p xml:id="eco_de_0000210_15080">
      »Wie eine Schar Frösche!« sagte Otto, der mit Hans und Fritz Völklein draussen vorbeifuhr.
     </p>
-    <p xml:id="eco_de_0000140_15090">
+    <p xml:id="eco_de_0000210_15090">
      »Wie Frösche kann man nicht sagen,« meinte Hans. »Sie tun eher wie Hühner, die ins Wasser gefallen sind. Sieh nur – kein einziges kann schwimmen ausser Lotti, und die macht's nicht besonders.«
     </p>
-    <p xml:id="eco_de_0000140_15100">
+    <p xml:id="eco_de_0000210_15100">
      »Nu, nu,« begütigte Fritz Völklein. »Sie sind eben noch klein. In Lottis Alter waren deine Schwimmkünste auch nicht bedeutend.«
     </p>
-    <p xml:id="eco_de_0000140_15110">
+    <p xml:id="eco_de_0000210_15110">
      »Ein paar aus meiner Klasse möchten auch gerne baden,« nahm Hans wieder auf, der schon an seine Gesellschaft dachte.
     </p>
-    <p xml:id="eco_de_0000140_15120">
+    <p xml:id="eco_de_0000210_15120">
      »Aber die andern sagen, es sei keine Zeit dazu. Mit meinen Buben geht es überhaupt ganz anders als mit Mariannes und Lottis Mädchen. Wir spielen Räubers, und da ziehen wir weit am See entlang oder gegen den Berg hinauf. Wir kommen erst spät zurück, und dann richtet man einen englischen Tee.«
     </p>
-    <p xml:id="eco_de_0000140_15130">
+    <p xml:id="eco_de_0000210_15130">
      Englisch nannten die Turnachkinder den Tee, wenn es dazu belegtes Brot gab.
     </p>
-    <p xml:id="eco_de_0000140_15140">
+    <p xml:id="eco_de_0000210_15140">
      »Du liebe Güte«, sagte Balbine, als sie am Donnerstag nachmittag die Buben daherkommen sah. »Das ist keine Gesellschaft mehr; das ist ja wie ein Truppenzusammenzug –!«
     </p>
-    <p xml:id="eco_de_0000140_15150">
+    <p xml:id="eco_de_0000210_15150">
      Es waren wirklich zweiunddreissig Buben, als man sie zählte. Da die Ferien zu Ende gingen, waren auch die, welche verreist gewesen, wieder in die Stadt zurückgekehrt. Zum Glück hatte Mama Onkel Alfred gebeten, zu kommen und ein wenig zum Rechten zu sehen. Fritz Völklein war natürlich auch da.
     </p>
-    <p xml:id="eco_de_0000140_15160">
+    <p xml:id="eco_de_0000210_15160">
      Nachdem die zweiunddreissig Buben alle Sehenswürdigkeiten der Seeweid aufgesucht und ein paar Partien Ball gespielt hatten, gab's ein kurzes Vesperbrot unter den Bäumen bei der Scheune, wo riesige Stücke Aniskuchen und eine ungezählte Menge saftiger gelber Birnen verzehrt wurden. Dann begann das Räuberspiel. Schon oft hatten es die Knaben zusammen gespielt, aber so »famos« noch nie. Onkel Alfred war mit einem Schiff in die Seeweid gekommen. Dieses wurde mit Landjägern gesetzt, das Turnachsche Schiff mit Räubern. Natürlich drängte alles zu den Schiffen.
     </p>
-    <p xml:id="eco_de_0000140_15170">
+    <p xml:id="eco_de_0000210_15170">
      »Es wird abgewechselt!« beruhigte Onkel Alfred. »Jeder muss seinen Seedienst tun. Aber dass ihr's wisst, Kerls«, fuhr er fort, indem er sich auf die Bank seines Schiffes stellte, »da ist strenge Disziplin! Wer nicht aufs Wort gehorcht, der ist ein Meuterer, der wird an Händen und Füssen gebunden und ohne Pardon in den See geworfen. Verstanden –?«
     </p>
-    <p xml:id="eco_de_0000140_15180">
+    <p xml:id="eco_de_0000210_15180">
      »Ja –!« schrien die Buben.
     </p>
-    <p xml:id="eco_de_0000140_15190">
+    <p xml:id="eco_de_0000210_15190">
      Die Räuber steckten sich zum Abzeichen grüne Zweige auf die Mützen und Hüte. Ihr Schiff stiess unter Fritz Völkleins Führung ab; die übrigen Räuber zogen von Hans geleitet zu Fuss ins Klaregg hinaus.
     </p>
-    <p xml:id="eco_de_0000140_15200">
+    <p xml:id="eco_de_0000210_15200">
      Die Landjäger, die rote Schnüre um den Arm bekamen, gaben den Räubern eine Viertelstunde vor; dann machten sie sich zu Wasser und zu Land auf, die Räuber zu verfolgen. Um sich mit ihrem Schiffe, in dem Onkel Alfred Kapitän war, zu verständigen, hatten sie eine Pfeife, während die Räuber einander durch Hornstösse Signale gaben.
     </p>
-    <p xml:id="eco_de_0000140_15210">
+    <p xml:id="eco_de_0000210_15210">
      Es wurde eine äusserst interessante Jagd, reich an kühnen Schlichen und Wagestücken. Einmal fuhr das Schiff der Landjäger spähend um das Südkap des Klaregg – und nichts ahnend vorbei an den Räubern, die mit ihrem Boote im Schilf versteckt lagen. Bald nachher aber gelang es ein paar Landjägern, eine Kiesgrube zu umzingeln und dort vier Räuber festzunehmen. Dann gab es eine spannende Szene am Seeufer, wo einige Piraten von den Landjägern verfolgt wurden und im letzten Augenblick sich in das Schiff schwingen konnten, das zu ihrer Rettung herbeigeeilt war.
     </p>
-    <p xml:id="eco_de_0000140_15220">
+    <p xml:id="eco_de_0000210_15220">
      Das Siebenuhrschiff fuhr gerade wieder der Stadt zu, als die Buben mit Hallo in die Seeweid zurückkehrten, um sich zu dem englischen Tee in die Buchenlaube zu setzen mit einem Hunger und Durst, wie er noch nie erlebt worden war. Marianne, Lotti und Trudi hatten nur zu rennen mit bei belegten Broten und den leeren Tassen, die Mama aus dem grossen Teekessel füllte. Drei grosse hochaufgetürmte Platten mit Broten waren dagestanden; im Hui hatten die Buben zwei geleert und die dritte in Angriff genommen.
     </p>
-    <p xml:id="eco_de_0000140_15230">
+    <p xml:id="eco_de_0000210_15230">
      »Gottlob«, sagte Balbine, die mit Sophie in der Küche schnitt und strich, »es ist doch genug da!«
     </p>
-    <p xml:id="eco_de_0000140_15240">
+    <p xml:id="eco_de_0000210_15240">
      Als aber Marianne und Lotti immer wieder kamen, um neue Schinken- und Wurstbrote zu verlangen, wurde ihr Angst.
     </p>
-    <p xml:id="eco_de_0000140_15250">
+    <p xml:id="eco_de_0000210_15250">
      »Sophie, so etwas hätte ich nicht für möglich gehalten. Wenn es nur noch zehn Minuten fortdauert, so gehen uns Schinken und Wurst aus; du wirst sehen!«
     </p>
-    <p xml:id="eco_de_0000140_15260">
+    <p xml:id="eco_de_0000210_15260">
      »Dann spring ich zu Frau Völklein hinauf«, sagte Sophie, während sie einen frischen Brotlaib anschnitt. Frau Völklein war immer die letzte Zuflucht. Sie wusste alles und hatte alles und war jederzeit bereit, zu helfen.
     </p>
-    <p xml:id="eco_de_0000140_15270">
+    <p xml:id="eco_de_0000210_15270">
      So gab sie auch jetzt ihre zwei Rauchwürste her, die dicke und die dünne. Und die dicke sowohl als die dünne wurden aufgegessen.
     </p>
-    <p xml:id="eco_de_0000140_15280">
+    <p xml:id="eco_de_0000210_15280">
      »Sehen Sie«, sagte Balbine zu Frau Völklein, »das ist gerade wie die Heuschrecken, die über Ägypten herfielen und alles kahl frassen!«
     </p>
-    <p xml:id="eco_de_0000140_15290">
+    <p xml:id="eco_de_0000210_15290">
      »O«, lachte Frau Völklein, »Sie machen einem fast Angst! Wenn mir die Heuschrecken nur nicht noch meine ganze liebe Buchenlaube abnagen!«
     </p>
-    <p xml:id="eco_de_0000140_15300">
+    <p xml:id="eco_de_0000210_15300">
      Schliesslich aber wurden die Buben doch satt. Es begann zu dunkeln; da brachten Hans und Otto sechs grosse bunte Papierlaternen, die an Stöcken in der Laube befestigt wurden.
     </p>
-    <p xml:id="eco_de_0000140_15310">
+    <p xml:id="eco_de_0000210_15310">
      »Fein – fein –!« schrien die Buben. »Eine venezianische Nacht! Jetzt bleiben wir noch lang da, gelt Hans!«
     </p>
-    <p xml:id="eco_de_0000140_15320">
+    <p xml:id="eco_de_0000210_15320">
      Und nun fingen sie in ihrer Fröhlichkeit an zu singen:
     </p>
-    <p xml:id="eco_de_0000140_15330">
+    <p xml:id="eco_de_0000210_15330">
      »Wenn einer eine Reise tut, So kann er was erzählen …«
     </p>
-    <p xml:id="eco_de_0000140_15340">
+    <p xml:id="eco_de_0000210_15340">
      und
     </p>
-    <p xml:id="eco_de_0000140_15350">
+    <p xml:id="eco_de_0000210_15350">
      »Ich hatt' einen Kameraden …«
     </p>
-    <p xml:id="eco_de_0000140_15360">
+    <p xml:id="eco_de_0000210_15360">
      Dann kam das Jägerlied:
     </p>
-    <p xml:id="eco_de_0000140_15370">
+    <p xml:id="eco_de_0000210_15370">
      »Im Wald und auf der Heide, Da such' ich meine Freude …«
     </p>
-    <p xml:id="eco_de_0000140_15380">
+    <p xml:id="eco_de_0000210_15380">
      und dann das alte, schöne:
     </p>
-    <p xml:id="eco_de_0000140_15390">
+    <p xml:id="eco_de_0000210_15390">
      »Freut euch des Lebens …«
     </p>
-    <p xml:id="eco_de_0000140_15400">
+    <p xml:id="eco_de_0000210_15400">
      Da musste immer einer allein singen. Arnold Weidmann, der am besten sang, übernahm die erste Solostrophe:
     </p>
-    <p xml:id="eco_de_0000140_15410">
+    <p xml:id="eco_de_0000210_15410">
      »Gar mancher macht sich Sorg' und Müh', Sucht Dornen auf und findet sie, Und lässt das Veilchen unbemerkt, Das uns am Wege blüht.«
     </p>
-    <p xml:id="eco_de_0000140_15420">
+    <p xml:id="eco_de_0000210_15420">
      Frisch und zweistimmig fiel dann der Chor ein:
     </p>
-    <p xml:id="eco_de_0000140_15430">
+    <p xml:id="eco_de_0000210_15430">
      »Freut euch des Lebens, Weil noch das Lämpchen glüht; Pflücket die Rose, Eh' sie verblüht.«
     </p>
-    <p xml:id="eco_de_0000140_15440">
+    <p xml:id="eco_de_0000210_15440">
      »Gegessen haben sie wie die Wilden; aber singen tun sie schön!« sagte Balbine, die mit Sophie und Frau Völklein an der Laube stand.
     </p>
-    <p xml:id="eco_de_0000140_15450">
+    <p xml:id="eco_de_0000210_15450">
      Endlich aber, als wieder ein Lied zu Ende war, trat Frau Turnach an den Tisch.
     </p>
-    <p xml:id="eco_de_0000140_15460">
+    <p xml:id="eco_de_0000210_15460">
      »Liebe Buben«, sagte sie, »es ist zwar nicht Sitte, dass man seine Gäste fortschickt. Aber jetzt muss ich doch allen Ernstes sagen: macht, dass ihr eilig aufbrecht, sonst wissen eure Eltern nicht, was sie denken sollen, und ihr findet weder Weg noch Steg mehr!«
     </p>
-    <p xml:id="eco_de_0000140_15470">
+    <p xml:id="eco_de_0000210_15470">
      »Dann übernachten wir hier in der Laube, Frau Turnach!« rief ein Übermütiger.
     </p>
-    <p xml:id="eco_de_0000140_15480">
+    <p xml:id="eco_de_0000210_15480">
      »Ja, ja! wir holen Heu im Stall!« schrien ein paar andere.
     </p>
-    <p xml:id="eco_de_0000140_15490">
+    <p xml:id="eco_de_0000210_15490">
      »Wenn wir einmal beim Militär sind, müssen wir auch im Freien übernachten!«
     </p>
-    <p xml:id="eco_de_0000140_15500">
+    <p xml:id="eco_de_0000210_15500">
      Aber die Vernünftigeren machten sich doch auf. Hans und Otto nahmen zwei von den Laternen, um auf dem dunklen Wiesenweg zu leuchten. Arnold Weidmann stimmte das Lied an:
     </p>
-    <p xml:id="eco_de_0000140_15510">
+    <p xml:id="eco_de_0000210_15510">
      »Nun ziehen wir zum Tor hinaus, Ade, du lieber Ort …«
     </p>
-    <p xml:id="eco_de_0000140_15520">
+    <p xml:id="eco_de_0000210_15520">
      Und im Takte marschierte die ganze Schar unter den Birnbäumen dahin und zur Landstrasse hinauf. Noch lange tönte ihr fröhliches Singen zur Seeweid zurück.
     </p>
    </div>
@@ -4808,337 +4808,337 @@
     <head>
      Ein Molch bringt Hans in Ungelegenheit.
     </head>
-    <p xml:id="eco_de_0000140_15530">
+    <p xml:id="eco_de_0000210_15530">
      Zwei Tage nach Hansens Gesellschaft mussten auch die kleinen Doktors die Seeweid verlassen. Die Kinder konnten nicht begreifen, dass die Zeit schon um war!
     </p>
-    <p xml:id="eco_de_0000140_15540">
+    <p xml:id="eco_de_0000210_15540">
      »Mich dünkt, es sei erst gestern gewesen, dass ich da den ›Schwan‹ habe herausfahren sehen!« sagte Otto, als man auf dem Weg zum Bahnhof wieder am Hafen vorbeikam.
     </p>
-    <p xml:id="eco_de_0000140_15550">
+    <p xml:id="eco_de_0000210_15550">
      Der sonst so lebhafte Bursche war sehr ernsthaft und schweigsam; nur von Zeit zu Zeit wendete er sich zurück:
     </p>
-    <p xml:id="eco_de_0000140_15560">
+    <p xml:id="eco_de_0000210_15560">
      »Also gelt, Tante, nächstes Jahr dürfen wir wiederkommen –? Gleich am ersten Tag der Ferien –?«
     </p>
-    <p xml:id="eco_de_0000140_15570">
+    <p xml:id="eco_de_0000210_15570">
      Und als der Bahnzug schon im Fahren war, rief er immer noch hinaus:
     </p>
-    <p xml:id="eco_de_0000140_15580">
+    <p xml:id="eco_de_0000210_15580">
      »Auf Wiedersehn! auf Wiedersehn! Hans, grüss mir die Seeweid und das Schiff und die Indianerhütte und die Seemauer und alles, alles –«
     </p>
-    <p xml:id="eco_de_0000140_15590">
+    <p xml:id="eco_de_0000210_15590">
      Am Montag ging für die Turnachkinder die Schule wieder an, und es verflossen nun ein paar Wochen, während welcher alles seinen gewohnten Gang ging. Am Ende der dritten aber gab es wieder einmal eine »Geschichte« in der Seeweid.
     </p>
-    <p xml:id="eco_de_0000140_15600">
+    <p xml:id="eco_de_0000210_15600">
      Die Kinder waren an einem Abend im Begriff, zum Klaregg hinauszugehen, als Mama sie zurückrief:
     </p>
-    <p xml:id="eco_de_0000140_15610">
+    <p xml:id="eco_de_0000210_15610">
      »Ihr habt kaum mehr Zeit, wegzulaufen. Ihr wisst, es kommt Besuch, und da möchte ich euch gerne sauber und ordentlich haben, nicht so, wie ihr mir gewöhnlich aus dem Klaregg kommt!«
     </p>
-    <p xml:id="eco_de_0000140_15620">
+    <p xml:id="eco_de_0000210_15620">
      »Mama, nur schnell hinrennen möchten wir!« bat Hans. »Marianne hat vorgestern ihr Taschenmesser dort verloren –«
     </p>
-    <p xml:id="eco_de_0000140_15630">
+    <p xml:id="eco_de_0000210_15630">
      »Eigentlich hab' ich dir's geliehen, Hans«, sagte Marianne, »und du hast's beim Wilden Kopf hingelegt –«
     </p>
-    <p xml:id="eco_de_0000140_15640">
+    <p xml:id="eco_de_0000210_15640">
      »Der Wilde Kopf« hiess bei den Turnachkindern die grösste und struppigste der alten Weiden im Klaregg.
     </p>
-    <p xml:id="eco_de_0000140_15650">
+    <p xml:id="eco_de_0000210_15650">
      Hans wollte sich verteidigen; aber Mama unterbrach ihn: »Nur nicht viele Reden! Lauft schnell; aber haltet euch nicht lange auf!«
     </p>
-    <p xml:id="eco_de_0000140_15660">
+    <p xml:id="eco_de_0000210_15660">
      Die Kinder liefen im Trab zum Klaregg hinaus. Das Messer lag wirklich im Klee dicht hinter dem Wilden Kopf. Es war aber sehr schwer, das Klaregg so schnell wieder zu verlassen. Lotti musste wenigstens rasch zum Thymianhügel rennen, um eine Handvoll von den Blüten abzurupfen; sie dufteten so gut, wenn man sie zwischen den Fingern zerrieb. Hans blieb am »Roten Meer« stehen und sah in das dunkle, tiefe Wasser. Marianne ging langsam voraus. Sie war froh, ihr Messer wieder zu haben. Lotti folgte mit dem Thymian nach.
     </p>
-    <p xml:id="eco_de_0000140_15670">
+    <p xml:id="eco_de_0000210_15670">
      »Das ist ein Kerl –! Nein, solch einen prachtvollen Kerl haben wir noch nie gefangen!« schrie Hans auf einmal.
     </p>
-    <p xml:id="eco_de_0000140_15680">
+    <p xml:id="eco_de_0000210_15680">
      Lotti lief zu Hans, um zu sehen, was er hatte. Marianne blieb auch neugierig stehen.
     </p>
-    <p xml:id="eco_de_0000140_15690">
+    <p xml:id="eco_de_0000210_15690">
      Der Kerl, den Hans triumphierend daher brachte, war ein schöner, grosser Molch, schwarz glänzend auf dem Rücken und rotgelb auf der Unterseite.
     </p>
-    <p xml:id="eco_de_0000140_15700">
+    <p xml:id="eco_de_0000210_15700">
      »Aber jetzt haben wir kein Glas, um ihn heimzunehmen«, meinte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_15710">
+    <p xml:id="eco_de_0000210_15710">
      »Ach, das richten wir schon ein!« sagte Hans. »Da, Marianne, nimm mein Taschentuch und netz' es dort im Wasser! Und du, Lotti, bring etwas Gras und Moos; aber es muss auch feucht sein.«
     </p>
-    <p xml:id="eco_de_0000140_15720">
+    <p xml:id="eco_de_0000210_15720">
      Marianne kam mit dem Taschentuch. Sie war beim Hinknien ziemlich nass geworden. Auch Lotti hatte sich mit dem feuchten Moos die Schürze schmutzig gemacht. Aber dafür war man im Besitz des schönsten Molches vom Klaregg.
     </p>
-    <p xml:id="eco_de_0000140_15730">
+    <p xml:id="eco_de_0000210_15730">
      »So, mein schwarzer Herr«, sagte Hans und setzte den Molch ins Taschentuch auf das feuchte Moos.
     </p>
-    <p xml:id="eco_de_0000140_15740">
+    <p xml:id="eco_de_0000210_15740">
      »Glaubst du, dass er das gern mag?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_15750">
+    <p xml:id="eco_de_0000210_15750">
      »O, das ist doch ganz schön weich und nass! Nachher kommt er gleich ins Aquarium!« Hans knüpfte das Taschentuch leicht zusammen. »Jetzt müssen wir aber rennen –«
     </p>
-    <p xml:id="eco_de_0000140_15760">
+    <p xml:id="eco_de_0000210_15760">
      Die Turnachkinder liefen heimwärts. Als sie in den obern Heckenweg einbogen, blieb Hans plötzlich stehen.
     </p>
-    <p xml:id="eco_de_0000140_15770">
+    <p xml:id="eco_de_0000210_15770">
      »Dort vorn ist Papa und Onkel Oberst und Onkel Alfred und die andern –« flüsterte er.
     </p>
-    <p xml:id="eco_de_0000140_15780">
+    <p xml:id="eco_de_0000210_15780">
      »Wie grässlich!« sagte Marianne. »Nun sind wir noch gar nicht ordentlich angezogen. Sieh einmal da unten mein Kleid –«
     </p>
-    <p xml:id="eco_de_0000140_15790">
+    <p xml:id="eco_de_0000210_15790">
      »Du liebe Güte!« – Lotti machte manchmal Balbine ein wenig nach – »und meine Schürze –! Hans, könnten wir uns nicht hinter der Hecke verstecken?«
     </p>
-    <p xml:id="eco_de_0000140_15800">
+    <p xml:id="eco_de_0000210_15800">
      Aber eben entdeckte Onkel Alfred die Kinder und schwenkte grüssend seinen Spazierstock.
     </p>
-    <p xml:id="eco_de_0000140_15810">
+    <p xml:id="eco_de_0000210_15810">
      »Sie haben uns gesehen!« flüsterte Hans. »Wir müssen vorwärts.«
     </p>
-    <p xml:id="eco_de_0000140_15820">
+    <p xml:id="eco_de_0000210_15820">
      »Nein! meine Hände!« sagte Lotti und hielt sie leise lachend dem Hans vors Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_15830">
+    <p xml:id="eco_de_0000210_15830">
      Hans gab ihr einen Stoss.
     </p>
-    <p xml:id="eco_de_0000140_15840">
+    <p xml:id="eco_de_0000210_15840">
      »Du bist schrecklich, Lotti! Wenn man so in Not ist, lachst du! Reib sie doch an der Schürze ab!«
     </p>
-    <p xml:id="eco_de_0000140_15850">
+    <p xml:id="eco_de_0000210_15850">
      Lotti rieb; aber die Schürze war noch nasser und schmutziger als die Hände.
     </p>
-    <p xml:id="eco_de_0000140_15860">
+    <p xml:id="eco_de_0000210_15860">
      Hans rieb währenddessen an seinem Jackenärmel, der beim Molchfang tief in das schlammige Wasser gekommen war.
     </p>
-    <p xml:id="eco_de_0000140_15870">
+    <p xml:id="eco_de_0000210_15870">
      »Und den Molch, den Molch –!« flüsterte Marianne, als man schon ganz nahe war. »Tante Oberst mag Frösche und Molche gar nicht. Sie hat einmal gesagt, das sei ein greuliches Ungeziefer! Hans, wirf ihn in die Hecke!«
     </p>
-    <p xml:id="eco_de_0000140_15880">
+    <p xml:id="eco_de_0000210_15880">
      Das brachte Hans aber nicht übers Herz. Rasch steckte er das nasse Tuch mit Moos und Molch in die Tasche seiner weiten Hose.
     </p>
-    <p xml:id="eco_de_0000140_15890">
+    <p xml:id="eco_de_0000210_15890">
      »Man sieht es nicht!« sagte Marianne noch schnell.
     </p>
-    <p xml:id="eco_de_0000140_15900">
+    <p xml:id="eco_de_0000210_15900">
      Es war die höchste Zeit gewesen. Onkel Oberst, ein grosser Herr mit grauem Schnurrbart, stand schon fast vor Hans.
     </p>
-    <p xml:id="eco_de_0000140_15910">
+    <p xml:id="eco_de_0000210_15910">
      »Aha, aha, die Kinder! der Hans, die Marianne und die kleine Lotti! Wie geht's, wie steht's? Wie verhält man sich in der Schule? Hat man ein ordentliches Zeugnis heimgebracht –?«
     </p>
-    <p xml:id="eco_de_0000140_15920">
+    <p xml:id="eco_de_0000210_15920">
      Onkel Oberst fragte immer zuerst nach der Schule. Da konnten alle drei Kinder mit ziemlich gutem Gewissen antworten:
     </p>
-    <p xml:id="eco_de_0000140_15930">
+    <p xml:id="eco_de_0000210_15930">
      »Ja, Onkel!«
     </p>
-    <p xml:id="eco_de_0000140_15940">
+    <p xml:id="eco_de_0000210_15940">
      Aber die Tante Oberst kam nun auch heran:
     </p>
-    <p xml:id="eco_de_0000140_15950">
+    <p xml:id="eco_de_0000210_15950">
      »Guten Tag, meine lieben Kinder! Marianne, nimm mir das Täschchen ab; es ist etwas für Mama darin …«
     </p>
-    <p xml:id="eco_de_0000140_15960">
+    <p xml:id="eco_de_0000210_15960">
      Marianne gehorchte schnell. Die Tante aber fuhr in bedauerndem Tone fort:
     </p>
-    <p xml:id="eco_de_0000140_15970">
+    <p xml:id="eco_de_0000210_15970">
      »O weh, o weh, dein nettes Kleidchen, Marianne! unten herum ganz schmutzig! Ein Mädchen, liebes Kind, muss immer sauber gehen und Sorge zu seinen Kleidern tragen!«
     </p>
-    <p xml:id="eco_de_0000140_15980">
+    <p xml:id="eco_de_0000210_15980">
      »Du, Tante, es macht nicht so viel. Am Montag wird Mariannes Kleid wieder gewaschen!« erklärte Lotti und vergass ganz, dass es vorsichtiger gewesen wäre, im Hintergrund zu bleiben.
     </p>
-    <p xml:id="eco_de_0000140_15990">
+    <p xml:id="eco_de_0000210_15990">
      »Ei, das Lottchen!« sagte die Tante. »Aber Kind, wie siehst du aus –! Ist es möglich, seine Schürze so herzurichten!«
     </p>
-    <p xml:id="eco_de_0000140_16000">
+    <p xml:id="eco_de_0000210_16000">
      »Das ist furchtbar leicht möglich«, dachte Hans, hütete sich aber, etwas zu sagen. Tante Obersts Blicke fielen allerdings nun doch auf ihn.
     </p>
-    <p xml:id="eco_de_0000140_16010">
+    <p xml:id="eco_de_0000210_16010">
      »Hans, und du auch –! Du bist der Älteste und solltest deinen Schwestern ein gutes Beispiel geben!«
     </p>
-    <p xml:id="eco_de_0000140_16020">
+    <p xml:id="eco_de_0000210_16020">
      Hans wurde rot und zupfte an seinem Ärmel, den die Tante missbilligend betrachtete.
     </p>
-    <p xml:id="eco_de_0000140_16030">
+    <p xml:id="eco_de_0000210_16030">
      Onkel Alfred aber zog jetzt die Kinder aus ihrer Bedrängnis.
     </p>
-    <p xml:id="eco_de_0000140_16040">
+    <p xml:id="eco_de_0000210_16040">
      »Fräulein Fanny«, sagte er und wandte sich zu einer jungen Dame in weissem Kleid, die mit Tante Oberst gekommen war. Die Kinder kannten sie nicht. »Fräulein Fanny, darf ich mir das Vergnügen machen, ihnen diese jungen Leute vorzustellen, deren glücklicher Onkel ich bin. Es vereinigen sich in ihnen die verschiedensten Anlagen; sie sind grosse Künstler und Sänger, daneben kühne Seefahrer und Jäger. Hin und wieder« – Onkel Alfred warf einen neckenden Blick auf Hans – »graben sie auch mit Erfolg nach Altertümern –«
     </p>
-    <p xml:id="eco_de_0000140_16050">
+    <p xml:id="eco_de_0000210_16050">
      Fräulein Fanny lachte belustigt, so dass es den Kindern ganz gemütlich wurde und sie zur Begrüssung ihre Hände hinstreckten. Fräulein Fanny zog die ihre etwas erschreckt zurück.
     </p>
-    <p xml:id="eco_de_0000140_16060">
+    <p xml:id="eco_de_0000210_16060">
      »Nein, Kinder!« wehrte Onkel Alfred. »Das könnt ihr Fräulein Fanny nicht zumuten! Zu ihren feinen weissen Handschuhen passen euere erdigen Maulwurfspfoten schlecht!«
     </p>
-    <p xml:id="eco_de_0000140_16070">
+    <p xml:id="eco_de_0000210_16070">
      »Ihr seht wirklich nett aus, Hans!« warf nun auch Papa ein. »Ihr macht einem Ehre! Marsch, nach Haus und gründlich gewaschen! Sagt Mama, dass wir noch zum Bauplatz von Herrn Schirmbach gehen und dann gleich zum Abendessen kommen werden.«
     </p>
-    <p xml:id="eco_de_0000140_16080">
+    <p xml:id="eco_de_0000210_16080">
      Die Kinder liefen davon.
     </p>
-    <p xml:id="eco_de_0000140_16090">
+    <p xml:id="eco_de_0000210_16090">
      »Sie kommen! Sie kommen!« riefen alle drei schon von weitem. »Sophie, Papa hat gesagt, wir sollen uns gründlich waschen! Bitte gib uns die schöne gelbe Seife und warmes Wasser! …«
     </p>
-    <p xml:id="eco_de_0000140_16100">
+    <p xml:id="eco_de_0000210_16100">
      Der Bäcker hatte vergessen die bestellten Semmeln zu schicken, und Hans musste noch einmal weglaufen, sie zu holen.
     </p>
-    <p xml:id="eco_de_0000140_16110">
+    <p xml:id="eco_de_0000210_16110">
      »Du und Marianne, ihr dürft heute mit den Grossen zu Nacht essen,« sagte Mama, als sie ihm das Brot abnahm. »Ich erwarte, dass ihr recht manierlich und bescheiden sein werdet.«
     </p>
-    <p xml:id="eco_de_0000140_16120">
+    <p xml:id="eco_de_0000210_16120">
      Hans versprach alles Gute und rannte hinauf in sein Stübchen, um die Haare zu bürsten und die bessere Jacke sowie einen frischen Kragen anzuziehen.
     </p>
-    <p xml:id="eco_de_0000140_16130">
+    <p xml:id="eco_de_0000210_16130">
      »Bin ich jetzt fein –?« fragte er, indem er sich vor Sophie stellte, die eben Mariannes Zopfschleife band.
     </p>
-    <p xml:id="eco_de_0000140_16140">
+    <p xml:id="eco_de_0000210_16140">
      »Es geht!« antwortete Sophie und gab dem wilden Burschen einen Klaps auf die Schulter.
     </p>
-    <p xml:id="eco_de_0000140_16150">
+    <p xml:id="eco_de_0000210_16150">
      Draussen ertönten Stimmen und Lachen; die Kinder liefen hinaus.
     </p>
-    <p xml:id="eco_de_0000140_16160">
+    <p xml:id="eco_de_0000210_16160">
      »Hans, Hans, hast du doch ein frisches Taschentuch?« rief Sophie. Aber Hans hörte nicht mehr.
     </p>
-    <p xml:id="eco_de_0000140_16170">
+    <p xml:id="eco_de_0000210_16170">
      Die Gäste gingen durch den Garten und zum See; dann wollte Onkel Oberst auch den Stall sehen. Die Kinder fanden es sehr lustig, dass Fräulein Fanny sich vor den Kühen fürchtete. Aber von den Kaninchen musste ihr Hans eines herausholen, und sie nannte es »süss.«
     </p>
-    <p xml:id="eco_de_0000140_16180">
+    <p xml:id="eco_de_0000210_16180">
      Man ging zum Haus zurück und setzte sich zu Tisch. Hans und Marianne kamen unten hin; sie waren still und bescheiden; nur manchmal machten sie sich eine kleine, fast unbemerkbare Grimasse. Das hiess in der Turnachkindersprache: Wir reden dann nachher über alles! Es begegnete keinem etwas Fatales; bloss am Anfang hatte Marianne die Gabel fallen lassen, und Hans hätte beinahe die Bratenbrühe mit dem Brot aufgetunkt. Da warf ihm Mama rasch einen Blick zu, dass man das nicht tue.
     </p>
-    <p xml:id="eco_de_0000140_16190">
+    <p xml:id="eco_de_0000210_16190">
      Die grossen Leute sprachen viel, und die Kinder verstanden nicht alles; aber sie waren doch vergnügt. Onkel Alfred, der neben Marianne sass, machte hin und wieder halblaut einen Spass und merkte immer, wenn die Kinder gern noch etwas gehabt hätten, aber nicht zu bitten wagten.
     </p>
-    <p xml:id="eco_de_0000140_16200">
+    <p xml:id="eco_de_0000210_16200">
      »Komm, Hans«, sagte er dann, »sei kameradschaftlich und nimm mir die Hälfte von diesem Bratenstück ab!«
     </p>
-    <p xml:id="eco_de_0000140_16210">
+    <p xml:id="eco_de_0000210_16210">
      Und zu Marianne:
     </p>
-    <p xml:id="eco_de_0000140_16220">
+    <p xml:id="eco_de_0000210_16220">
      »Die gerösteten Kartöffelchen sehen dich so freundlich an, Mariannchen! Mach' ihnen das Vergnügen und nimm noch zwei auf deinen Teller –«
     </p>
-    <p xml:id="eco_de_0000140_16230">
+    <p xml:id="eco_de_0000210_16230">
      Dann kam ein süsser kalter Pudding mit rotem Himbeersaft. Hans zog die Augenbrauen in die Höhe und schnappte ein wenig mit dem Mund, um Marianne zu bedeuten, dass das furchtbar gut sei.
     </p>
-    <p xml:id="eco_de_0000140_16240">
+    <p xml:id="eco_de_0000210_16240">
      Da auf einmal stiess Fräulein Fanny, die die ganze Zeit sehr munter gewesen war, einen durchdringenden Schrei aus und bog sich zu Frau Turnach hinüber, deren Arm sie krampfhaft fasste.
     </p>
-    <p xml:id="eco_de_0000140_16250">
+    <p xml:id="eco_de_0000210_16250">
      Alles sprang auf.
     </p>
-    <p xml:id="eco_de_0000140_16260">
+    <p xml:id="eco_de_0000210_16260">
      »Fanny – Fräulein Fanny – um des Himmels willen, was ist –?«
     </p>
-    <p xml:id="eco_de_0000140_16270">
+    <p xml:id="eco_de_0000210_16270">
      Das Fräulein, totenblass, warf einen Blick seitwärts zu Boden und schrie entsetzt noch einmal auf. Die andern folgten dem Blick.
     </p>
-    <p xml:id="eco_de_0000140_16280">
+    <p xml:id="eco_de_0000210_16280">
      Es war nun allerdings greulich: Auf Fräulein Fannys weissem Kleid sass der Molch, der Molch aus dem Klaregg, lang und schwarz! Er hatte offenbar den Aufenthalt in Hansens Tasche trotz des schönen Mooses nicht mehr angenehm gefunden, war herausgekrabbelt und unbemerkt hinüber auf Fräulein Fannys duftiges Kleid gekrochen.
     </p>
-    <p xml:id="eco_de_0000140_16290">
+    <p xml:id="eco_de_0000210_16290">
      »Das Tier – das grauenhafte Tier –!« stöhnte Fräulein Fanny, fuhr, ihr Kleid ausschüttelnd, auf und stürzte in die fernste Ecke des Zimmers.
     </p>
-    <p xml:id="eco_de_0000140_16300">
+    <p xml:id="eco_de_0000210_16300">
      Das schwarze Reptil sass verdutzt auf dem Fussboden.
     </p>
-    <p xml:id="eco_de_0000140_16310">
+    <p xml:id="eco_de_0000210_16310">
      »Ein Molch –!« Papas Augen fielen sofort auf Hans, der zerknirscht dastand.
     </p>
-    <p xml:id="eco_de_0000140_16320">
+    <p xml:id="eco_de_0000210_16320">
      »Was soll das heissen, Hans –! Ihr treibt es wirklich zu arg –«
     </p>
-    <p xml:id="eco_de_0000140_16330">
+    <p xml:id="eco_de_0000210_16330">
      »Pfui, wie scheusslich! Pfui, dieses Greueltier –«
     </p>
-    <p xml:id="eco_de_0000140_16340">
+    <p xml:id="eco_de_0000210_16340">
      Tante Oberst streckte ihre beiden Arme im Abscheu von sich. »Wie ekelhaft! Nein Luise, bei euch ist ja die reine Menagerie! Verzeih, ich setze mich hinüber in dein Zimmer! Wer weiss, was die lieben Kinder noch für Überraschungen ausgedacht haben …«
     </p>
-    <p xml:id="eco_de_0000140_16350">
+    <p xml:id="eco_de_0000210_16350">
      »Wie kommt das Tier hieher –?« nahm Papa wieder auf. Hans sah, dass er böse war.
     </p>
-    <p xml:id="eco_de_0000140_16360">
+    <p xml:id="eco_de_0000210_16360">
      »Papa«, sagte Marianne, »Hans hat's nicht mit Fleiss getan!« »Nein, Papa,« bestätigte Hans. »Wir haben ihn aus dem Klaregg mitgenommen, weil er so schön war –«
     </p>
-    <p xml:id="eco_de_0000140_16370">
+    <p xml:id="eco_de_0000210_16370">
      »Schon –!« fiel ihm Tante Oberst empört ins Wort.
     </p>
-    <p xml:id="eco_de_0000140_16380">
+    <p xml:id="eco_de_0000210_16380">
      »Und da seid ihr gekommen«, fuhr Hans fort, »und da haben wir gedacht, Tante Oberst möge die Molche nicht so gern, und ich hab' ihn schnell in die Tasche gesteckt und hab' gedacht, zu Haus wolle ich ihn gleich ins Aquarium tun –« Er sog verlegen sein feuchtes Taschentuch heraus.
     </p>
-    <p xml:id="eco_de_0000140_16390">
+    <p xml:id="eco_de_0000210_16390">
      »Hast du gedacht? Aber dann sind dir die Gedanken scheint's vollständig ausgegangen!« sagte Papa streng. »Sonst hättest du das arme Tier nicht vergessen, für das es doch gewiss peinlich war, in deiner Tasche zu stecken!«
     </p>
-    <p xml:id="eco_de_0000140_16400">
+    <p xml:id="eco_de_0000210_16400">
      »Ja, Hans«, nahm Onkel Alfred das Wort und zog den Neffen am Schopf, »den alten Spruch:
     </p>
-    <p xml:id="eco_de_0000140_16410">
+    <p xml:id="eco_de_0000210_16410">
      Quäle nie ein Tier zum Scherz, Denn es fühlt wie du den Schmerz!
     </p>
-    <p xml:id="eco_de_0000140_16420">
+    <p xml:id="eco_de_0000210_16420">
      soll dir Marianne einmal in dein Mützenfutter sticken. Wie wäre denn dir zu Mut, wenn ich unversehens käme, dich in ein nasses Leintuch wickelte und in meine Tasche steckte –!«
     </p>
-    <p xml:id="eco_de_0000140_16430">
+    <p xml:id="eco_de_0000210_16430">
      Hans sah Papa von der Seite an, ob man lachen dürfe; doch es war nicht recht drauszukommen.
     </p>
-    <p xml:id="eco_de_0000140_16440">
+    <p xml:id="eco_de_0000210_16440">
      In der Ecke stand noch immer Fräulein Fanny und hielt zitternd ihr Kleid zusammen.
     </p>
-    <p xml:id="eco_de_0000140_16450">
+    <p xml:id="eco_de_0000210_16450">
      »Aber wir reden da hin und her«, rief Onkel Alfred, »und vergessen das arme Opfer des Überfalls! Hans, Missetäter! Tue einen Fussfall vor dem Fräulein und bitte sie um Verzeihung, während ich –«, er nahm eine Gabel vom Tische, »ich werde Ritter Georg sein und Fräulein Fanny von dem grimmigen Drachen befreien –«
     </p>
-    <p xml:id="eco_de_0000140_16460">
+    <p xml:id="eco_de_0000210_16460">
      Onkel Alfred fasste die Gabel mit beiden Händen wie eine Lanze und tat vorgebeugt ein paar Schritte gegen den Molch, der immer noch am gleichen Fleck sass und träge die Augen auf und zu machte.
     </p>
-    <p xml:id="eco_de_0000140_16470">
+    <p xml:id="eco_de_0000210_16470">
      »Stirb, Ungeheuer –!« rief Onkel Alfred mit dumpfer Stimme, indem er schaft auf den Kopf des Tieres zielte; dann tat er einen Stoss –
     </p>
-    <p xml:id="eco_de_0000140_16480">
+    <p xml:id="eco_de_0000210_16480">
      »O!« schrie Marianne mitleidig.
     </p>
-    <p xml:id="eco_de_0000140_16490">
+    <p xml:id="eco_de_0000210_16490">
      Aber die Gabel flog auf die Seite; Onkel Alfred hielt den unversehrten Molch zwischen zwei Fingern in die Höhe.
     </p>
-    <p xml:id="eco_de_0000140_16500">
+    <p xml:id="eco_de_0000210_16500">
      »Hier, meine Herrschaften!« Er drehte sich auf dem Absatz um und verbeugte sich. Das zappelnde Tier gab er Hans:
     </p>
-    <p xml:id="eco_de_0000140_16510">
+    <p xml:id="eco_de_0000210_16510">
      »Mach', dass du hinauskommst mit ihm!«
     </p>
-    <p xml:id="eco_de_0000140_16520">
+    <p xml:id="eco_de_0000210_16520">
      Alles lachte; Fräulein Fanny wagte sich aus ihrer Ecke hervor, und selbst Tante Oberst kam auf Mamas Bitte wieder an den Tisch.
     </p>
-    <p xml:id="eco_de_0000140_16530">
+    <p xml:id="eco_de_0000210_16530">
      »Für euch aber ist's jetzt Zeit, ins Bett zu gehen«, sagte Papa, als Hans zurückkam. »Und den Molch setzt ihr morgen, weil es ihm heut' so übel ging, sofort in Freiheit. Ihr holt überhaupt diesen Sommer nun keinerlei Getier mehr aus dem Klaregg! Vor gar nicht langer Zeit war Lottis Geschichte mit den Rosenkäfern und jetzt – ich will nicht sagen, dass das heute die selbe Quälerei war; aber immerhin, bei euerer Liebe zu den Tieren denkt ihr doch meist bloss an euch und euern Spass. Ihr sollt lernen, vor allem, was draussen lebt und sich bewegt, etwas mehr Achtung zu haben. Verstanden –? Jetzt verabschiedet euch!«
     </p>
-    <p xml:id="eco_de_0000140_16540">
+    <p xml:id="eco_de_0000210_16540">
      Hans und Marianne gaben beschämt einem nach dem andern die Hand.
     </p>
-    <p xml:id="eco_de_0000140_16550">
+    <p xml:id="eco_de_0000210_16550">
      »Pension Froschheim polizeilich geschlossen wegen schlechter Behandlung der Pensionäre!« sagte Onkel Alfred und blinzelte zu Hans hinüber. –
     </p>
-    <p xml:id="eco_de_0000140_16560">
+    <p xml:id="eco_de_0000210_16560">
      »Lotti, Lotti, schläfst du noch nicht?« flüsterte Marianne, und Hans schlüpfte hinter ihr drein; er wollte auch erzählen.
     </p>
-    <p xml:id="eco_de_0000140_16570">
+    <p xml:id="eco_de_0000210_16570">
      Lotti war noch ganz wach und sehr neugierig. Sie hatte Fräulein Fannys Schrei gehört.
     </p>
-    <p xml:id="eco_de_0000140_16580">
+    <p xml:id="eco_de_0000210_16580">
      »Wenn du wüsstest, Lotti, wie das gewesen ist –! Halb grässlich und halb wieder lustig wegen Onkel Alfred, der mit der Gabel den Ritter Georg dargestellt hat – weisst du, den Ritter Georg im Sagenbuch! Und dann war's auch traurig; denn wir dürfen jetzt keinen mehr holen, weil er auf Fräulein Fannys Kleid gesessen ist –«
     </p>
-    <p xml:id="eco_de_0000140_16590">
+    <p xml:id="eco_de_0000210_16590">
      »Wer ist auf Fräulein Fannys Kleid gesessen –?« fragte Lotti. Man konnte wirklich nicht verlangen, dass sie klug wurde aus dem Bericht.
     </p>
-    <p xml:id="eco_de_0000140_16600">
+    <p xml:id="eco_de_0000210_16600">
      »Der Molch natürlich! Er ist aus meiner Tasche gekrochen –«
     </p>
-    <p xml:id="eco_de_0000140_16610">
+    <p xml:id="eco_de_0000210_16610">
      Und nun begann die Erzählung ordentlich von vorn und dauerte fort, bis Sophie hereinschaute.
     </p>
-    <p xml:id="eco_de_0000140_16620">
+    <p xml:id="eco_de_0000210_16620">
      »Ja was, Hans!« rief sie. »Willst du wohl machen, dass du in dein Bett kommst –?«
     </p>
-    <p xml:id="eco_de_0000140_16630">
+    <p xml:id="eco_de_0000210_16630">
      Da nahm Hans das Lämpchen und stieg hinauf in seine Dachstube.
     </p>
    </div>
@@ -5146,517 +5146,517 @@
     <head>
      Nachtgeschichten.
     </head>
-    <p xml:id="eco_de_0000140_16640">
+    <p xml:id="eco_de_0000210_16640">
      Die Turnachkinder hatten ausser der Seemauer noch einen Lieblingsplatz. Er befand sich auf dem Dache des kleinen Waschhauses. Fritz Völklein und Hans hatten da auf dem First ein Brett befestigt, das eine niedrige und sehr angenehme Bank bildete. Von der einen Seite hing der breite Holunderstrauch über das Dach hin, so dass man traulich im Schatten sass. Der Holunderstrauch war wie ein guter Freund, den man durch und durch kannte. Im Frühjahr, wenn die Turnachs in die Seeweid kamen, schoss eben das erste helle Grün aus den glatten grauen Ästen. Das wuchs und wuchs und hatte auf einmal kleine Dolden, die sich ausdehnten und eines Sommertages in Blüte standen. Zahllose feine, weisse, starkduftende Blümchen drängten sich zusammen in einer Dolde. Dann verschwanden sie, und man beachtete die grünen Büschel weiter nicht, bis die Beerchen daran grösser wurden und sich bräunlich rot färbten. Die Dolden senkten sich; wenn man sie mit der Hand hob, waren sie ganz schwer. Schliesslich wurden die Beeren glänzend schwarz und weich. Dann pflückte man sie, und Balbine kochte sie mit Zucker zu einem guten Brei, den die Kinder abends mit Butterbrot assen.
     </p>
-    <p xml:id="eco_de_0000140_16650">
+    <p xml:id="eco_de_0000210_16650">
      Man konnte auf zwei Arten auf das Dach kommen. Erstens, indem man in dem starken Strauch emporkletterte; selbst Marianne und Lotti brachten das zu stande; die Stämmchen boten überall Halt zum Klettern. Dann konnte man auch im Holzbehälter die kleine Leiter holen und an das Dach anlegen. Eins, zwei, drei – da war man wie der Blitz oben. –
     </p>
-    <p xml:id="eco_de_0000140_16660">
+    <p xml:id="eco_de_0000210_16660">
      An dem Abend der ersten Septemberwoche, da die Kinder wieder einmal sich auf das Dach setzten, waren die Beeren des Holunderstrauches schon schwarz und reif.
     </p>
-    <p xml:id="eco_de_0000140_16670">
+    <p xml:id="eco_de_0000210_16670">
      »Heut' ist's an mir, beim Kamin zu sitzen!« rief Lotti. Die Ecke, wo man sich an den Kamin anlehnen konnte, war der beste Platz. An der andern Seite des Kamins lag auf den alten, moosbewachsenen Ziegeln die Hauswurz. Das war eine seltsame Pflanze; sie sah aus wie das Stück eines dicken Teppichs, darin sich eine grüne Rose an die andere fügte, grosse und kleine mit fleischigen, glatten Blättern. Dieser Teppich oder Pelz von Blätterrosen wurzelte nicht fest; man konnte ihn herumtragen und bald auf diese, bald auf jene Seite des Daches legen.
     </p>
-    <p xml:id="eco_de_0000140_16680">
+    <p xml:id="eco_de_0000210_16680">
      Einmal hatten die Kinder die Hauswurz herunternehmen wollen; aber da war Frau Völkleins Grite gerade dazugekommen.
     </p>
-    <p xml:id="eco_de_0000140_16690">
+    <p xml:id="eco_de_0000210_16690">
      »Dass ihr auf der Stelle die Hauswurz wieder hinlegt –!« hatte sie gesagt und ein ziemlich böses Gesicht gemacht. »Sie bringt dem Hause Glück; wenn man sie fortträgt, geschieht etwas Schlimmes!«
     </p>
-    <p xml:id="eco_de_0000140_16700">
+    <p xml:id="eco_de_0000210_16700">
      Hans stieg mit der Hauswurz schnell wieder auf das Waschhaus und legte sie hin. Dann aber rief er vom Dach herunter.
     </p>
-    <p xml:id="eco_de_0000140_16710">
+    <p xml:id="eco_de_0000210_16710">
      »Du, Grite, warum tut man denn die Hauswurz nicht aufs grosse Dach? Der alten Waschküche braucht sie doch kein Glück zu bringen; da wohnen höchstens Spinnen drin und etwa eine Maus.«
     </p>
-    <p xml:id="eco_de_0000140_16720">
+    <p xml:id="eco_de_0000210_16720">
      »Das macht nichts«, sagte Grite. »Wenn sie nur auf einem Dach liegt, das zum Gut gehört. Sei du nicht so vorwitzig und lass die Hauswurz in Ruhe! Sie ist viel älter als du!« –
     </p>
-    <p xml:id="eco_de_0000140_16730">
+    <p xml:id="eco_de_0000210_16730">
      Also Lotti sass diesmal nächst dem Kamin, Marianne neben ihr und Hans zu äusserst. Es war ein schöner, stiller Abend. Man sah über den Garten weg zum See, auf dem ein paar Steinschiffe mit grossen weissen Segeln dahinzogen.
     </p>
-    <p xml:id="eco_de_0000140_16740">
+    <p xml:id="eco_de_0000210_16740">
      »Jetzt singen wir«, schlug Lotti vor.
     </p>
-    <p xml:id="eco_de_0000140_16750">
+    <p xml:id="eco_de_0000210_16750">
      »Ja«, sagte Marianne, »wir wollen singen:
     </p>
-    <p xml:id="eco_de_0000140_16760">
+    <p xml:id="eco_de_0000210_16760">
      Es ist ein Schnitter, der heisst Tod, Der hat Gewalt vom ew'gen Gott …«
     </p>
-    <p xml:id="eco_de_0000140_16770">
+    <p xml:id="eco_de_0000210_16770">
      »Das ist aber so ernst!« meinten Lotti und Hans.
     </p>
-    <p xml:id="eco_de_0000140_16780">
+    <p xml:id="eco_de_0000210_16780">
      »Eben, wenn ich so da oben sitze an dem schönen Platz«, sagte Marianne, »dann mag ich gern ein ernstes Lied.«
     </p>
-    <p xml:id="eco_de_0000140_16790">
+    <p xml:id="eco_de_0000210_16790">
      Also sangen die drei Kinder vom Schnitter Tod und sahen in den hellen Abend hinaus. Die Schwalben flogen schwirrend über das Dach hin und her.
     </p>
-    <p xml:id="eco_de_0000140_16800">
+    <p xml:id="eco_de_0000210_16800">
      »Viel hunderttausend ungezählt, Da unter seiner Sichel fällt«,
     </p>
-    <p xml:id="eco_de_0000140_16810">
+    <p xml:id="eco_de_0000210_16810">
      begannen die Kinder die dritte Strophe.
     </p>
-    <p xml:id="eco_de_0000140_16820">
+    <p xml:id="eco_de_0000210_16820">
      »Rot Rosen, weiss Ilgen, Beid' wird er austilgen; Ihr stolzen Kaiserkronen, Man wird euch nicht schonen. Hüte sich, schön's Blümelein!«
     </p>
-    <p xml:id="eco_de_0000140_16830">
+    <p xml:id="eco_de_0000210_16830">
      Aber dann sahen sie einander an und wussten nicht mehr weiter.
     </p>
-    <p xml:id="eco_de_0000140_16840">
+    <p xml:id="eco_de_0000210_16840">
      »Trotz Tod! Komm her; ich fürcht' dich nit! Trotz, komm daher und tu dein Schnitt …«
     </p>
-    <p xml:id="eco_de_0000140_16850">
+    <p xml:id="eco_de_0000210_16850">
      klang es von unten, und die Turnachkinder setzten ein und sangen die letzte Strophe zu Ende.
     </p>
-    <p xml:id="eco_de_0000140_16860">
+    <p xml:id="eco_de_0000210_16860">
      Als das Lied verklungen war, sah Fritz Völkleins Kopf durch den Holunderbusch.
     </p>
-    <p xml:id="eco_de_0000140_16870">
+    <p xml:id="eco_de_0000210_16870">
      »Hallo! Da seid ihr alle beisammen! Hab' ich auch Platz? Das ist ein schönes Lied, eins meiner liebsten.«
     </p>
-    <p xml:id="eco_de_0000140_16880">
+    <p xml:id="eco_de_0000210_16880">
      Die Turnachkinder rückten etwas, und Fritz setzte sich neben Hans.
     </p>
-    <p xml:id="eco_de_0000140_16890">
+    <p xml:id="eco_de_0000210_16890">
      »Ja«, sagte Marianne, »wo es heisst: Trotz Tod, komm her; ich fürcht dich nit! wird einem ganz tapfer zu Mut. Man denkt, wenn der Tod käme, würde man sich wirklich nicht fürchten –«
     </p>
-    <p xml:id="eco_de_0000140_16900">
+    <p xml:id="eco_de_0000210_16900">
      »Der Tod sieht aber schrecklich aus; gelt, Fritz?« warf Lotti ein. »Er hat grosse schwarze Löcher statt Augen und lange Zähne, und nur Knochen im Gesicht und am Leibe. Uh –!«
     </p>
-    <p xml:id="eco_de_0000140_16910">
+    <p xml:id="eco_de_0000210_16910">
      »Zu Haus haben wir ein Bild, wo der Tod gar nicht schrecklich, sondern fast freundlich aussieht«, sagte Fritz. »Es stellt ein Turmzimmer das; der alte Turmwächter ist soeben gestorben. Durch das offene Fenster, unter dem ein kleiner Vogel sitzt, sieht man weit ins Land hinaus und zu den Bergen hinüber, wo die Sonne untergeht. Der Tod in langem Pilgerkleid zieht am Seile, um die Abendglocke zu läuten, ganz sanft, damit der alte Mann im Lehnstuhle nicht gestört werde. Es ist ein schönes Bild.«
     </p>
-    <p xml:id="eco_de_0000140_16920">
+    <p xml:id="eco_de_0000210_16920">
      »Gelt, halb schön und halb schaurig?« fragte Lotti. »Möchtest du ihn einmal sehen, den Tod?«
     </p>
-    <p xml:id="eco_de_0000140_16930">
+    <p xml:id="eco_de_0000210_16930">
      »Lotti, du musst dir das nicht so denken«, sagte Hans. »Es gibt doch keinen wirklichen Tod, der als Gerippe herumgeht, so wenig wie Gespenster.«
     </p>
-    <p xml:id="eco_de_0000140_16940">
+    <p xml:id="eco_de_0000210_16940">
      »Mama sagt auch, es gebe keine Gespenster«, fuhr Lotti fort, die gern von so etwas sprach. »Aber Grite hat mir eine Geschichte erzählt von ihrer Mutter; der ihr Vetter habe manchmal ein Gespenst gesehen mit feurigen Augen; das sei durch den Stall gegangen und habe die Kühe gestreichelt.«
     </p>
-    <p xml:id="eco_de_0000140_16950">
+    <p xml:id="eco_de_0000210_16950">
      Die beiden Knaben lachten.
     </p>
-    <p xml:id="eco_de_0000140_16960">
+    <p xml:id="eco_de_0000210_16960">
      »Dann war es wenigstens ein freundliches Gespenst. Lotti, Lotti, du wirst doch nicht an so etwas glauben!«
     </p>
-    <p xml:id="eco_de_0000140_16970">
+    <p xml:id="eco_de_0000210_16970">
      Doch Lotti liess sich nicht so schnell abbringen:
     </p>
-    <p xml:id="eco_de_0000140_16980">
+    <p xml:id="eco_de_0000210_16980">
      »Wenn es aber Gespenster gäbe, würdest du dich fürchten, Hans, wenn nachts eines zu dir ins Zimmer käme?«
     </p>
-    <p xml:id="eco_de_0000140_16990">
+    <p xml:id="eco_de_0000210_16990">
      »Ich fürchte mich überhaupt nicht!« sagte Hans stolz. »Es ist eine Feigheit, sich zu fürchten; nicht wahr, Fritz?«
     </p>
-    <p xml:id="eco_de_0000140_17000">
+    <p xml:id="eco_de_0000210_17000">
      »Nur nicht zu rasch, Hans. Mit dem Fürchten ist es so eine Sache. Wenn man am hellen Tag beisammen sitzt, sagt man leicht: Ich fürchte mich nie! Aber in der Nacht kann einem doch begegnen, dass man –«
     </p>
-    <p xml:id="eco_de_0000140_17010">
+    <p xml:id="eco_de_0000210_17010">
      »Du willst doch nicht sagen, dass du dich einmal gefürchtet habest –?« fragte Hans und sah Fritz erstaunt an.
     </p>
-    <p xml:id="eco_de_0000140_17020">
+    <p xml:id="eco_de_0000210_17020">
      »Doch, eben das will ich sagen«, gab Fritz zurück und schwieg dann, als ob er über etwas nachsinne.
     </p>
-    <p xml:id="eco_de_0000140_17030">
+    <p xml:id="eco_de_0000210_17030">
      »O, Fritz, erzähl' uns, was das war!« baten die Turnachkinder, und Lotti, der Freude und Erwartung immer gleich in alle Glieder fuhren, trommelte mit den Füssen auf die Dachziegel.
     </p>
-    <p xml:id="eco_de_0000140_17040">
+    <p xml:id="eco_de_0000210_17040">
      »Meinetwegen. Es ist eigentlich nicht viel«, fing Fritz an. »Also, ich machte vor zwei Jahren eine kleine Fussreise zum Grossonkel Andreas, dem Bruder von Tante Völklein. Er hat ein kleines Gut bei Flinbach mitten in den Reben. Als ich zum Urstein kam, war es etwa halb acht. Die Magd, die mir die Haustüre aufmachte, lachte und rief:
     </p>
-    <p xml:id="eco_de_0000140_17050">
+    <p xml:id="eco_de_0000210_17050">
      ›O, Herrjeh! Da kommt noch einer!‹
     </p>
-    <p xml:id="eco_de_0000140_17060">
+    <p xml:id="eco_de_0000210_17060">
      ›Was?‹ fragte ich. ›Wie viele sind denn schon da?‹
     </p>
-    <p xml:id="eco_de_0000140_17070">
+    <p xml:id="eco_de_0000210_17070">
      ›Drei‹, sagte sie. ›Aber kommen Sie nur herein, Fritz!‹
     </p>
-    <p xml:id="eco_de_0000140_17080">
+    <p xml:id="eco_de_0000210_17080">
      Sie führte mich auf die grosse Altane. Da war der Bruder von Tante Marie mit seinen zwei Töchtern. Und alles wollte bei Onkels übernachten. Sie sassen gerade beim Nachtessen.
     </p>
-    <p xml:id="eco_de_0000140_17090">
+    <p xml:id="eco_de_0000210_17090">
      ›Jetzt nimmt's mich wirklich wunder, wie man dich noch unterbringt –!‹ rief der Onkel mir zu und lachte mit seiner lauten Stimme. Er hiess mich hinsitzen und schob mir die Platten mit Schinken und mit Eierkuchen zu, während die Tante mir eine grosse Tasse voll Kaffee und Milch einschenkte. Sie haben dort immer Kaffee zum Abendessen.
     </p>
-    <p xml:id="eco_de_0000140_17100">
+    <p xml:id="eco_de_0000210_17100">
      Dann gab es eine eifrige Beratung, wo ich schlafen könnte, bis Fräulein Anna, die ältere der zwei Töchter, rief:
     </p>
-    <p xml:id="eco_de_0000140_17110">
+    <p xml:id="eco_de_0000210_17110">
      ›Tante, ihr hattet ja früher im Rebhäuschen ein Gastzimmer eingerichtet. Kann Fritz nicht dort übernachten? Mich dünkt, da müsste ein prächtiges Schlafen sein. Ich will gern hinaufziehen, wenn Fritz sich etwa fürchten sollte.‹
     </p>
-    <p xml:id="eco_de_0000140_17120">
+    <p xml:id="eco_de_0000210_17120">
      Fräulein Anna sah mich dabei lustig an. Sie ist eine Lehrerin und sehr klug und neckt einen gern.
     </p>
-    <p xml:id="eco_de_0000140_17130">
+    <p xml:id="eco_de_0000210_17130">
      ›Nein, Fräulein Anna, ich fürchte mich nicht‹, sagte ich, und die Tante stimmte ein:
     </p>
-    <p xml:id="eco_de_0000140_17140">
+    <p xml:id="eco_de_0000210_17140">
      ›Ja, Fritz, wenn's dir nicht zu einsam ist. Das Bett steht noch droben; Lisette hat dir's schnell gerichtet. So wäre die Schwierigkeit gehoben.‹
     </p>
-    <p xml:id="eco_de_0000140_17150">
+    <p xml:id="eco_de_0000210_17150">
      Wir sassen noch lange vergnügt beisammen. Endlich sagte ich ›Gute Nacht‹ und ging hinter Lisette durch den Garten und den Stufenweg hinauf. Sie sahen mir nach, und Fräulein Anna rief noch:
     </p>
-    <p xml:id="eco_de_0000140_17160">
+    <p xml:id="eco_de_0000210_17160">
      ›Also, Fritzchen, wenn die Angst kommt, so ruf' nur! Wir haben das Fenster offen!‹
     </p>
-    <p xml:id="eco_de_0000140_17170">
+    <p xml:id="eco_de_0000210_17170">
      ›Danke, Fräulein Anna‹, sagte ich und lachte. ›Ich brauche gewiss keine Hilfe.‹
     </p>
-    <p xml:id="eco_de_0000140_17180">
+    <p xml:id="eco_de_0000210_17180">
      Ich fand es herrlich, in dem Rebhaus zu übernachten, das seit uralten Zeiten am Flinbacher Berg steht. Es ist kein gewöhnliches Rebhaus, sondern ein kleiner Turm mit grauen Mauern und spitzigem Dach. Ich kam mir vor wie ein Schlossherr, als Lisette mit dem schweren Schlüssel die Türe aufmachte und wir die steile Treppe hinaufstiegen. Während Lisette mein Bett und einen Waschtisch herrichtete, machte ich das Fenster auf und sah hinaus. Der Mond war noch nicht ganz voll, schien aber hell über das Tal hin. Die Rebenhügel und Baumwiesen waren in einem feinen Glanz.
     </p>
-    <p xml:id="eco_de_0000140_17190">
+    <p xml:id="eco_de_0000210_17190">
      ›Nehmen Sie das Laternchen mit, Lisette‹, sagte ich. ›Der Mond leuchtet mir.‹
     </p>
-    <p xml:id="eco_de_0000140_17200">
+    <p xml:id="eco_de_0000210_17200">
      Lisette ging. Ich legte mich zu Bett, ziemlich müde; denn es war eine gehörige Fusstour gewesen. So kam der Schlaf bald. Das letzte, was ich noch hörte, war ein fernes Posthorn.
     </p>
-    <p xml:id="eco_de_0000140_17210">
+    <p xml:id="eco_de_0000210_17210">
      Also, ich schlief fest ein und hatte wahrscheinlich ein paar Stunden geschlafen, als ich plötzlich aufwachte. Mir war, als habe jemand leicht über meine Stirne gestrichen. Ich fuhr auf und sah um mich. Aber der Mond war untergegangen, es war dunkel in meiner Stube und still, totenstill. Ich horchte; dann dachte ich, ich hätte mich wohl getäuscht und legte mich wieder hin. Da – noch einmal fuhr's mir über das Gesicht, leise und unheimlich. Ich steckte den Kopf unter die Decke und blieb eine Weile so, bis ich nicht mehr atmen konnte. Als ich wieder hervorgeschlüpft war, versuchte ich, mir die Furcht auszureden. Doch bevor mir das gelang, kam's zum drittenmal. Beinahe hätte ich geschrien; aber ich dachte an Fräulein Anna und schämte mich. Ich horchte wieder, hörte aber nichts als mein Herz, das stark klopfte.
     </p>
-    <p xml:id="eco_de_0000140_17220">
+    <p xml:id="eco_de_0000210_17220">
      Ein Vogel, Käfer oder Nachtfalter konnte es nicht sein. Da würde man ein Flattern oder Schwirren gehört haben. Dass es so ganz lautlos kam und ging, war eben das Unheimliche. Es war doch nicht etwa ein Mensch im Zimmer? Ich hatte ja den Schlüssel innen umgedreht. Oder doch?
     </p>
-    <p xml:id="eco_de_0000140_17230">
+    <p xml:id="eco_de_0000210_17230">
      Ich setzte mich auf, nahm meinen Mut zusammen und rief:
     </p>
-    <p xml:id="eco_de_0000140_17240">
+    <p xml:id="eco_de_0000210_17240">
      ›Ist jemand da –?‹
     </p>
-    <p xml:id="eco_de_0000140_17250">
+    <p xml:id="eco_de_0000210_17250">
      Aber wenn man angefangen hat, sich zu fürchten, so macht einem die eigene Stimme bang. Noch einmal rief ich:
     </p>
-    <p xml:id="eco_de_0000140_17260">
+    <p xml:id="eco_de_0000210_17260">
      ›Bitte, ist jemand da –?‹
     </p>
-    <p xml:id="eco_de_0000140_17270">
+    <p xml:id="eco_de_0000210_17270">
      Dann schwieg ich, und als ich etwa fünf Minuten mich ruhig verhalten hatte, kam es wieder wie eine Geisterhand.
     </p>
-    <p xml:id="eco_de_0000140_17280">
+    <p xml:id="eco_de_0000210_17280">
      In so einem Augenblick nützt es gar nichts, zu wissen, dass es keine Gespenster gibt. Es graut einem doch vor irgend etwas Unbegreiflichem, Unmöglichem. Zum erstenmale im Leben fühlte ich, wie sich mir die Haare sträubten vor Entsetzen. Ich hielt es nicht mehr aus. Ich sprang aus dem Bett und stiess an das Laternchen, das Lisette doch auf dem Tisch hatte stehen lassen. Ich tastete und fand auch Streichhölzchen. Die Hand zitterte mir stank beim Anzünden.
     </p>
-    <p xml:id="eco_de_0000140_17290">
+    <p xml:id="eco_de_0000210_17290">
      Im Zimmer war nichts zu entdecken. Ich leuchtete hinter den grossen Schrank und unter das Bett; auch da fand ich nichts. Ich legte mich endlich wieder hin; das Licht aber löschte ich nicht aus; es war wie ein guter Freund, der mich beschützte: Die gespenstische Hand kam nicht wieder. Mit Bangen sah ich, wie das Kerzenstümpfchen tiefer und tiefer brannte. Doch als es erlöschte, da graute draussen schon der Morgen, und von Flinbach herauf hörte ich einen Hahnenschrei. Da kam eine grosse angenehme Müdigkeit über mich, und ich schlief ein.«
     </p>
-    <p xml:id="eco_de_0000140_17300">
+    <p xml:id="eco_de_0000210_17300">
      Fritz schwieg einen Augenblick.
     </p>
-    <p xml:id="eco_de_0000140_17310">
+    <p xml:id="eco_de_0000210_17310">
      Lotti, die in höchster Spannung zugehört hatte, ergriff sofort das Wort:
     </p>
-    <p xml:id="eco_de_0000140_17320">
+    <p xml:id="eco_de_0000210_17320">
      »Das war grässlich, Fritz! Aber zum Zuhören ist es prachtvoll! Jetzt geh' ich dann gleich zu Grite und sag' ihr, ich wisse auch eine Gespenstergeschichte!«
     </p>
-    <p xml:id="eco_de_0000140_17330">
+    <p xml:id="eco_de_0000210_17330">
      »Lotti«, wehrte Hans, »jetzt störst du den Fritz wieder, bevor man noch das Ende von der ganzen Sache weiss –!«
     </p>
-    <p xml:id="eco_de_0000140_17340">
+    <p xml:id="eco_de_0000210_17340">
      »Ja«, sagte Fritz, »und das Ende einer Gespenstergeschichte ist meistens die Hauptsache! Also, ich schlief, bis ich durch die Stimme des Onkels geweckt wurde. Er hatte einen Gang durch seine Reben gemacht, und ich hörte ihn zum Haus hinunter rufen:
     </p>
-    <p xml:id="eco_de_0000140_17350">
+    <p xml:id="eco_de_0000210_17350">
      ›Es ist schon über acht Uhr! Aber wir lassen ihn schlafen. Er ist gestern weit marschiert.‹
     </p>
-    <p xml:id="eco_de_0000140_17360">
+    <p xml:id="eco_de_0000210_17360">
      Da stand ich auf und war bald unten auf der Altane. Die andern hatten längst gefrühstückt. Lisette brachte mir den gewärmten Kaffee. Auch Fräulein Anna kam mit einem Strauss Herbstenzianen; sie war schon am Berg oben gewesen.
     </p>
-    <p xml:id="eco_de_0000140_17370">
+    <p xml:id="eco_de_0000210_17370">
      ›Gut geschlafen im Turm, Herr Fritz?‹ fragte sie.
     </p>
-    <p xml:id="eco_de_0000140_17380">
+    <p xml:id="eco_de_0000210_17380">
      ›Fräulein Anna‹, sagte ich, ›wenn Sie die nächste Nacht da oben wohnen wollen – ich trete Ihnen mein Logis gerne ab. Es war ein wenig ungemütlich!‹
     </p>
-    <p xml:id="eco_de_0000140_17390">
+    <p xml:id="eco_de_0000210_17390">
      Und dann erzählte ich ihr und dem Onkel, der mit Fräulein Hermine herzugetreten war, die ganze Geschichte.
     </p>
-    <p xml:id="eco_de_0000140_17400">
+    <p xml:id="eco_de_0000210_17400">
      ›Das ist ja greulich!‹ sagte Fräulein Anna. ›Onkel, ich tue keinen Schritt mehr in diesen Geisterturm, wenn man nicht herausbringt, was das war!‹
     </p>
-    <p xml:id="eco_de_0000140_17410">
+    <p xml:id="eco_de_0000210_17410">
      Der Onkel schüttelte zuerst den Kopf. Auf einmal lachte er und sagte:
     </p>
-    <p xml:id="eco_de_0000140_17420">
+    <p xml:id="eco_de_0000210_17420">
      ›Du, Fritz, ich glaube fast, ich sei dem Gespenst auf der Spur –‹
     </p>
-    <p xml:id="eco_de_0000140_17430">
+    <p xml:id="eco_de_0000210_17430">
      Wir gingen zusammen in den Turm. Der Onkel stieg vom Stuhl am Fenster auf das Gesimse und griff behutsam hinauf in den Raum zwischen Laden und Fenster. Wir sahen erwartungsvoll zu.
     </p>
-    <p xml:id="eco_de_0000140_17440">
+    <p xml:id="eco_de_0000210_17440">
      ›So‹, sagte der Onkel, ›da haben wir die Geisterhand –!‹
     </p>
-    <p xml:id="eco_de_0000140_17450">
+    <p xml:id="eco_de_0000210_17450">
      Und was hielt er uns entgegen, als er herunterstieg –? Eine Fledermaus!
     </p>
-    <p xml:id="eco_de_0000140_17460">
+    <p xml:id="eco_de_0000210_17460">
      Eine kleine, ungefährliche Fledermaus, die in ihre Flügel eingewickelt war wie in einen grauen, weichen Mantel und die winzigen Augen gar nicht aufmachen konnte in der hellen Sonne.
     </p>
-    <p xml:id="eco_de_0000140_17470">
+    <p xml:id="eco_de_0000210_17470">
      Alle lachten, als sie das Tierchen der Reihe nach in die Hand nahmen, und ich dachte, ich müsste mich recht schämen. Aber der Onkel sagte, eine Fledermaus, die so ganz geräuschlos nachts im Zimmer herumfahre, sei wirklich etwas Unheimliches. Er habe einmal eine, die nicht mehr den Ausweg aus seiner Stube gefunden, bei Licht fliegen sehen mit dem seltsamen Kopf und den weit ausgespannten Flügeln, und er habe gedacht, wenn es Gespenster gäbe, müssten sie aussehen wie eine Fledermaus.« –
     </p>
-    <p xml:id="eco_de_0000140_17480">
+    <p xml:id="eco_de_0000210_17480">
      »Fritz«, fragte Lotti, »was hättest du getan, wenn das Laternchen nicht auf dem Tisch gestanden wäre –? Hättest du um Hilfe geschrien –?«
     </p>
-    <p xml:id="eco_de_0000140_17490">
+    <p xml:id="eco_de_0000210_17490">
      »Das würdet ihr beide jedenfalls getan haben, Lotti, schon gleich am Anfang!« sagte Hans.
     </p>
-    <p xml:id="eco_de_0000140_17500">
+    <p xml:id="eco_de_0000210_17500">
      »Wer weiss –!« verteidigte sich Lotti. »Wir sind ziemlich mutig, gelt du, Marianne!«
     </p>
-    <p xml:id="eco_de_0000140_17510">
+    <p xml:id="eco_de_0000210_17510">
      »Oho, Lotti, oho!« lachten Fritz und Hans.
     </p>
-    <p xml:id="eco_de_0000140_17520">
+    <p xml:id="eco_de_0000210_17520">
      Lotti wurde eifriger:
     </p>
-    <p xml:id="eco_de_0000140_17530">
+    <p xml:id="eco_de_0000210_17530">
      »Jetzt wollte ich gerade, es gäbe bald einmal etwas nachts in unserm Zimmer, damit wir zeigen könnten, wie wir sind –!«
     </p>
-    <p xml:id="eco_de_0000140_17540">
+    <p xml:id="eco_de_0000210_17540">
      »So, wolltest du –!« fragte Fritz.
     </p>
-    <p xml:id="eco_de_0000140_17550">
+    <p xml:id="eco_de_0000210_17550">
      »Ja«, meinte Marianne, »nun wird aber nicht gleich etwas begegnen.«
     </p>
-    <p xml:id="eco_de_0000140_17560">
+    <p xml:id="eco_de_0000210_17560">
      »Das kann man nie wissen«, sagte Fritz und lächelte so ein wenig vor sich hin.
     </p>
-    <p xml:id="eco_de_0000140_17570">
+    <p xml:id="eco_de_0000210_17570">
      Bald darauf rief Sophie die Kinder, und Fritz musste heim.
     </p>
-    <p xml:id="eco_de_0000140_17580">
+    <p xml:id="eco_de_0000210_17580">
      Es war zwei Wochen später; die Kinder dachten nicht mehr an die Gespenstergeschichte. Marianne und Lotti lagen in ihren Betten. Da erwachte Marianne mitten in der Nacht und horchte auf: Was hatte denn Lotti zu rascheln und zu knistern –?
     </p>
-    <p xml:id="eco_de_0000140_17590">
+    <p xml:id="eco_de_0000210_17590">
      »Lotti, was tust du? Schlaf doch!« rief Marianne halblaut hinüber.
     </p>
-    <p xml:id="eco_de_0000140_17600">
+    <p xml:id="eco_de_0000210_17600">
      Lotti gab keine Antwort, und da Marianne lauschte, hörte sie langsame, regelmässige Atemzüge. Lotti schlief. Aber was war denn jetzt wieder das seltsame Rasseln und Tappen –?
     </p>
-    <p xml:id="eco_de_0000140_17610">
+    <p xml:id="eco_de_0000210_17610">
      »Lotti!« rief Marianne lauter. »Wie kannst du denn schlafen, wenn etwas immer so sonderbar tut! Hör doch –!«
     </p>
-    <p xml:id="eco_de_0000140_17620">
+    <p xml:id="eco_de_0000210_17620">
      Lotti liess ein undeutliches Gebrumm vernehmen. Sie war sehr unzufrieden, aufgeweckt zu werden. Aber Marianne gab nicht nach:
     </p>
-    <p xml:id="eco_de_0000140_17630">
+    <p xml:id="eco_de_0000210_17630">
      »Horch, Lotti – jetzt –!«
     </p>
-    <p xml:id="eco_de_0000140_17640">
+    <p xml:id="eco_de_0000210_17640">
      Lotti setzte sich auf; sie hörte nichts.
     </p>
-    <p xml:id="eco_de_0000140_17650">
+    <p xml:id="eco_de_0000210_17650">
      »Marianne«, sagte sie, »du hast gewiss nur geträumt. Manchmal träumt man so stark, dass man meint, es sei wahr. Vorletzte Nacht hab' ich auch geträumt, Sophie stehe am Bügelofen, und aus dem Ofen kommen grosse gelbe Flammen, und Sophies Kleid fange an zu brennen, und ich wollte –«
     </p>
-    <p xml:id="eco_de_0000140_17660">
+    <p xml:id="eco_de_0000210_17660">
      Lotti hätte ihre ganze, lange Traumgeschichte zum besten gegeben, wenn Marianne sie nicht unterbrochen hätte:
     </p>
-    <p xml:id="eco_de_0000140_17670">
+    <p xml:id="eco_de_0000210_17670">
      »Still, Lotti – jetzt kommt's wieder –!«
     </p>
-    <p xml:id="eco_de_0000140_17680">
+    <p xml:id="eco_de_0000210_17680">
      Diesmal hörte auch Lotti ein leises, seltsames Rasseln und Reiben.
     </p>
-    <p xml:id="eco_de_0000140_17690">
+    <p xml:id="eco_de_0000210_17690">
      »Ich rufe Mama!« sagte Lotti. »Es ist etwas Schreckliches hinten an der Türe!«
     </p>
-    <p xml:id="eco_de_0000140_17700">
+    <p xml:id="eco_de_0000210_17700">
      »Lotti« wisperte Marianne, »jetzt ist es, glaube ich, unter meinem Bett –! Aber wir wollen noch nicht rufen, sonst lachen uns nachher Fritz und Hans aus. Weisst du, wir sagten ja, wir könnten schon mutig sein!«
     </p>
-    <p xml:id="eco_de_0000140_17710">
+    <p xml:id="eco_de_0000210_17710">
      »Ja, aber das unter deinem Bett ist jedenfalls ärger als eine Fledermaus! Ich – ich mag gar nicht, wenn im Dunkeln auf einmal etwas so tönt! O, o – jetzt fängt es wieder an!«
     </p>
-    <p xml:id="eco_de_0000140_17720">
+    <p xml:id="eco_de_0000210_17720">
      »Nein, Lotti, sei doch still! Das bin ja ich!«
     </p>
-    <p xml:id="eco_de_0000140_17730">
+    <p xml:id="eco_de_0000210_17730">
      Marianne hatte auf dem Tisch hinter sich gesucht und war an die Schachtel mit Streichhölzchen gestossen. Die Kerze aber fand sie nicht.
     </p>
-    <p xml:id="eco_de_0000140_17740">
+    <p xml:id="eco_de_0000210_17740">
      »Lotti, nun gib acht, wenn ich anzünde, ob du von dir aus nichts sehen kannst!«
     </p>
-    <p xml:id="eco_de_0000140_17750">
+    <p xml:id="eco_de_0000210_17750">
      Marianne strich; das erste Streichholz brach ab; das zweite fiel hinunter; das dritte löschte gleich.
     </p>
-    <p xml:id="eco_de_0000140_17760">
+    <p xml:id="eco_de_0000210_17760">
      »Du hast Angst«, sagte Lotti, die hinüber sah.
     </p>
-    <p xml:id="eco_de_0000140_17770">
+    <p xml:id="eco_de_0000210_17770">
      Endlich das fünfte Hölzchen brannte. Aber weit konnte Lotti bei dem schwachen Lichte nicht sehen.
     </p>
-    <p xml:id="eco_de_0000140_17780">
+    <p xml:id="eco_de_0000210_17780">
      »Lotti, wenn du aufstündest, könntest du bis an die Wand sehen«, schlug Marianne vor, während sie ein sechstes Hölzchen anstrich.
     </p>
-    <p xml:id="eco_de_0000140_17790">
+    <p xml:id="eco_de_0000210_17790">
      »Du kannst ganz gut selber aufstehen«, erwiderte Lotti »dann komm ich auch.«
     </p>
-    <p xml:id="eco_de_0000140_17800">
+    <p xml:id="eco_de_0000210_17800">
      Da der unheimliche Ton nicht mehr zu hören war, sprang Marianne tapfer mit einem weiten Satze aus dem Bett, und Lotti kroch auch heraus. Die Mädchen kauerten nun beide am Boden und sahen beim Schein eines neuen Streichholzes unter das Bett.
     </p>
-    <p xml:id="eco_de_0000140_17810">
+    <p xml:id="eco_de_0000210_17810">
      Plötzlich fing Lotti leise an zu lachen.
     </p>
-    <p xml:id="eco_de_0000140_17820">
+    <p xml:id="eco_de_0000210_17820">
      »Marianne, wir sind grässlich dumm –! Das ist ja Werners grosser Ball; der ist vielleicht ein wenig hin und her gerollt an der Wand, und das war der sonderbare Ton –!«
     </p>
-    <p xml:id="eco_de_0000140_17830">
+    <p xml:id="eco_de_0000210_17830">
      Die beiden Kinder guckten kichernd nach dem Ball, und Marianne, nun ganz übermütig, zündete drei Streichhölzer mit einander an, um recht zu sehen. Da auf einmal – fing der Ball an sich zu bewegen! Erst langsam, dann schneller kam er auf die Kinder zu mit einem unheimlichen Knistern und Rasseln.
     </p>
-    <p xml:id="eco_de_0000140_17840">
+    <p xml:id="eco_de_0000210_17840">
      Das war zu schrecklich. Marianne und Lotti fuhren entsetzt zurück.
     </p>
-    <p xml:id="eco_de_0000140_17850">
+    <p xml:id="eco_de_0000210_17850">
      »Ein Gespenst, Marianne – ein Gespenst –! Es kann sehr gut runde Gespenster geben!« schrie Lotti.
     </p>
-    <p xml:id="eco_de_0000140_17860">
+    <p xml:id="eco_de_0000210_17860">
      Die drei Streichhölzer erlöschten; Marianne lief im Finstern nach der Türe und stiess an den kleinen Tisch, so dass Bücher und Hefte auf den Boden fielen. Lotti schoss nach der andern Seite, gerade auf den Stuhl los, der mit Gepolter hinstürzte und auch den Puppenwagen mitnahm, in welchem Ella und Julchen ruhten. Lotti fuhr zurück, tat aber im selben Augenblick einen lauten Schrei, weil sie mit dem Fuss an etwas ganz Sonderbares, Stachliges gestossen war; das pickte wie mit zwanzig Nadeln! Sie machte einen Sprung und prallte an die Schwester – nun lag alles übereinander am Boden, Bücher, Stuhl, Puppenwagen, Ella und Julchen, Marianne und Lotti! »Mama, Mama –« schrien die beiden aus Leibeskräften und wagten vor Schrecken gar nicht aufzustehen.
     </p>
-    <p xml:id="eco_de_0000140_17870">
+    <p xml:id="eco_de_0000210_17870">
      Mama aber machte schon die Türe auf mit einem Lichte in der Hand.
     </p>
-    <p xml:id="eco_de_0000140_17880">
+    <p xml:id="eco_de_0000210_17880">
      »Ja, Kinder! Was ist denn das für ein Lärm –?« sagte sie und half den Mädchen und dann dem Stuhl auf die Beine.
     </p>
-    <p xml:id="eco_de_0000140_17890">
+    <p xml:id="eco_de_0000210_17890">
      »Ach, Mama, es – es ist etwas Grässliches in unserm Zimmer –« Lotti schluchzte und Marianne konnte auch kaum sprechen. »Zuerst war es bloss ein Ball und dann fing es an zu laufen und stach mich in den Fuss und warf den Stuhl um –« die Kinder wussten gar nicht, wie alles geschehen war.
     </p>
-    <p xml:id="eco_de_0000140_17900">
+    <p xml:id="eco_de_0000210_17900">
      »– und frass uns auf! – Grauenvoll, höchst grauenvoll!« sagte Papa, der nun auch im Schlafrock erschien. »Ihr seid angenehme Zimmernachbarn!«
     </p>
-    <p xml:id="eco_de_0000140_17910">
+    <p xml:id="eco_de_0000210_17910">
      »Papa, wenn du wüsstest –! Wir waren zuerst tapfer und haben nicht gerufen; aber es war zu furchtbar!«
     </p>
-    <p xml:id="eco_de_0000140_17920">
+    <p xml:id="eco_de_0000210_17920">
      »Ja, ja, ihr habt euch als Heldenjungfrauen betragen! Nun, wo befindet sich denn der geheimnisvolle Ball –?«
     </p>
-    <p xml:id="eco_de_0000140_17930">
+    <p xml:id="eco_de_0000210_17930">
      »Dort – dort ist er wieder –!« beutete Marianne in die Ecke.
     </p>
-    <p xml:id="eco_de_0000140_17940">
+    <p xml:id="eco_de_0000210_17940">
      Papa trat hin und fing an zu lachen.
     </p>
-    <p xml:id="eco_de_0000140_17950">
+    <p xml:id="eco_de_0000210_17950">
      »Nein, nein, Papa!« flüsterte Lotti. »Du musst nicht lachen. Wir haben auch gelacht. Da wird er böse und kommt auf dich los!«
     </p>
-    <p xml:id="eco_de_0000140_17960">
+    <p xml:id="eco_de_0000210_17960">
      Papa hörte nicht auf die Warnung seiner Tochter. Er nahm ein Handtuch doppelt und rollte die Kugel, die sich zurückziehen wollte, behutsam hinein.
     </p>
-    <p xml:id="eco_de_0000140_17970">
+    <p xml:id="eco_de_0000210_17970">
      »So, Kinder –! Dass er dich ein bisschen gestochen hat, glaub' ich, Lotti. Das liegt so in seiner Gewohnheit. Im übrigen ist er sehr harmloser Art.«
     </p>
-    <p xml:id="eco_de_0000140_17980">
+    <p xml:id="eco_de_0000210_17980">
      »Ein Igel!« rief Mama. Die Kinder streckten die Köpfe, und ihre Angst ging plötzlich in Vergnügen über. Sie knieten vor das wunderliche Tier hin, das Papa auf den Boden legte. Es war über und über mit gelbbräunlichen Stacheln bedeckt. Sein Kopf endete in eine spitze dunkle Schnauze mit feuchtem Näslein. Die kleinen schwarzen Äuglein, die im Lichte zwinkerten, sahen drollig und treuherzig drein. Manchmal fuhr der komische Kleine zusammen und pustete wie ein Hund. Papa schüttelte das Tuch, so dass der Igel auf den Rücken kam und man seine kurzen Beinchen mit den festen Krallen sah.
     </p>
-    <p xml:id="eco_de_0000140_17990">
+    <p xml:id="eco_de_0000210_17990">
      Lotti schloss das »runde Gespenst« sofort in ihr Herz. Immer wieder vergass sie, dass sein Fell kein Katzenpelz war und wollte streichelnd darüber fahren.
     </p>
-    <p xml:id="eco_de_0000140_18000">
+    <p xml:id="eco_de_0000210_18000">
      »Au!« schrie sie. »Aber er ist reizend! Marianne, sieh, wie er niedlich schnuppert!«
     </p>
-    <p xml:id="eco_de_0000140_18010">
+    <p xml:id="eco_de_0000210_18010">
      Papa gab dem Igel einen kleinen Stoss; das Tier zog Kopf und Beine gegen die Unterseite ein, so dass man rundum nichts mehr sah als die Stacheln.
     </p>
-    <p xml:id="eco_de_0000140_18020">
+    <p xml:id="eco_de_0000210_18020">
      »Jetzt macht er wieder den Ball, Papa!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000140_18030">
+    <p xml:id="eco_de_0000210_18030">
      »Ja«, sagte Papa, »und es ist ein Glück für ihn, dass er das kann. Wenn Hunde oder andere Tiere ihn angreifen, dann setzt er sich in Verteidigung, indem er nach allen Seiten seine kleinen Spiesse ausstreckt.«
     </p>
-    <p xml:id="eco_de_0000140_18040">
+    <p xml:id="eco_de_0000210_18040">
      »Was frisst er, Papa?«
     </p>
-    <p xml:id="eco_de_0000140_18050">
+    <p xml:id="eco_de_0000210_18050">
      »O, alles mögliche: Schnecken, Würmer, Frösche, Mäuse, und dann auch Obst –«
     </p>
-    <p xml:id="eco_de_0000140_18060">
+    <p xml:id="eco_de_0000210_18060">
      »Ja, meine lieben Leute, soll das eine Naturgeschichtsstunde geben mitten in der Nacht –?« unterbrach Mama. »Schnell, schnell in euere Betten, Kinder! Schlaft rasch ein und träumt schön von dem Stacheltier!«
     </p>
-    <p xml:id="eco_de_0000140_18070">
+    <p xml:id="eco_de_0000210_18070">
      Papa nahm den Igel, um ihn in den Garten zu bringen. Aber Marianne und Lotti baten flehentlich, dass man das nette Tier in die grosse leere Holzkiste tue, damit Hans es morgen doch auch sehe.
     </p>
-    <p xml:id="eco_de_0000140_18080">
+    <p xml:id="eco_de_0000210_18080">
      »Oder wollen wir ihn jetzt gleich herunter rufen?« fragte Lotti eifrig.
     </p>
-    <p xml:id="eco_de_0000140_18090">
+    <p xml:id="eco_de_0000210_18090">
      »Nein, Lotti, kleiner Hitzkopf! Morgen ist auch ein Tag. Da habt ihr immer noch Zeit, Hans die Igelgeschichte zu erzählen und euch auslachen zu lassen.«
     </p>
-    <p xml:id="eco_de_0000140_18100">
+    <p xml:id="eco_de_0000210_18100">
      »Papa«, sagte Marianne, »ich besinne mich immer, wie wohl der Igel in unser Zimmer gekommen ist!«
     </p>
-    <p xml:id="eco_de_0000140_18110">
+    <p xml:id="eco_de_0000210_18110">
      »Ja, darüber liesse sich nachdenken. Mach du jetzt schnell die Augen zu, Marianndel, dann fällt's dir vielleicht im Schlafe ein!« –
     </p>
-    <p xml:id="eco_de_0000140_18120">
+    <p xml:id="eco_de_0000210_18120">
      Am andern Morgen musste Hans zu allererst den Igel besehen. Als er dann die Gespenstergeschichte hörte, wollte er sich halb tot lachen.
     </p>
-    <p xml:id="eco_de_0000140_18130">
+    <p xml:id="eco_de_0000210_18130">
      »Das ist famos!« rief er. »Das ist famos! Wenn nur Fritz heute abend kommt, damit man ihm die Sache erzählen kann. Ihr seid Hasen – nein, was seid ihr für Hasen –!«
     </p>
-    <p xml:id="eco_de_0000140_18140">
+    <p xml:id="eco_de_0000210_18140">
      Auf einmal bekam er einen neuen Lachanfall; er setzte sich und schlug mit beiden Händen auf die Knie. »Jetzt weiss ich – jetzt weiss ich –«
     </p>
-    <p xml:id="eco_de_0000140_18150">
+    <p xml:id="eco_de_0000210_18150">
      Lotti und Marianne standen vor ihm.
     </p>
-    <p xml:id="eco_de_0000140_18160">
+    <p xml:id="eco_de_0000210_18160">
      »Tu doch nicht so!« sagte Lotti. »Was weisst du denn –?«
     </p>
-    <p xml:id="eco_de_0000140_18170">
+    <p xml:id="eco_de_0000210_18170">
      »Meinst du am Ende, Fritz habe den Igel – nein, das wäre doch zu arg!« unterbrach sich Marianne.
     </p>
-    <p xml:id="eco_de_0000140_18180">
+    <p xml:id="eco_de_0000210_18180">
      »Ja eben, das meine ich!« sagte Hans unter fortwährendem Lachen. »Das ist gar nicht zu arg! Das war ein feiner Einfall von Fritz!«
     </p>
-    <p xml:id="eco_de_0000140_18190">
+    <p xml:id="eco_de_0000210_18190">
      Als Fritz am Abend den Weg herunter kam, rannten ihm alle drei Kinder entgegen.
     </p>
-    <p xml:id="eco_de_0000140_18200">
+    <p xml:id="eco_de_0000210_18200">
      »Du hast's getan, Fritz! Du hast ihn in unser Zimmer gebracht!«
     </p>
-    <p xml:id="eco_de_0000140_18210">
+    <p xml:id="eco_de_0000210_18210">
      »Wen –? Was –?« Fritz versuchte, erstaunt auszusehen; aber es ging nicht lange, so gestand er seine Tat und erzählte, während er mit den Turnachkindern zu dem Igel ging, dass er ihn vom alten Lienhard erhalten hatte und dass er gestern abend schnell durchs Fenster in das Zimmer der Kinder gesprungen sei, um den Igel in eine Ecke zu setzen.
     </p>
-    <p xml:id="eco_de_0000140_18220">
+    <p xml:id="eco_de_0000210_18220">
      »Es hat seine Rolle gut zu spielen verstanden und listig gewartet mit Herumrascheln, bis ihr beide eingeschlafen seid!«
     </p>
-    <p xml:id="eco_de_0000140_18230">
+    <p xml:id="eco_de_0000210_18230">
      Der Igel befand sich jetzt in einem Verschlag im Garten; Papa hatte erlaubt, dass man ihn noch bis zum folgenden Tag behalte, wo Onkel Alfred erwartet wurde. Der Igel schien sich ganz behaglich zu fühlen und schnupperte an einem Stückchen Apfel, das Werner ihm gebracht. Der Kleine war den ganzen Tag nicht wegzubringen gewesen von dem Stacheltier, das so seltsam aussah und so komisch am Boden herumfuhr. Höchstens lief er vom Verschlag zu Mama, dass sie ihm noch einmal und noch einmal erzähle, wie das in der Nacht bei den Schwestern zugegangen sei.
     </p>
-    <p xml:id="eco_de_0000140_18240">
+    <p xml:id="eco_de_0000210_18240">
      »Wenn es einmal so raschelt unter meinem Bett, dann fürcht' ich mich gar nicht!« erklärte der Kleine. »Dann sag' ich bloss: ›Das ist ein Igel‹. Und dann zünden wir ein Licht an und gucken ihm zu.«
     </p>
-    <p xml:id="eco_de_0000140_18250">
+    <p xml:id="eco_de_0000210_18250">
      »Ja, mein Schatz«, lachte Mama. »Es fehlt gerade, dass man nun auch bei dir noch die Probe macht!«
     </p>
-    <p xml:id="eco_de_0000140_18260">
+    <p xml:id="eco_de_0000210_18260">
      Am zweiten Morgen aber war zur grossen Bestürzung der Kinder kein Igel mehr zu sehen! Es war ihm offenbar zu eng geworden, und in der Nacht hatte er, statt zu schlafen, unter einem Brette des Verschlages dich hindurchgegraben. Das Loch in der Ecke zeigte die Stelle. Auch im Garten war der Igel nicht mehr zu finden. –
     </p>
-    <p xml:id="eco_de_0000140_18270">
+    <p xml:id="eco_de_0000210_18270">
      Doch von ihrem nächtlichen Abenteuer mussten Marianne und Lotti noch lange hören.
     </p>
-    <p xml:id="eco_de_0000140_18280">
+    <p xml:id="eco_de_0000210_18280">
      Mitten drin, wenn die Kinder mit Fritz auf der Seemauer oder auf dem Waschhausdach plauderten, klopfte Hans mit einem Stöckchen und rief wie ein Lehrer in strengem Ton:
     </p>
-    <p xml:id="eco_de_0000140_18290">
+    <p xml:id="eco_de_0000210_18290">
      »Also jetzt wollen wir die Gespenster repetieren! Fritz Völklein, sage mir, wie viele Arten gibt es?«
     </p>
-    <p xml:id="eco_de_0000140_18300">
+    <p xml:id="eco_de_0000210_18300">
      Dann räusperte sich Fritz und antwortete mit der hohen Stimme eines Erstklässlers:
     </p>
-    <p xml:id="eco_de_0000140_18310">
+    <p xml:id="eco_de_0000210_18310">
      »Es gibt sechs Arten von Gespenstern: Lange, kurze, dicke, dünne, viereckige und runde!«
     </p>
-    <p xml:id="eco_de_0000140_18320">
+    <p xml:id="eco_de_0000210_18320">
      »Gut, Fritz Völklein«, sagte Hans ernsthaft. »Kannst du mir noch sagen, welches die grässlichsten von allen Gespenstern sind?«
     </p>
-    <p xml:id="eco_de_0000140_18330">
+    <p xml:id="eco_de_0000210_18330">
      Dann sah Fritz nach Lotti und krähte:
     </p>
-    <p xml:id="eco_de_0000140_18340">
+    <p xml:id="eco_de_0000210_18340">
      »Die grässlichsten Gespenster sind die runden!«
     </p>
    </div>
@@ -5664,439 +5664,439 @@
     <head>
      Marianne sucht den verlorenen Werner und geht fast selbst verloren.
     </head>
-    <p xml:id="eco_de_0000140_18350">
+    <p xml:id="eco_de_0000210_18350">
      »Marianne, ist Werner bei euch?« rief Sophie, während sie mit einem Arm voll trockener Wäsche zum Haus ging.
     </p>
-    <p xml:id="eco_de_0000140_18360">
+    <p xml:id="eco_de_0000210_18360">
      »Nein! Er ist, glaub' ich, bei Frau Völklein«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_18370">
+    <p xml:id="eco_de_0000210_18370">
      Sie war gerade mit Lotti in Verhandlung wegen zweier Hüte. Marianne war eine Putzmacherin und hatte eine Auswahl von Hüten, die sie aus Blättern geschnitten und mit Tannadeln zusammengesteckt hatte, Kopf und Krempe. Lotti kam als eine Mama, um für ihre Kinder Sonntagshüte zu bestellen. Die Modistin zeigte ihr allerlei Aufputz, und nach reiflichem Erwägen wählte Mama Lotti dunkelblaue Bänder, aus der Blüte einer grossen Klematis geschnitten, und für vorn ein Bouquet feiner, weisser Blümchen.
     </p>
-    <p xml:id="eco_de_0000140_18380">
+    <p xml:id="eco_de_0000210_18380">
      Sophie legte ihre Wäsche zusammen. Nach einer Weile aber sah sie Frau Völklein vom Hühnerstall kommen ohne Werner.
     </p>
-    <p xml:id="eco_de_0000140_18390">
+    <p xml:id="eco_de_0000210_18390">
      »Vielleicht ist er bei Fritz und Hans«, meinte die alte Frau.
     </p>
-    <p xml:id="eco_de_0000140_18400">
+    <p xml:id="eco_de_0000210_18400">
      »Nein«, sagte Mama, die auch hinzutrat. »Die beiden sind auf den See hinausgefahren; Werner ist nicht dabei.« Sie ging in den Garten.
     </p>
-    <p xml:id="eco_de_0000140_18410">
+    <p xml:id="eco_de_0000210_18410">
      »Marianne, Lotti!« rief sie; »lasst euer Spiel und seht, wo Werner ist. Ich mag nicht, dass er sich so ganz allein herumtreibt.«
     </p>
-    <p xml:id="eco_de_0000140_18420">
+    <p xml:id="eco_de_0000210_18420">
      Die beiden Mädchen liefen rufend ums Haus, durch den Garten, dann in die Buchenlaube, in die hinteren Anlagen und wieder zurück. Aber Werner war nicht zu finden.
     </p>
-    <p xml:id="eco_de_0000140_18430">
+    <p xml:id="eco_de_0000210_18430">
      Währenddessen war Sophie in den Stall gegangen. Jakob sagte, er habe den kleinen Werner den ganzen Tag nicht gesehen.
     </p>
-    <p xml:id="eco_de_0000140_18440">
+    <p xml:id="eco_de_0000210_18440">
      Als Marianne und Lotti zum See kamen, wo Werner manchmal Muscheln suchte, stand Mama auch da, nach allen Seiten ausblickend.
     </p>
-    <p xml:id="eco_de_0000140_18450">
+    <p xml:id="eco_de_0000210_18450">
      »Wo mag er nur sein –?« sagte sie, und Marianne fühlte, das Mama in Angst war.
     </p>
-    <p xml:id="eco_de_0000140_18460">
+    <p xml:id="eco_de_0000210_18460">
      »Frau Turnach«, suchte Sophie zu beruhigen, »er kommt gewiss gleich irgendwoher gelaufen. Kürzlich rief ich auch lang. Da stand der kleine Schlingel ganz nah hinter dem Waschhaus.«
     </p>
-    <p xml:id="eco_de_0000140_18470">
+    <p xml:id="eco_de_0000210_18470">
      Frau Turnach schüttelte den Kopf. Sophie wusste wohl, dass sie ans Wasser dachte.
     </p>
-    <p xml:id="eco_de_0000140_18480">
+    <p xml:id="eco_de_0000210_18480">
      »Werner ist nicht so unbedacht, wenn er allein ist«, fuhr Sophie fort. »Und dann – überall geht's ja ganz flach hinaus. Höchstens wird er wieder einmal recht nass –«
     </p>
-    <p xml:id="eco_de_0000140_18490">
+    <p xml:id="eco_de_0000210_18490">
      »Aber der Färbergraben –!« warf Mama ein.
     </p>
-    <p xml:id="eco_de_0000140_18500">
+    <p xml:id="eco_de_0000210_18500">
      Sophie und die Kinder sahen einander an. Werner war hoffentlich nicht zum Färbergraben gegangen –! Der Färbergraben war eine schmale Bucht am Ende der hinteren Anlagen. Das Wasser des Grabens, das von der nahen Färberei immer trüb und dunkel gefärbt war, hatte eine ziemliche Tiefe.
     </p>
-    <p xml:id="eco_de_0000140_18510">
+    <p xml:id="eco_de_0000210_18510">
      »Es nützt nichts, hier zu stehen«, sagte Mama, indem sie sich zum Garten zurückwandte. »Wir müssen uns besinnen, wo Werner sein kann!«
     </p>
-    <p xml:id="eco_de_0000140_18520">
+    <p xml:id="eco_de_0000210_18520">
      »Mama«, rief Marianne, »jetzt fällt mir etwas ein! Wahrscheinlich ist Werner bei Frau Höfler. Als ich vorgestern mit ihm Brot holte, gab sie ihm drei Zuckermandeln. Da hat er gesagt, er komme bald wieder. Soll ich schnell hinauf laufen?«
     </p>
-    <p xml:id="eco_de_0000140_18530">
+    <p xml:id="eco_de_0000210_18530">
      »Ja, geh!« sagte Mama. Alle waren etwas erleichtert. Es war wirklich gut möglich, dass Werner auf einmal Lust nach Zuckermandeln bekommen hatte.
     </p>
-    <p xml:id="eco_de_0000140_18540">
+    <p xml:id="eco_de_0000210_18540">
      Doch als Marianne in den Bäckerladen trat, sass da Frau Höfler ganz allein und las in einer Zeitung.
     </p>
-    <p xml:id="eco_de_0000140_18550">
+    <p xml:id="eco_de_0000210_18550">
      »Nein, dein Brüderlein ist nicht da gewesen«, sagte sie, »Es ist ein herziger Bub; sag ihm nur, er solle mich bald wieder besuchen. Da – das sei von der Frau Höfler –«
     </p>
-    <p xml:id="eco_de_0000140_18560">
+    <p xml:id="eco_de_0000210_18560">
      Die freundliche Frau nahm ein paar braune Bonbons aus einer Glasbüchse.
     </p>
-    <p xml:id="eco_de_0000140_18570">
+    <p xml:id="eco_de_0000210_18570">
      Marianne dankte und steckte die Bonbons ein. Aber draussen blieb sie ratlos stehen und sah die Strasse auf und ab. Wo konnte sie den kleinen Werner finden?
     </p>
-    <p xml:id="eco_de_0000140_18580">
+    <p xml:id="eco_de_0000210_18580">
      Da kam ihr wieder ein Gedanke, und sie bog mit neuem Mut in den nächsten Seitenweg ein. Wenn man da hinaufging an der Kirche vorbei und über den Bach, dann kam die Wiese, die Frau Völklein gehörte und zu der die Kinder etwa mit Jakob fuhren, wenn er Gras oder Heu holte. In der Nähe stand ein kleines Haus; die Kinder nannten es das Katzenhäuslein, weil da ein Mann und eine Frau mit fünf oder sechs Katzen wohnten. Das letztemal waren gar noch vier ganz kleine, junge dagewesen; Werner hatte sich gar nicht trennen können davon, und heute morgen hatte er wieder von den Kätzlein gesprochen. »So trinken sie!« hatte er gesagt und dabei versucht, mit seiner Zunge die Milch aus der Untertasse zu lecken. Gewiss war Werner zu den Katzen gegangen!
     </p>
-    <p xml:id="eco_de_0000140_18590">
+    <p xml:id="eco_de_0000210_18590">
      Als Marianne vor das kleine Haus kam, stand der Mann auf einer Leiter und pflückte Birnen von seinem Spalier.
     </p>
-    <p xml:id="eco_de_0000140_18600">
+    <p xml:id="eco_de_0000210_18600">
      »Guten Abend«, sagte Marianne höflich. »Ist nicht vielleicht mein Brüderlein da?«
     </p>
-    <p xml:id="eco_de_0000140_18610">
+    <p xml:id="eco_de_0000210_18610">
      Der alte Mann tat einen Schritt herunter und hielt die Hand ans Ohr:
     </p>
-    <p xml:id="eco_de_0000140_18620">
+    <p xml:id="eco_de_0000210_18620">
      »Dein – was?«
     </p>
-    <p xml:id="eco_de_0000140_18630">
+    <p xml:id="eco_de_0000210_18630">
      »Mein Brüderlein. Es ist blond und hat eine rot und weisse Schürze an«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_18640">
+    <p xml:id="eco_de_0000210_18640">
      Der Mann schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000140_18650">
+    <p xml:id="eco_de_0000210_18650">
      »Kinder laufen viele vorbei. Ob grad eins eine rot und weisse Schürze hatte, weiss ich nicht. Da im Haus war keines.«
     </p>
-    <p xml:id="eco_de_0000140_18660">
+    <p xml:id="eco_de_0000210_18660">
      Damit griff er nach einer schönen gelben Birne und kümmerte sich nicht weiter um Marianne, welche traurig zu ihm hinaufsah. Zwei grosse Katzen, eine schwarze und eine rötlich getigerte, strichen, zutraulich schnurrend, um sie herum. Aber sie konnten ihr auch nicht sagen, wo der kleine Werner war.
     </p>
-    <p xml:id="eco_de_0000140_18670">
+    <p xml:id="eco_de_0000210_18670">
      Vor einem Hause etwas weiter oben stand eine Frau am Waschzuber. Marianne trat zu ihr.
     </p>
-    <p xml:id="eco_de_0000140_18680">
+    <p xml:id="eco_de_0000210_18680">
      »Haben Sie kein Büblein gesehen mit blonden Haaren und einer rot und weissen Schürze?«
     </p>
-    <p xml:id="eco_de_0000140_18690">
+    <p xml:id="eco_de_0000210_18690">
      »Ein Büblein? Ist es dein Brüderlein?« fragte die Frau freundlich und neugierig und wischte den Seifenschaum von den Händen. »Ist es euch davongelaufen? Ja, zu so Kleinen muss man sehen, sonst gibt's leicht etwas. Wie heissest du? Wie heisst das Brüderlein? Wie viele seid ihr? Was ist dein Papa? …«
     </p>
-    <p xml:id="eco_de_0000140_18700">
+    <p xml:id="eco_de_0000210_18700">
      Marianne kam kaum nach mit Antworten. Doch tat ihr die Teilnahme wohl, und als die Frau noch einmal fragte:
     </p>
-    <p xml:id="eco_de_0000140_18710">
+    <p xml:id="eco_de_0000210_18710">
      »Also blond ist es? Und eine rot und weisse Schürze, sagst du, habe es an?« da war Marianne, als ob die Frau sie jetzt dann gleich zu dem kleinen Werner führe.
     </p>
-    <p xml:id="eco_de_0000140_18720">
+    <p xml:id="eco_de_0000210_18720">
      »Nein, wahrhaftig, es tut mir leid – gesehen habe ich kein solches Büblein«, fuhr aber die redselige Frau fort. »Hingegen bin ich noch nicht lang da; es kann deswegen doch vorbeigegangen sein. Frag' doch einmal dort beim kleinen Tannenhof. Die lahme Christine sitzt den ganzen Tag vor dem Hause und sieht alles, was hin und her geht. Wenn du das Brüderlein gefunden hast, so komm' dann wieder da vorbei, dass ich es auch sehe!«
     </p>
-    <p xml:id="eco_de_0000140_18730">
+    <p xml:id="eco_de_0000210_18730">
      Marianne versprach es und ging auf den »kleinen Tannenhof« zu, rechts den Weg hinan.
     </p>
-    <p xml:id="eco_de_0000140_18740">
+    <p xml:id="eco_de_0000210_18740">
      Die lahme Christine war ein junges Mädchen mit blassem Gesicht und scharfen braunen Augen.
     </p>
-    <p xml:id="eco_de_0000140_18750">
+    <p xml:id="eco_de_0000210_18750">
      »Ein Büblein –? Ja, eine ganze Menge Kinder, Buben und Mädchen, sind vorbeigelaufen, alle hinter einem fremden Mann, der einen Affen auf der Schulter hatte, einen allerliebsten kleinen Affen. Und wart' – ja, ja, ich meine, zu hinterst sei ein Büblein gewesen mit rot und weisser Schürze und blonden Haaren. – Hat er Löcklein, dein kleiner Bruder?«
     </p>
-    <p xml:id="eco_de_0000140_18760">
+    <p xml:id="eco_de_0000210_18760">
      »Ja, ja, nette Löcklein!« sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_18770">
+    <p xml:id="eco_de_0000210_18770">
      Die lahme Christine wies vor sich die Anhöhe hinauf.
     </p>
-    <p xml:id="eco_de_0000140_18780">
+    <p xml:id="eco_de_0000210_18780">
      »Da ist der Mann mit dem Äffchen weitergegangen, und der ganze Kinderschwarm hinter ihm. Aber es ist schon eine Weile seither.«
     </p>
-    <p xml:id="eco_de_0000140_18790">
+    <p xml:id="eco_de_0000210_18790">
      Marianne war nun ganz sicher, den kleinen Werner zu finden. Die Beschreibung passte genau, und natürlich – wenn Werner das Äffchen gesehen hatte, war er nachgelaufen.
     </p>
-    <p xml:id="eco_de_0000140_18800">
+    <p xml:id="eco_de_0000210_18800">
      Rasch ging Marianne die Strasse hinauf, die die lahme Christine gezeigt hatte. Zwei- oder dreimal, wo ein Kreuzweg war, fragte sie, und immer wusste man ihr zu sagen, welche Richtung der Mann mit dem Äffchen genommen hatte. Sie kam nach und nach aus den Häusern heraus. Hinter Wiesen und Obstbäumen lag am Berge schon der Wald. Links an der Strasse stand ein kleines Wirtshaus.
     </p>
-    <p xml:id="eco_de_0000140_18810">
+    <p xml:id="eco_de_0000210_18810">
      »Der Mann mit dem Äffchen –?« sagte ein Bursche, der mit einem Brotkorb aus dem Hause kam und den Marianne gefragt hatte. »Da drin sitzt er.«
     </p>
-    <p xml:id="eco_de_0000140_18820">
+    <p xml:id="eco_de_0000210_18820">
      Marianne sah sich um. Nirgends waren die Kinder zu sehen, von denen die lahme Christine gesprochen. Vielleicht waren sie bei dem Mann in der Stube. Marianne trat in den Hausgang und sah durch die halb offene Türe. Da sassen mehrere Männer, und vor ihnen auf dem Tische kauerte ein kleiner grauer Affe, der einen Apfel in der Hand hielt. Aber kein Kind und kein Werner war in der Wirtsstube zu sehen.
     </p>
-    <p xml:id="eco_de_0000140_18830">
+    <p xml:id="eco_de_0000210_18830">
      Marianne blieb regungslos an der Türe stehen. Es war eine zu bittere Enttäuschung. Sie hatte so sicher gemeint, Werner hier zu finden und ihn heim bringen zu können zu Mama.
     </p>
-    <p xml:id="eco_de_0000140_18840">
+    <p xml:id="eco_de_0000210_18840">
      Da drang eine ärgerliche Stimme den Gang hervor:
     </p>
-    <p xml:id="eco_de_0000140_18850">
+    <p xml:id="eco_de_0000210_18850">
      »Nun hab' ich gemeint, ich hätte das Kinderzeugs endlich fortgejagt! Jetzt steht wieder eins da – Macht, dass du aus dem Haus kommst! Der Affe ist jetzt nicht mehr zu sehen.«
     </p>
-    <p xml:id="eco_de_0000140_18860">
+    <p xml:id="eco_de_0000210_18860">
      Es war eine dicke Frau mit einem Brett voll Teller und Gläser.
     </p>
-    <p xml:id="eco_de_0000140_18870">
+    <p xml:id="eco_de_0000210_18870">
      »Ich suche nur meinen kleinen Bruder,« sagte Marianne und gab sich Mühe, nicht zu weinen.
     </p>
-    <p xml:id="eco_de_0000140_18880">
+    <p xml:id="eco_de_0000210_18880">
      »Deinen kleinen Bruder –? Es laufen viele kleine Brüder herum. Warum schaut ihr nicht besser zu ihnen!«
     </p>
-    <p xml:id="eco_de_0000140_18890">
+    <p xml:id="eco_de_0000210_18890">
      »Man hat mir gesagt, er sei dem Mann mit dem Äffchen nachgelaufen«, erklärte Marianne zaghaft.
     </p>
-    <p xml:id="eco_de_0000140_18900">
+    <p xml:id="eco_de_0000210_18900">
      »Es kann sein. Was weiss ich! Die einen Kinder sind da die Strasse hinunter gegangen, die andern dort hinüber –« Weil die dicke Frau keine Hand frei hatte, deutete sie mit dem Kopf nach der Seite, wo man durch das Fenster den Wald sah. Dann ging sie in die Wirtsstube; die Türe schlug hinter ihr zu.
     </p>
-    <p xml:id="eco_de_0000140_18910">
+    <p xml:id="eco_de_0000210_18910">
      Marianne stand vor dem Hause. Noch nie im Leben war ihr so schwer zu Mut gewesen. Die Tränen liefen ihr über das Gesicht. Aber sie wischte sie ab. Man musste jetzt tapfer bleiben und keine Zeit verlieren.
     </p>
-    <p xml:id="eco_de_0000140_18920">
+    <p xml:id="eco_de_0000210_18920">
      Die Strasse hinunter war Werner nicht gegangen; da hätte Marianne ihn getroffen. Einige grössere Kinder waren ihr entgegengekommen. Also den Weg dort, der am Walde entlang führte. Vielleicht hatten ein paar Kinder Werner mitgenommen. Aber fremde Kinder, die nicht wussten, wo er wohnte. Weit konnte er nicht sein; endlich musste Marianne ihn doch finden. Die lahme Christine hatte ihn ja gesehen hinter dem Mann mit dem Äffchen; ein Büblein mit blonden Löckchen und einer rot und weissen Schürze, hatte sie gesagt.
     </p>
-    <p xml:id="eco_de_0000140_18930">
+    <p xml:id="eco_de_0000210_18930">
      Marianne ging raschen Schrittes am Waldsaum weiter. Es dunkelte schon. Am Wege standen Büsche mit roten und schwarzen Beeren; von der Wiese, in der die Herbstzeitlosen blühten, stieg ein weisser Nebel auf. Sonst waren Blumen und rote Beeren schön; aber heute sah alles so traurig aus.
     </p>
-    <p xml:id="eco_de_0000140_18940">
+    <p xml:id="eco_de_0000210_18940">
      Es kamen zwei Wege; welchen sollte Marianne nehmen?
     </p>
-    <p xml:id="eco_de_0000140_18950">
+    <p xml:id="eco_de_0000210_18950">
      »Werner – Werner –!« fing sie an zu rufen; vielleicht konnte das Brüderlein sie hören.
     </p>
-    <p xml:id="eco_de_0000140_18960">
+    <p xml:id="eco_de_0000210_18960">
      »Werner –!« Ihre Stimme kam ihr fremd und unheimlich vor in dieser stillen Waldgegend. Sie schwieg wieder und ging geradeaus an einem Weiher vorbei, der trüb und dunkel da lag. Wenn Werner hineingefallen wäre –! Es gab ihr einen Stich ins Herz.
     </p>
-    <p xml:id="eco_de_0000140_18970">
+    <p xml:id="eco_de_0000210_18970">
      Da hörte sie von der Wiese drüben ein Hundegebell. Zwei Männer gingen dort auf dem Fussweg. Der Hund kam in grossen Sätzen daher gerannt.
     </p>
-    <p xml:id="eco_de_0000140_18980">
+    <p xml:id="eco_de_0000210_18980">
      »Hier, Pasche – hier!« rief einer der Männer, und der Hund gehorchte, um aber im nächsten Augenblick wieder bellend über die Wiese zu rennen.
     </p>
-    <p xml:id="eco_de_0000140_18990">
+    <p xml:id="eco_de_0000210_18990">
      Marianne zitterte vor Angst. Einmal hatte ein fremder Hund sie in den Arm gebissen; seither fürchtete sie die grossen Hunde.
     </p>
-    <p xml:id="eco_de_0000140_19000">
+    <p xml:id="eco_de_0000210_19000">
      Wieder rief der Mann den Hund zurück und versuchte, ihn zu fassen. Aber er entwischte und schoss zum dritten Mal daher. Da sprang Marianne in ihrer Angst in den Wald hinein. Bellend kam der Hund ihr nach; die zweige knackten; Marianne lief, was sie konnte. jetzt war der Hund ganz nahe; sie stürzte vorwärts und fiel über eine Baumwurzel. Mit einem Satze war der Hund auf ihr; sie hörte ihn keuchen und fühlte seinen heissen Atem. Die Sinne vergingen ihr fast – da sauste der Hund wieder zum Weg hinunter.
     </p>
-    <p xml:id="eco_de_0000140_19010">
+    <p xml:id="eco_de_0000210_19010">
      Marianne stand auf und rannte weiter, immer weiter durch das Dickicht. Die Zweige schlugen ihr ins Gesicht; ihre Füsse blieben in den Dornranken hängen; wieder hörte sie hinter sich das Hundegebell. Abermals fiel sie hin und raffte sich auf; die Stimmen der Männer tönten näher, dann ferner. Endlich verhallte auch das Gebell.
     </p>
-    <p xml:id="eco_de_0000140_19020">
+    <p xml:id="eco_de_0000210_19020">
      Aber Marianne in ihrer Angst lief immer zu, immer zu, bergan und wieder bergab, bis sie endlich ausser Atem auf eine breite Strasse kam, die mitten durch den Wald führte.
     </p>
-    <p xml:id="eco_de_0000140_19030">
+    <p xml:id="eco_de_0000210_19030">
      Da stand sie nun hülflos, verirrt, verloren. In welcher Richtung sollte sie gehen –? Wo war der Heimweg –? Sie dachte nicht mehr an den kleinen Werner. Ihre eigene Not und Verlassenheit war zu gross und schrecklich.
     </p>
-    <p xml:id="eco_de_0000140_19040">
+    <p xml:id="eco_de_0000210_19040">
      Es war ganz dunkel geworden. Hohe, finstere Tannen ragten zu beiden Seiten der Strasse auf. Da setzte sich Marianne am Rande hin und fing an, bitterlich zu weinen.
     </p>
-    <p xml:id="eco_de_0000140_19050">
+    <p xml:id="eco_de_0000210_19050">
      »Mama – Mama –« schluchzte sie von Zeit zu Zeit. Aber dann fiel ihr ein, wie weit sie von Mama weg sei. Nie konnte sie sich durch den grossen dunkeln Wald heimfinden. Sie musste die ganze Nacht hier bleiben und vor Angst sterben. So sass Marianne lange an der einsamen Bergstrasse. Hin und wieder rauschte und knackte es hinter ihr im Dickicht; dann fuhr sie entsetzt zusammen …
     </p>
-    <p xml:id="eco_de_0000140_19060">
+    <p xml:id="eco_de_0000210_19060">
      »Hü – hü –! Du bist doch ein Fauler!« sagte der alte Mann, der auf seinem Wagen daher fuhr. Er schüttelte das Leitseil, und der dicke Gaul tat, als wollte er einen Trab anschlagen, kam aber gleich wieder in seinen gemächlichen Schritt zurück.
     </p>
-    <p xml:id="eco_de_0000140_19070">
+    <p xml:id="eco_de_0000210_19070">
      »Wie die Tage kurz werden! Jetzt fahren wir schon völlig im Dunkeln durch das Fuchstobel. Ja, ja, es geht eben langsam dem Winter zu.«
     </p>
-    <p xml:id="eco_de_0000140_19080">
+    <p xml:id="eco_de_0000210_19080">
      Der alte Mann fuhr jede Woche zweimal von der Stadt hier herauf, und weil er niemand zum Plaudern hatte unterwegs, so sagte er hin und wieder ein Wort zu sich selber.
     </p>
-    <p xml:id="eco_de_0000140_19090">
+    <p xml:id="eco_de_0000210_19090">
      Die Laterne am Wagen warf einen hellen Schein auf die breite Strasse.
     </p>
-    <p xml:id="eco_de_0000140_19100">
+    <p xml:id="eco_de_0000210_19100">
      »Nu! was sitzt denn da am Weg –? Heh – heh –! Wenn du eine Stimme hast, so gib Antwort!« Der alte Mann hielt seinen Gaul an.
     </p>
-    <p xml:id="eco_de_0000140_19110">
+    <p xml:id="eco_de_0000210_19110">
      Marianne erhob sich und sah mit ihren verweinten Augen zu dem Manne auf.
     </p>
-    <p xml:id="eco_de_0000140_19120">
+    <p xml:id="eco_de_0000210_19120">
      »Ja Herrjeh, Kind – wie kommst denn du so allein und so spät ins Fuchstobel –?«
     </p>
-    <p xml:id="eco_de_0000140_19130">
+    <p xml:id="eco_de_0000210_19130">
      Marianne versuchte zu antworten; aber Jammer und Weinen schüttelten sie so, dass sie nicht sprechen konnte.
     </p>
-    <p xml:id="eco_de_0000140_19140">
+    <p xml:id="eco_de_0000210_19140">
      »Was ist mit dir? Red'! Was willst da im Wald oben?« fragte der alte Mann wieder.
     </p>
-    <p xml:id="eco_de_0000140_19150">
+    <p xml:id="eco_de_0000210_19150">
      Marianne schluchzte laut auf.
     </p>
-    <p xml:id="eco_de_0000140_19160">
+    <p xml:id="eco_de_0000210_19160">
      »Ich – ich hab' mein Brüderlein suchen wollen, und da hab' ich – den Weg –«
     </p>
-    <p xml:id="eco_de_0000140_19170">
+    <p xml:id="eco_de_0000210_19170">
      »Da hast den Weg verloren. Aha! Und jetzt werden sie daheim noch dich suchen müssen! Was mach' ich doch mit dir –? Allein kann man dich nicht gehen lassen –« Der alte Mann rieb sich das Kinn. »Komm – sitz' halt auf! Musst aber noch einen kleinen Umweg mit mir machen; so ohne weiteres kann ich dich nicht hinunterfahren. Meine Alte würde einen schönen Jammer haben, wenn ich um halb acht Uhr nicht zu Haus wäre.«
     </p>
-    <p xml:id="eco_de_0000140_19180">
+    <p xml:id="eco_de_0000210_19180">
      Marianne kletterte mit Hülfe des alten Mannes auf den Sitz neben ihm. Der Gaul, damit er wisse, dass es jetzt ernst gelte, bekam eins mit der Peitsche. In etwa einer Viertelstunde hielt der Wagen vor einem einzeln stehenden Hause.
     </p>
-    <p xml:id="eco_de_0000140_19190">
+    <p xml:id="eco_de_0000210_19190">
      »Guten Abend, Vater«, sagte eine Frau, die mit dem Lichte unter die Türe trat. »Du kommst spät!«
     </p>
-    <p xml:id="eco_de_0000140_19200">
+    <p xml:id="eco_de_0000210_19200">
      »Ja, und muss gleich noch einmal hinunter an den See.«
     </p>
-    <p xml:id="eco_de_0000140_19210">
+    <p xml:id="eco_de_0000210_19210">
      »Ach, was machst du für Spässe!« rief die Frau, indem sie näher trat. »In keinem Fall lass ich dich noch einmal fort so bei Nacht und Nebel!«
     </p>
-    <p xml:id="eco_de_0000140_19220">
+    <p xml:id="eco_de_0000210_19220">
      »Wirst doch müssen, Alte«, sagte der Mann gleichmütig. »Mach, dass das Abendessen auf den Tisch kommt. Vrene soll dem Bless etwas geben, aber ihn nicht ausspannen! So, und da hab' ich dir ein Stadtjüngferlein mitgebracht –« Damit hob der alte Mann, der abgestiegen war, Marianne vom Wagen.
     </p>
-    <p xml:id="eco_de_0000140_19230">
+    <p xml:id="eco_de_0000210_19230">
      »Nein, aber nein –!« rief die Frau und schlug die Hände zusammen. »Was wär' mir doch das! Wo hast du es gefunden? Was –? Im Fuchstobel? Hat es sich verirrt? Wohin gehört es?«
     </p>
-    <p xml:id="eco_de_0000140_19240">
+    <p xml:id="eco_de_0000210_19240">
      Der alte Mann erzählte, während sie ins Haus gingen, was er von Marianne erfahren hatte, und bei jedem Satze gab es von Seiten der Frau und der Magd Vrene neue Ausrufe des Erstaunens!
     </p>
-    <p xml:id="eco_de_0000140_19250">
+    <p xml:id="eco_de_0000210_19250">
      »Nein, aber nein –! Du mein Trost! Ist denn das möglich –!«
     </p>
-    <p xml:id="eco_de_0000140_19260">
+    <p xml:id="eco_de_0000210_19260">
      Marianne folgte ihnen in einer Art Betäubung. Von dem Schrecken, dem Laufen und Weinen war sie ganz erschöpft. Als der Mann sie aus dem dunkeln Walde zu sich auf den Wagen genommen und freundlich mit ihr geredet hatte, war ihr gewesen, als ob sie nun gleich heim in Mamas Arme käme. Jetzt stand sie bei den fremden Leuten in der fremden Stube. Es ging wie in einem Traum, wo man meint, ans Ziel zu kommen und immer wieder eine Strasse und noch eine Strasse vor sich sieht.
     </p>
-    <p xml:id="eco_de_0000140_19270">
+    <p xml:id="eco_de_0000210_19270">
      Die Frau goss dem Manne Kaffee und Milch in sein Schüsselchen und schob ihm die Platte mit gerösteten Erdäpfeln hin. Auch vor Marianne stellte sie Tasse und Teller:
     </p>
-    <p xml:id="eco_de_0000140_19280">
+    <p xml:id="eco_de_0000210_19280">
      »Das Stadtjüngferlein wird wohl Hunger bekommen haben!«
     </p>
-    <p xml:id="eco_de_0000140_19290">
+    <p xml:id="eco_de_0000210_19290">
      Aber Marianne konnte nicht essen. Sie sah beständig nach dem alten Manne. Es dünkte sie, er brauche endlos lang zu seiner Abendmahlzeit. Immer schenkte die Frau ihm wieder ein.
     </p>
-    <p xml:id="eco_de_0000140_19300">
+    <p xml:id="eco_de_0000210_19300">
      »Weisst, Vater«, sagte sie, »es ist mir schrecklich, dass du noch einmal fort willst. Eigentlich könnte die Vrene –«
     </p>
-    <p xml:id="eco_de_0000140_19310">
+    <p xml:id="eco_de_0000210_19310">
      »Die Vrene –? Im Stallgewand wird sie nicht ausfahren wollen, und wenn sie einmal in ihrer Kammer zum Anziehen ist, kommt sie in Ewigkeit nicht heraus. Auch fände sie sich in der Nacht da unten am See nicht so gut zurecht.«
     </p>
-    <p xml:id="eco_de_0000140_19320">
+    <p xml:id="eco_de_0000210_19320">
      »Es wäre mir aber doch lieber«, sagte die Frau.
     </p>
-    <p xml:id="eco_de_0000140_19330">
+    <p xml:id="eco_de_0000210_19330">
      Marianne sah ängstlich von einem zum andern. Wenn sie nun warten musste auf diese Vrene, »sie in Ewigkeit nicht aus ihrer Kammer kam« –!
     </p>
-    <p xml:id="eco_de_0000140_19340">
+    <p xml:id="eco_de_0000210_19340">
      Aber nein, der alte Mann stand auf.
     </p>
-    <p xml:id="eco_de_0000140_19350">
+    <p xml:id="eco_de_0000210_19350">
      »Gib meinen wärmeren Rock heraus und ein Tuch für das Kind. Es ist frisch draussen. Und sag mir jetzt nichts mehr. Wenn dir vor dreissig Jahren der Emil oder die Marie einmal so abhanden gekommen wären, so wärest auch froh gewesen, wenn man sie dir bald wieder gebracht hätte.«
     </p>
-    <p xml:id="eco_de_0000140_19360">
+    <p xml:id="eco_de_0000210_19360">
      Bald sass Marianne in einen Schal gewickelt wieder auf dem Wagen neben dem guten alten Mann.
     </p>
-    <p xml:id="eco_de_0000140_19370">
+    <p xml:id="eco_de_0000210_19370">
      »Längstens in fünf Viertelstunden bin ich zurück«, sagte er. »Hü, Bless, zeig, was du kannst!«
     </p>
-    <p xml:id="eco_de_0000140_19380">
+    <p xml:id="eco_de_0000210_19380">
      Bless schickte sich tapfer in die Sache. In gutem Trab ging es in die Nacht hinaus, durch das Fuchstobel, in einer Biegung auf die Höhe und dann immer bergab. Nun kam man zu Häusern, in denen Lichter brannten, und bei der Kirche vorbei. Marianne kannte sich aus. Jetzt waren sie nimmer weit von zu Haus, nimmer weit von Mama und Papa –! Aber wie die freudige Erwartung in Marianne aufstieg, kam auch auf einmal wieder die Unruhe um Werner. Wenn sie nun ankam und Mama fragte: Marianne, hast du mir den Kleinen gebracht –?
     </p>
-    <p xml:id="eco_de_0000140_19390">
+    <p xml:id="eco_de_0000210_19390">
      Schon bogen sie von der Landstrasse ab zum See hinunter. Die Laterne warf ihren Schein an die Stämme der Birnbäume.
     </p>
-    <p xml:id="eco_de_0000140_19400">
+    <p xml:id="eco_de_0000210_19400">
      »Brrr –! Da wären wir, denk' ich!« Der alte Mann hielt den Bless an.
     </p>
-    <p xml:id="eco_de_0000140_19410">
+    <p xml:id="eco_de_0000210_19410">
      Aus der Türe kam Hans gerannt, hinter ihm Sophie mit einem Licht.
     </p>
-    <p xml:id="eco_de_0000140_19420">
+    <p xml:id="eco_de_0000210_19420">
      »Marianne –! Es ist Marianne –! Gottlob und Dank! Frau Turnach –! Mama –!«
     </p>
-    <p xml:id="eco_de_0000140_19430">
+    <p xml:id="eco_de_0000210_19430">
      Sophie hob Marianne vom Wagen. Aus dem Haus kamen Papa, Mama, Lotti, Balbine, Frau Völklein und was nur da war.
     </p>
-    <p xml:id="eco_de_0000140_19440">
+    <p xml:id="eco_de_0000210_19440">
      »Marianne –! Was haben wir für eine Angst ausgestanden –«
     </p>
-    <p xml:id="eco_de_0000140_19450">
+    <p xml:id="eco_de_0000210_19450">
      Mama schloss ihr Kind in die Arme.
     </p>
-    <p xml:id="eco_de_0000140_19460">
+    <p xml:id="eco_de_0000210_19460">
      »Mama – Mama – ich habe ihn bis zum Walde hinauf gesucht – Ich hab' ihn nicht gefunden –« Marianne brach in ein bitterliches Weinen aus.
     </p>
-    <p xml:id="eco_de_0000140_19470">
+    <p xml:id="eco_de_0000210_19470">
      Da legte sich ein kleines rundes Händchen in Mariannes Hand.
     </p>
-    <p xml:id="eco_de_0000140_19480">
+    <p xml:id="eco_de_0000210_19480">
      »Marianne, warum bist du so lang nicht gekommen?« fragte Werner mit seiner hellen Stimme. »Ich bin beim Lienhard gewesen, und dann bin ich gefallen, und meine Schürze ist schmutzig geworden, und er hat mir einen Fisch gegeben –«
     </p>
-    <p xml:id="eco_de_0000140_19490">
+    <p xml:id="eco_de_0000210_19490">
      Marianne umarmte das Brüderlein und küsste es; aber die Tränen liefen ihr unaufhaltsam übers Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_19500">
+    <p xml:id="eco_de_0000210_19500">
      »Warum tust du weinen?« fragte Werner. »Ich geb' dir meinen Fisch. Balbine tut dir ihn morgen braten –«
     </p>
-    <p xml:id="eco_de_0000140_19510">
+    <p xml:id="eco_de_0000210_19510">
      Und von der anderen Seite redeten sie auch auf Marianne ein.
     </p>
-    <p xml:id="eco_de_0000140_19520">
+    <p xml:id="eco_de_0000210_19520">
      »Marianne, wo warft du denn? Denk' nur, jetzt sind Jakob und Fritz gegangen, dich zu suchen! Weisst du, das ist wie in dem Märchen von der klugen Else! Wein' doch jetzt nicht mehr, wo du ja da bist! Wie weit bist du gegangen? Bis in den Berg hinauf? Wie bist du auf den Wagen gekommen? Erzähl' doch, Marianne!« So bestürmten Hans und Lotti die Schwester.
     </p>
-    <p xml:id="eco_de_0000140_19530">
+    <p xml:id="eco_de_0000210_19530">
      Doch Marianne konnte noch nicht reden. Sie umfasste immer wieder Mama und dann das Brüderlein und schluchzte.
     </p>
-    <p xml:id="eco_de_0000140_19540">
+    <p xml:id="eco_de_0000210_19540">
      Papa war zu dem alten Mann getreten.
     </p>
-    <p xml:id="eco_de_0000140_19550">
+    <p xml:id="eco_de_0000210_19550">
      »Vor lauter Freude vergessen wir, Ihnen zu danken!« sagte er und schüttelte dem Alten beide Hände. »Sie haben uns aus einer furchtbaren Angst befreit. Wie sollen wir Ihnen das vergelten!«
     </p>
-    <p xml:id="eco_de_0000140_19560">
+    <p xml:id="eco_de_0000210_19560">
      »Es ist gern geschehen, es ist gern geschehen!« sagte der alte Mann und erzählte Herrn Turnach, wie er das Kind im Fuchstobel am Strassenrand gefunden.
     </p>
-    <p xml:id="eco_de_0000140_19570">
+    <p xml:id="eco_de_0000210_19570">
      Herr Turnach bat ihn, abzusteigen und ins Haus zu treten. Aber der Alte meinte, es sei besser, er fahre gleich wieder zu. Es werde sonst gar spät.
     </p>
-    <p xml:id="eco_de_0000140_19580">
+    <p xml:id="eco_de_0000210_19580">
      »Gute Nacht allerseits!« sagte er und griff nach dem Leitseil. »Gute Nacht und schlaft wohl nach dem Schrecken!«
     </p>
-    <p xml:id="eco_de_0000140_19590">
+    <p xml:id="eco_de_0000210_19590">
      Alle traten auf ihn zu, um ihm die Hand zu geben, und Herr Turnach versprach, dass man mit den Kindern einmal in den »Finkenbaum« hinauf komme. Der Bless zog an, und der Wagen rollte davon.
     </p>
-    <p xml:id="eco_de_0000140_19600">
+    <p xml:id="eco_de_0000210_19600">
      Mama nahm Marianne ins Zimmer.
     </p>
-    <p xml:id="eco_de_0000140_19610">
+    <p xml:id="eco_de_0000210_19610">
      »Lasst mir jetzt mein armes Kind in Ruhe. Wenn es heut' nicht mehr erzählen kann, so warten wir bis morgen. Marianne trinkt nun noch eine Tasse Milch und legt sich zu Bett, und Mama setzt sich neben sie.«
     </p>
-    <p xml:id="eco_de_0000140_19620">
+    <p xml:id="eco_de_0000210_19620">
      Wie das gut tat, in dem warmen, weichen Bett die müden Glieder zu strecken und Mamas Hans zu halten! Mit dem Einschlafen ging es aber nicht schnell; Marianne begann nun doch, ihr Herz auszuschütten. Und Lotti, die auch im Bette lag, erzählte, wie das mit Werner gewesen.
     </p>
-    <p xml:id="eco_de_0000140_19630">
+    <p xml:id="eco_de_0000210_19630">
      »Also bloss zum Lienhard ist er gegangen, Marianne! Und der hat ihm noch seine schmutzige Schürze gewaschen und ihn dann gebracht. Und wir dachten immer, du kämest auch bald, und dann wurde es dunkel und Jakob und Fritz Völklein sagten, sie wollten gehen, sich zu suchen. Und als Papa heimkam, wollte er auch noch fort; er sagte, er halte es nicht aus. Und dann kam der Wagen und brachte dich –«
     </p>
-    <p xml:id="eco_de_0000140_19640">
+    <p xml:id="eco_de_0000210_19640">
      »Mama«, fragte Marianne, »ist wohl das Büblein mit der rot und weissen Schürze und dem blonden Haar, weisst du, von dem die lahme Christine gemeint hat, es sei der Werner, jetzt auch zu Hause –?«
     </p>
-    <p xml:id="eco_de_0000140_19650">
+    <p xml:id="eco_de_0000210_19650">
      »Gewiss, mein Kind, gewiss! Es war ein wenig unbedacht von dieser Christine, dich ihm nachzuschicken; aber es war ja gut gemeint.«
     </p>
-    <p xml:id="eco_de_0000140_19660">
+    <p xml:id="eco_de_0000210_19660">
      »Mama, sind wohl Jakob und Fritz weit hinauf in den Berg –? Jetzt muss man wieder für sie Angst haben!«
     </p>
-    <p xml:id="eco_de_0000140_19670">
+    <p xml:id="eco_de_0000210_19670">
      Mama lächelte.
     </p>
-    <p xml:id="eco_de_0000140_19680">
+    <p xml:id="eco_de_0000210_19680">
      »Ihnen wird nicht so leicht etwas begegnen, Marianne. Aber froh wären wir schon, wenn sie beide nun bald zurückkämen.«
     </p>
-    <p xml:id="eco_de_0000140_19690">
+    <p xml:id="eco_de_0000210_19690">
      »Ich muss ihnen dann auch danken«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_19700">
+    <p xml:id="eco_de_0000210_19700">
      »Ja, Kind, ihnen und vor allem dem lieben, guten Gott –«
     </p>
-    <p xml:id="eco_de_0000140_19710">
+    <p xml:id="eco_de_0000210_19710">
      Mama faltete die Hände und sah ernst vor sich hin. Marianne und Lotti waren still. –
     </p>
-    <p xml:id="eco_de_0000140_19720">
+    <p xml:id="eco_de_0000210_19720">
      Da hörte man plötzlich Lärm von draussen.
     </p>
-    <p xml:id="eco_de_0000140_19730">
+    <p xml:id="eco_de_0000210_19730">
      »Sie sind da, Mama! Sie sind da!« rief Hans zur Türe herein.
     </p>
-    <p xml:id="eco_de_0000140_19740">
+    <p xml:id="eco_de_0000210_19740">
      Und nun begann im Wohnzimmer noch einmal ein lautes Erzählen. Jakob und Fritz hatten weit herum gesucht. Bis zu dem Wirtshaus am Walde hatten die Leute noch von Marianne etwas gewusst. Von dort an war die Spur ausgegangen.
     </p>
-    <p xml:id="eco_de_0000140_19750">
+    <p xml:id="eco_de_0000210_19750">
      »Nun, gottlob, dass das Kind wieder da ist, Herr Turnach! Mir ist ein rechter Stein vom Herzen!« sagte Jakob und trank das Glas Wein, das Herr Turnach ihm einschenkte, auf Mariannes Gesundheit.
     </p>
-    <p xml:id="eco_de_0000140_19760">
+    <p xml:id="eco_de_0000210_19760">
      Lange wollte es heute nicht ruhig werden in der Seeweid.
     </p>
-    <p xml:id="eco_de_0000140_19770">
+    <p xml:id="eco_de_0000210_19770">
      Und als Marianne endlich einschlief, zog im Traume noch einmal alles an ihr vorüber. Im Walde im Fuchstobel waren lauter kleine Affen auf den Bäumen, und bei ihnen sah Marianne den kleinen Werner. Sie wollte ihn rufen; aber er hörte nicht, sondern sprang wild von Ast zu Ast, dass seine rot und weisse Schürze flatterte. Dann stand Marianne auf einmal vor dem trüben, dunklen Teich; darin war die lahme Christine und suchte den kleinen Werner. Sie sank immer tiefer ins Wasser, und Marianne wollte ihr heraushelfen; aber sie konnte nicht zu dem Teich gelangen und konnte auch nicht fliehen vor dem Hunde, der daher rannte mit feurigem Atem –
     </p>
-    <p xml:id="eco_de_0000140_19780">
+    <p xml:id="eco_de_0000210_19780">
      Zwei-, dreimal erwachte Marianne aufschreiend. Dann sah sie Mama neben sich am Tisch bei der Lampe und seufzte erleichtert.
     </p>
-    <p xml:id="eco_de_0000140_19790">
+    <p xml:id="eco_de_0000210_19790">
      Nach und nach aber wurde ihr Schlaf fest, und sie erwachte nicht mehr bis zum hellen Morgen.
     </p>
    </div>
@@ -6104,196 +6104,196 @@
     <head>
      Es wird Herbst.
     </head>
-    <p xml:id="eco_de_0000140_19800">
+    <p xml:id="eco_de_0000210_19800">
      Man merkte deutlich, dass der Sommer zu Ende ging. Auf den Äckern waren die weissen Rüben schon ganz gross. Die Birnen und Äpfel an den Bäumen leuchteten gelb und rot, und die blauen Zwetschgen hingen schwer herunter. Wo man ging und stand, gab es reifes Obst aufzulesen. Die Turnachkinder hatten immer die Taschen voll und konnten die Schulkameraden beschenken.
     </p>
-    <p xml:id="eco_de_0000140_19810">
+    <p xml:id="eco_de_0000210_19810">
      Es wurden allerlei Früchte eingekocht, und eines Tages, nachdem die Kinder immer gebettelt hatten, man möchte dich den Besuch im »Finkenbaum« machen, sagte Mama:
     </p>
-    <p xml:id="eco_de_0000140_19820">
+    <p xml:id="eco_de_0000210_19820">
      »Gut! Ziehen wir heut' nachmittag aus! Jedes nimmt ein Körbchen mit; zuerst geht's in die Brombeeren und dann in den ›Finkenbaum‹. Am Montag bringt mir zwar eine Frau einen grossen Korb Beeren. Wenn ich aber an meine Schleckmäuler denke, so scheint mir das nicht genug. Auch finde ich es nett für euch, die Beeren selbst zu pflücken. Im Winter, wenn es schneit, wenn im Ofen das Feuer brennt und ihr zum Abendbrot das Eingemachte esst, denkt ihr dann an den Waldhang, wo die dunkelgrünen Brombeerranken in schönen Bogen übereinander wucherten, wo es so herrlich nach Harz duftete und die lustigen Meisen in den Tannen auf und ab flatterten.«
     </p>
-    <p xml:id="eco_de_0000140_19830">
+    <p xml:id="eco_de_0000210_19830">
      Die Kinder klatschten freudig in die Hände. Am Nachmittag brach man beizeiten auf. Balbine übernahm das Schwesterlein, so dass Sophie auch mitkonnte. Den kleinen Werner wollte man erst zu Hause lassen, weil der Weg weit war. Aber er bat und bat:
     </p>
-    <p xml:id="eco_de_0000140_19840">
+    <p xml:id="eco_de_0000210_19840">
      »Mama, mich auch mitnehmen –! Ich möchte auch Brombeeren pflücken; bitte, bitte, Mama –!«
     </p>
-    <p xml:id="eco_de_0000140_19850">
+    <p xml:id="eco_de_0000210_19850">
      Er kam sich sehr wichtig vor, als er neben Marianne ging und sie ihm alle Orte zeigte, wo sie ihn gesucht hatte. Die lahme Christine war heute nicht zu sehen, wohl aber die gesprächige Frau; diese begrüsste mit vielen Worten Marianne und die ganze Gesellschaft und ging den Weg hinauf mit, bis sie Mariannes Geschichte vollständig vernommen hatte. Als man beim Wirtshaus am Walde ankam, war Werner sehr enttäuscht, den Mann mit dem Äffchen nicht zu sehen.
     </p>
-    <p xml:id="eco_de_0000140_19860">
+    <p xml:id="eco_de_0000210_19860">
      »Dann gehen wir jetzt zum bösen Hund, Marianne«, erklärte er und zog die Schwester erwartungsvoll vorwärts.
     </p>
-    <p xml:id="eco_de_0000140_19870">
+    <p xml:id="eco_de_0000210_19870">
      »Ach, du Dummerlein«, sagte Sophie. »Der Hund ist längst nicht mehr da, und es wird auch besser sein. Du würdest schön schreien, wenn er käme!«
     </p>
-    <p xml:id="eco_de_0000140_19880">
+    <p xml:id="eco_de_0000210_19880">
      Marianne hielt sich, als jetzt der Fussweg am Waldsaum begann, zu Mama. Es war so gut, im hellen Sonnenschein neben ihr denselben Weg zu gehen, den sie an jenem trüben Abend allein in Angst und Schrecken gegangen war. Da hingen wieder die roten und schwarzen Beeren büschelweise an den Sträuchern, und in der Wiese standen fein und schön die blassvioletten Herbstzeitlosen. Sogar der kleine Weiher war heute hell und spiegelte den blauen Himmel wieder.
     </p>
-    <p xml:id="eco_de_0000140_19890">
+    <p xml:id="eco_de_0000210_19890">
      Bei der Waldwiese, wo damals die zwei Männer gewesen waren, bog man rechts zum Brombeerschlag ab. Sophie kannte sich aus; denn sie hatte früher am Berge gewohnt.
     </p>
-    <p xml:id="eco_de_0000140_19900">
+    <p xml:id="eco_de_0000210_19900">
      »Wenn es an der Schleifhalde noch aussieht wie vor ein paar Jahren und man nicht etwa neu angepflanzt hat«, sagte sie, »so werdet ihr bald euere Körbe voll haben.«
     </p>
-    <p xml:id="eco_de_0000140_19910">
+    <p xml:id="eco_de_0000210_19910">
      Und richtig, die sonnige Schleifhalde war weithin überwachsen mit Brombeerstauden, die prächtige reife Beeren trugen. Ringsum aber stand der Wald, wie Mama ihn geschildert hatte.
     </p>
-    <p xml:id="eco_de_0000140_19920">
+    <p xml:id="eco_de_0000210_19920">
      Die Kinder fingen an zu pflücken, vergnügt und so eifrig, dass keines ans Naschen dachte. Nur Werner kam, als Mama ihn herrief, ein bisschen verlegen. In seinem Körbchen war kaum eine Handvoll Beeren. Sein Gesicht hingegen war schwarz gefärbt. »Ich habe gar nicht so viele gefunden –« versuchte der kleine Schelm sich herauszureden.
     </p>
-    <p xml:id="eco_de_0000140_19930">
+    <p xml:id="eco_de_0000210_19930">
      »So, so«, sagte Mama. »Ich glaubt eher, die Beeren, die du gepflückt hast, haben nicht den rechten Weg gefunden. Statt ins Körbchen sind sie ins Mäulchen gegangen.« Mama lachte; sie mochte Werner wohl gönnen, dass er nach Herzenslust ass.
     </p>
-    <p xml:id="eco_de_0000140_19940">
+    <p xml:id="eco_de_0000210_19940">
      Als dann die Grossen herbeikamen, neckten sie Werner allerdings ein wenig.
     </p>
-    <p xml:id="eco_de_0000140_19950">
+    <p xml:id="eco_de_0000210_19950">
      »Schade, dass du nicht Jakobs Graskorb entlehnt hast; deine Brombeeren hätten dann besser Platz gehabt«, meinte Hans. »Wieviel Töpfe Eingemachtes gibt das wohl, Sophie, was Werner gesammelt hat?«
     </p>
-    <p xml:id="eco_de_0000140_19960">
+    <p xml:id="eco_de_0000210_19960">
      Mama aber trieb, dass man weiter wandere, wenn man noch in den »Finkenbaum« wolle. Die Kinder waren fast nicht wegzubringen. Immer entdeckte eines wieder einen Zweig mit besonders grossen schwarzen Beeren.
     </p>
-    <p xml:id="eco_de_0000140_19970">
+    <p xml:id="eco_de_0000210_19970">
      Endlich kam man zum »Finkenbaum«. Die alte Frau, die vor dem Hause Äpfel auflas, stand auf.
     </p>
-    <p xml:id="eco_de_0000140_19980">
+    <p xml:id="eco_de_0000210_19980">
      »Nein, was wär' jetzt doch das« rief sie. »Unser Stadtjüngferlein! So, so! Zeig, wie siehst du aus am hellen Tag –? An jenem Abend hat man fast nichts gesehen vor lauter Tränen. Und das ist allem Anschein nach das verlorene Brüderlein –?« Die alte Frau strich über Werners blonden Kopf.
     </p>
-    <p xml:id="eco_de_0000140_19990">
+    <p xml:id="eco_de_0000210_19990">
      Mama hatte zwei schöne buntseidene Taschentücher mitgebracht für den alten Mann, und für die Frau ein mürbes Kaffeebrot, das Balbine gebacken hatte.
     </p>
-    <p xml:id="eco_de_0000140_20000">
+    <p xml:id="eco_de_0000210_20000">
      »Ja, was denkt ihr auch!« rief die Frau. »Warum nicht gar! Das wäre nicht nötig gewesen! He nun, so will ich es nehmen und vielmal danken! Der Vater ist über Land gegangen. Er wird sagen, die Tücher seien viel zu schön für ihn. Aber wenn er am Sonntag eines nimmt, wird er allemal an das Kind denken, wie es da unten im Fuchstobel gesessen ist …«
     </p>
-    <p xml:id="eco_de_0000140_20010">
+    <p xml:id="eco_de_0000210_20010">
      Die Frau hiess die ganze Gesellschaft in die Stube treten und begann dann, Frau Turnach zu erzählen von ihren Kindern, die längst erwachsen und in der Welt draussen waren.
     </p>
-    <p xml:id="eco_de_0000140_20020">
+    <p xml:id="eco_de_0000210_20020">
      Die Turnachkinder sahen sich in der Stube um, die so niedrig war, dass Mama leicht mit der Hand hätte an die Decke reichen können. Die Wände waren von braunem Holz; ihnen entlang liefen schmale Bänke. In der Ecke stand ein grüner Kachelofen mit einem Aufsatz. Hans dachte, es wäre nett, da herumzuklettern. An den kleinen Fenstern brühten rote Geranien.
     </p>
-    <p xml:id="eco_de_0000140_20030">
+    <p xml:id="eco_de_0000210_20030">
      »Stand der Teller mit den gerösteten Kartoffeln und der Kaffee dort auf dem grossen Tisch?« fragte Lotti, die alles genau wissen musste.
     </p>
-    <p xml:id="eco_de_0000140_20040">
+    <p xml:id="eco_de_0000210_20040">
      Marianne nickte. Halb kam ihr die Stube bekannt vor und doch wieder so anders als an jenem Abend.
     </p>
-    <p xml:id="eco_de_0000140_20050">
+    <p xml:id="eco_de_0000210_20050">
      »Bitte, dürfen wir jetzt noch den Bless sehen und den Wagen und die Vrene?« fragte Lotti, indem sie vor die alte Frau trat.
     </p>
-    <p xml:id="eco_de_0000140_20060">
+    <p xml:id="eco_de_0000210_20060">
      Diese nickte lachend, und die Kinder liefen mit Sophie zum Stall, wo der Bless neben zwei Kühen stand und vergnügt das Brot nahm, das die Kinder für ihn mitgebracht hatten.
     </p>
-    <p xml:id="eco_de_0000140_20070">
+    <p xml:id="eco_de_0000210_20070">
      Vrene stand dabei und fragte, ob die Kinder den Hühnerstall oder vielleicht die jungen Schweinchen sehen wollten.
     </p>
-    <p xml:id="eco_de_0000140_20080">
+    <p xml:id="eco_de_0000210_20080">
      »Ja, ja! bitte, die jungen Schweinchen! Schweinchen haben wir nicht zu Hause!«
     </p>
-    <p xml:id="eco_de_0000140_20090">
+    <p xml:id="eco_de_0000210_20090">
      Die Schweinchen lagen zu acht dicht bei ihrer Mutter; acht allerliebste Schweinchen, rosig und fett, mit kleinen Augen und niedlichen geringelten Schwänzchen. Werner geriet in lautes Entzücken.
     </p>
-    <p xml:id="eco_de_0000140_20100">
+    <p xml:id="eco_de_0000210_20100">
      »Nu, regt euch ein wenig, wenn ihr Besuch bekommt!« sagte Vrene und schlug mit einem Rütlein leicht auf die runden Tierchen.
     </p>
-    <p xml:id="eco_de_0000140_20110">
+    <p xml:id="eco_de_0000210_20110">
      Da fuhren sie schreiend und quieksend nach allen Seiten ihres engen Stalles und stiessen mit den komischen Nasen im Stroh herum. Es war zu lustig.
     </p>
-    <p xml:id="eco_de_0000140_20120">
+    <p xml:id="eco_de_0000210_20120">
      Werner wollte durchaus eines der Schweinchen auf den Arm nehmen, um es in die Stube zu Mama zu tragen.
     </p>
-    <p xml:id="eco_de_0000140_20130">
+    <p xml:id="eco_de_0000210_20130">
      »Du könntest es gar nicht halten, so würde es strampeln«, sagte Vrene. »Und dann sind das überhaupt keine Stubengäste.«
     </p>
-    <p xml:id="eco_de_0000140_20140">
+    <p xml:id="eco_de_0000210_20140">
      Mama kam jedoch selbst in den Stall, um die Schweinchen zu bewundern und die Kinder zum Aufbruch zu nahmen.
     </p>
-    <p xml:id="eco_de_0000140_20150">
+    <p xml:id="eco_de_0000210_20150">
      Die alte Frau brachte Marianne ein Büschelchen fein duftender trockener Lavendelblüten.
     </p>
-    <p xml:id="eco_de_0000140_20160">
+    <p xml:id="eco_de_0000210_20160">
      »Leg's in deine Kommode. Es riecht noch nach Jahren gut, und du kannst dabei manchmal an die alten Leute im ›Finkenbaum‹ denken. So kommet denn gut heim und kehret wieder einmal ein bei uns!«
     </p>
-    <p xml:id="eco_de_0000140_20170">
+    <p xml:id="eco_de_0000210_20170">
      Der Heimweg war weit. Sophie und Hans trugen abwechselnd den kleinen Werner, der das lange Gehen nicht gewöhnt war, auf dem Rücken.
     </p>
-    <p xml:id="eco_de_0000140_20180">
+    <p xml:id="eco_de_0000210_20180">
      »Wie früh es dunkelt!« sagte Mama, als man bei einer Biegung der Strasse auf die Stadt hinuntersah, wo die Lichter angezündet wurden. »Mich hat es fast traurig gemacht, wie ich droben am Walde eine Buche gesehen habe, die schon anfing sich bräunlich zu färben.«
     </p>
-    <p xml:id="eco_de_0000140_20190">
+    <p xml:id="eco_de_0000210_20190">
      Mama begann, mit Sophie über den Umzug zu sprechen, und die Kinder wurden ganz ernsthaft, als sie hörten, dass man in etwa drei Wochen schon die Seeweid verlasse. Ja, der kleine Werner, den die Müdigkeit etwas verdriesslich machte, fing plötzlich an zu weinen:
     </p>
-    <p xml:id="eco_de_0000140_20200">
+    <p xml:id="eco_de_0000210_20200">
      »Ich will nicht in die Stadt – huhuh –! Ich will in der Seeweid bleiben bei Frau Völklein – huhuh –«
     </p>
-    <p xml:id="eco_de_0000140_20210">
+    <p xml:id="eco_de_0000210_20210">
      »Ja, die würde eine Freude haben!« sagte Hans, der ihn gerade auf dem Rücken hatte. »Besonders, wenn du heulst wie jetzt. Überhaupt, wer so schreien kann, der kann auch wieder ein wenig gehen. Da –«, Hans stellte den Kleinen hin und nahm ihn an der Hand. Marianne fasste die andere.
     </p>
-    <p xml:id="eco_de_0000140_20220">
+    <p xml:id="eco_de_0000210_20220">
      »Links, rechts – links, rechts –!« kommandierte Hans. »Brust heraus, Leib hinein –! links, rechts – links, rechts –!«
     </p>
-    <p xml:id="eco_de_0000140_20230">
+    <p xml:id="eco_de_0000210_20230">
      Und halb lachend, halb weinend, schritt das Wernermännchen zwischen den beiden her, so weit er nur ausschreiten konnte mit seinen kleinen Beinen.
     </p>
-    <p xml:id="eco_de_0000140_20240">
+    <p xml:id="eco_de_0000210_20240">
      Am andern Morgen wurden sie Kinder in aller Frühe geweckt. Vom See tönten laute, tiefe Hornstösse, dazwischen schrille Pfiffe, dann wieder Glockenschläge und ein lang gezogenes Heulen. Das setzte an, hörte auf und begann aufs neue.
     </p>
-    <p xml:id="eco_de_0000140_20250">
+    <p xml:id="eco_de_0000210_20250">
      »Marianne! Nebel! Nebel –!« rief Lotti und lief zum Fenster. Wie seltsam das war: Vom Berge, von den Dörfern drüben, vom See und dem Himmel sah man nichts. Ein weisser, dichter Dunst verhüllte alles. Gerade dass man den nahen Birnbaum und die junge Tanne im Garten noch erkennen konnte.
     </p>
-    <p xml:id="eco_de_0000140_20260">
+    <p xml:id="eco_de_0000210_20260">
      Die beiden Mädchen zogen sich schnell an. Hans war schon auf der Gartenmauer.
     </p>
-    <p xml:id="eco_de_0000140_20270">
+    <p xml:id="eco_de_0000210_20270">
      »Tüh, tütüh –« tönte ein Horn draussen. Es klang ganz unheimlich. »Bing, bing, bing –« antwortete eine helle Glocke.
     </p>
-    <p xml:id="eco_de_0000140_20280">
+    <p xml:id="eco_de_0000210_20280">
      Das Horn kam von einem Steinschiff, der Glockenklang von einem kleinen Schraubendampfer. Langsam, mit der grössten Vorsicht mussten die Schiffe durch den dichten Nebel fahren, der heute über See und Land lag. Alle Augenblicke konnte ein Zusammenstoss geschehen.
     </p>
-    <p xml:id="eco_de_0000140_20290">
+    <p xml:id="eco_de_0000210_20290">
      Die Kinder horchten hinaus; es war so geheimnisvoll, alle die Töne zu hören und nichts zu sehen. Einen Augenblick tauchte ziemlich nahe vor der Mauer riesenhaft mit schlaffem Segel am hohen Maste ein Steinschiff auf und verschwand im nächsten Augenblick wie ein Gespensterfahrzeug.
     </p>
-    <p xml:id="eco_de_0000140_20300">
+    <p xml:id="eco_de_0000210_20300">
      »Wenn wir nur hinausrudern dürften!« sagte Hans. »Ich würde meine kleine Pfeife mitnehmen; mit der müsstest du dann Zeichen geben, Marianne. Eigentlich sollte man das auch üben, wenn man am See wohnt!«
     </p>
-    <p xml:id="eco_de_0000140_20310">
+    <p xml:id="eco_de_0000210_20310">
      Da er aber wohl wusste, dass Mama für diese Art von Probefahrten nicht zu gewinnen wäre, begnügte er sich, mit den Schwestern den Nebel auf dem festen Lande zu durchstreifen. Es war ein Glück, dass Hans gerade heute erst um acht Uhr in der Schule sein musste. So konnte man zu dritt auf dem Wege ein lustiges Versteckspiel machen. Man lief auf dem freien Felde davon, bis in dem dichten Nebel keins das andere mehr sah. Man wirbelte sich ein dutzendmal im Kreise herum, stand dann still und wusste nun nicht mehr, ging es rechts oder links, vor- oder rückwärts zur Strasse hinauf.
     </p>
-    <p xml:id="eco_de_0000140_20320">
+    <p xml:id="eco_de_0000210_20320">
      Das war ein solcher Spass, dass man ihn etwas zu lange trieb. Von dem unsichtbaren Kirchturm schlug es schon viertel vor acht. Hans fing an zu rennen und rannte bis in die Stadt, so dass er gerade noch recht in die Klasse kam. Marianne und Lotti liefen auch, was sie konnten; aber als sie in ihr Schulhaus kamen, war's in den Korridoren schon ganz still. Glücklicherweise war Mariannes Lehrerin aufgehalten worden und trat eben erst aus dem Lehrerzimmer; so konnte Marianne noch hineinschlüpfen. Lotti öffnete etwas zaghaft die Türe ihres Zimmers. Fräulein Matthias stand schon vor der Klasse. Aber sie schaute Lotti freundlich an.
     </p>
-    <p xml:id="eco_de_0000140_20330">
+    <p xml:id="eco_de_0000210_20330">
      »Sieh, sieh! Hat Lotti Turnach doch auch den Weg durch den Nebel gefunden –! Du bist wohl froh, wenn ihr nun bald in die Stadt zieht?«
     </p>
-    <p xml:id="eco_de_0000140_20340">
+    <p xml:id="eco_de_0000210_20340">
      »Nein«, sagte Lotti. »Wir mögen den Nebel furchtbar gern. Er riecht auch so gut!«
     </p>
-    <p xml:id="eco_de_0000140_20350">
+    <p xml:id="eco_de_0000210_20350">
      Da lachte Fräulein Matthias und fing an, mit den Kindern vom Nebel zu sprechen. Über den Gassen der Stadt lag er ja auch. Alle, die etwas vom Nebel zu sagen wussten, hielten die Hand auf; aber so viel wie Lotti Turnach konnte keines erzählen.
     </p>
-    <p xml:id="eco_de_0000140_20360">
+    <p xml:id="eco_de_0000210_20360">
      Es folgten nun eine Reihe solcher Herbstmorgen, aus denen die schönsten, hellsten Tage wurden. Wenn die Kinder aus der Schule heimkamen, stand die Sonne am blauen Himmel; vom Nebel war keine Spur mehr zu sehen. Wohin war er geschwunden? Am Sonntag konnten die Kinder zusehen, wie das ging. So etwa um neun, zehn Uhr kam eine Bewegung in die weisse stille Luft. Sie wallte auf und nieder. Es wurde lichter und wieder trüb. Plötzlich sah man ein Stück vom Ufer drüben, eine Linie des Berges oder etwas Himmel. Alles wurde wieder verhüllt und erschien von neuem, wurde grösser – und dann auf einmal brach der helle Sonnenschein durch. Der blaue See wurde weit und das andere Ufer klar. Ein streifen feinen Dunstes zog noch da übers Wasser, dort an der Waldhöhe entlang; dann zerfloss und verging auch er.
     </p>
-    <p xml:id="eco_de_0000140_20370">
+    <p xml:id="eco_de_0000210_20370">
      »Fräulein Matthias hat gesagt, die starke Sonne mit ihren warmen Strahlen schlucke den Nebel auf«, erklärte Lotti, als die Kinder gegen Mittag auf den See hinausfuhren. »Jetzt scheint sie auf uns. Wenn sie uns nur nicht auch verschluckt!«
     </p>
-    <p xml:id="eco_de_0000140_20380">
+    <p xml:id="eco_de_0000210_20380">
      Hans und Lotti lachten.
     </p>
-    <p xml:id="eco_de_0000140_20390">
+    <p xml:id="eco_de_0000210_20390">
      »O, seid einmal beide ganz still, und Hans, hör' auf zu rudern!« bat Marianne und sah ringsum.
     </p>
-    <p xml:id="eco_de_0000140_20400">
+    <p xml:id="eco_de_0000210_20400">
      Hinter ihr lag die Seeweid mit der grauen Mauer, über die das purpurrote Laub des wilden Weines herunter hing. Drüben am Ufer blinkten die weissen Häuser aus ihren Gärten. Und fern ragte hinter den bläulichen Vorbergen das schimmernde Schneegebirge auf, so klar wie man es im Sommer selten sah. Es war, als ob jetzt zum Abschied noch alles sich doppelt prächtig zeigen wollte.
     </p>
-    <p xml:id="eco_de_0000140_20410">
+    <p xml:id="eco_de_0000210_20410">
      Am schönsten aber war es beim Sonnenuntergang, wenn die Schneegipfel in roter Glut sich vom reinen Himmel abhoben.
     </p>
-    <p xml:id="eco_de_0000140_20420">
+    <p xml:id="eco_de_0000210_20420">
      »Das ist unser liebes, schönes Heimatland, Kinder«, sagte Papa, als er am Abend mit ihnen draussen sass. »Ihr wisst noch nicht recht, was ihr besitzt. Erst wer einmal lange fort gewesen ist, fühlt ganz, wie er sein Vaterland liebt –«
     </p>
-    <p xml:id="eco_de_0000140_20430">
+    <p xml:id="eco_de_0000210_20430">
      Papa sah über den See zu den verglühenden Bergen hin, und die Kinder merkten, dass er an jene Zeit dachte, wo er viele Jahre in der fremde gewesen war und bitteres Heimweh nach seiner lieben, schönen Heimat gehabt hatte.
     </p>
    </div>
@@ -6301,427 +6301,427 @@
     <head>
      Der Fackelzug.
     </head>
-    <p xml:id="eco_de_0000140_20440">
+    <p xml:id="eco_de_0000210_20440">
      »Papa«, sagte Hans eines Montags nach dem Mittagessen, »wir haben in der Klasse ausgemacht, dass wir Herrn Altschmid einen Fackelzug bringen.«
     </p>
-    <p xml:id="eco_de_0000140_20450">
+    <p xml:id="eco_de_0000210_20450">
      Herr Altschmid, Hansens Lehrer, war seit einiger Zeit krank.
     </p>
-    <p xml:id="eco_de_0000140_20460">
+    <p xml:id="eco_de_0000210_20460">
      »Schön«, sagte Papa. »Woher bekommt ihr Fackeln?«
     </p>
-    <p xml:id="eco_de_0000140_20470">
+    <p xml:id="eco_de_0000210_20470">
      »Ja, wir machen es mit Rübenlichtern. Herr Altschmid hat einmal in der Naturkundstunde uns erzählt, er möge sie so gern; er habe als Bube im Herbst immer Rübenlampen geschnitzt.«
     </p>
-    <p xml:id="eco_de_0000140_20480">
+    <p xml:id="eco_de_0000210_20480">
      »Wenn aber Herr Altschmid krank ist, kann er euern Fackelzug nicht sehen«, warf Lotti ein.
     </p>
-    <p xml:id="eco_de_0000140_20490">
+    <p xml:id="eco_de_0000210_20490">
      »Vom Fenster aus schon. Es geht ihm jetzt besser. Nach den Herbstferien kommt er wieder in die Schule, und wir sind sehr froh; wir mögen Herrn Moosrang gar nicht.«
     </p>
-    <p xml:id="eco_de_0000140_20500">
+    <p xml:id="eco_de_0000210_20500">
      »Das ist ein schnelles Wort«, sagte Papa, »aber eines, das mir nicht gefällt, Hans!«
     </p>
-    <p xml:id="eco_de_0000140_20510">
+    <p xml:id="eco_de_0000210_20510">
      »Papa, keiner hat ihn gern, nicht einmal Karl Binder und Walter Schürmann, und das sind doch die Besten in der Klasse. Er macht auch alles ganz anders als Herr Altschmid und hat gar keine Ordnung. Und er zankt beständig, schon wenn er hereinkommt. Aber die Buben hören nicht auf mit Lachen und Schwatzen. Letzthin hat der Wohlkomm ganz laut mit dem Lineal auf den Tisch geschlagen, und dann, wie man gemeint hat, es werde endlich ruhig, läuft der Beschel bis zur vordersten Bank und gibt dem Adolf Kurz eins. Da hat alles gelacht, und der Lärm ging noch einmal von vorn an.«
     </p>
-    <p xml:id="eco_de_0000140_20520">
+    <p xml:id="eco_de_0000210_20520">
      »Ihr seid aber unartige Buben!« rief Marianne.
     </p>
-    <p xml:id="eco_de_0000140_20530">
+    <p xml:id="eco_de_0000210_20530">
      »Hoffentlich sind nicht alle so? Hoffentlich sind einige, die sich schämen mitzumachen –?« sagte Papa und sah Hans scharf an.
     </p>
-    <p xml:id="eco_de_0000140_20540">
+    <p xml:id="eco_de_0000210_20540">
      »Ja, schon –«, antwortete Hans etwas verlegen. Er gehörte nicht zu den Schlimmen; aber ein ganz gutes Gewissen hatte er doch nicht. Um abzulenken, fing er wieder an, vom Fackelzug zu sprechen.
     </p>
-    <p xml:id="eco_de_0000140_20550">
+    <p xml:id="eco_de_0000210_20550">
      »Frau Altschmid hat gesagt, am Samstag dürften ein paar von uns Herrn Altschmid sehen. Also wählen wir einige aus dem Fackelzug, die hinaufgehen. Vielleicht komme ich auch dazu. Dann erzählen wir Herrn Altschmid, wie es bei Herrn Moosrang ist und dass wir gar nicht mehr gern in die Schule gehen.«
     </p>
-    <p xml:id="eco_de_0000140_20560">
+    <p xml:id="eco_de_0000210_20560">
      »Hans«, sagte Papa, »die ganze Geschichte gefällt mir nicht.«
     </p>
-    <p xml:id="eco_de_0000140_20570">
+    <p xml:id="eco_de_0000210_20570">
      »Aber doch das mit dem Fackelzug?«
     </p>
-    <p xml:id="eco_de_0000140_20580">
+    <p xml:id="eco_de_0000210_20580">
      »Nein, das mit dem Fackelzug auch nicht. Ich finde, dass es unter diesen Umständen gar nicht geht, Herrn Altschmid einen Fackelzug zu bringen.«
     </p>
-    <p xml:id="eco_de_0000140_20590">
+    <p xml:id="eco_de_0000210_20590">
      Hans und die Schwestern sahen Papa erstaunt an.
     </p>
-    <p xml:id="eco_de_0000140_20600">
+    <p xml:id="eco_de_0000210_20600">
      »Wenn er nun von euch hört, dass ihr unartig und unfolgsam seid und Herrn Moosrang die Arbeit so schwer als möglich macht, wie kann er da Freude haben an euerm Fackelzug –? Herr Altschmid ist krank; jetzt bereitet ihr ihm noch Sorge und Ärger dazu. Er hoffte, ihr würdet bei Herrn Moosrang tüchtig lernen, so dass er sich zu Hause ruhig erholen könnte; statt dessen hört er, dass die Zeit verloren geht. Denn wo keine Ordnung ist, da ist auch kein Vorwärtskommen. Nein, erst müsst ihr euch bei Herrn Moosrang wacker halten, bevor ihr da grossartig mit Lichtern zu Herrn Altschmid ziehen könnt. Das ist meine Meinung, Hans, und ich wollte, sie wäre auch die deine.«
     </p>
-    <p xml:id="eco_de_0000140_20610">
+    <p xml:id="eco_de_0000210_20610">
      Papa zog seine Uhr heraus.
     </p>
-    <p xml:id="eco_de_0000140_20620">
+    <p xml:id="eco_de_0000210_20620">
      »Es ist höchste Zeit, dass ihr zur Schule geht, Kinder!«
     </p>
-    <p xml:id="eco_de_0000140_20630">
+    <p xml:id="eco_de_0000210_20630">
      Als Papa Hans die Hand reichte, sah er ihm noch einmal ernsthaft ins Gesicht. –
     </p>
-    <p xml:id="eco_de_0000140_20640">
+    <p xml:id="eco_de_0000210_20640">
      Von zwei bis drei war Schreibstunde. Hans sass still über seinem Heft, während es um ihn her flüsterte und herumrutschte. Herr Moosrang zeigte an der Wandtafel das grosse P und schrieb darunter: Paris, Paul, Po, Petersburg. Er machte schöne, grosse Buchstaben; aber beim g brach ihm die Kreide.
     </p>
-    <p xml:id="eco_de_0000140_20650">
+    <p xml:id="eco_de_0000210_20650">
      »Au weh!« rief Wohlkomm über die Klasse hin, so dass alles laut lachte. Herr Moosrang kam und schüttelte den Wohlkomm am Arm; aber Wohlkomm machte ein sehr unartiges Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_20660">
+    <p xml:id="eco_de_0000210_20660">
      »Schreibt jetzt –!« rief Herr Moosrang ärgerlich.
     </p>
-    <p xml:id="eco_de_0000140_20670">
+    <p xml:id="eco_de_0000210_20670">
      Hans versuchte, ob er einen recht schönen Bogen auf seinem P herausbringe. Da stiess ihn sein Nachbar, der kleine Haubinger, der absichtlich einen grossen Tintenfleck auf ein Stück Papier gemacht und dies gefaltet hatte. Nun war ein greuliches Gebilde entstanden, einem Gesicht ähnlich mit struppigen Haaren. Haubinger setzte Arme und Beine an.
     </p>
-    <p xml:id="eco_de_0000140_20680">
+    <p xml:id="eco_de_0000210_20680">
      »Gib's weiter, Turnach!«
     </p>
-    <p xml:id="eco_de_0000140_20690">
+    <p xml:id="eco_de_0000210_20690">
      Aber Hans rückte weg.
     </p>
-    <p xml:id="eco_de_0000140_20700">
+    <p xml:id="eco_de_0000210_20700">
      »Lass mich in Ruh!« sagte er.
     </p>
-    <p xml:id="eco_de_0000140_20710">
+    <p xml:id="eco_de_0000210_20710">
      »Puh –!« machte der andere und schnitt eine Grimasse. »Wie tust denn du auf einmal tugendhaft –!« Er bot sein Kunstwerk in die hintere Bank und verfertigte dann ein neues.
     </p>
-    <p xml:id="eco_de_0000140_20720">
+    <p xml:id="eco_de_0000210_20720">
      In der Pause ging Hans mit Karl Binder und Walter Schürmann unter den Kastanienbäumen des Hofes auf und ab.
     </p>
-    <p xml:id="eco_de_0000140_20730">
+    <p xml:id="eco_de_0000210_20730">
      »Wisst ihr – eigentlich ist das nichts, wie es bei und jetzt zugeht. Neben dem Haubinger kann man gar nicht arbeiten, wenn man noch möchte«, sagte er.
     </p>
-    <p xml:id="eco_de_0000140_20740">
+    <p xml:id="eco_de_0000210_20740">
      »Ja, und erst neben dem Kurz –!« erwiderte Karl Binder. »Es ist wirtlich zu arg, wie sie's machen.«
     </p>
-    <p xml:id="eco_de_0000140_20750">
+    <p xml:id="eco_de_0000210_20750">
      »Wenn das Herr Altschmid erfährt, ist es ihm gewiss nicht recht«, sagte Hans. Er redete jetzt wie sein Papa; aber er durfte; denn er hatte die ganze Stunde über die Sache nachgedacht. »Der Fackelzug ist mir jetzt fast verleidet.«
     </p>
-    <p xml:id="eco_de_0000140_20760">
+    <p xml:id="eco_de_0000210_20760">
      »Ja, dumm wär' es schon, wenn Herr Altschmid dann früge, was wir in der Schule treiben«, sagte Karl Binder.
     </p>
-    <p xml:id="eco_de_0000140_20770">
+    <p xml:id="eco_de_0000210_20770">
      »Aber was wollt ihr tun, wenn die ganze Klasse so ist!« meinte Walter Schürmann.
     </p>
-    <p xml:id="eco_de_0000140_20780">
+    <p xml:id="eco_de_0000210_20780">
      »Ho, man braucht wenigstens nicht mitzumachen«, antwortete Karl Binder. »Ich gebe dem Kurz nie Antwort, wenn er mit seinen Dummheiten kommt.«
     </p>
-    <p xml:id="eco_de_0000140_20790">
+    <p xml:id="eco_de_0000210_20790">
      »Ich dem Haubinger jetzt auch nicht mehr!« rief Hans eifrig.
     </p>
-    <p xml:id="eco_de_0000140_20800">
+    <p xml:id="eco_de_0000210_20800">
      Um vier Uhr trafen die drei wieder zusammen und gingen die Treppe hinunter. Da rannte Haubinger an ihnen vorbei, tat einen scharfen Pfiff und schrie, indem er sich gegen die andern wandte:
     </p>
-    <p xml:id="eco_de_0000140_20810">
+    <p xml:id="eco_de_0000210_20810">
      »Die Tugendbündler – da gehen die Tugendbündler –!« Das Wort lief gleich durch die ganze Schar auf der Treppe:
     </p>
-    <p xml:id="eco_de_0000140_20820">
+    <p xml:id="eco_de_0000210_20820">
      »Seht, seht, das ist der Tugendbund! Das ist die Kompanie der Tugendhaften – die Gesellschaft der artigen Büblein –!«
     </p>
-    <p xml:id="eco_de_0000140_20830">
+    <p xml:id="eco_de_0000210_20830">
      Binder, Schürmann und Hans Turnach gingen weiter und antworteten vorerst nicht auf die Spottreden. Als aber einer den Karl Binder grob in die Seite stiess, stellte sich dieser:
     </p>
-    <p xml:id="eco_de_0000140_20840">
+    <p xml:id="eco_de_0000210_20840">
      »Komm her, wenn du Mut hast –!« rief er.
     </p>
-    <p xml:id="eco_de_0000140_20850">
+    <p xml:id="eco_de_0000210_20850">
      Vogelberger, ein grosser Bub, zögerte. Doch als er sah, dass etwa zehn oder zwölf andere Lust hatten, mit ihm den Tugendbund anzugreifen, warf er die Schulmappe in die Ecke und wandte sich mit einem kriegerischen »Hoh – hoh!« gegen die drei.
     </p>
-    <p xml:id="eco_de_0000140_20860">
+    <p xml:id="eco_de_0000210_20860">
      Hans erhielt den ersten Schlag von der Faust des Vogelberger und gab ihn gehörig zurück. Da kam um die Ecke Herr Späth, der Lehrer der sechsten Klasse, ein alter weisshaariger, aber noch sehr handfester Herr, den man im Schulhaus fürchtete. Die Knaben fuhren zurück.
     </p>
-    <p xml:id="eco_de_0000140_20870">
+    <p xml:id="eco_de_0000210_20870">
      »Ihr Erzschlingel –!« rief er mit dröhnender Stimme. »Ihr heillosen Kerle! Muss denn immer geprügelt sein –? immer geprügelt? Kennt ihr gar keine andere Art, euch mit einander zu verständigen? Schämt euch, und macht, dass ihr heimkommt! …«
     </p>
-    <p xml:id="eco_de_0000140_20880">
+    <p xml:id="eco_de_0000210_20880">
      So weitersprechend trieb Herr Späth die Buben durch den Schulhof und draussen über den Platz. Es war keine Möglichkeit, den Streit fortzusetzen.
     </p>
-    <p xml:id="eco_de_0000140_20890">
+    <p xml:id="eco_de_0000210_20890">
      Dafür ging es am andern Morgen wieder an. Die drei Freunde setzten sich ruhig an ihre Plätze; aber die andern trieben es um so toller. Die waren heute besonders ungebärdig, um die »Tugendbündler« zu ärgern. Herr Moosrang kam gar nicht aus dem Schelten heraus.
     </p>
-    <p xml:id="eco_de_0000140_20900">
+    <p xml:id="eco_de_0000210_20900">
      In der Geometriestunde hatte die Klasse spitze und stumpfe Winkel zu zeichnen und zu messen. Da sah Hans auf einmal, dass Julius Beschel etwas in den Seitengang warf. Karl Binder bemerkte es auch; er bückte sich und hob ein Knallplätzchen auf. Weiter hinten sah er noch eins und ein drittes. Sie mussten losgehen, sowie Herr Moosrang daherkam.
     </p>
-    <p xml:id="eco_de_0000140_20910">
+    <p xml:id="eco_de_0000210_20910">
      »Lass liegen –!« wisperte Vogelberger. »Das geht dich nichts an!« Damit warf auch er zwei Knallplätzchen hin.
     </p>
-    <p xml:id="eco_de_0000140_20920">
+    <p xml:id="eco_de_0000210_20920">
      Karl Binder lob sie auf, und Hans bückte sich nach einem in seiner Nähe.
     </p>
-    <p xml:id="eco_de_0000140_20930">
+    <p xml:id="eco_de_0000210_20930">
      »Ihr seid dumme, langweilige Spielverderber!« sagte Haubinger, der dem Treiben zusah.
     </p>
-    <p xml:id="eco_de_0000140_20940">
+    <p xml:id="eco_de_0000210_20940">
      Als Beschel wieder warf, musste Karl Binder um drei Bänke zurückschleichen, bis er zu dem Knallplätzchen kam.
     </p>
-    <p xml:id="eco_de_0000140_20950">
+    <p xml:id="eco_de_0000210_20950">
      Herr Moosrang sah auf. Was war das wieder für ein Hin und Her, ein Flüstern und Lachen –?
     </p>
-    <p xml:id="eco_de_0000140_20960">
+    <p xml:id="eco_de_0000210_20960">
      »Karl Binder! Wie kannst du dich unterstehen –! Was ist das! Nicht fünf Minuten könnt ihr euch anständig benehmen!« Herr Moosrang war so böse wie noch nie. Wenn nun dieser Binder auch anfing, der doch sonst einer der Besten war –!
     </p>
-    <p xml:id="eco_de_0000140_20970">
+    <p xml:id="eco_de_0000210_20970">
      Herr Moosrang stand hart vor Karl Binder.
     </p>
-    <p xml:id="eco_de_0000140_20980">
+    <p xml:id="eco_de_0000210_20980">
      »Was hattest du da hinten zu tun –? Ich will es wissen!«
     </p>
-    <p xml:id="eco_de_0000140_20990">
+    <p xml:id="eco_de_0000210_20990">
      Karl Binder sah zu Beschel und Vogelberger hinüber; aber die rührten sich nicht.
     </p>
-    <p xml:id="eco_de_0000140_21000">
+    <p xml:id="eco_de_0000210_21000">
      »Nun? Wird's bald –?« rief Herr Moosrang scharf.
     </p>
-    <p xml:id="eco_de_0000140_21010">
+    <p xml:id="eco_de_0000210_21010">
      Es war Karl Binder leid, so trotzig zu scheinen; aber verklagen wollte er die beiden nicht und eine Lüge sagen auch nicht.
     </p>
-    <p xml:id="eco_de_0000140_21020">
+    <p xml:id="eco_de_0000210_21020">
      »Kannst du nicht reden? nicht –? Nun, dann besinnst du dich vielleicht da draussen auf eine Antwort – marsch –!« Herr Moosrang riss die Türe auf.
     </p>
-    <p xml:id="eco_de_0000140_21030">
+    <p xml:id="eco_de_0000210_21030">
      Alle Knaben sahen gespannt zu. Das war noch nie erlebt worden, dass der Binder vor die Türe musste. Hans hätte bei einem Haare geschrien: »Er ist unschuldig –!«
     </p>
-    <p xml:id="eco_de_0000140_21040">
+    <p xml:id="eco_de_0000210_21040">
      Aber Karl Binder winkte ihm mit den Augen und ging ruhig hinaus. Nur als er bei Beschel und Vogelberger vorbeikam, machte er ein verächtliches Gesicht.
     </p>
-    <p xml:id="eco_de_0000140_21050">
+    <p xml:id="eco_de_0000210_21050">
      Herr Moosrang hatte die Türklinke in der Hand behalten und wollte hinter Karl Binder schliessen; da rief ihn ein Lehrer hinaus, der etwas mit ihm zu besprechen hatte.
     </p>
-    <p xml:id="eco_de_0000140_21060">
+    <p xml:id="eco_de_0000210_21060">
      So war jetzt die Klasse allein. Statt aber, wie sonst bei solch einem Anlass, Lärm anzufangen, waren die Buben still und sahen einander verblüfft an. Beschel und Vogelberger beugten sich über ihre Hefte, als ob sie eifrig ihre Winkel messen würden.
     </p>
-    <p xml:id="eco_de_0000140_21070">
+    <p xml:id="eco_de_0000210_21070">
      Da stand Herrmann Villeiner in der ersten Bankreihe auf, drehte dich gegen die Klasse um und sagte laut:
     </p>
-    <p xml:id="eco_de_0000140_21080">
+    <p xml:id="eco_de_0000210_21080">
      »Eigentlich ist das gemein.«
     </p>
-    <p xml:id="eco_de_0000140_21090">
+    <p xml:id="eco_de_0000210_21090">
      Villeiner war ein blondhaariger Bube mit dicken Backen und galt für etwas faul. In der Klasse hatte man ihn aber nicht ungern.
     </p>
-    <p xml:id="eco_de_0000140_21100">
+    <p xml:id="eco_de_0000210_21100">
      »Eigentlich ist das gemein«, sagte er noch einmal und setzte sich auf seinen Tisch vor alle hin. »Wenn einer etwas tut, sann soll er dazu stehen. In rechten Klassen macht man es immer so. Aber bei uns sind ein paar, die keinen Mut haben und keine Ehre, ein paar miserable Tröpfe –«
     </p>
-    <p xml:id="eco_de_0000140_21110">
+    <p xml:id="eco_de_0000210_21110">
      Alle sahen auf Beschel und Vogelberger, und es gab ein lautes Gemurmel durch die Klasse:
     </p>
-    <p xml:id="eco_de_0000140_21120">
+    <p xml:id="eco_de_0000210_21120">
      »Der Villeiner hat recht! Karl Binder gehörte nicht vor die Türe! Von ihm war's fein, dass er sie nicht verklagen wollte! In der sechsten Klasse verklagen sie auch nie. Wenn etwas auskommt, so muss der, der es getan hat, selber bekennen; oder er gilt als ehrlos –«, so hiess es durcheinander unter den Buben.
     </p>
-    <p xml:id="eco_de_0000140_21130">
+    <p xml:id="eco_de_0000210_21130">
      Da kam Herr Moosrang zurück und liess auch Karl Binder hereintreten.
     </p>
-    <p xml:id="eco_de_0000140_21140">
+    <p xml:id="eco_de_0000210_21140">
      »Um elf Uhr reden wir dann miteinander!« sagte er kurz.
     </p>
-    <p xml:id="eco_de_0000140_21150">
+    <p xml:id="eco_de_0000210_21150">
      Alle waren neugierig, was Karl Binder für ein Gesicht mache. Er ging aber ruhig an seinen Platz und nahm sofort Bleistift und Transporteur zur Hand. Das war wie ein Zeichen für die andern. Die Stunde ging ohne weitere Störung zu Ende.
     </p>
-    <p xml:id="eco_de_0000140_21160">
+    <p xml:id="eco_de_0000210_21160">
      In der Pause aber gab es viel zu reden, und die Parteien standen wieder abgesondert in zwei Ecken des Hofes. Während jedoch gestern der »Tugendbund« bloss drei Mitglieder gezählt hatte, traten jetzt fast drei Viertel der Klasse zu Karl Binder hinüber. Auf der andern Seite waren nur noch Beschel, Vogelberger, Kurz, Wohlkomm und sonst ein paar »Nichtsnutzige«, wie Villeiner verächtlich sagte. Er, der sonst so bequem war, ging als Vermittler zwischen beiden Parteien hin und her. Zuerst verlangte man, die Werfer von Knallplätzchen sollten bei Karl Binder abbitten und dann Herrn Moosrang alles sagen. Sie sträubten sich, und Karl Binder erklärte, er begehre keine Abbitte und bei Herrn Moosrang könne er die Sache vielleicht selbst abmachen; sie sollten aber versprechen, nie mehr Knallplätzchen zu werfen und sich überhaupt nicht so miserabel aufzuführen. Villeiner ging hinüber, das auszurichten.
     </p>
-    <p xml:id="eco_de_0000140_21170">
+    <p xml:id="eco_de_0000210_21170">
      »Und wenn ihr wieder anfangt, so prügelt euch die ganze Klasse durch!« setzte er aus eigenem Gutdünken seiner Botschaft hinzu. Die Partei Beschel und Vogelberger fügte sich.
     </p>
-    <p xml:id="eco_de_0000140_21180">
+    <p xml:id="eco_de_0000210_21180">
      Als nach der Pause Herr Moosrang hereinkam, war er ganz erstaunt, alle so ordentlich und still an ihren Plätzen zu finden. Auch im Verlauf der Stunde, da ein Lesestück durchgenommen wurde, gab es fast nichts zu tadeln. Es war von einem Seehafen die Rede. Da fing Herr Moosrang an von Marseille zu erzählen, von dem Schiffverkehr dort und dem Treiben im Hafen, von den mächtigen Dampfern und den Drei- und Fünfmastern mit Flaggen aus aller Herren Ländern, von den kleinen Seglern, die mit Orangen beladen von Spanien herüberkommen, und von den winzigen Motorbooten, die wie Wasserspinnen im Hafen herumschnurren.
     </p>
-    <p xml:id="eco_de_0000140_21190">
+    <p xml:id="eco_de_0000210_21190">
      Er erzählte so lebhaft, dass die Knaben meinten, dabei zu sein. Es läutete elf Uhr, ehe man sich's versah.
     </p>
-    <p xml:id="eco_de_0000140_21200">
+    <p xml:id="eco_de_0000210_21200">
      Da fiel Herrn Moosrangs Blick auf Karl Binder.
     </p>
-    <p xml:id="eco_de_0000140_21210">
+    <p xml:id="eco_de_0000210_21210">
      »Komm her, du dort!« sagte er und sah wieder ärgerlich aus.
     </p>
-    <p xml:id="eco_de_0000140_21220">
+    <p xml:id="eco_de_0000210_21220">
      Es bildete sich ein Kreis Neugieriger um Karl Binder, als er vor Herrn Moosrang stand; aber bescheiden sagte er:
     </p>
-    <p xml:id="eco_de_0000140_21230">
+    <p xml:id="eco_de_0000210_21230">
      »Herr Moosrang – wir haben etwas gegen einander gehabt. Drum bin ich schnell vom Platz gegangen. Ich hab' nicht anders können. Aber wir haben es unter uns ausgemacht in der Pause; es ist eine Art Streit gewesen. Jetzt ist alles in Ordnung.«
     </p>
-    <p xml:id="eco_de_0000140_21240">
+    <p xml:id="eco_de_0000210_21240">
      Herrn Moosrangs Gesicht hellte sich auf; es lag ihm offenbar nichts an einer Untersuchung.
     </p>
-    <p xml:id="eco_de_0000140_21250">
+    <p xml:id="eco_de_0000210_21250">
      »So – nun, wenn ihr die Sache selbst in Ordnung gebracht habt –! Nehmt euch aber in acht, dass ihr nicht eine neue anfangt!«
     </p>
-    <p xml:id="eco_de_0000140_21260">
+    <p xml:id="eco_de_0000210_21260">
      Er nahm seine Mappe und verliess das Zimmer.
     </p>
-    <p xml:id="eco_de_0000140_21270">
+    <p xml:id="eco_de_0000210_21270">
      »Famos!« sagten die Buben, als sie die Treppe hinunter gingen. »Fein war das vom Binder! Er hat sie nicht angegeben und doch ganz die Wahrheit gesagt –«
     </p>
-    <p xml:id="eco_de_0000140_21280">
+    <p xml:id="eco_de_0000210_21280">
      Am Nachmittag in der Geschichtsstunde ging wieder alles in Frieden, und um drei Uhr kam Herr Moosrang mit ganz fröhlichem Gesicht in die Turnhalle:
     </p>
-    <p xml:id="eco_de_0000140_21290">
+    <p xml:id="eco_de_0000210_21290">
      »Weil ihr euch so gut gehalten habt, Bursche, gibt's eine Spielstunde draussen!«
     </p>
-    <p xml:id="eco_de_0000140_21300">
+    <p xml:id="eco_de_0000210_21300">
      Die Buben jubelten, aber manierlich. Herr Moosrang liess sie im Hofe die alten Ballspiele spielen und lehrte sie ein neues, das ihnen sehr gefiel. Er selbst schleuderte den Ball ausgezeichnet und war lustig und freundlich. Einmal lobte er den Beschel für einen besonders guten Schlag und wählte den Kurz zum Führer, als ob er gar nicht mehr an all den Ärger denke, den ihm die zwei schon gemacht –
     </p>
-    <p xml:id="eco_de_0000140_21310">
+    <p xml:id="eco_de_0000210_21310">
      »Papa«, schloss Hans, als er am Abend die Schulgeschichte erzählte, »seit heute haben wir Herrn Moosrang ganz gern!«
     </p>
-    <p xml:id="eco_de_0000140_21320">
+    <p xml:id="eco_de_0000210_21320">
      »So«, sagte Papa, »das ist schnell besser geworden! Wenn's jetzt nur dabei bleibt!«
     </p>
-    <p xml:id="eco_de_0000140_21330">
+    <p xml:id="eco_de_0000210_21330">
      Und wirklich, auch die folgenden Tage verliefen gut. Nicht, dass nun die ganze Klasse auf einmal sich tadellos aufgeführt hätte; es musste hie und da einer gestraft werden. Aber der ganze Ton war doch ein anderer.
     </p>
-    <p xml:id="eco_de_0000140_21340">
+    <p xml:id="eco_de_0000210_21340">
      So fingen denn die Buben wieder an, vom Fackelzug zu sprechen.
     </p>
-    <p xml:id="eco_de_0000140_21350">
+    <p xml:id="eco_de_0000210_21350">
      »Wir dürfen Herrn Altschmid jetzt schon einen bringen«, meinte Walter Schürmann. »Herr Moosrang hat gesagt, wenn etwa einer von und zu Herrn Altschmid gehe, so sollen wir ihn grüssen und ihm ausrichten, Herr Moosrang sei jetzt recht zufrieden mit uns.«
     </p>
-    <p xml:id="eco_de_0000140_21360">
+    <p xml:id="eco_de_0000210_21360">
      Der Fackelzug wurde auf Samstag halb sieben festgesetzt, und am Freitag abend brachte Hans aus der Schule etwa zwölf Buben mit, darunter Karl Binder, Walter Schürmann, Villeiner und sogar den Haubinger, mit dem er wieder Frieden geschlossen hatte.
     </p>
-    <p xml:id="eco_de_0000140_21370">
+    <p xml:id="eco_de_0000210_21370">
      »Wir brauchen alle recht grosse Rüben, Jakob« sagte Hans, als er mit den Kameraden zum Stall kam. »Bitte, geh mit uns zum obern Acker; Frau Völklein hat es erlaubt.«
     </p>
-    <p xml:id="eco_de_0000140_21380">
+    <p xml:id="eco_de_0000210_21380">
      Jakob wusste schon vom Fackelzug und nahm grossen Anteil an dem Unternehmen. Er hatte es wie Herr Altschmid: die Rübenlichter erinnerten ihn an seine Kindheit.
     </p>
-    <p xml:id="eco_de_0000140_21390">
+    <p xml:id="eco_de_0000210_21390">
      Jeder der Buben bekam zwei oder drei Rüben für den Fall, dass ein Stück misslinge. Dann ging's ans Aushöhlen. Marianne und Lotti, die mit einem Korb voll Brotstücke und Äpfel gekommen waren, blieben da und halfen; denn es stellte sich heraus, dass einige Buben noch nie eine Rübenlampe gemacht hatten.
     </p>
-    <p xml:id="eco_de_0000140_21400">
+    <p xml:id="eco_de_0000210_21400">
      »Innen muss alles sauber heraus«, erklärte Lotti dem Haubinger, der heute sehr artig war. »So – die Wand muss ganz dünn werden; aber es darf kein Loch geben. Oben kommen dann die Einschnitte für die Schnüre –«
     </p>
-    <p xml:id="eco_de_0000140_21410">
+    <p xml:id="eco_de_0000210_21410">
      Marianne half dem Villeiner, der etwas ungeschickte Hände besass.
     </p>
-    <p xml:id="eco_de_0000140_21420">
+    <p xml:id="eco_de_0000210_21420">
      »Fertig!« sagte er zufrieden, als Marianne seine Rübe ausgehöhlt hatte.
     </p>
-    <p xml:id="eco_de_0000140_21430">
+    <p xml:id="eco_de_0000210_21430">
      »Nein, du! die ist noch nicht fertig!« erwiderte Marianne. »Du wirst doch nicht an den Fackelzug wollen mit einer Lampe ohne Verzierung –? Sieh dort dem Karl Binder und dem Hans zu –«
     </p>
-    <p xml:id="eco_de_0000140_21440">
+    <p xml:id="eco_de_0000210_21440">
      Karl Binder hatte eine hübsche Bordüre von Zacken und Ringen in Arbeit, Hans eine Reihe von Bäumchen, immer ein kugelrundes und dann ein spitziges. Es war nicht leicht, so aussen die oberste Schicht der Rübe abzulösen, ohne durchzustechen. Aber alle Buben versuchten nun, Figuren einzuschneiden oder dann die Anfangsbuchstaben ihres Namens mit der Klasse und der Jahreszahl. Walter Schürmann, der gut zeichnete, brachte auf seiner Lampe drei grosse Hähne an mit zackigem Kamm. Und ebenso hübsch wurde Mariannes Rübe mit zwei Kindern, die sich an der Hand hielten.
     </p>
-    <p xml:id="eco_de_0000140_21450">
+    <p xml:id="eco_de_0000210_21450">
      Die meisten Knaben machten zwei Lampen; denn es liess sich ganz gut ein Paar an einem Stock befestigen.
     </p>
-    <p xml:id="eco_de_0000140_21460">
+    <p xml:id="eco_de_0000210_21460">
      »Du«, sagte Lotti leise zu Hans, »Marianne und ich, wir möchten furchtbar gern auch mit an den Fackelzug.«
     </p>
-    <p xml:id="eco_de_0000140_21470">
+    <p xml:id="eco_de_0000210_21470">
      »Das geht nicht«, antwortete Hans. »Wir können keine Mädchen brauchen.«
     </p>
-    <p xml:id="eco_de_0000140_21480">
+    <p xml:id="eco_de_0000210_21480">
      »Warum nicht?« sagte Karl Binder. »Sie können Ehrenjungfrauen sein. Ich habe das einmal bei einem Sängerfestzug gesehen. Sie waren weiss gekleidet und trugen Blumen.«
     </p>
-    <p xml:id="eco_de_0000140_21490">
+    <p xml:id="eco_de_0000210_21490">
      Lotti lief voll Freude zur Schwester hinüber:
     </p>
-    <p xml:id="eco_de_0000140_21500">
+    <p xml:id="eco_de_0000210_21500">
      »Du, Marianne – Karl Binder hat gesagt, wir dürften Ehrenjungfrauen sein!«
     </p>
-    <p xml:id="eco_de_0000140_21510">
+    <p xml:id="eco_de_0000210_21510">
      »Wenn aber die andern nicht wollen –?« warf Hans ein.
     </p>
-    <p xml:id="eco_de_0000140_21520">
+    <p xml:id="eco_de_0000210_21520">
      »Man muss es ihnen nur recht sagen«, antwortete Karl. »Wir haben ja auch noch die Abgeordneten zu wählen morgen.«
     </p>
-    <p xml:id="eco_de_0000140_21530">
+    <p xml:id="eco_de_0000210_21530">
      Die Wahlen nahmen zwei Pausen in Anspruch. Zuerst und einstimmig wurde Karl Binder gewählt, dann ebenfalls mit schönem Mehr Hans Turnach und Walter Schürmann; als vierter und fünfter Villeiner und sein Freund Kolb. Alles war erstaunt, dass Karl Binder noch den Wohlkomm vorschlug.
     </p>
-    <p xml:id="eco_de_0000140_21540">
+    <p xml:id="eco_de_0000210_21540">
      »Aber, Karl – den Wohlkomm!« sagte Hans leise.
     </p>
-    <p xml:id="eco_de_0000140_21550">
+    <p xml:id="eco_de_0000210_21550">
      »Eben gerade! Wir müssen einen von den früheren Feinden wählen. Sie haben uns auch ihre Stimmen gegeben.«
     </p>
-    <p xml:id="eco_de_0000140_21560">
+    <p xml:id="eco_de_0000210_21560">
      Wohlkomm bekam vor Überraschung einen ganz roten Kopf, als er wirklich gewählt wurde.
     </p>
-    <p xml:id="eco_de_0000140_21570">
+    <p xml:id="eco_de_0000210_21570">
      Dann folgte die Frage wegen der Ehrenjungfrauen. Ein paar von den Buben wollten zuerst nichts davon wissen und sagten, sie begehrten nicht hinter Mädeln herzuziehen.
     </p>
-    <p xml:id="eco_de_0000140_21580">
+    <p xml:id="eco_de_0000210_21580">
      »So bleibt daheim!« rief Haubinger, dem Lotti gestern bei seiner Rübenlampe geholfen, und versetzte einem der Gegner einen festen Puff, der erwidert wurde. Fast wäre um die Ehrenjungfrauen eine regelrechte Prügelei entstanden, wenn nicht Karl Binder erklärt hätte, an jenem Sängerfest seien sehr viele Herren und sogar Präsidenten hinter den Ehrenjungfrauen gezogen.
     </p>
-    <p xml:id="eco_de_0000140_21590">
+    <p xml:id="eco_de_0000210_21590">
      Am Samstag versammelte die Klasse sich unten bei der stillen Vorstadtstrasse, an der Herr Altschmid wohnte. Von allen Seiten kamen die Knaben daher mit ihren Lampen, in denen das Lichtstümpchen schon brannte. Sie zeigten sich gegenseitig ihr Schnitzwerk, das, von innen beleuchtet, hell und hübsch schimmerte. Dann ordnete man sich zum Zug. Er wurde eröffnet durch drei Doppellampenträger, die in gleichmässigem Abstand neben einander herschritten. Ihnen folgten die Ehrenjungfrauen, zu denen als dritte noch Emma Schürmann gekommen war. Lotti ging in der Mitte mit einem Rübenlicht, rechts Emma Schürmann mit einem Blumenstrauss, links Marianne mit einem Körbchen Birnen. Statt weisser Kleider hatten sie weisse Schärpen, die Marianne aus Seidenpapier verfertigt hatte. Es sah sehr festlich aus. Nach den Ehrenjungfrauen kamen mit ihren Lichtern die sechs Abgeordneten, welche als Zeichen Zweige an den Hüten stecken hatten. Hinter ihnen marschierten die übrigen Buben, eine Dreierreihe nach der andern, in Abständen, damit der Zug möglichst lang werde.
     </p>
-    <p xml:id="eco_de_0000140_21600">
+    <p xml:id="eco_de_0000210_21600">
      Es war schon ziemlich dunkel, und die vielen Rübenlichter schimmerten die Strasse hinauf wie ein Schwarm Leuchtkäfer. Die Leute standen und hatten ihre Freude an dem Zug.
     </p>
-    <p xml:id="eco_de_0000140_21610">
+    <p xml:id="eco_de_0000210_21610">
      »Oha –!« sagte auf einmal Villeiner. »Dort kommt ein Polizeidiener –«
     </p>
-    <p xml:id="eco_de_0000140_21620">
+    <p xml:id="eco_de_0000210_21620">
      Die Buben hielten verdutzt an. Ein Polizeidiener und eine Schar Fünftklässler, das gab sehr oft ein unerfreuliches Zusammentreffen. Aber Karl Binder und Hans Turnach erklärten dem Manne, dass es ein Fackelzug sei, der dem Herrn Lehrer Altschmid gebracht werde. Der Polizeidiener lachte gutmütig und folgte in einiger Entfernung, um zu sehen, wie sich die Sache abspiele.
     </p>
-    <p xml:id="eco_de_0000140_21630">
+    <p xml:id="eco_de_0000210_21630">
      Es verlief alles sehr schön. Bei Herrn Altschmid angelangt, der im ersten Stockwerk wohnte, stellten sich die Knaben rasch und leise zusammen und stimmten dass Lied an:
     </p>
-    <p xml:id="eco_de_0000140_21640">
+    <p xml:id="eco_de_0000210_21640">
      »Im schönsten Wiesengrunde liegt meiner Heimat Haus …«
     </p>
-    <p xml:id="eco_de_0000140_21650">
+    <p xml:id="eco_de_0000210_21650">
      Die Fenster öffneten sich; Frau Altschmid und ihre Tochter sahen heraus.
     </p>
-    <p xml:id="eco_de_0000140_21660">
+    <p xml:id="eco_de_0000210_21660">
      »Vater, Vater!« rief Fräulein Altschmid ins Zimmer zurück.
     </p>
-    <p xml:id="eco_de_0000140_21670">
+    <p xml:id="eco_de_0000210_21670">
      »Da ist deine ganze Klasse mit Rübenlichtern! Wie nett, alle die kleinen Lampen! Und wie die Buben schön singen –«
     </p>
-    <p xml:id="eco_de_0000140_21680">
+    <p xml:id="eco_de_0000210_21680">
      Am Ende der dritten Strophe wurde auch Herr Altschmid sichtbar.
     </p>
-    <p xml:id="eco_de_0000140_21690">
+    <p xml:id="eco_de_0000210_21690">
      »Guten Abend, Herr Altschmid! guten Abend –« riefen die Buben und streckten ihre Stöcke mit den Lampen zum Gruss in die Höhe.
     </p>
-    <p xml:id="eco_de_0000140_21700">
+    <p xml:id="eco_de_0000210_21700">
      Die sechs Gewählten gingen hinauf in die Wohnung. Walter Schürmann trug die Blumen, Hans Turnach den Birnenkorb. Herr Altschmid bewunderte die Lampen mit den hübschen Verzierungen.
     </p>
-    <p xml:id="eco_de_0000140_21710">
+    <p xml:id="eco_de_0000210_21710">
      »Also einen Fackelzug bringt ihr mir –? Denk' doch Mutter, so eine Ehre!« wandte er sich lächelnd an seine Frau. »Das habt ihr nett ausgedacht; das macht mir Freude!«
     </p>
-    <p xml:id="eco_de_0000140_21720">
+    <p xml:id="eco_de_0000210_21720">
      Dann aber kam gleich, was die Buben erwartet hatten:
     </p>
-    <p xml:id="eco_de_0000140_21730">
+    <p xml:id="eco_de_0000210_21730">
      »Nun, Bürschlein, und wie geht's in der Schule? Macht ihr mir Ehre? Ist Herr Moosrang zufrieden?«
     </p>
-    <p xml:id="eco_de_0000140_21740">
+    <p xml:id="eco_de_0000210_21740">
      Da waren denn alle sehr froh, dass sie mit einem Ja antworten konnten.
     </p>
-    <p xml:id="eco_de_0000140_21750">
+    <p xml:id="eco_de_0000210_21750">
      »So, so, das ist ja schön, Wohlkomm!« sagte Herr Altschmid und sah den Wohlkomm, der fast verlegen wurde, etwas ungläubig aber freundlich an.
     </p>
-    <p xml:id="eco_de_0000140_21760">
+    <p xml:id="eco_de_0000210_21760">
      Herr Altschmid sprach mit müder Stimme; die Knaben merkten, dass er noch leidend war, und verabschiedeten sich. Drunten aber stimmte die Klasse ein zweites Lied an, wieder ein sanftes, wie die Buben es passend fanden für ihren kranken Lehrer.
     </p>
-    <p xml:id="eco_de_0000140_21770">
+    <p xml:id="eco_de_0000210_21770">
      »Guter Mond, du gehst so stille Durch die Abendwolken hin …«
     </p>
-    <p xml:id="eco_de_0000140_21780">
+    <p xml:id="eco_de_0000210_21780">
      Überall an den Fenstern und vor den Häusern standen Leute und sagten, das sei ein netter Einfall von den Knaben. Am meisten aber freute es diese, als Herr Altschmid noch einmal ans Fenster trat und einen herzlichen Dank herunterrief.
     </p>
-    <p xml:id="eco_de_0000140_21790">
+    <p xml:id="eco_de_0000210_21790">
      Die Buben schwenkten ihre Mützen und Lampen.
     </p>
-    <p xml:id="eco_de_0000140_21800">
+    <p xml:id="eco_de_0000210_21800">
      »Gute Besserung, Herr Altschmid! Hoch, hoch, Herr Altschmid! Gute Nacht –!« riefen sie wieder und wieder, stellten sich dann aber auf Anordnung von Karl Binder in Reih und Glied; die Ehrenjungfrauen, zu denen Fräulein Altschmid heruntergekommen war, um sie zu begrüssen, huschten an ihre Plätze, und stramm marschierte die Schar zum Takte eines Turnerliedes die Strasse hinab. Herr Altschmid schaute nach, bis die letzte leuchtende Rübenlampe verschwunden war.
     </p>
-    <p xml:id="eco_de_0000140_21810">
+    <p xml:id="eco_de_0000210_21810">
      »Schön ist es gewesen, Papa –!« berichteten die Turnachkinder zu Hause.
     </p>
-    <p xml:id="eco_de_0000140_21820">
+    <p xml:id="eco_de_0000210_21820">
      »Ja«, sagte Marianne, »und am Anfang der Woche hat man gemeint, es könne gar nichts werden aus dem Fackelzug!«
     </p>
-    <p xml:id="eco_de_0000140_21830">
+    <p xml:id="eco_de_0000210_21830">
      »Wenn Papa nicht gewesen wäre«, erklärte Hans, »so wäre auch alles gar nicht so gegangen.«
     </p>
-    <p xml:id="eco_de_0000140_21840">
+    <p xml:id="eco_de_0000210_21840">
      »Wir wollen sagen, der gute Wille hat's gemacht«, antwortete Papa. »Der gute Wille allerseits. Zuerst in einigen wenigen, und dann, als die tapfer und fest bei der Sache blieben, wurden auch die andern herumgebracht, und es haben sogar Leute wie dieser Beschel und Haubinger und Vogelberger ihre vernünftige und ordentliche Seite herausgekehrt. Ich freue mich darüber, Hans.«
     </p>
    </div>
@@ -6729,151 +6729,151 @@
     <head>
      Der Abschied von der Seeweid naht, und Lotti versucht, traurig zu sein.
     </head>
-    <p xml:id="eco_de_0000140_21850">
+    <p xml:id="eco_de_0000210_21850">
      Frau Völklein sass in ihrer Laube und schälte Bohnen aus. Lotti stand bei ihr. Die Laube war ein hölzerner Vorbau, der an der einen Seite des Hauses entlang lief; man war wie im Freien da und doch geschützt vor Sonne und Regen. Frau Völklein machte die meisten ihrer Hausgeschäfte in der Laube ab.
     </p>
-    <p xml:id="eco_de_0000140_21860">
+    <p xml:id="eco_de_0000210_21860">
      Lotti half beim Bohnenausschälen; es war eine sehr nette Arbeit: Aus den dürren, raschelnden Hülsen kamen alle möglichen Arten von Bohnen zum Vorschein: dunkelbraune, gelbliche, kleine schneeweisse, schwarze mit gelben Tupfen, flache rote oder violette mit weissen Sprenkeln.
     </p>
-    <p xml:id="eco_de_0000140_21870">
+    <p xml:id="eco_de_0000210_21870">
      Lotti schrie jedesmal vor Vergnügen, wenn sie wieder eine neue Sorte entdeckte. Sie durfte eine Menge Bohnen sammeln und erhielt von Frau Völklein ein weisses Säckchen dazu.
     </p>
-    <p xml:id="eco_de_0000140_21880">
+    <p xml:id="eco_de_0000210_21880">
      »Du kannst dann mit Hans und Marianne ›Grad oder ungrad‹ spielen«, sagte die alte Frau.
     </p>
-    <p xml:id="eco_de_0000140_21890">
+    <p xml:id="eco_de_0000210_21890">
      »Wie ist das ›Grad oder ungrad‹?«
     </p>
-    <p xml:id="eco_de_0000140_21900">
+    <p xml:id="eco_de_0000210_21900">
      »Das geht so –« Frau Völklein nahm einige Bohnen in die Hand. »Nun rate – hab' ich eine grade Zahl oder eine ungrade!«
     </p>
-    <p xml:id="eco_de_0000140_21910">
+    <p xml:id="eco_de_0000210_21910">
      »Ungrad!« sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_21920">
+    <p xml:id="eco_de_0000210_21920">
      Aber als Frau Völklein die Hand aufmachte, waren es sechs Bohnen.
     </p>
-    <p xml:id="eco_de_0000140_21930">
+    <p xml:id="eco_de_0000210_21930">
      »So, das ist grad. Du hast verloren und musst mir sechs Bohnen geben.«
     </p>
-    <p xml:id="eco_de_0000140_21940">
+    <p xml:id="eco_de_0000210_21940">
      Nun kam das Raten an Frau Völklein.
     </p>
-    <p xml:id="eco_de_0000140_21950">
+    <p xml:id="eco_de_0000210_21950">
      »Grad!« sagte sie.
     </p>
-    <p xml:id="eco_de_0000140_21960">
+    <p xml:id="eco_de_0000210_21960">
      Und richtig, Lotti hielt vier Bohnen, welche Frau Völklein bekam. Dann gewann Lotti sieben Bohnen. So ging es hin und her. Lotti wurde sehr eifrig; einmal riet sie hintereinander immer ungrad, und jedesmal hatte Frau Völklein neun Bohnen in der Hand, so dass Lotti in kürzester Zeit sechsunddreissig Bohnen gewann. Sie lachte hell auf.
     </p>
-    <p xml:id="eco_de_0000140_21970">
+    <p xml:id="eco_de_0000210_21970">
      »Das ist aber lustig!« rief sie, während sie die Bohnen in ihr Säckchen steckte. »Finden Sie es nicht auch, Frau Völklein?« fragte sie und schaute in das Gesicht der alten Frau, das auf einmal ernsthaft aussah.
     </p>
-    <p xml:id="eco_de_0000140_21980">
+    <p xml:id="eco_de_0000210_21980">
      »Doch, doch, Lotti!« sagte Frau Völklein. »Mir ist nur eingefallen, dass ihr nun sehr bald fortzieht und dass es dann wieder so still und einsam wird in der Seeweid. Die langen Winterabende kommen, und ich sitze allein. Kein Werner, der mir durch alle Zimmer nachspringt, dass ich ihm Fritzens altes Holzpferd gebe; keine Marianne, die mir hilft Johannisbeeren pflücken; kein Hans, der mit zum Taubenschlag hinaufgeht; kein Lotti, mit dem ich das Bohnenspiel spielen kann –«
     </p>
-    <p xml:id="eco_de_0000140_21990">
+    <p xml:id="eco_de_0000210_21990">
      »Nächstes Jahr im Frühling kommen wir wieder«, sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_22000">
+    <p xml:id="eco_de_0000210_22000">
      »Ja, Kind, das sagst du so leicht hin. Ich bin aber eine alte Frau; der Winter kann vieles bringen; wer weiss, ob ich den Frühling erlebe. Mir ist traurig zu Mut, dass ich euch jetzt dann nicht mehr sehe.«
     </p>
-    <p xml:id="eco_de_0000140_22010">
+    <p xml:id="eco_de_0000210_22010">
      Frau Völklein schwieg und sah in den dämmerigen Abend hinaus.
     </p>
-    <p xml:id="eco_de_0000140_22020">
+    <p xml:id="eco_de_0000210_22020">
      Lotti hatte Frau Völklein sehr lieb und wäre gerne länger in der Seeweid geblieben. Sie schaute die alte Frau an; dann aber fielen ihre Augen auf das Bohnensäcklein, und sie dachte an »Grad oder ungrad«, das sie Hans und Marianne zeigen wollte. Doch blieb sie bei Frau Völklein sitzen; es wäre nicht nett gewesen, sie allein zu lassen, wo sie so betrübt war.
     </p>
-    <p xml:id="eco_de_0000140_22030">
+    <p xml:id="eco_de_0000210_22030">
      Da kam Grite und rief Frau Völklein in die Küche. Die alte Frau stand auf.
     </p>
-    <p xml:id="eco_de_0000140_22040">
+    <p xml:id="eco_de_0000210_22040">
      »So geh jetzt, Lotti! Ich lasse Mama und den andern Gute Nacht wünschen.«
     </p>
-    <p xml:id="eco_de_0000140_22050">
+    <p xml:id="eco_de_0000210_22050">
      Lotti lief hinunter, um Hans und Marianne zu suchen. Es dunkelte schon stark.
     </p>
-    <p xml:id="eco_de_0000140_22060">
+    <p xml:id="eco_de_0000210_22060">
      »Wo seid ihr denn?« rief sie.
     </p>
-    <p xml:id="eco_de_0000140_22070">
+    <p xml:id="eco_de_0000210_22070">
      »Da!« tönte eine Stimme aus dem Garten.
     </p>
-    <p xml:id="eco_de_0000140_22080">
+    <p xml:id="eco_de_0000210_22080">
      »Ich habe ganz viele Bohnen von Frau Völklein gekommen, und ich weiss ein lustiges Spiel damit, ›Grad oder ungrad‹ –«
     </p>
-    <p xml:id="eco_de_0000140_22090">
+    <p xml:id="eco_de_0000210_22090">
      Lotti sah Hans und Marianne auf der Seemauer sitzen.
     </p>
-    <p xml:id="eco_de_0000140_22100">
+    <p xml:id="eco_de_0000210_22100">
      »Was tut ihr dort –?«
     </p>
-    <p xml:id="eco_de_0000140_22110">
+    <p xml:id="eco_de_0000210_22110">
      »Wir tun nichts. Wir sitzen nur so da und sind traurig –«
     </p>
-    <p xml:id="eco_de_0000140_22120">
+    <p xml:id="eco_de_0000210_22120">
      Lotti hielt einen Augenblick an. Jetzt waren die auch traurig –!
     </p>
-    <p xml:id="eco_de_0000140_22130">
+    <p xml:id="eco_de_0000210_22130">
      »Warum seid ihr traurig?« fragte sie, während sie auf die Mauer kletterte.
     </p>
-    <p xml:id="eco_de_0000140_22140">
+    <p xml:id="eco_de_0000210_22140">
      »Du könntest wohl wissen warum, Lotti!« sagte Hans. »Nächsten Mittwoch schon ziehen wir in die Stadt, fort von der Seeweid! Ist das vielleicht nicht schrecklich –? Wenn ich denke, dass wir dann den See nicht mehr haben und den Schilf und das Klaregg und das Schiff – nur schon das! unser Schiff –! nicht mehr hinausrudern können –«
     </p>
-    <p xml:id="eco_de_0000140_22150">
+    <p xml:id="eco_de_0000210_22150">
      Hans verstummte; er fand für seinen Schmerz keine Worte.
     </p>
-    <p xml:id="eco_de_0000140_22160">
+    <p xml:id="eco_de_0000210_22160">
      »Vielleicht schneit es bald, wenn wir in der Stadt sind; dann kannst du Schlitten fahren«, meinte Lotti.
     </p>
-    <p xml:id="eco_de_0000140_22170">
+    <p xml:id="eco_de_0000210_22170">
      »Ach, Lotti! Wie magst du Rudern mit Schlittenfahren vergleichen! Das ist wie Tag und Nacht –«
     </p>
-    <p xml:id="eco_de_0000140_22180">
+    <p xml:id="eco_de_0000210_22180">
      »Ja«, begann nun auch Marianne, »die Seeweid ist der Tag und die Stadt ist die Nacht. Mich dünkt, es sei jetzt dann alles Lustige und Schöne vorbei, alles was wir gern gehabt haben! Denk, Lotti – unser Garten und der Hühnerhof und der Stall mit den Kaninchen, die so herzig sind! Und unsere Lieblingsplätze, Lotti, auf dem Waschhaus und da auf der Seemauer –! Das weiss ich, dass ich Heimweh nach der Seemauer bekomme!«
     </p>
-    <p xml:id="eco_de_0000140_22190">
+    <p xml:id="eco_de_0000210_22190">
      Marianne sah auf den See hinaus. Er lag dunkel da; auch der Himmel war dunkel; nur drüben, wo die Sonne untergegangen war, sah man noch einen schwachroten Streifen. Im Schilf rauschte es leise, und das Wasser plätscherte an die Seemauer.
     </p>
-    <p xml:id="eco_de_0000140_22200">
+    <p xml:id="eco_de_0000210_22200">
      »Alles ist so traurig; ich könnte fast weinen«, sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000140_22210">
+    <p xml:id="eco_de_0000210_22210">
      »Am Montag fangen die Ferien an«, ermunterte Lotti die betrübte Schwester.
     </p>
-    <p xml:id="eco_de_0000140_22220">
+    <p xml:id="eco_de_0000210_22220">
      »Was nützen sie uns«, sagte Hans, »wenn wir doch gleich in die Stadt ziehen! Wir haben vorhin gebettelt, dass man noch eine Woche länger bleibe. Aber Mama hat gesagt, es gehe nicht; aus zwei oder drei Gründen müsse der Umzug am Mittwoch sein.«
     </p>
-    <p xml:id="eco_de_0000140_22230">
+    <p xml:id="eco_de_0000210_22230">
      »In der Stadt ist es eigentlich auch nett«, fing Lotti wieder an. »Da ist dann der Schnauzel und der Ulrich; dem können wir wieder zusehen, wenn er die Ballen einnäht und schnürt, und dann spielt er uns auf seiner Harmonika. Und unsere Puppen, Marianne –! Ich weiss gar nicht mehr, wie die Klara aussieht – und mein Märchenbuch – Du, Marianne, mich wundert, was wir für Winterhüte bekommen –«
     </p>
-    <p xml:id="eco_de_0000140_22240">
+    <p xml:id="eco_de_0000210_22240">
      »Grässlich!« sagte Hans. »Jetzt denkt sie an die Winterhüte –! Nein, Lotti, mit dir kann man von nichts Ernsthaftem reden. Lass uns lieber allein! Geh zu Werner! Der ist auch so. Nein – eigentlich hat er damals geweint auf dem Heimweg, als er hörte, dass man bald aus der Seeweid fortgehe!«
     </p>
-    <p xml:id="eco_de_0000140_22250">
+    <p xml:id="eco_de_0000210_22250">
      Lotti liess sich aber nicht wegschicken.
     </p>
-    <p xml:id="eco_de_0000140_22260">
+    <p xml:id="eco_de_0000210_22260">
      »Ich kann auch ernsthaft sein, und ich habe die Seeweid so lieb wie ihr«, sagte sie etwas gekränkt und setzte sich neben Marianne.
     </p>
-    <p xml:id="eco_de_0000140_22270">
+    <p xml:id="eco_de_0000210_22270">
      Die beiden erwiderten nichts, und Lotti schwieg auch. Nach einer Weile tat Marianne einen Seufzer. Lotti seufzte ebenfalls tief. Sie legte die Hände ineinander, wie sie es vorhin bei Frau Völklein gesehen hatte, und sah vor sich nieder.
     </p>
-    <p xml:id="eco_de_0000140_22280">
+    <p xml:id="eco_de_0000210_22280">
      Aber da, wie sie es fast zu Stande gebracht hätte, traurig zu sein, hörte sie ein Rauschen. Sie hob den Kopf: Ein Dampfschiff kam daher mit vielen Lichtern; unten aus den Kajütenfenstern schimmerten sie in einer Reihe; auf dem Verdeck leuchteten sie gelb, rot und weisslich.
     </p>
-    <p xml:id="eco_de_0000140_22290">
+    <p xml:id="eco_de_0000210_22290">
      »O, o – seht, wie hübsch!« Lotti klatschte in die Hände. »Wisst ihr, wie das aussieht –? Das sieht aus wie die Lichter am Christbaum! Jetzt wird es Winter; jetzt kommt bald Weihnacht – Weihnacht, Marianne –! Ich gehe hinein und frage Mama, wieviel Wochen noch bis Weihnacht sind –«
     </p>
-    <p xml:id="eco_de_0000140_22300">
+    <p xml:id="eco_de_0000210_22300">
      Lotti sprang von der Mauer und lief zum Haus.
     </p>
-    <p xml:id="eco_de_0000140_22310">
+    <p xml:id="eco_de_0000210_22310">
      Marianne sah dem Schiffe nach, bis die Lichter verschwanden.
     </p>
-    <p xml:id="eco_de_0000140_22320">
+    <p xml:id="eco_de_0000210_22320">
      »Hans«, sagte sie dann, »jetzt kann ich fast auch nicht mehr traurig sein. Weisst du, wenn man nur das Wort Weihnacht hört, fällt einem so viel Schönes ein! Du – wenn es dann klingelt und wir hinunterrennen dürfen zum Christbaum und zu unsern Tischen –! Ich wünsche mir ein Zeichnungsbuch und eine neue Malschachtel und Schlittschuhe –« Marianne stand auf. »Das ist komisch: in meinem Kopfe geht's ganz durcheinander; halb bin ich traurig wegen der Seeweid und halb schrecklich vergnügt wegen Weihnacht!« Damit verliess auch Marianne die Seemauer.
     </p>
-    <p xml:id="eco_de_0000140_22330">
+    <p xml:id="eco_de_0000210_22330">
      Und Hans –? Allein in Trübsal da draussen bleiben wollte er doch nicht. Er ging langsam nach und merkte, dass er gleichfalls von Lotti angesteckt war. Eben hatte er noch gemeint, nur Leid um die vergangenen Sommertage zu fühlen, und jetzt tauchten in ihm lauter lustige Gedanken an die kommenden Winterfreuden auf.
     </p>
    </div>

--- a/tei/Bindschedler_Ida_Die_Turnachkinder_im_Winter.xml
+++ b/tei/Bindschedler_Ida_Die_Turnachkinder_im_Winter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000141" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000211" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000141_20">
+   <p xml:id="eco_de_0000211_20">
     Die Turnachkinder im Winter
    </p>
   </front>
@@ -93,340 +93,340 @@
     <head>
      Die Reise nach Larstetten
     </head>
-    <p xml:id="eco_de_0000141_30">
+    <p xml:id="eco_de_0000211_30">
      Der Mittwoch, an welchem die Familie Turnach in die Stadt ziehen wollte, rückte heran. Aber die Kinder hatten nicht Zeit, an den Umzug zu denken. Am Montag war ganz plötzlich ein Brief von Tante Doktor gekommen, in welchem sie Hans, Marianne und Lotti für die Herbstferien einlud.
     </p>
-    <p xml:id="eco_de_0000141_40">
+    <p xml:id="eco_de_0000211_40">
      »Papa, Papa, bitte, gelt, wir dürfen –!« riefen die drei, als Papa ins Zimmer trat.
     </p>
-    <p xml:id="eco_de_0000141_50">
+    <p xml:id="eco_de_0000211_50">
      »Ja, das ist nun die Frage«, sagte Mama zu Papa gewendet. »Niemand hat am Mittwoch Zeit, die Kinder nach Larstetten zu begleiten –«
     </p>
-    <p xml:id="eco_de_0000141_60">
+    <p xml:id="eco_de_0000211_60">
      »O, Mama, wir können allein reisen!« bat Hans. »Ich will gewiss acht geben und alles recht machen! In Konradzell müssen wir aussteigen und auf der andern Seite vom Stationshaus eine halbe Stunde warten. Der Zug für Larstetten steht dann schon da, und man kann zusehen, wie sie die Lokomotive heizen.«
     </p>
-    <p xml:id="eco_de_0000141_70">
+    <p xml:id="eco_de_0000211_70">
      »Ja, Mama!« flehte Lotti. »Es ist so furchtbar lustig, allein zu reisen! Ich will aber mein Billett selber haben, Hans!« Sie zog ein dickes altes Portemonnaie heraus. »Da, in das Extrafach kommt es.«
     </p>
-    <p xml:id="eco_de_0000141_80">
+    <p xml:id="eco_de_0000211_80">
      »So«, meinte Hans, »und dann, wenn du es dem Kondukteur zeigen musst, ist es natürlich nicht mehr da. Ich wollte wetten.«
     </p>
-    <p xml:id="eco_de_0000141_90">
+    <p xml:id="eco_de_0000211_90">
      »Vielleicht verlierst du deines noch vorher!« erwiderte Lotti kampflustig.
     </p>
-    <p xml:id="eco_de_0000141_100">
+    <p xml:id="eco_de_0000211_100">
      »Kinder, das heisst man nun, um die Haut des Bären streiten, bevor man ihn hat!« sagte Papa. Aber die Kinder merkten, dass er nichts Ernstliches gegen die Reise hatte.
     </p>
-    <p xml:id="eco_de_0000141_110">
+    <p xml:id="eco_de_0000211_110">
      »Sie sollen es einmal versuchen«, wendete er sich zu Mama.
     </p>
-    <p xml:id="eco_de_0000141_120">
+    <p xml:id="eco_de_0000211_120">
      »Wenn sie in Konradzell aus Versehen den Zug nehmen, zurückfährt, dann behalten wir sie eben wieder da.«
     </p>
-    <p xml:id="eco_de_0000141_130">
+    <p xml:id="eco_de_0000211_130">
      »Nein, nein, Papa, wir passen schon auf! Also dürfen wir ja –? Juhuh!«
     </p>
-    <p xml:id="eco_de_0000141_140">
+    <p xml:id="eco_de_0000211_140">
      »Mama«, rief der kleine Werner, der merkte, dass es sich um ihn gar nicht handle, »ich will auch mit!«
     </p>
-    <p xml:id="eco_de_0000141_150">
+    <p xml:id="eco_de_0000211_150">
      »Ach, Wernermännchen, du bist noch zu klein; du bleibst bei mir und bei Sophie und bei dem Schwesterlein.«
     </p>
-    <p xml:id="eco_de_0000141_160">
+    <p xml:id="eco_de_0000211_160">
      »Nein!« rief Werner kläglich. »Ich will auch nach Larstetten! Ich will auch sehen, wie man die Loko – die Lokomotive heizt!«
     </p>
-    <p xml:id="eco_de_0000141_170">
+    <p xml:id="eco_de_0000211_170">
      Es dauerte lange, bis Werner sich zufrieden gab mit dem Versprechen, er dürfe im nächsten Jahre ganz bestimmt nach Larstetten reisen.
     </p>
-    <p xml:id="eco_de_0000141_180">
+    <p xml:id="eco_de_0000211_180">
      Am Dienstag nachmittag wurde gepackt. Hans rannte mit den Schwestern hinauf in die Bodenkammer, um das Handköfferchen zu holen und die Rolle.
     </p>
-    <p xml:id="eco_de_0000141_190">
+    <p xml:id="eco_de_0000211_190">
      »Die Botanisierbüchsen hängen wir auch um; da geht viel hinein!« beschlossen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_200">
+    <p xml:id="eco_de_0000211_200">
      »Und ich brauche eine Schachtel, Sophie«, erklärte Lotti. »Ich will Trudi alle meine Muscheln mitbringen.«
     </p>
-    <p xml:id="eco_de_0000141_210">
+    <p xml:id="eco_de_0000211_210">
      »Ich wüsste für Otto etwas«, sagte Hans, »– etwas ganz Feines. Eigentlich hat Fritz Völklein ihn für mich gemacht; aber weil am Samstag Ottos Geburtstag ist – ja, ich bringe Otto den Bogen mit den Pfeilen!«
     </p>
-    <p xml:id="eco_de_0000141_220">
+    <p xml:id="eco_de_0000211_220">
      Marianne aber ging, ihre Puppe, das Julchen zu holen, das nun auch einmal auf der Eisenbahn fahren sollte.
     </p>
-    <p xml:id="eco_de_0000141_230">
+    <p xml:id="eco_de_0000211_230">
      »Das gibt ein hübsches Handgepäck!« sagte Mama lachend, als zu dem Köfferchen, der Rolle, den zusammengeschnallten Schirmen und den Botanisierbüchsen noch der Bogen, die blaue Schachtel und die Puppe kamen. »Ich will gern hören, wie viel von dem allem wirklich in Larstetten ankommt.«
     </p>
-    <p xml:id="eco_de_0000141_240">
+    <p xml:id="eco_de_0000211_240">
      »Wir lassen nichts liegen«, versicherte Marianne. »Onkel Alfred hat mir ein gutes Mittel gesagt: Wie er nach London und noch viel weiter gereist ist, habe er immer beim Aussteigen gedacht: Jetzt nur ruhig Blut; vier Stück müssen es sein.«
     </p>
-    <p xml:id="eco_de_0000141_250">
+    <p xml:id="eco_de_0000211_250">
      »Eins – zwei – drei«, zählte Hans »– neun; das ist eine Zahl, die man gut im Sinn behält.«
     </p>
-    <p xml:id="eco_de_0000141_260">
+    <p xml:id="eco_de_0000211_260">
      »Man wird den Kindern etwas zum Essen mitgeben müssen, Frau Turnach?« meinte Sophie. »Sie fahren über Mittag.«
     </p>
-    <p xml:id="eco_de_0000141_270">
+    <p xml:id="eco_de_0000211_270">
      »Mama«, bat Hans, »in Sommerweil hält der Zug zehn Minuten; da hat uns Papa das letztemal warme Würstchen geholt und Semmel. Bitte, dürfen wir's auch so machen, Mama! Weisst du, alles ganz wie rechte Reisende.«
     </p>
-    <p xml:id="eco_de_0000141_280">
+    <p xml:id="eco_de_0000211_280">
      »Also, Hans! wie rechte Reisende, vernünftig und besonnen!«
     </p>
-    <p xml:id="eco_de_0000141_290">
+    <p xml:id="eco_de_0000211_290">
      Der Zug fuhr um elf Uhr ab. Aber schon um halb elf standen die Turnachkinder in der Einsteigehalle.
     </p>
-    <p xml:id="eco_de_0000141_300">
+    <p xml:id="eco_de_0000211_300">
      »Das Ganze dauert dann länger«, erklärten sie.
     </p>
-    <p xml:id="eco_de_0000141_310">
+    <p xml:id="eco_de_0000211_310">
      Die Turnachkinder reisten selten. So eine Eisenbahnfahrt mit allem, was drum und dran hing, war ein ungeheures Vergnügen.
     </p>
-    <p xml:id="eco_de_0000141_320">
+    <p xml:id="eco_de_0000211_320">
      »Ah, das riecht schon so schön nach Reisen!« rief Lotti, die mit der Schachtel unterm Arm und den Schirmen in der Hand neben Hans stand. Sie schnupperte den Rauch ein, der die Halle erfüllte.
     </p>
-    <p xml:id="eco_de_0000141_330">
+    <p xml:id="eco_de_0000211_330">
      Hans aber war in die Betrachtung einer Lokomotive versunken. Ein Mann wischte mit einem Lappen an den Rädern und Stangen; es sah aus, als ob er das schwarze Ungetüm streicheln wollte, weil es so brav gelaufen war.
     </p>
-    <p xml:id="eco_de_0000141_340">
+    <p xml:id="eco_de_0000211_340">
      »He – phäs – tos, was heisst das?« fragte Hans den Fritz Völklein, der auf Frau Turnachs Bitte die Kinder begleitet hatte. »Hephästos hiess bei den Griechen der Gott der Schmiedekunst«, erklärte Fritz. »In seiner Werkstätte war viel Feuer und Getöse; also passt der Name nicht schlecht für eine Lokomotive.«
     </p>
-    <p xml:id="eco_de_0000141_350">
+    <p xml:id="eco_de_0000211_350">
      Marianne war vorn stehen geblieben und sah dem Strom von angekommenen Leuten nach. Männer rollten Handwagen vorbei mit hochaufgetürmten Koffern. »Rom« stand auf dem einen. Das war ziemlich unten auf Papas Wandkarte. »Frankfurt, Dresden« buchstabierte Marianne weiter. Wie viel Städte es gab und eine Menge fremder Menschen darin! Draussen in der Seeweid dachte man gar nicht an das …
     </p>
-    <p xml:id="eco_de_0000141_360">
+    <p xml:id="eco_de_0000211_360">
      »Hallo, Marianne! Einsteigen!« rief Fritz Völklein. »Einsteigen oder dableiben!«
     </p>
-    <p xml:id="eco_de_0000141_370">
+    <p xml:id="eco_de_0000211_370">
      Er brachte die Kinder in den Wagen. Marianne und Lotti eroberten glücklich zwei Fensterplätze, und Hans stellte sich zwischen sie; so konnte man alles sehen und besprechen.
     </p>
-    <p xml:id="eco_de_0000141_380">
+    <p xml:id="eco_de_0000211_380">
      Die Gepäckstücke machten einige Schwierigkeiten. Der Bogen wollte nicht oben auf dem Köfferchen bleiben, und Lottis Botanisierbüchse fiel auch zweimal herunter, ihr fast auf die Nase.
     </p>
-    <p xml:id="eco_de_0000141_390">
+    <p xml:id="eco_de_0000211_390">
      »Na, ich muss sagen – so ein Kram!« brummte ein älterer Herr mit grauem Backenbart und grauer Reisemütze. »Ihr wollt wohl nach Amerika auswandern –? Übrigens seid ihr dann nicht im rechten Zug!«
     </p>
-    <p xml:id="eco_de_0000141_400">
+    <p xml:id="eco_de_0000211_400">
      »Nein, wir reisen nur nach Larstetten in die Ferien!« sagte Lotti und sah den Herrn vergnügt an. Der aber faltete eine grosse Zeitung auseinander und verschwand dahinter mit samt seinem Backenbart und seiner Mütze.
     </p>
-    <p xml:id="eco_de_0000141_410">
+    <p xml:id="eco_de_0000211_410">
      Fritz gab noch Ermahnungen:
     </p>
-    <p xml:id="eco_de_0000141_420">
+    <p xml:id="eco_de_0000211_420">
      »Nicht zum Fenster hinauslehnen, Lotti! Weisst, auf der Eisenbahn geht alles rasend geschwind. Im Hui saust man an eine Telegraphenstange und – weg der Kopf! Ja, lach nur!«
     </p>
-    <p xml:id="eco_de_0000141_430">
+    <p xml:id="eco_de_0000211_430">
      Dann schüttelte er den Kindern die Hand:
     </p>
-    <p xml:id="eco_de_0000141_440">
+    <p xml:id="eco_de_0000211_440">
      »Lebt wohl, lebt wohl! Grüsst mir den Otto und das Trudi! Otto soll ordentlich umgehen mit dem Bogen. Au – Hans! lass los!«
     </p>
-    <p xml:id="eco_de_0000141_450">
+    <p xml:id="eco_de_0000211_450">
      Fritz sprang ab. Der Zug tat einen Ruck und fing an zu pusten und zu rasseln: Tem-tem-tem- langsam und dann immer rascher: Temteretem, temteretem – Die Kinder sahen einander strahlend an; jetzt ging's los! Fast vergassen sie draussen Fritz Völklein, der schon weit zurück war und den Hut schwenkte.
     </p>
-    <p xml:id="eco_de_0000141_460">
+    <p xml:id="eco_de_0000211_460">
      »Ade, ade!« Die Kinder winkten mit den Taschentüchern, und Lotti liess das ihre flattern, als schon lange kein Fritz mehr zu sehen war, bis plötzlich – hui! nicht zwar Lottis Kopf, aber das Taschentuch davon flog. Die Kinder schrien auf.
     </p>
-    <p xml:id="eco_de_0000141_470">
+    <p xml:id="eco_de_0000211_470">
      »Das fängt gut an!« brummte der Herr mit der Mütze.
     </p>
-    <p xml:id="eco_de_0000141_480">
+    <p xml:id="eco_de_0000211_480">
      »Es war nur ein altes mit zwei Löchern; Mama hat mir's mitgegeben, die Hände abzuwischen«, beruhigte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_490">
+    <p xml:id="eco_de_0000211_490">
      Aber das Gesicht des Herrn war schon wieder hinter der Zeitung. Nicht ein einziges Mal sah er hinaus, und es gab doch so ungeheuer viel zu sehen: Die Geleise mit den Weichen und Signalen, die Schuppen und Werkstätten, ein halbrunder Raum, in dem die Lokomotiven standen wie Pferde im Stall. Dann sauste der Zug hinaus aus der Stadt an Gemüsegärten und Wiesen vorbei; von ein paar neuen Häusern lachten Kinder herunter; am Bahndamm arbeiteten Italiener.
     </p>
-    <p xml:id="eco_de_0000141_500">
+    <p xml:id="eco_de_0000211_500">
      »Guckt, guckt!« rief Lotti. »Die Telegraphendrähte sind lebendig! Sie hüpfen hinunter, da – ganz tief! und wenn die Stange kommt, springen sie wieder hinauf! Nein, wie lustig!«
     </p>
-    <p xml:id="eco_de_0000141_510">
+    <p xml:id="eco_de_0000211_510">
      Aber als der Zug an einem grossen Walde vorbeifuhr, wurde es noch lustiger. Die Bäume tanzten; alle wirbelten durcheinander, hohe Buchen und niedrige junge Tannen; diese drehten sich wie Mädchen in grünen Röcken. Zuletzt wurde einem selbst wirblig zu Mut. Marianne schloss die Augen und hörte auf das Temteretem des Zuges:
     </p>
-    <p xml:id="eco_de_0000141_520">
+    <p xml:id="eco_de_0000211_520">
      »Jetzt ist mir, als führe der Zug rückwärts – nein, das wäre grässlich, wenn es wieder zurückginge –!«
     </p>
-    <p xml:id="eco_de_0000141_530">
+    <p xml:id="eco_de_0000211_530">
      Marianne riss die Augen auf, um sich zu versichern, dass man in der Richtung nach Larstetten fahre, und Lotti machte das Experiment nach. Dann fingen beide an zu singen nach dem Takte des rasselnden Wagens. Draussen flogen die Hügel vorbei und die Felder, wo die Bauern pflügten und einen Augenblick aufsahen nach dem Bahnzuge. Hin und wieder hielt man an einem mit Weinlaub umsponnenen Stationshaus. Hans schrieb sich die Ortsnamen in sein Notizbuch und allerlei dazu; später sollte das eine Reisebeschreibung geben.
     </p>
-    <p xml:id="eco_de_0000141_540">
+    <p xml:id="eco_de_0000211_540">
      Nun ging's an einer grossen Fabrik vorbei; links und rechts standen Häuser und Warengebäude; die Schienen verzweigten sich; der Zug pfiff und bremste.
     </p>
-    <p xml:id="eco_de_0000141_550">
+    <p xml:id="eco_de_0000211_550">
      »Sommerweil!« rief Hans und steckte sein Notizbuch ein. »Jetzt also die Würstchen! Ihr bleibt ruhig sitzen, Marianne! Die Restauration ist weit vorn.«
     </p>
-    <p xml:id="eco_de_0000141_560">
+    <p xml:id="eco_de_0000211_560">
      Er sprang ab und verschwand in der Menge der Reisenden.
     </p>
-    <p xml:id="eco_de_0000141_570">
+    <p xml:id="eco_de_0000211_570">
      »Wenn er nur recht warme bringt!« sagte Lotti, indem sie sich auf den Magen klopfte.
     </p>
-    <p xml:id="eco_de_0000141_580">
+    <p xml:id="eco_de_0000211_580">
      Es stiegen Leute aus und ein; Marianne sah immer nach Hans aus.
     </p>
-    <p xml:id="eco_de_0000141_590">
+    <p xml:id="eco_de_0000211_590">
      »Hoffentlich kommt er bald. Es ist, glaub' ich, höchste Zeit; alles rennt hin und her.«
     </p>
-    <p xml:id="eco_de_0000141_600">
+    <p xml:id="eco_de_0000211_600">
      Da, auf einmal – die Mädchen sahen sich starr an – begann der Zug zu fahren, wegzufahren ohne Hans –! Entsetzt schrien beide:
     </p>
-    <p xml:id="eco_de_0000141_610">
+    <p xml:id="eco_de_0000211_610">
      »Hans! Halten, halten –! unser Bruder ist noch nicht da –«
     </p>
-    <p xml:id="eco_de_0000141_620">
+    <p xml:id="eco_de_0000211_620">
      Unter lautem Weinen liefen sie an die Türe des Wagens.
     </p>
-    <p xml:id="eco_de_0000141_630">
+    <p xml:id="eco_de_0000211_630">
      »Hans, Hans –!« schrie Lotti und wollte vom Tritt abspringen. Ohne Hans konnte man doch nicht fahren!
     </p>
-    <p xml:id="eco_de_0000141_640">
+    <p xml:id="eco_de_0000211_640">
      Aber da stand breit ein Kondukteur auf der untern Stufe und versperrte den Weg:
     </p>
-    <p xml:id="eco_de_0000141_650">
+    <p xml:id="eco_de_0000211_650">
      »Oha, mein Fräulein! im Fahren springt man nicht ab!«
     </p>
-    <p xml:id="eco_de_0000141_660">
+    <p xml:id="eco_de_0000211_660">
      Und Marianne wurde ebenfalls zurückgehalten, und zwar von dem Herrn mit der grauen Mütze, der sie fest am Rockzipfel gepackt hatte.
     </p>
-    <p xml:id="eco_de_0000141_670">
+    <p xml:id="eco_de_0000211_670">
      Von aussen aber ertönte auch ein Geschrei. Es war Hans, der im grössten Schrecken dahergerannt kam.
     </p>
-    <p xml:id="eco_de_0000141_680">
+    <p xml:id="eco_de_0000211_680">
      »Halt, halt!« rief er atemlos. »Ich muss mit; ich muss zu meinen Schwestern –«
     </p>
-    <p xml:id="eco_de_0000141_690">
+    <p xml:id="eco_de_0000211_690">
      Vor Aufregung und Jammer bemerkte keins von den Kindern, dass der Zug seinen Lauf wieder verlangsamte.
     </p>
-    <p xml:id="eco_de_0000141_700">
+    <p xml:id="eco_de_0000211_700">
      »Da!« sagte der Herr mit der Mütze. »Jetzt steht er! Sie hängen ja bloss einen Wagen an. Wie kann man gleich so den Kopf verlieren –!«
     </p>
-    <p xml:id="eco_de_0000141_710">
+    <p xml:id="eco_de_0000211_710">
      Er liess Marianne los und setzte sich wieder mit seiner Zeitung. Die andern Reisenden lachten. Hans aber kam hereingestürzt; er konnte noch kaum reden vor Überraschung und Schrecken, und den Schwestern liefen die Tränen herunter. Doch als dann Hans das Papier aufmachte, wischte sich Lotti die Augen.
     </p>
-    <p xml:id="eco_de_0000141_720">
+    <p xml:id="eco_de_0000211_720">
      »Hast du doch keine Wurst verloren?« fragte sie.
     </p>
-    <p xml:id="eco_de_0000141_730">
+    <p xml:id="eco_de_0000211_730">
      Nein, es waren alle drei da und auch die Semmel. Und nun schmeckte nach der überstandenen Angst das Mittagessen doppelt gut; dazu erzählte man sich immer wieder, wie furchtbar es gewesen sei, als der Zug plötzlich angefangen hatte zu fahren.
     </p>
-    <p xml:id="eco_de_0000141_740">
+    <p xml:id="eco_de_0000211_740">
      »Das brauchst du nicht aufzuschreiben, Hans! das behältst du gewiss im Sinn«, sagte Marianne, während sie die Botanisierbüchse aufmachte, in welche die gute Frau Völklein Butterbirnen und Fenchelbrötchen gepackt hatte.
     </p>
-    <p xml:id="eco_de_0000141_750">
+    <p xml:id="eco_de_0000211_750">
      In Konradzell nahm Hans sich vor, recht vernünftig und besonnen zu sein, wie Mama ihm anempfohlen hatte, und stellte sich mit den Schwestern nahe zum Larstetter Zug. Es war nicht seine Schuld, dass gegen Ende der halben Stunde Wartezeit vorn beim Güterschuppen ein Kälbchen jämmerlich zu brüllen anhub.
     </p>
-    <p xml:id="eco_de_0000141_760">
+    <p xml:id="eco_de_0000211_760">
      »O, das Arme!« sagte Marianne und lief hin. Hans und Lotti folgten und entdeckten, dass das Kälbchen über eine Stufe hinuntergerutscht war und nicht mehr aufstehen konnte, weil der Strick zu straff zog. Es lag auf den Knien und sah die Kinder mit seinen grossen Augen an. Hans legte das Gepäck weg und versuchte, das Kälbchen hinaufzubringen. Es ging aber schwer. Das Kälbchen, das vielleicht auf seiner Reise schon allerlei Böses von groben Leuten und grossen Hunden ausgestanden hatte, begriff nicht, dass die Turnachkinder ihm helfen wollten. Es benahm sich störrisch und brüllte fort und fort. Schliesslich, als Lotti und Marianne mit aller Kraft von hinten schoben, kam es doch wieder auf die Beine. Hans band den Strick fester, damit das Kälbchen nicht noch einmal die Stufe hinunterfalle.
     </p>
-    <p xml:id="eco_de_0000141_770">
+    <p xml:id="eco_de_0000211_770">
      »Reiss halt nicht so, sondern steh still!« mahnte er, indem er das Tier auf den rauhhaarigen Rücken patschte.
     </p>
-    <p xml:id="eco_de_0000141_780">
+    <p xml:id="eco_de_0000211_780">
      Da ertönte eine laute, ärgerliche Stimme; die Kinder wandten sich zurück; es war der Herr mit der Mütze, der zu einem Waggonfenster hinaussah:
     </p>
-    <p xml:id="eco_de_0000141_790">
+    <p xml:id="eco_de_0000211_790">
      »Was ist –? wollt ihr nach Larstetten oder nicht? Im Augenblick fahren wir ab!«
     </p>
-    <p xml:id="eco_de_0000141_800">
+    <p xml:id="eco_de_0000211_800">
      Die Kinder rafften ihre Sachen zusammen und rannten zum Zug; der Kondukteur schob sie scheltend hinein, pfiff, und fort ging's!
     </p>
-    <p xml:id="eco_de_0000141_810">
+    <p xml:id="eco_de_0000211_810">
      »Grad noch recht!« sagte Marianne aufatmend.
     </p>
-    <p xml:id="eco_de_0000141_820">
+    <p xml:id="eco_de_0000211_820">
      Hans aber fuhr sich übers Haar. Das Reisen war doch eigentlich schwieriger, als man meinte. Indessen begegnete nun weiter nichts mehr, und nach einer kleinen Stunde sah man schon den Weissberg und die rote Turmspitze von Larstetten. Die Kinder griffen nach ihrem Gepäck.
     </p>
-    <p xml:id="eco_de_0000141_830">
+    <p xml:id="eco_de_0000211_830">
      »Nur ruhig Blut!« sagte Marianne. »Neun Stück müssen es sein.«
     </p>
-    <p xml:id="eco_de_0000141_840">
+    <p xml:id="eco_de_0000211_840">
      Wahrhaftig! alle neun Stück waren noch beisammen.
     </p>
-    <p xml:id="eco_de_0000141_850">
+    <p xml:id="eco_de_0000211_850">
      »Und Mama hat gemeint, wir verlieren die Hälfte«, sagte Marianne draussen, als ihr plötzlich aus dem Fenster ihre Jacke, die sie ausgezogen hatte, auf den Kopf flog.
     </p>
-    <p xml:id="eco_de_0000141_860">
+    <p xml:id="eco_de_0000211_860">
      »So«, sagte der Herr mit der Mütze, der die Jacke nachgeworfen hatte, »jetzt ist es mir dann aber recht, wenn ich nicht mehr Kindswärterin sein muss!«
     </p>
-    <p xml:id="eco_de_0000141_870">
+    <p xml:id="eco_de_0000211_870">
      »Er hat immer gebrummt; aber eigentlich war er doch nett!« fand Lotti, als sie hinter Hans über die Schienen hüpfte.
     </p>
-    <p xml:id="eco_de_0000141_880">
+    <p xml:id="eco_de_0000211_880">
      Ein lautes Freudengeschrei empfing die Turnachkinder; denn am Stationsgebäude standen nicht nur Otto und Trudi, sondern noch etwa zwei Dutzend andere Larstetter Buben und Mädchen.
     </p>
-    <p xml:id="eco_de_0000141_890">
+    <p xml:id="eco_de_0000211_890">
      Larstetten war ein ganz kleiner Ort. Dass die Doktorskinder Besuch bekamen, war ein Ereignis; alle Freunde und Freundinnen wollten am Abholen teilnehmen. Zuerst zwar liessen sie Otto und Trudi mit ihren Gästen vorausgehen und folgten kichernd und sich stossend. Aber als Otto sich umdrehte, um Lehrers Bernhard den schönen Bogen zu zeigen, kamen alle Buben herzu, und die Mädchen rückten auch näher, um zu hören, was da von einem Taschentuch, einem Kälbchen und von Würsten erzählt wurde.
     </p>
-    <p xml:id="eco_de_0000141_900">
+    <p xml:id="eco_de_0000211_900">
      »Du«, fragte Marianne Uhrenmachers Pauline. »Lebt doch der Peter noch?«
     </p>
-    <p xml:id="eco_de_0000141_910">
+    <p xml:id="eco_de_0000211_910">
      Der Peter war ein zahmer Rabe, den die Turnachkinder von früher kannten.
     </p>
-    <p xml:id="eco_de_0000141_920">
+    <p xml:id="eco_de_0000211_920">
      »Freilich«, sagte Pauline. »Und wir haben jetzt noch eine Merkwürdigkeit in Larstetten. Wir haben eine Amerikanerin –«
     </p>
-    <p xml:id="eco_de_0000141_930">
+    <p xml:id="eco_de_0000211_930">
      »Ja, und sie ist fast immer dabei, wenn wir etwas Lustiges machen«, fiel Otto ein.
     </p>
-    <p xml:id="eco_de_0000141_940">
+    <p xml:id="eco_de_0000211_940">
      »Sie hat einen kuriosen Namen«, erklärte Pauline weiter. »Auf deutsch heisst's Edith; aber wenn man englisch reden will, muss man sagen Idiss –«
     </p>
-    <p xml:id="eco_de_0000141_950">
+    <p xml:id="eco_de_0000211_950">
      »Eigentlich Idifs«, erklärte Trudi.
     </p>
-    <p xml:id="eco_de_0000141_960">
+    <p xml:id="eco_de_0000211_960">
      »Nein, Idids«, verbesserte Otto. Er machte einen seltsamen Mund und steckte die Zunge zwischen die Zähne, um das schwierige englische th herauszubringen.
     </p>
-    <p xml:id="eco_de_0000141_970">
+    <p xml:id="eco_de_0000211_970">
      Nun versuchten alle Larstetter- und auch die Turnachkinder ihre Kunst:
     </p>
-    <p xml:id="eco_de_0000141_980">
+    <p xml:id="eco_de_0000211_980">
      »Idids, Idifs, Idiss –« ging es durcheinander, als die Schar zum Städtchen hinein und über den kleinen Kirchenplatz kam.
     </p>
-    <p xml:id="eco_de_0000141_990">
+    <p xml:id="eco_de_0000211_990">
      »Was wollen Sie?« antwortete eine frische Stimme aus dem Pfarrgarten. »Tun Sie nicht stören mich!«
     </p>
-    <p xml:id="eco_de_0000141_1000">
+    <p xml:id="eco_de_0000211_1000">
      Die Kinder traten ans Gitter. Vor dem Hause neben Frau Pfarrers Oleanderbäumen stand ein etwa dreizehnjähriges Mädchen mit einer hellblauen Schleife im braunen Haar und versuchte, ein graues Kätzchen auf den Rücken des grossen weissen Pfarrspitzes zu setzen. Der Spitz knurrte. Er war ein wackeres Tier und wusste manches Kunststück zu machen; aber was ihm nun da zugemutet wurde, ging doch über alles Mass. Und das Kätzchen wollte auch nicht, sondern miaute ärgerlich.
     </p>
-    <p xml:id="eco_de_0000141_1010">
+    <p xml:id="eco_de_0000211_1010">
      »Was machst du?« rief Otto. »Das geht nicht!«
     </p>
-    <p xml:id="eco_de_0000141_1020">
+    <p xml:id="eco_de_0000211_1020">
      »Ich gebe Lektion an diese Tieren«, sagte Edith. »Ich auch muss lernen bei Onkel Pfarrer jedes Vormittag. Guten Abend, kleine Mädchen! guten Abend, kleine Knabe!« wandte sie sich den Turnachkindern zu, während die kleine Katze die Pause benutzte, um auf das Fenstersims zu springen, von wo sie mit feindselig erhobenem Schwanze auf den Spitz herabsah, der sie anbellte.
     </p>
-    <p xml:id="eco_de_0000141_1030">
+    <p xml:id="eco_de_0000211_1030">
      Hans bot Edith höflich die Hand, obgleich die Anrede ihn etwas kränkte. Des Mädchens Augen aber fielen auf den Bogen.
     </p>
-    <p xml:id="eco_de_0000141_1040">
+    <p xml:id="eco_de_0000211_1040">
      »Feiner Gewehr!« sagte sie anerkennend. »Zeig, Otto –«
     </p>
-    <p xml:id="eco_de_0000141_1050">
+    <p xml:id="eco_de_0000211_1050">
      Sie spannte den Bogen und schoss den Pfeil hoch zum Dach des Waschhauses hinauf.
     </p>
-    <p xml:id="eco_de_0000141_1060">
+    <p xml:id="eco_de_0000211_1060">
      »Schlecht getrefft!« rief sie. »Ich habe wollen durch den Loch von die Kamin.«
     </p>
-    <p xml:id="eco_de_0000141_1070">
+    <p xml:id="eco_de_0000211_1070">
      Lotti lachte hell auf, weil Edith alles so verkehrt sagte.
     </p>
-    <p xml:id="eco_de_0000141_1080">
+    <p xml:id="eco_de_0000211_1080">
      »Warum lachen Sie?« fragte Edith scheinbar ernsthaft. »Es ist sehr traurig, dass deutsche Sprache hat so viel unnütze Worten: der, die, das, dem, den – horrible!«
     </p>
-    <p xml:id="eco_de_0000141_1090">
+    <p xml:id="eco_de_0000211_1090">
      Edith wollte eben den Bogen noch einmal spannen. Aber um die Ecke kam Tante Doktor.
     </p>
-    <p xml:id="eco_de_0000141_1100">
+    <p xml:id="eco_de_0000211_1100">
      »Ja – Kinder! wo bleibt ihr denn stecken mit Sack und Pack –? Aha, Edith –! Nun, trennt euch jetzt für einmal. In unserm Larstetten findet man sich ja immer wieder.«
     </p>
-    <p xml:id="eco_de_0000141_1110">
+    <p xml:id="eco_de_0000211_1110">
      »Wir wollen sein Freunde«, sagte Edith, indem sie den Turnachkindern die Hände schüttelte.
     </p>
-    <p xml:id="eco_de_0000141_1120">
+    <p xml:id="eco_de_0000211_1120">
      »Gud bei!« rief Otto sich verabschiedend in den Pfarrgarten zurück. »Das bedeutet nämlich, leb wohl«, erklärte er Hans. »Man schreibt es aber g-o-o-d b-y-e. Im Englischen ist die Hauptsache, dass man alles ganz anders sagt, als es eigentlich heisst.«
     </p>
-    <p xml:id="eco_de_0000141_1130">
+    <p xml:id="eco_de_0000211_1130">
      Die Tante Doktor hatte Mühe, die Kinder vor sich herzutreiben. Immer drehten sie sich wieder um:
     </p>
-    <p xml:id="eco_de_0000141_1140">
+    <p xml:id="eco_de_0000211_1140">
      »Gud bei, Idifs, gud bei!« Besonders die Turnachkinder fanden es prächtig, nun auf einmal englisch sprechen zu können.
     </p>
    </div>
@@ -434,313 +434,313 @@
     <head>
      Wie es auf dem Larstetter Jahrmarkt zuging
     </head>
-    <p xml:id="eco_de_0000141_1150">
+    <p xml:id="eco_de_0000211_1150">
      Jedes Jahr im Herbst war Markt in Larstetten. Das war immer ein grosses Vergnügen. Schon in aller Frühe wurden die Kinder am Freitag geweckt. Wagen mit quiekenden Schweinen rasselten über das holperige Pflaster. Laut schwatzende Frauen kamen daher mit Körben auf dem Kopfe. Einige Buben mussten bereits Einkäufe gemacht haben; schrille Pfeifen- und Trompetentöne drangen herauf.
     </p>
-    <p xml:id="eco_de_0000141_1160">
+    <p xml:id="eco_de_0000211_1160">
      »Geld habe ich ziemlich viel«, sagte Trudi beim Frühstück. »Ich hab noch zuletzt vier Zehner verdient!«
     </p>
-    <p xml:id="eco_de_0000141_1170">
+    <p xml:id="eco_de_0000211_1170">
      »Potz! mit was denn?« fragte Hans.
     </p>
-    <p xml:id="eco_de_0000141_1180">
+    <p xml:id="eco_de_0000211_1180">
      »Ja, es war gar nicht so lustig. Allemal am Samstag haben wir zwei Stunden lang gejätet. Man bekommt einen ganz steifen Rücken. Aber ich hab immerfort an das Karussell gedacht. Im ganzen hab ich 70 Rappen Marktgeld.« Trudi klapperte freudig mit der gelben Hornbüchse, die ihr als Börse diente.
     </p>
-    <p xml:id="eco_de_0000141_1190">
+    <p xml:id="eco_de_0000211_1190">
      Die andern überzählten auch ihren Besitz. Mama hatte den Turnachkindern zum Glück etwas Taschengeld mitgegeben. Eilig ging's nun auf die Strasse hinunter. Es war kalt und neblig. Undeutlich tauchten die Merkwürdigkeiten des Larstetter Marktes aus der weissen Luft auf. Vor dem Doktorhaus befand sich ein Stand mit Mützen und Hüten, daneben einer mit Schuhen und einer mit geblümten Stoffen; das war nicht besonders interessant. Dann aber kam eine Geschirrbude, von der man die Mädchen nicht wegbrachte; denn sie hatten einen Korb mit Puppengeschirr entdeckt, mit kleinen Tassen, Milchkrügen und braunen Tiegelchen, die man aufs Feuer stellen konnte. Marianne und Lotti kauften zusammen ein weiss und gelbes Töpfchen, und Trudi nahm sechs kleine blaue Teller, die ihr die Händlerin zu 40 Rappen erliess. Dann ging's weiter. Aber auf einmal, als Marianne zurücksah, war Trudi stehen geblieben.
     </p>
-    <p xml:id="eco_de_0000141_1200">
+    <p xml:id="eco_de_0000211_1200">
      »Was hast du?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_1210">
+    <p xml:id="eco_de_0000211_1210">
      »Mir ist –« Trudi schluckte halb weinend. »Mir ist eingefallen, dass ich jetzt schon viel weniger Geld habe. Und ich wollte noch Abziehbilder kaufen und eine Waffel – und dann das K – K –«
     </p>
-    <p xml:id="eco_de_0000141_1220">
+    <p xml:id="eco_de_0000211_1220">
      Das Karussell blieb im Halse des schluchzenden Trudi stecken.
     </p>
-    <p xml:id="eco_de_0000141_1230">
+    <p xml:id="eco_de_0000211_1230">
      Da beschlossen Marianne und Lotti, dem von Reue gequälten Cousinchen zwei Teller abzukaufen, worauf Trudi wieder lachte und mit den beiden die Buben einholte, die vor einem Mann in grünem Rock standen. Er hatte keine Bude, nur einen Tisch; aber er redete sehr viel und sagte, er könne alles, was zerschlagen sei, wieder ganz machen.
     </p>
-    <p xml:id="eco_de_0000141_1240">
+    <p xml:id="eco_de_0000211_1240">
      »Oh, o weh, o weh!« rief er und hielt zwei Scherben in den Händen mit einem schrecklichen Gesicht des Jammers, der sich plötzlich in die grösste Heiterkeit verwandelte, sowie die Stücke wieder aneinander waren.
     </p>
-    <p xml:id="eco_de_0000141_1250">
+    <p xml:id="eco_de_0000211_1250">
      »Wenn ich nur solche Grimassen machen könnte!« sagte Otto bewundernd und stellte einige Versuche an.
     </p>
-    <p xml:id="eco_de_0000141_1260">
+    <p xml:id="eco_de_0000211_1260">
      Marianne aber wurde gegenüber festgehalten. Da sass eine Frau vor einem Kissen, in dem sehr viele Nadeln steckten mit Fäden, und an jedem Faden hing ein Hölzchen. Wenn die Frau die Hölzchen recht rasch übereinander warf, so entstand eine schöne Spitze. Es war wie eine Zauberei. Hans musste Marianne schliesslich am Arm fortziehen.
     </p>
-    <p xml:id="eco_de_0000141_1270">
+    <p xml:id="eco_de_0000211_1270">
      Die Dreissigrappenbude war weiter oben. Viele Leute standen schon davor. Es war aber auch zum Stillstehen. Hier konnte man alles, geradezu alles haben: Puppen, Dominospiele, Malhefte, Federnschachteln, Perlschnüre, Handwerkszeug, nette Taschenmesser, kleine Käfige mit gelbwollenen Vögeln, Uhren, kurz, was sich nur denken liess.
     </p>
-    <p xml:id="eco_de_0000141_1280">
+    <p xml:id="eco_de_0000211_1280">
      »Hört«, flüsterte Lotti. »Balbine hat einmal gesagt, man solle nie so schnell sein auf dem Markt; sie halte immer die Hand in der Tasche und spaziere zuerst bloss so vorbei.«
     </p>
-    <p xml:id="eco_de_0000141_1290">
+    <p xml:id="eco_de_0000211_1290">
      Doch kaum hatte Lotti den weisen Rat gegeben, so schrie sie laut auf:
     </p>
-    <p xml:id="eco_de_0000141_1300">
+    <p xml:id="eco_de_0000211_1300">
      »O, o, ein Kaleidoskop!«
     </p>
-    <p xml:id="eco_de_0000141_1310">
+    <p xml:id="eco_de_0000211_1310">
      »Ein – was?« fragte Trudi.
     </p>
-    <p xml:id="eco_de_0000141_1320">
+    <p xml:id="eco_de_0000211_1320">
      »Ein Kaleidoskop!« Und Lotti fuhr mit der Hand, die sie hatte in der Tasche behalten wollen, nach einer kleinen mit lila Papier überzogenen Röhre. »Man guckt hinein und dreht es. Dann sieht man lauter gelb und rot und blaue Figuren, die sich immer bewegen, Trudi! Wie lebendige Sterne. Es ist furchtbar nett!«
     </p>
-    <p xml:id="eco_de_0000141_1330">
+    <p xml:id="eco_de_0000211_1330">
      »Jetzt geht es dir dann wie vorhin dem Trudi!« warnte Otto; aber im selben Moment fiel sein Auge auf einen Kompass.
     </p>
-    <p xml:id="eco_de_0000141_1340">
+    <p xml:id="eco_de_0000211_1340">
      »Hans, sieh –!«
     </p>
-    <p xml:id="eco_de_0000141_1350">
+    <p xml:id="eco_de_0000211_1350">
      »Ach, das kann doch kein rechter Kompass sein für 30 Rappen –« sagte Hans leise.
     </p>
-    <p xml:id="eco_de_0000141_1360">
+    <p xml:id="eco_de_0000211_1360">
      »Doch, doch«, erwiderte Otto eifrig. »Sieh, das ist Norden, und dann kommt Nordwest! Wenn ich im Sommer wieder bei euch bin und wir im dicken Nebel auf den See hinausfahren, so haben wir mit dem Kompass immer die Richtung!«
     </p>
-    <p xml:id="eco_de_0000141_1370">
+    <p xml:id="eco_de_0000211_1370">
      »In den Sommerferien gibt es ja gar keinen dicken Nebel.«
     </p>
-    <p xml:id="eco_de_0000141_1380">
+    <p xml:id="eco_de_0000211_1380">
      Otto liess sich jedoch nicht abbringen. Entschlossen zählte er sein Geld heraus.
     </p>
-    <p xml:id="eco_de_0000141_1390">
+    <p xml:id="eco_de_0000211_1390">
      »Ich häng ihn gleich um. Hans, gib mir ein wenig Bindfaden!«
     </p>
-    <p xml:id="eco_de_0000141_1400">
+    <p xml:id="eco_de_0000211_1400">
      Hans hörte nicht. Er hatte einen kleinen Hammer ergriffen und wiegte ihn in der Hand:
     </p>
-    <p xml:id="eco_de_0000141_1410">
+    <p xml:id="eco_de_0000211_1410">
      »Genau so einen hätte ich eigentlich schon lang gebraucht.«
     </p>
-    <p xml:id="eco_de_0000141_1420">
+    <p xml:id="eco_de_0000211_1420">
      »Hans!« flüsterte Marianne. »Wir haben ja zwei daheim. Besinn dich doch noch –«
     </p>
-    <p xml:id="eco_de_0000141_1430">
+    <p xml:id="eco_de_0000211_1430">
      Plötzlich aber entdeckte sie eine kleine Schachtel, hinter deren Glasdeckel vier Strähnchen bunter Perlen lagen. Da vergass sie selbst das Besinnen, und im gleichen Augenblick, da Hans seinen Hammer von der Händlerin in Empfang nahm, bot ihr der Mann die eingewickelte Perlenschachtel herüber.
     </p>
-    <p xml:id="eco_de_0000141_1440">
+    <p xml:id="eco_de_0000211_1440">
      So, jetzt waren alle fünf Kinder ungefähr gleich weit in ihren Finanzen. Balbine hatte gut reden! Vor diesem Dreissigrappenstand wäre sie gewiss auch nicht vorbeispaziert mit der Hand in der Tasche!
     </p>
-    <p xml:id="eco_de_0000141_1450">
+    <p xml:id="eco_de_0000211_1450">
      Nun war es aber höchste Zeit, weiter zu gehen. Trudi stand in Gefahr, sich schon wieder in einen Handel einzulassen.
     </p>
-    <p xml:id="eco_de_0000141_1460">
+    <p xml:id="eco_de_0000211_1460">
      »Trudi, du bist wirklich zu dumm!« sagte Otto. »Eine Uhr, die nicht geht –!«
     </p>
-    <p xml:id="eco_de_0000141_1470">
+    <p xml:id="eco_de_0000211_1470">
      »Aber man kann ja den Zeiger drehen. Und von meinem Platz in der Schule sehe ich grad auf den Kirchturm; da könnte ich die Uhr immer richten –«
     </p>
-    <p xml:id="eco_de_0000141_1480">
+    <p xml:id="eco_de_0000211_1480">
      »Bis Herr Fink sie dir wegnimmt! Nein, Trudi –!« Otto zog die Schwester aus dem Bereich der verführerischen Uhr weg. »Komm, jetzt gehen wir zu den Waffeln!«
     </p>
-    <p xml:id="eco_de_0000141_1490">
+    <p xml:id="eco_de_0000211_1490">
      Die Waffelbude stand an der Ecke des Seilergässchens. Ohne sie liess sich der Larstetter Jahrmarkt nicht denken. Es war ein Hauptvergnügen, da eine frische braungebackene Waffel zu kaufen, nachdem man eine Weile zugesehen hatte, wie die dicke Frau in der Haube die langstielige Form in den Teig tauchte, dann in die Pfanne hielt und hierauf den fertigen Kuchen von der Form klopfte und mit Zucker bestreute.
     </p>
-    <p xml:id="eco_de_0000141_1500">
+    <p xml:id="eco_de_0000211_1500">
      Von ihren Waffeln herunterbeissend lenkten die Kinder ihre Schritte zur Halde. Die Sonne schien jetzt hell, und von der Sägenwiese herauf tönte lustig und einladend die Musik des Karussells.
     </p>
-    <p xml:id="eco_de_0000141_1510">
+    <p xml:id="eco_de_0000211_1510">
      »So, und den Lebkuchen für die Josephine!« rief Otto plötzlich anhaltend. Josephine war die Köchin.
     </p>
-    <p xml:id="eco_de_0000141_1520">
+    <p xml:id="eco_de_0000211_1520">
      »Dort hat's Lebkuchen!« deutete Lotti in eine Seitengasse, wo auch noch ein paar Buden standen. Ein altes Männlein sass da und hielt Lebkuchen feil.
     </p>
-    <p xml:id="eco_de_0000141_1530">
+    <p xml:id="eco_de_0000211_1530">
      »Beim Rathaus ist ein viel grösserer Stand«, meinte Otto. »Dort kaufen alle Leute.«
     </p>
-    <p xml:id="eco_de_0000141_1540">
+    <p xml:id="eco_de_0000211_1540">
      »Vielleicht hat der Mann aber auch gern, wenn man zu ihm kommt«, erwiderte Marianne und ging zu dem Alten, der freundlich nickte.
     </p>
-    <p xml:id="eco_de_0000141_1550">
+    <p xml:id="eco_de_0000211_1550">
      »Brav einkaufen! Lauter gute Ware!« rief er und legte seine Lebkuchen her.
     </p>
-    <p xml:id="eco_de_0000141_1560">
+    <p xml:id="eco_de_0000211_1560">
      »Wir möchten einen für zehn Rappen«, sagte Otto.
     </p>
-    <p xml:id="eco_de_0000141_1570">
+    <p xml:id="eco_de_0000211_1570">
      »Fünf Kinder und bloss einen kleinen Lebkuchen –?« Der Alte machte ein enttäuschtes Gesicht.
     </p>
-    <p xml:id="eco_de_0000141_1580">
+    <p xml:id="eco_de_0000211_1580">
      »Wir haben eben schon Waffeln gekauft, und jetzt möchten wir zum Karussell«, erklärte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_1590">
+    <p xml:id="eco_de_0000211_1590">
      »O jeh, o jeh! heut geht das Geschäft doch gar nicht!« jammerte das Männchen. »Es kommt kein Mensch da vorbei, und wenn einer kommt, so hat er schon eingekauft. O jeh!«
     </p>
-    <p xml:id="eco_de_0000141_1600">
+    <p xml:id="eco_de_0000211_1600">
      Betrübt schob er die Pakete wieder zusammen.
     </p>
-    <p xml:id="eco_de_0000141_1610">
+    <p xml:id="eco_de_0000211_1610">
      Die Kinder sahen einander an und berieten leise, bis sie zu dem Entschluss kamen, zusammen einen runden Lebkuchen für 25 Rappen zu kaufen.
     </p>
-    <p xml:id="eco_de_0000141_1620">
+    <p xml:id="eco_de_0000211_1620">
      »So ist's recht!« sagte das Männlein und suchte den bestgeformten Kuchen aus. »Und wenn man etwa bei euch zu Haus noch mehr brauchen sollte, so denkt an mich.«
     </p>
-    <p xml:id="eco_de_0000141_1630">
+    <p xml:id="eco_de_0000211_1630">
      Die Kinder versprachen es. Es war jedoch schwer, das Lebkuchenmännlein im Sinn zu behalten. Auf der Sägenwiese gab es neben dem Karussell noch ein Kasperletheater; das war über alle Beschreibung lustig. Am Nachmittag war grosse Vorstellung. Es trat ein Sultan Schurimuri auf mit seinem Diener Karabatschi, und dann der freche Kasperle, der eine Reihe von Missetaten ausführte und sich immer hinausredete, ja den stolzen Sultan sogar in eine Kiste sperrte. Auf diese Kiste setzte er sich und sang: »Tirallala, tirallala!« bis der Herrscher der Hölle erschien, schwarz und grauenvoll, und den verbrecherischen Kasperle davon schleppte.
     </p>
-    <p xml:id="eco_de_0000141_1640">
+    <p xml:id="eco_de_0000211_1640">
      »Wie schade!« riefen Lotti und Trudi, als nach dieser Höllenfahrt das Stück zu Ende war.
     </p>
-    <p xml:id="eco_de_0000141_1650">
+    <p xml:id="eco_de_0000211_1650">
      Sie trösteten sich dann aber mit der Aussicht auf eine zweite Vorstellung um drei Uhr. Inzwischen konnte man wieder zum Karussell oder ins Städtchen hinauf zu den Verkaufsbuden gehen. So wären die Kinder beständig von einer Herrlichkeit zur andern hin und her gelaufen, wenn nicht schliesslich etwas Besonderes sie festgehalten hätte …
     </p>
-    <p xml:id="eco_de_0000141_1660">
+    <p xml:id="eco_de_0000211_1660">
      Der Lärm des Jahrmarktes drang nur von Ferne in den Pfarrgarten. Frau Pfarrer pflückte vom Spalier die letzten Birnen; Spitz sah ihr zu, und die schwarze Katze lag in der Sonne. Beide hatten heute frei; denn Edith war nach dem Essen gegangen, sich den Markt anzusehen. Frau Pfarrer wandte sich ein paarmal nach der Strasse; jetzt sollte das Kind eigentlich zurück sein.
     </p>
-    <p xml:id="eco_de_0000141_1670">
+    <p xml:id="eco_de_0000211_1670">
      Da kamen Doktors Otto und Hans Turnach herangerannt:
     </p>
-    <p xml:id="eco_de_0000141_1680">
+    <p xml:id="eco_de_0000211_1680">
      »Guten Abend, Frau Pfarrer –«
     </p>
-    <p xml:id="eco_de_0000141_1690">
+    <p xml:id="eco_de_0000211_1690">
      »Guten Abend, Otto! Wisst ihr vielleicht, wo Edith ist?«
     </p>
-    <p xml:id="eco_de_0000141_1700">
+    <p xml:id="eco_de_0000211_1700">
      »Ja, sie steht in einer Bude an der Trümpengasse und verkauft Lebkuchen –«
     </p>
-    <p xml:id="eco_de_0000141_1710">
+    <p xml:id="eco_de_0000211_1710">
      »Was sagt ihr? Wo steht sie –?«
     </p>
-    <p xml:id="eco_de_0000141_1720">
+    <p xml:id="eco_de_0000211_1720">
      »In einer Bude und verkauft Lebkuchen. Es ist ein ganzes Gedränge um sie herum, und wir sollen Einwickelpapier holen –«
     </p>
-    <p xml:id="eco_de_0000141_1730">
+    <p xml:id="eco_de_0000211_1730">
      »In einem Lebkuchenstand – auf dem Jahrmarkt – nein, das ist nun doch zu arg! David –!«
     </p>
-    <p xml:id="eco_de_0000141_1740">
+    <p xml:id="eco_de_0000211_1740">
      Der Herr Pfarrer sah oben zu dem grün umrankten Fenster heraus und lachte. Er hatte die Geschichte mitangehört.
     </p>
-    <p xml:id="eco_de_0000141_1750">
+    <p xml:id="eco_de_0000211_1750">
      »Rege dich nicht auf, Berta! Ediths Taten sind manchmal etwas ungewöhnlich; aber sie meint's gut.«
     </p>
-    <p xml:id="eco_de_0000141_1760">
+    <p xml:id="eco_de_0000211_1760">
      »Nein, David, was zu viel ist, ist zu viel –«
     </p>
-    <p xml:id="eco_de_0000141_1770">
+    <p xml:id="eco_de_0000211_1770">
      »Marianne und Lotti und Trudi sind auch in dem Lebkuchenstand«, fuhren Hans und Otto in ihrem Bericht fort.
     </p>
-    <p xml:id="eco_de_0000141_1780">
+    <p xml:id="eco_de_0000211_1780">
      Frau Pfarrer seufzte erleichtert auf.
     </p>
-    <p xml:id="eco_de_0000141_1790">
+    <p xml:id="eco_de_0000211_1790">
      »Und der Mann ist sehr froh, und wenn Sie uns, bitte, Papier geben wollten – Edith hat gesagt, wir sollten schnell wieder kommen –«
     </p>
-    <p xml:id="eco_de_0000141_1800">
+    <p xml:id="eco_de_0000211_1800">
      »Siehst du, Berta«, sagte der Herr Pfarrer. »Gib den Buben, was sie brauchen. Zu deiner Beruhigung und zu meinem Vergnügen gehe ich nachher gleich hinüber in die Trümpengasse und sehe, wie sie es treiben.«
     </p>
-    <p xml:id="eco_de_0000141_1810">
+    <p xml:id="eco_de_0000211_1810">
      Das mit der Lebkuchenbude war so gekommen: Edith hatte in der Hauptgasse vor einem Stande, wo man nach Scheiben schiessen konnte, die Turnach- und Doktorskinder getroffen.
     </p>
-    <p xml:id="eco_de_0000141_1820">
+    <p xml:id="eco_de_0000211_1820">
      »Ich kann nicht verständen«, sagte sie, »dass Tante Pfarrer mich verbietet zu schiessen hier. Ist doch eine sehr hübschen Sache.«
     </p>
-    <p xml:id="eco_de_0000141_1830">
+    <p xml:id="eco_de_0000211_1830">
      Aber sie widerstand der Versuchung und schlenderte mit den Kindern weiter.
     </p>
-    <p xml:id="eco_de_0000141_1840">
+    <p xml:id="eco_de_0000211_1840">
      Auf einmal lief Hans um die Ecke. Der Lebkuchenmann war ihm eingefallen. Der kleine Alte stand wie am Morgen da und sah nach Käufern aus.
     </p>
-    <p xml:id="eco_de_0000141_1850">
+    <p xml:id="eco_de_0000211_1850">
      »Einkaufen, einkaufen!« rief er mit seiner dünnen Stimme, als er die Kinder wieder sah.
     </p>
-    <p xml:id="eco_de_0000141_1860">
+    <p xml:id="eco_de_0000211_1860">
      Die Kinder waren etwas verlegen; denn sie hatten gar kein Geld mehr. Und der Edith, die sonst immer viel Taschengeld besass, war es heute auch ausgegangen.
     </p>
-    <p xml:id="eco_de_0000141_1870">
+    <p xml:id="eco_de_0000211_1870">
      »Das ist ein Unglück«, sagte sie. »In zwei oder drei Tage ich bekomme wieder von mein Papa; aber jetzt ich habe nur noch diesen Zwanzig.«
     </p>
-    <p xml:id="eco_de_0000141_1880">
+    <p xml:id="eco_de_0000211_1880">
      Dafür nahm sie einen Kuchen. Sie sah umher. Warum kamen denn keine Leute?
     </p>
-    <p xml:id="eco_de_0000141_1890">
+    <p xml:id="eco_de_0000211_1890">
      »Sie haben eine schlechte Platz hier!« sagte sie.
     </p>
-    <p xml:id="eco_de_0000141_1900">
+    <p xml:id="eco_de_0000211_1900">
      »Ja freilich«, nickte das Männlein. »Sonst geht immer meine Frau auf die Märkte. Sie versteht das besser.«
     </p>
-    <p xml:id="eco_de_0000141_1910">
+    <p xml:id="eco_de_0000211_1910">
      »Warum Sie haben nicht ein weisses Mütze und Schürze wie die Frau,in der Waffelladen?«
     </p>
-    <p xml:id="eco_de_0000141_1920">
+    <p xml:id="eco_de_0000211_1920">
      Der kleine Mann sah sie an.
     </p>
-    <p xml:id="eco_de_0000141_1930">
+    <p xml:id="eco_de_0000211_1930">
      »Warum Sie machen nicht Lärm? In Amerika man hat eine Trommel oder ein Glocke und die Leute kommen und kaufen –. Geben Sie acht –«, man sah, dass Edith ein lustiger Gedanke kam. »Geben Sie acht! ich will Sie zeigen, wie man macht bei uns!«
     </p>
-    <p xml:id="eco_de_0000141_1940">
+    <p xml:id="eco_de_0000211_1940">
      Sie nahm einen Bogen, weisses Papier, heftete es mit einer Stecknadel zu einer Mütze zusammen und setzte sie auf ihr Haar. Dann schlüpfte sie zu dem kleinen Alten in die Bude hinein. Die Mütze stand ihr sehr gut.
     </p>
-    <p xml:id="eco_de_0000141_1950">
+    <p xml:id="eco_de_0000211_1950">
      »Edith, wir wollen auch Mützen! wir wollen auch helfen!« rief Lotti, angefeuert durch das Beispiel.
     </p>
-    <p xml:id="eco_de_0000141_1960">
+    <p xml:id="eco_de_0000211_1960">
      »Ja, ist sehr gut!« erwiderte Edith. »Jeden muss haben ein weisses Mütze. Sechs Bäcker von Kuchen in einem Reihe, und man denkt, es ist ein sehr grosse, gute Geschäft. Otto, wir brauchen eine Glocke. Besinne dir, wer hat ein Glocke!«
     </p>
-    <p xml:id="eco_de_0000141_1970">
+    <p xml:id="eco_de_0000211_1970">
      Otto rannte davon und kam zurück mit einer laut bimmelnden Kuhglocke.
     </p>
-    <p xml:id="eco_de_0000141_1980">
+    <p xml:id="eco_de_0000211_1980">
      Es gab ein starkes Gedränge in dem kleinen Lebkuchenstand, als nun alle sechs Kinder drin waren. Der kleine Mann wusste nicht recht, was er sagen sollte, und rieb sich hinter dem Ohr.
     </p>
-    <p xml:id="eco_de_0000141_1990">
+    <p xml:id="eco_de_0000211_1990">
      Drei Bauern, die in der Hauptgasse vorbeigehen wollten, drehten sich um bei dem lauten Schall der Glocke; ein paar Frauen aus den Nachbarhäusern traten auch näher.
     </p>
-    <p xml:id="eco_de_0000141_2000">
+    <p xml:id="eco_de_0000211_2000">
      »Meine Herren und Damen, kommen Sie schnell kaufen, vor es ist zu spät!« rief Edith mit heller Stimme. »Hier, nehmen Sie von dieses ausserordentlich schöne Lebkuchen für –« sie wandte sich zu dem Männlein – »für dreissig Rappen!«
     </p>
-    <p xml:id="eco_de_0000141_2010">
+    <p xml:id="eco_de_0000211_2010">
      Die Leute bildeten schon einen Kreis um die Bude, in der sechs Kuchenbäcker standen mit weissen Mützen und lustigen Gesichtern. Das Männlein dahinter sah man kaum.
     </p>
-    <p xml:id="eco_de_0000141_2020">
+    <p xml:id="eco_de_0000211_2020">
      »Für dreissig Rappen! Ein ganz unglaubig kleine Preis!«
     </p>
-    <p xml:id="eco_de_0000141_2030">
+    <p xml:id="eco_de_0000211_2030">
      Das wunderliche Deutsch machte die Leute lachen.
     </p>
-    <p xml:id="eco_de_0000141_2040">
+    <p xml:id="eco_de_0000211_2040">
      »Ja, Jungfer, wir haben eben schon eingekauft, beim Rathaus drüben«, sagte ein Bauer.
     </p>
-    <p xml:id="eco_de_0000141_2050">
+    <p xml:id="eco_de_0000211_2050">
      »Ist gut. Jene Mann am Rathaus will verkaufen Lebkuchen, und wir wollen verkaufen, und kleine Kinder zu Hause wollen haben Lebkuchen. Also, bitte, nicht stehen hier und verlieren Zeit!«
     </p>
-    <p xml:id="eco_de_0000141_2060">
+    <p xml:id="eco_de_0000211_2060">
      Wieder ertönte ein lautes Gelächter, das andere Neugierige herbeilockte.
     </p>
-    <p xml:id="eco_de_0000141_2070">
+    <p xml:id="eco_de_0000211_2070">
      »Die versteht das Geschäft«, sagte der Bauer und liess sich drei runde Lebkuchen geben. Zwei Frauen kauften kleine Pakete. Und nun rückte eins nach dem andern heran, um der munteren Verkäuferin mit dem Kauderwelsch etwas abzunehmen.
     </p>
-    <p xml:id="eco_de_0000141_2080">
+    <p xml:id="eco_de_0000211_2080">
      Das Lebkuchenmännlein fuhr geschäftig umher. Es kam fast nicht nach mit Geldeinziehen und -herausgeben; Marianne wickelte ein; Hans und Otto handhabten die Glocke, während Lotti und Trudi an den Gestellen hinaufkletterten, um neue Pakete herunterzuholen. Und nun erschien der Herr Pfarrer und lachte herzlich und kaufte natürlich. Und dann langte Tante Doktor an, erstaunt und belustigt, und kaufte auch. Und Frau Pfarrer kam ebenfalls, und Edith sah, dass sie wie die andern lachte, und rief:
     </p>
-    <p xml:id="eco_de_0000141_2090">
+    <p xml:id="eco_de_0000211_2090">
      »Hier, ich habe dich der letzte Pack Mandelkuchen behalten! Wir mussten diese Mann ein wenig helfen. Er immer stand da und nichts verkaufte!«
     </p>
-    <p xml:id="eco_de_0000141_2100">
+    <p xml:id="eco_de_0000211_2100">
      Also kaufte Frau Pfarrer die Mandelkuchen und noch drei grosse Pakete dazu. Der kleine Alte hatte sich ganz überwältigt auf seine Kiste im Hintergrund gesetzt. Er wollte immer zählen, was er schon eingenommen; aber beständig kam neues Geld hinzu.
     </p>
-    <p xml:id="eco_de_0000141_2110">
+    <p xml:id="eco_de_0000211_2110">
      »Es ist unerhört, unerhört!« sagte er vor sich hin. »Was wird doch meine Alte sagen daheim! Die wird mir gesund vor lauter Freude.«
     </p>
-    <p xml:id="eco_de_0000141_2120">
+    <p xml:id="eco_de_0000211_2120">
      Schon dunkelte es stark. Hans und Otto zündeten ein paar Kerzenstümpfchen an. Als aber der Polizeidiener Drehbaum sich durch die Leute schob und mit strenger Miene erklärte, die Marktzeit sei um, es müsse geschlossen werden, da war der Vorrat des Lebkuchenmännleins zu Ende, rein zu Ende.
     </p>
-    <p xml:id="eco_de_0000141_2130">
+    <p xml:id="eco_de_0000211_2130">
      »Ausverkauft!« schrien die zwei Buben und warfen ihre Mützen in die Höhe.
     </p>
-    <p xml:id="eco_de_0000141_2140">
+    <p xml:id="eco_de_0000211_2140">
      »Ihr habt Glück gehabt!« sagte Drehbaum zu dem Männlein.
     </p>
-    <p xml:id="eco_de_0000141_2150">
+    <p xml:id="eco_de_0000211_2150">
      »Ja, über Verdienen!« sagte das Männlein. »Aber der liebe Herrgott wird es wegen meiner Alten daheim so gerichtet haben. So will ich ihm halt recht danken und dem gescheiten Jüngferlein da auch und den andern, tausendmal!«
     </p>
-    <p xml:id="eco_de_0000141_2160">
+    <p xml:id="eco_de_0000211_2160">
      Er schüttelte den Kindern ringsum die Hand. Unter Hallo und Glockengeschell krochen die sechs aus der Bude heraus.
     </p>
-    <p xml:id="eco_de_0000141_2170">
+    <p xml:id="eco_de_0000211_2170">
      »Und nächstes Jahr«, erklärte Lotti dem Lebkuchenmännlein zum Abschied, »wenn wir in den Herbstferien nach Larstetten kommen, helfen wir Ihnen wieder!«
     </p>
    </div>
@@ -748,469 +748,469 @@
     <head>
      Eine Theatervorstellung
     </head>
-    <p xml:id="eco_de_0000141_2180">
+    <p xml:id="eco_de_0000211_2180">
      Nach dem Jahrmarkt wurde das Wetter schlecht. Der Wind trieb einen Regenguss um den andern daher. In der Hauptgasse von Larstetten, wo am Freitag solch ein Getümmel geherrscht hatte, war es jetzt still und leer. Drinnen im Doktorhaus ging es um so lebhafter zu.
     </p>
-    <p xml:id="eco_de_0000141_2190">
+    <p xml:id="eco_de_0000211_2190">
      Die Kinder standen alle in dem weiten, weiss getünchten Hausgang an dem alten Guckkasten, den schon Tante Doktor und Mama Turnach besessen hatten, als sie klein waren. Wenn man vorn durch das runde Glas sah, so erschienen die Bilder, die man hineinstellte, stark vergrössert. Es waren prächtige Sachen da: Eine Eisbärenjagd mit glutroter Mitternachtssonne; der Turmbau von Babel; eine Überschwemmung, bei der das Meer über einen Damm hereinstürzte; ein Negertanz; ein feuerspeiender Berg; Attila, der furchtbare Hunnenkönig mit seinen Reiterscharen dahersausend, und viel andere gewaltige Dinge.
     </p>
-    <p xml:id="eco_de_0000141_2200">
+    <p xml:id="eco_de_0000211_2200">
      »Halt, Hans! Noch einmal den Wald mit den Elefanten –! Nein, die Jungfrau von Orleans –!« Jedes der Kinder wollte selbst ein Bild hineinstecken.
     </p>
-    <p xml:id="eco_de_0000141_2210">
+    <p xml:id="eco_de_0000211_2210">
      »Bitte, meine Herrschaften«, rief Hans mit schnarrender Stimme, »immer der Reihe nach –«
     </p>
-    <p xml:id="eco_de_0000141_2220">
+    <p xml:id="eco_de_0000211_2220">
      »Ja«, lachte Lotti, »grade so hat gestern der Herr mit den goldenen Borten geredet vor der Bude, wo wir nicht haben hinein dürfen. Wenn ich gross bin, gehe ich der Reihe nach in alle Schaubuden. Hans, gib doch den Negertanz her!«
     </p>
-    <p xml:id="eco_de_0000141_2230">
+    <p xml:id="eco_de_0000211_2230">
      Aber Hans legte das Blatt weg. Er überlegte etwas.
     </p>
-    <p xml:id="eco_de_0000141_2240">
+    <p xml:id="eco_de_0000211_2240">
      »Hört«, sagte er. »Wir könnten eigentlich selber eine Bude einrichten da mit dem Guckkasten! Natürlich kostet es Eintrittsgeld –«
     </p>
-    <p xml:id="eco_de_0000141_2250">
+    <p xml:id="eco_de_0000211_2250">
      »Ja«, rief Otto. »Wir machen eine Kasse! Ein Tischchen mit einem roten Tuch und einem Teller –«
     </p>
-    <p xml:id="eco_de_0000141_2260">
+    <p xml:id="eco_de_0000211_2260">
      »Aber, Hans, Eintrittsgeld und dann bloss den Guckkasten!« wandte Marianne ein.
     </p>
-    <p xml:id="eco_de_0000141_2270">
+    <p xml:id="eco_de_0000211_2270">
      »Wir hätten ja noch das Lebensrad!« schlug Otto vor. »Trudi, hol das Lebensrad!«
     </p>
-    <p xml:id="eco_de_0000141_2280">
+    <p xml:id="eco_de_0000211_2280">
      Trudi brachte das Lebensrad. Es sah aus wie eine runde Pappschachtel ohne Deckel, die sich auf einem Gestell drehte; sie besass viele Einschnitte zum Hineinsehen. Die Bilder da drinnen vergrösserten sich nicht; aber was noch merkwürdiger war, sie fingen an, sich zu bewegen, wenn man rasch drehte, und trieben allerlei komisches Zeug: Ein Mann warf grüne Kugeln auf und fing sie wieder; ein kleines Mädchen sprang Seil; ein Schuster wollte seinem Lehrbuben eine Ohrfeige geben; aber jedesmal, wenn er ausholte, bog der Bub den Kopf weg; es war sehr spasshaft. Ebenso ein Pudel, dem eine Brummfliege um die Nase summte. Er tat einen Schnapp – und die Fliege flog davon.
     </p>
-    <p xml:id="eco_de_0000141_2290">
+    <p xml:id="eco_de_0000211_2290">
      Also hatte man schon die zweite Nummer für die Aufführung. Aber in Hansens Sinn wurde die Sache immer grossartiger.
     </p>
-    <p xml:id="eco_de_0000141_2300">
+    <p xml:id="eco_de_0000211_2300">
      »Otto, du hast doch einmal so Taschenspielerkünste gehabt!«
     </p>
-    <p xml:id="eco_de_0000141_2310">
+    <p xml:id="eco_de_0000211_2310">
      »Das Zauber-Ei meinst du und die Schnur, die man zerschneidet und mit dem Spruch wieder ganz macht? Und die geheimnisvollen Münzen, die bald in der kleinen und bald in der grossen Büchse sind –«
     </p>
-    <p xml:id="eco_de_0000141_2320">
+    <p xml:id="eco_de_0000211_2320">
      Otto lief die Treppe hinauf; die andern folgten ihm. Glücklich fanden sich die Sachen. Der Zauber-Eierbecher hatte verschiedene ineinander steckende Deckel. Wenn man die Sache rasch und gut machte, so konnte man das weisse Ei in ein rotes verwandeln, dann in ein blaues, und schliesslich das ganze Ei verschwinden lassen.
     </p>
-    <p xml:id="eco_de_0000141_2330">
+    <p xml:id="eco_de_0000211_2330">
      »Das wären also drei Zauberkünste«, sagte Hans.
     </p>
-    <p xml:id="eco_de_0000141_2340">
+    <p xml:id="eco_de_0000211_2340">
      »Otto – und die sterbenden Schweinchen!« rief Marianne. »Nimm die sterbenden Schweinchen dazu!«
     </p>
-    <p xml:id="eco_de_0000141_2350">
+    <p xml:id="eco_de_0000211_2350">
      Otto hatte die sterbenden Schweinchen vor kurzem von einem Freunde seines Papas geschenkt bekommen.
     </p>
-    <p xml:id="eco_de_0000141_2360">
+    <p xml:id="eco_de_0000211_2360">
      »Du hast sie doch noch keinem gezeigt?« fragte Hans.
     </p>
-    <p xml:id="eco_de_0000141_2370">
+    <p xml:id="eco_de_0000211_2370">
      Nein, zum Glück waren die sterbenden Schweinchen etwas durchaus Neues für Larstetten.
     </p>
-    <p xml:id="eco_de_0000141_2380">
+    <p xml:id="eco_de_0000211_2380">
      Otto sah in der halbdunkeln Kammer umher, ob sich vielleicht noch etwas finde. In den Ecken standen allerlei Kisten und altes Spielzeug, ein Schaukelpferd ohne Kopf, auf dem Lotti und Trudi zu reiten begannen.
     </p>
-    <p xml:id="eco_de_0000141_2390">
+    <p xml:id="eco_de_0000211_2390">
      »Was ist da drin, Otto?«, fragte Marianne und zog eine grosse Schachtel hervor.
     </p>
-    <p xml:id="eco_de_0000141_2400">
+    <p xml:id="eco_de_0000211_2400">
      »Ach, das ist ein Theater – Papas Theater, wie er noch ein Bub war.«
     </p>
-    <p xml:id="eco_de_0000141_2410">
+    <p xml:id="eco_de_0000211_2410">
      »Ein Theater –?« rief Hans. »Und das sagst du einem erst jetzt!«
     </p>
-    <p xml:id="eco_de_0000141_2420">
+    <p xml:id="eco_de_0000211_2420">
      »Es ist ja gar nichts Rechtes mehr da«, antwortete Otto und machte auf.
     </p>
-    <p xml:id="eco_de_0000141_2430">
+    <p xml:id="eco_de_0000211_2430">
      Man sah einige Drähte mit abgerissenen Köpfen und verschiedene Kartonstücke, auf denen man Teile eines gemalten Waldes und einer Säulenhalle erkennen konnte.
     </p>
-    <p xml:id="eco_de_0000141_2440">
+    <p xml:id="eco_de_0000211_2440">
      »Das waren die Kulissen«, erklärte Otto. »Papa hatte mehr als zwanzig Puppen; aber später sind seine kleinen Vettern darüber gekommen.«
     </p>
-    <p xml:id="eco_de_0000141_2450">
+    <p xml:id="eco_de_0000211_2450">
      Hans hatte indessen unter den Trümmern zwei noch ziemlich guterhaltene Figuren entdeckt. Die eine stellte einen Hirtenjüngling dar mit blonden Locken, die andere einen ältern Mann in braunem Rock und grauen Strümpfen.
     </p>
-    <p xml:id="eco_de_0000141_2460">
+    <p xml:id="eco_de_0000211_2460">
      Hans betrachtete die zwei Drahtpuppen um und um. Dann sah er auf.
     </p>
-    <p xml:id="eco_de_0000141_2470">
+    <p xml:id="eco_de_0000211_2470">
      »Ich will euch etwas sagen! Mit den zweien da können wir ein feines Stück aufführen!«
     </p>
-    <p xml:id="eco_de_0000141_2480">
+    <p xml:id="eco_de_0000211_2480">
      »O!« riefen Otto und Marianne.
     </p>
-    <p xml:id="eco_de_0000141_2490">
+    <p xml:id="eco_de_0000211_2490">
      »Ja, wir führen Siegfrieds Kampf mit dem Drachen auf! Onkel Alfred hat das auf dem Theater gesehen. Er hat mir alles erzählt. Der da –« Hans deutete auf die Figur mit den Locken, »der da ist Siegfried, und der –« Hans nahm den Mann im bräunen Rock und knickte ihn zusammen.
     </p>
-    <p xml:id="eco_de_0000141_2500">
+    <p xml:id="eco_de_0000211_2500">
      »Au! Du zerbrichst ihn ja!« schrien Otto und Marianne.
     </p>
-    <p xml:id="eco_de_0000141_2510">
+    <p xml:id="eco_de_0000211_2510">
      »Nein, ich richte ihn zu einem Zwerg her. Jetzt brauchen wir nur noch einen Drachen, eine Höhle, Goldschätze und einen Wald.«
     </p>
-    <p xml:id="eco_de_0000141_2520">
+    <p xml:id="eco_de_0000211_2520">
      »Zu was brauchst du einen Drachen?« fragte Trudi und stieg von ihrem Schaukelpferd herunter.
     </p>
-    <p xml:id="eco_de_0000141_2530">
+    <p xml:id="eco_de_0000211_2530">
      »Ach, Trudi, du wirst wohl keinen haben«, sagte Hans etwas geringschätzig.
     </p>
-    <p xml:id="eco_de_0000141_2540">
+    <p xml:id="eco_de_0000211_2540">
      Aber Trudi zeigte sich wider Erwarten von grossem Nutzen.
     </p>
-    <p xml:id="eco_de_0000141_2550">
+    <p xml:id="eco_de_0000211_2550">
      »Mama hat einen Drachen in einem Buch. Er hat einen grünen geringelten Schwanz, und aus dem Maule haucht er Feuer –«
     </p>
-    <p xml:id="eco_de_0000141_2560">
+    <p xml:id="eco_de_0000211_2560">
      Zu fünft ging's hinunter ins Wohnzimmer, wo Tante Doktor nähte.
     </p>
-    <p xml:id="eco_de_0000141_2570">
+    <p xml:id="eco_de_0000211_2570">
      »Mama! Tante! wir sollten einen Drachen haben! Bitte zeig uns das alte Buch mit dem Drachen!«
     </p>
-    <p xml:id="eco_de_0000141_2580">
+    <p xml:id="eco_de_0000211_2580">
      Die Tante vernahm, was im Plane war, und holte das Buch, in welchem die Kinder das Ungeheuer alsbald fanden.
     </p>
-    <p xml:id="eco_de_0000141_2590">
+    <p xml:id="eco_de_0000211_2590">
      »Mama«, rief Otto. »Wenn wir doch den Drachen herausschneiden dürften! Das Buch ist ja schon ein wenig zerrissen.«
     </p>
-    <p xml:id="eco_de_0000141_2600">
+    <p xml:id="eco_de_0000211_2600">
      »Ja, Tante!« bettelte Lotti. »Es wäre doch nett für den Drachen, wenn er mitmachen dürfte!«
     </p>
-    <p xml:id="eco_de_0000141_2610">
+    <p xml:id="eco_de_0000211_2610">
      Da lachte die Tante:
     </p>
-    <p xml:id="eco_de_0000141_2620">
+    <p xml:id="eco_de_0000211_2620">
      »Also, Lotti; er soll mitmachen!« Und sie gab Marianne das Blatt, dass sie den Drachen für die Vorstellung herrichte Er wurde auf steifes Papier geklebt, ausgeschnitten und auf der Rückseite bemalt, damit er da ebenso natürlich aussehe wie vorn. Dann versah ihn Hans mit einer Holzleiste und einem Draht. Siegfried erhielt ein Fell über die Schulter aus einem Stückchen Katzenpelz; Tantes Trennmesserchen bildete sein Schwert. Es gab alle Hände voll zu tun. Als Goldschätze konnten einige Vorhangringe, ein Messingkettchen und ein Schlüsselschildchen dienen.
     </p>
-    <p xml:id="eco_de_0000141_2630">
+    <p xml:id="eco_de_0000211_2630">
      Jetzt der Wald. Hans und Otto schleppten Geranien- und Laurusstöcke und ein Gummibäumchen herbei und stellten sie in Form eines Hufeisens auf eine breite Kiste in den Hausgang. Dann wurden Brettchen zurechtgesägt und über die Topfränder gelegt. Das gab den Boden für die Drahtpuppen und den Drachen. Es sah sehr hübsch aus, wie ein freier Platz unter Bäumen.
     </p>
-    <p xml:id="eco_de_0000141_2640">
+    <p xml:id="eco_de_0000211_2640">
      »Zur Drachenhöhle nehmen wir ein paar Tuffsteine aus dem Garten«, ordnete Hans an und setzte sich dann in eine Ecke, um die Gespräche aufzuschreiben, die Siegfried, der Zwerg und der Drache halten sollten. Das war auch noch ein Stück Arbeit.
     </p>
-    <p xml:id="eco_de_0000141_2650">
+    <p xml:id="eco_de_0000211_2650">
      »Wir müssen tüchtig einüben«, sagte Hans. »Während man spricht, rückt man die Figur immer ein wenig hin und her, wie wenn sie sich bewegte. Ich nehme den Siegfried, Marianne hat den Zwerg –«
     </p>
-    <p xml:id="eco_de_0000141_2660">
+    <p xml:id="eco_de_0000211_2660">
      »Wenn ich ihn nur kann!« sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_2670">
+    <p xml:id="eco_de_0000211_2670">
      »Vielleicht kann ich ihn?« schlug Lotti vor.
     </p>
-    <p xml:id="eco_de_0000141_2680">
+    <p xml:id="eco_de_0000211_2680">
      »Nein, Lotti, dazu passest du nicht!« erwiderte Hans. »Du darfst die Dame an der Kasse sein.«
     </p>
-    <p xml:id="eco_de_0000141_2690">
+    <p xml:id="eco_de_0000211_2690">
      »Und ich?« fragte nun auch Trudi.
     </p>
-    <p xml:id="eco_de_0000141_2700">
+    <p xml:id="eco_de_0000211_2700">
      »Du ziehst die Billette ein an der Türe. Otto, du nimmst natürlich den Drachen.«
     </p>
-    <p xml:id="eco_de_0000141_2710">
+    <p xml:id="eco_de_0000211_2710">
      »Ja, ich muss aber auch noch meine Zauberkünste probieren.«
     </p>
-    <p xml:id="eco_de_0000141_2720">
+    <p xml:id="eco_de_0000211_2720">
      In diesem Augenblicke trat Edith zur Haustüre herein mit einem Korb Birnen aus dem Pfarrgarten. Mit grossem Interesse vernahm sie, was im Tun war, und besichtigte die Figuren, besonders den Drachen.
     </p>
-    <p xml:id="eco_de_0000141_2730">
+    <p xml:id="eco_de_0000211_2730">
      »O, ich weiss«, rief sie. »Das ist ein europäische wilde Tier, welchen es nicht gibt! Otto, lass mich das Drache spielen!«
     </p>
-    <p xml:id="eco_de_0000141_2740">
+    <p xml:id="eco_de_0000211_2740">
      Otto willigte ein; Hans war etwas bedenklich.
     </p>
-    <p xml:id="eco_de_0000141_2750">
+    <p xml:id="eco_de_0000211_2750">
      »Du musst aber ganz ohne Fehler sprechen und sehr ernst!« sagte er. »Es ist nämlich kein Stück zum Lachen.«
     </p>
-    <p xml:id="eco_de_0000141_2760">
+    <p xml:id="eco_de_0000211_2760">
      »Ich werde lern, bis ich kann, und ich will so ein ernste Drache machen, dass alle werden zitter!« versprach Edith und lief dann schnell zurück, um dem Onkel Pfarrer zu sagen, dass sie heute eine Deutschstunde im Doktorhaus habe.
     </p>
-    <p xml:id="eco_de_0000141_2770">
+    <p xml:id="eco_de_0000211_2770">
      Lotti und Trudi wurden indessen ausgeschickt, um den Freunden und Freundinnen im Städtchen die Vorstellung anzukündigen.
     </p>
-    <p xml:id="eco_de_0000141_2780">
+    <p xml:id="eco_de_0000211_2780">
      An die Haustüre aber befestigte man einen grossen Zettel, auf dem folgendes geschrieben stand:
     </p>
-    <p xml:id="eco_de_0000141_2790">
+    <p xml:id="eco_de_0000211_2790">
      Theatervorstellung.
     </p>
-    <p xml:id="eco_de_0000141_2800">
+    <p xml:id="eco_de_0000211_2800">
      1. Der Guckkasten mit elf Bildern aus verschiedenen Ländern und Völkern.
     </p>
-    <p xml:id="eco_de_0000141_2810">
+    <p xml:id="eco_de_0000211_2810">
      2. Das Lebensrad, wo sich alles bewegt.
     </p>
-    <p xml:id="eco_de_0000141_2820">
+    <p xml:id="eco_de_0000211_2820">
      3. Der wunderbare Eierbecher, die Zauberschnur, die geheimnisvollen Münzen und die sterbenden Schweinchen.
     </p>
-    <p xml:id="eco_de_0000141_2830">
+    <p xml:id="eco_de_0000211_2830">
      4. Siegfrieds Kampf mit dem Drachen. (Es kommt ein Zwerg vor; der Drache und der Zwerg werden umgebracht.)
     </p>
-    <p xml:id="eco_de_0000141_2840">
+    <p xml:id="eco_de_0000211_2840">
      Beginn um drei Uhr. Erster Platz zehn Rappen, zweiter Platz fünf Rappen.
     </p>
-    <p xml:id="eco_de_0000141_2850">
+    <p xml:id="eco_de_0000211_2850">
      Es war kein Wunder, dass auf diese verlockende Anzeige hin eine Menge Kinder sich gegen drei Uhr im Doktorhaus einfanden. Lotti sass an der Türe und verkaufte mit wichtigem Gesicht die Billette. Der zweite Platz wurde stark bevorzugt. Spenglers Klara brachte zwar einen Zehner, aber zugleich drei kleine Geschwister und sagte, die Mutter lasse grüssen, und für zehn Rappen werden wohl vier zusehen dürfen. Einige hatten nur einen Zweier, und Felix Scharrelbach kam mit einer Tüte voll Sonnenblumenkörner und behauptete, die seien gut einen Fünfer wert.
     </p>
-    <p xml:id="eco_de_0000141_2860">
+    <p xml:id="eco_de_0000211_2860">
      Die grosse Zuschauerzahl machte allerdings einige Schwierigkeiten, als die Vorstellung mit dem Guckkasten eröffnet wurde. Hans rief umsonst:
     </p>
-    <p xml:id="eco_de_0000141_2870">
+    <p xml:id="eco_de_0000211_2870">
      »Bitte, meine Herrschaften, immer der Reihe nach!«
     </p>
-    <p xml:id="eco_de_0000141_2880">
+    <p xml:id="eco_de_0000211_2880">
      Alles drückte herzu, und die Hintern schrien, sie sehen nichts. Als jedoch Hans mit lauter Stimme die Bilder zu erklären begann, horchte man gespannt zu, und wer vorn keinen Platz fand, guckte von der Seite hinein.
     </p>
-    <p xml:id="eco_de_0000141_2890">
+    <p xml:id="eco_de_0000211_2890">
      Auch das Lebensrad mit dem bösen Schuster und der Brummfliege gefiel sehr.
     </p>
-    <p xml:id="eco_de_0000141_2900">
+    <p xml:id="eco_de_0000211_2900">
      Dann erschien Otto als Zauberer; er hatte eine spitze gelbe Mütze auf und einen schwarzen Mantel um. Er machte seine Künste geschickt. Nur als er das rote Ei unter »Hokus pokus tamalachtuggtugg« in ein blaues verwandeln wollte, kam es noch einmal rot zum Vorschein.
     </p>
-    <p xml:id="eco_de_0000141_2910">
+    <p xml:id="eco_de_0000211_2910">
      »Oha!« rief Felix Scharrelbach. »Das könnte ich auch!«
     </p>
-    <p xml:id="eco_de_0000141_2920">
+    <p xml:id="eco_de_0000211_2920">
      Als aber Hans einen drohenden Blick hinüberwarf und Klara, die ein handfestes Mädchen war, dem vorlauten Felix einen Puff gab, schwieg er, umsomehr, als Otto ihm das jetzt blaue Ei unter die Nase hielt.
     </p>
-    <p xml:id="eco_de_0000141_2930">
+    <p xml:id="eco_de_0000211_2930">
      Am meisten Beifall fanden Ottos Schweinchen. Dick und vergnügt standen sie da mit ihren langen Ohren und RingelSchwänzchen. Aber ihr Wohlbefinden dauerte nur kurz. Unter kläglichem Geschrei magerten sie zusehends ab; das Schwänzchen senkte sich trübselig; sie schrumpften ganz ein, sanken zusammen, erst das eine, dann die zwei andern und legten mit einem letzten Quiek den Kopf auf den Boden. Als Otto sie aufhob, bestanden sie nur noch aus Haut, Ohren und Schwanz.
     </p>
-    <p xml:id="eco_de_0000141_2940">
+    <p xml:id="eco_de_0000211_2940">
      »Noch einmal, noch einmal!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_2950">
+    <p xml:id="eco_de_0000211_2950">
      Immer wieder musste Otto die Schweinchen rund werden und sterben lassen.
     </p>
-    <p xml:id="eco_de_0000141_2960">
+    <p xml:id="eco_de_0000211_2960">
      Dann kam die Pause. Die Zuschauer wurden aufgefordert, in der Holzkammer zu warten, wo Otto sie einsperrte. Als er sie nach einer Weile herausholte, war das vorgespannte Leintuch im hintern Teil des Hausganges weggenommen, und man erblickte das Puppentheater. Links auf der Bühne neben dem zweiten Geranienbusch stand Siegfried, sein Tierfell über den Schultern; neben ihm war im braunen Kittel der bucklige Zwerg zu sehen.
     </p>
-    <p xml:id="eco_de_0000141_2970">
+    <p xml:id="eco_de_0000211_2970">
      Still vor Erwartung nahm das Publikum auf den bereitgestellten Bänken und Stühlen Platz. In der Höhe quer über dem Walde und zu beiden Seiten waren Vorhänge angebracht. Dahinter hörte man leise flüstern; das machte die Sache noch geheimnisvoller.
     </p>
-    <p xml:id="eco_de_0000141_2980">
+    <p xml:id="eco_de_0000211_2980">
      »Zwerg!« begann jetzt Siegfried laut. »Du hast gesagt, du wollest mich das Fürchten lehren!« Hans, rückte, während er sprach, den Siegfried am Drahte gegen die Mitte vor.
     </p>
-    <p xml:id="eco_de_0000141_2990">
+    <p xml:id="eco_de_0000211_2990">
      Der Zwerg rutschte an Siegfrieds Seite und fragte ihn, ob er sich denn wirklich noch nie gefürchtet habe im dunkeln Wald, wo die reissenden Tiere herumschleichen. Marianne, die für den Zwerg sprach, nahm eine sehr hohe Stimme an, wie es zu der kleinen Gestalt passte. Siegfried aber lachte:
     </p>
-    <p xml:id="eco_de_0000141_3000">
+    <p xml:id="eco_de_0000211_3000">
      »Hahaha! Die wilden Tiere! Erst gestern habe ich einen Bären bezwungen und ihn festgebunden, so dass er mir nachfolgen musste wie ein Hündchen!«
     </p>
-    <p xml:id="eco_de_0000141_3010">
+    <p xml:id="eco_de_0000211_3010">
      »Siegfried«, erwiderte der Zwerg, »wenn du so tapfer bist, so suche doch den Drachen auf, der hier haust, und erschlage ihn! Dann wärst du der grösste Held der Welt und würdest die Schätze gewinnen, die er bewacht.«
     </p>
-    <p xml:id="eco_de_0000141_3020">
+    <p xml:id="eco_de_0000211_3020">
      Der Zwerg beschrieb dem Siegfried die Pracht der Goldgeschmeide.
     </p>
-    <p xml:id="eco_de_0000141_3030">
+    <p xml:id="eco_de_0000211_3030">
      »Dort hinten wohnt er in der Felsenhöhle. Ich muss jetzt gehen. Lebe wohl.«
     </p>
-    <p xml:id="eco_de_0000141_3040">
+    <p xml:id="eco_de_0000211_3040">
      Arglistig kichernd zog sich der Zwerg gegen die Laurusstöcke zurück, indem er leise für sich sagte:
     </p>
-    <p xml:id="eco_de_0000141_3050">
+    <p xml:id="eco_de_0000211_3050">
      »Wenn es nur so käme, dass sie sich beide umbrächten, dann würde ich der Besitzer des Schatzes werden!«
     </p>
-    <p xml:id="eco_de_0000141_3060">
+    <p xml:id="eco_de_0000211_3060">
      Damit verschwand er.
     </p>
-    <p xml:id="eco_de_0000141_3070">
+    <p xml:id="eco_de_0000211_3070">
      Siegfried aber eilte kampflustig der Felshöhle zu, die unter dem Gummibaum sichtbar war. Da begegnete ihm etwas Fatales: Er verfing sich in einem Zweige und fiel der Länge nach hin.
     </p>
-    <p xml:id="eco_de_0000141_3080">
+    <p xml:id="eco_de_0000211_3080">
      »Hoppla!« rief Felix Scharrelbach. »So geht's, wenn man nicht acht gibt!«
     </p>
-    <p xml:id="eco_de_0000141_3090">
+    <p xml:id="eco_de_0000211_3090">
      »Still!« riefen die andern, die in höchster Spannung auf den Kampf mit dem Drachen warteten.
     </p>
-    <p xml:id="eco_de_0000141_3100">
+    <p xml:id="eco_de_0000211_3100">
      »He, man wird wohl noch etwas sagen dürfen!«
     </p>
-    <p xml:id="eco_de_0000141_3110">
+    <p xml:id="eco_de_0000211_3110">
      »Nein! Still! wenn's jetzt grad so schön wird!«
     </p>
-    <p xml:id="eco_de_0000141_3120">
+    <p xml:id="eco_de_0000211_3120">
      Felix bekam von links und rechts Püffe und Vorwürfe.
     </p>
-    <p xml:id="eco_de_0000141_3130">
+    <p xml:id="eco_de_0000211_3130">
      Siegfried hatte sich rasch wieder erhoben und versuchte, weiterzusprechen. Doch der Tumult unter den Zuschauern wuchs. Felix setzte sich lärmend zur Wehr:
     </p>
-    <p xml:id="eco_de_0000141_3140">
+    <p xml:id="eco_de_0000211_3140">
      »Mach du, dass du aufhörst!« schrie er seinem Nachbarn zu.
     </p>
-    <p xml:id="eco_de_0000141_3150">
+    <p xml:id="eco_de_0000211_3150">
      »Hör du zuerst auf! Du, mit deinen Sonnenblumenkernen!«
     </p>
-    <p xml:id="eco_de_0000141_3160">
+    <p xml:id="eco_de_0000211_3160">
      »Und du mit deinem Zweier –«
     </p>
-    <p xml:id="eco_de_0000141_3170">
+    <p xml:id="eco_de_0000211_3170">
      Felix stiess an die Bank, so dass die Spenglerkinder fast herunterfielen und zu weinen begannen. Es gab ein allgemeines Geschrei und Gepolter.
     </p>
-    <p xml:id="eco_de_0000141_3180">
+    <p xml:id="eco_de_0000211_3180">
      Hans, Otto und Marianne waren empört. Hans liess den Siegfried neben dem Gummibaum stehen und trat hervor.
     </p>
-    <p xml:id="eco_de_0000141_3190">
+    <p xml:id="eco_de_0000211_3190">
      »Wenn ihr nicht sogleich Ruhe gebt, so hören wir ganz auf und jagen euch alle fort!«
     </p>
-    <p xml:id="eco_de_0000141_3200">
+    <p xml:id="eco_de_0000211_3200">
      »Man braucht bloss den Felix hinauszutun, Hans!« rief Lehrers Bernhard. »Sollen wir –?« Ein halbes Dutzend Hände packten bereitwillig an.
     </p>
-    <p xml:id="eco_de_0000141_3210">
+    <p xml:id="eco_de_0000211_3210">
      Das half denn doch. Felix setzte sich und knurrte bloss noch ein wenig. Nach verschiedenen Ssst –! Ssst –! wurde es ruhig, und alle Augen wandten sich wieder dem Theater zu, wo das Schauspiel nun seinen Fortgang nahm.
     </p>
-    <p xml:id="eco_de_0000141_3220">
+    <p xml:id="eco_de_0000211_3220">
      Siegfried stand furchtlos unter dem Baume; aber in der Drachenhöhle begann es sich zu regen, und plötzlich ertönte von ihr her ein furchtbares Gähnen:
     </p>
-    <p xml:id="eco_de_0000141_3230">
+    <p xml:id="eco_de_0000211_3230">
      »U-ah!«
     </p>
-    <p xml:id="eco_de_0000141_3240">
+    <p xml:id="eco_de_0000211_3240">
      Edith hatte das zuhause besonders geübt; denn Hans hatte gesagt, es gehöre dazu. Es klang ungemein natürlich. Bernhards kleiner Bruder wurde sogar angesteckt und gähnte laut nach, was man aber weiter nicht beachtete; denn jetzt streckte der Drache den Kopf zwischen den Steinen hervor.
     </p>
-    <p xml:id="eco_de_0000141_3250">
+    <p xml:id="eco_de_0000211_3250">
      Siegfried näherte sich und rief:
     </p>
-    <p xml:id="eco_de_0000141_3260">
+    <p xml:id="eco_de_0000211_3260">
      »Was ist denn das für ein seltsames Tier?«
     </p>
-    <p xml:id="eco_de_0000141_3270">
+    <p xml:id="eco_de_0000211_3270">
      »Komm nur her!« antwortete der Drache. Edith machte ihre Sache sehr gut. Sie sprach mit einer so unheimlich dumpfen Stimme, dass die Spenglerskinder näher an die Schwester hinrückten und mit ängstlichen Augen guckten, was nun begegne.
     </p>
-    <p xml:id="eco_de_0000141_3280">
+    <p xml:id="eco_de_0000211_3280">
      »Komm nur her, damit ich dich verschlinge!«
     </p>
-    <p xml:id="eco_de_0000141_3290">
+    <p xml:id="eco_de_0000211_3290">
      Siegfried aber lachte:
     </p>
-    <p xml:id="eco_de_0000141_3300">
+    <p xml:id="eco_de_0000211_3300">
      »Wir wollen sehen, ob dir das gelingt, oder ob du nicht vielmehr von mir getötet wirst!«
     </p>
-    <p xml:id="eco_de_0000141_3310">
+    <p xml:id="eco_de_0000211_3310">
      Drohend fuhr der Drache zwischen den Felsen hin und her und schoss dann gegen Siegfried. Aber dieser wusste ihm auszuweichen, indem er in weitem Sprung über ihn wegsetzte. Dann drang er plötzlich auf das Untier ein und traf ihn mit einem offenbar tödlichen Stich; denn der Drache brüllte laut auf und legte sich mit einem Ruck auf die Seite.
     </p>
-    <p xml:id="eco_de_0000141_3320">
+    <p xml:id="eco_de_0000211_3320">
      »Ich sterbe!« stöhnte er. »Aber ich verzeihe dir und gebe dir noch einen Rat: Traue dem Zwerge nicht! Er ist falsch!«
     </p>
-    <p xml:id="eco_de_0000141_3330">
+    <p xml:id="eco_de_0000211_3330">
      Siegfried betrachtete den toten Lindwurm; dann trat er hinter den Felsen, um die Schätze zu holen.
     </p>
-    <p xml:id="eco_de_0000141_3340">
+    <p xml:id="eco_de_0000211_3340">
      Vorsichtig kam nun der Zwerg wieder hinter dem Laurus hervor.
     </p>
-    <p xml:id="eco_de_0000141_3350">
+    <p xml:id="eco_de_0000211_3350">
      »Aha!« sagte er leise. »Es scheint, dass Siegfried den Drachen getötet hat; aber er selbst ist am Leben geblieben. Jetzt muss ich versuchen, ihn zu vergiften.«
     </p>
-    <p xml:id="eco_de_0000141_3360">
+    <p xml:id="eco_de_0000211_3360">
      Siegfried erschien mit den Ringen und Ketten behängt. Sowie er jedoch den Zwerg erblickte, rief er:
     </p>
-    <p xml:id="eco_de_0000141_3370">
+    <p xml:id="eco_de_0000211_3370">
      »Ha! Zwerg! ich kenne jetzt deine Gedanken. Du hast Böses gegen mich im Sinn! Da nimm deinen Lohn!«
     </p>
-    <p xml:id="eco_de_0000141_3380">
+    <p xml:id="eco_de_0000211_3380">
      Er drang auf den Zwerg ein, und alsbald stürzte dieser erschlagen hin, womit das Stück schloss. Siegfried stand stolz mit seinem Schwert und seinem Gold zwischen dem toten Drachen und dem toten Zwerg, und der Vorhang fiel herunter.
     </p>
-    <p xml:id="eco_de_0000141_3390">
+    <p xml:id="eco_de_0000211_3390">
      Das war aber schön gewesen! Lehrers Bernhard, den sein Vater einmal ins Theater mitgenommen hatte, wusste, was Brauch war. Er fing an zu klatschen, und alle klatschten mit, so stark sie konnten, und die vorn auf der Kiste sassen, trommelten mit den Füssen.
     </p>
-    <p xml:id="eco_de_0000141_3400">
+    <p xml:id="eco_de_0000211_3400">
      In diesem Augenblick traten Ottos und Trudis Papa zur Haustüre herein.
     </p>
-    <p xml:id="eco_de_0000141_3410">
+    <p xml:id="eco_de_0000211_3410">
      »Papa! Onkel! grade ist es aus! Aber wir spielen es dir und Mama heut abend noch einmal!«
     </p>
-    <p xml:id="eco_de_0000141_3420">
+    <p xml:id="eco_de_0000211_3420">
      »Gut!« sagte Onkel Doktor. Dann jedoch fiel sein Blick auf den Teller mit dem Geld.
     </p>
-    <p xml:id="eco_de_0000141_3430">
+    <p xml:id="eco_de_0000211_3430">
      »Was soll denn das sein? Ihr habt doch den Kindern nicht in, Ernst Geld abgenommen? Was fällt euch ein? Das geht nicht!«
     </p>
-    <p xml:id="eco_de_0000141_3440">
+    <p xml:id="eco_de_0000211_3440">
      Die fünf machten verlegene Gesichter. Das war grade so nett gewesen, das Eintrittsgeld! Mit dem Zwanziger, den Edith hinzulegte, machte es fast einen Franken.
     </p>
-    <p xml:id="eco_de_0000141_3450">
+    <p xml:id="eco_de_0000211_3450">
      »Oder seht wenigstens, dass ihr das Geld gemeinnützig verwendet!« sagte der Onkel, indem er rasch die Treppe hinaufging.
     </p>
-    <p xml:id="eco_de_0000141_3460">
+    <p xml:id="eco_de_0000211_3460">
      »Papa, was ist das, gemeinnützig –?« rief Trudi. Doch Papa schritt schon durch den Korridor seinem Zimmer zu.
     </p>
-    <p xml:id="eco_de_0000141_3470">
+    <p xml:id="eco_de_0000211_3470">
      Im Hausgange aber entspann sich eine lebhafte Beratung, an der die Zuschauer ebenfalls teilnahmen.
     </p>
-    <p xml:id="eco_de_0000141_3480">
+    <p xml:id="eco_de_0000211_3480">
      Gemeinnützig, das hiess natürlich das Geld so verbrauchen, dass jedes etwas davon hatte. Das war nett.
     </p>
-    <p xml:id="eco_de_0000141_3490">
+    <p xml:id="eco_de_0000211_3490">
      »Ja, so machen wir's!« riefen alle, auch die Turnach- und die Doktorskinder.
     </p>
-    <p xml:id="eco_de_0000141_3500">
+    <p xml:id="eco_de_0000211_3500">
      »Wir könnten bei Frau Schlumpf Marbeln kaufen und sie verteilen!« schlug eines vor.
     </p>
-    <p xml:id="eco_de_0000141_3510">
+    <p xml:id="eco_de_0000211_3510">
      »Sie hat auch Schokoladebonbons«, sagte Trudi. »Man bekommt fünf für einen Fünfer.«
     </p>
-    <p xml:id="eco_de_0000141_3520">
+    <p xml:id="eco_de_0000211_3520">
      »Wenn nur noch Jahrmarkt wäre!« meinte Spenglers Klara. »Dann würden wir das Geld dem Karussellmann geben, dass er uns alle recht lang reiten liesse –«
     </p>
-    <p xml:id="eco_de_0000141_3530">
+    <p xml:id="eco_de_0000211_3530">
      »Hört!« rief einer hinten hervor. »Wir machen miteinander eine kleine Reise. Wir fahren nach Schiebeldorf. Das halbe Billet kostet bloss fünf Rappen, und zurück können wir zu Fuss gehen.«
     </p>
-    <p xml:id="eco_de_0000141_3540">
+    <p xml:id="eco_de_0000211_3540">
      Edith, die den Verhandlungen folgte, lachte unbändig über diesen Vorschlag.
     </p>
-    <p xml:id="eco_de_0000141_3550">
+    <p xml:id="eco_de_0000211_3550">
      »Ja, wir reisen allen nach dieses Schiebeldorf. Ich will gehen und packen mein Reisetasche!«
     </p>
-    <p xml:id="eco_de_0000141_3560">
+    <p xml:id="eco_de_0000211_3560">
      »Wenn wir es ganz fein machen wollen«, sagte jetzt aber Hans, »so wüsste ich etwas! Otto, der Onkel hat doch heute vorgelesen, dass der Larstetter Gesangverein nach seinem Konzert das Geld geschenkt hat für die Anlagen am –«
     </p>
-    <p xml:id="eco_de_0000141_3570">
+    <p xml:id="eco_de_0000211_3570">
      »Am Weissberg!« fielen die Larstetter Buben und Mädchen ein. »Es gibt einen Aussichtsturm und Bänke und junge Bäume –«
     </p>
-    <p xml:id="eco_de_0000141_3580">
+    <p xml:id="eco_de_0000211_3580">
      »Also, wir machen es auch so. Wir schenken unser Geld für die Anlagen –«
     </p>
-    <p xml:id="eco_de_0000141_3590">
+    <p xml:id="eco_de_0000211_3590">
      »Ja, ja!« riefen Otto, Bernhard, Marianne und verschiedene andere. »Hans hat recht! Das wäre am allernobelsten!«
     </p>
-    <p xml:id="eco_de_0000141_3600">
+    <p xml:id="eco_de_0000211_3600">
      Lotti, Trudi und die Kleineren dachten vielleicht einen Augenblick noch an die Schokolade und die Reise nach Schiebeldorf; aber dann rannten sie wichtig mit zu Bernhards Vater, der die Gelder für die Anlagen einkassierte.
     </p>
-    <p xml:id="eco_de_0000141_3610">
+    <p xml:id="eco_de_0000211_3610">
      Herr Fink sass am Tisch und ordnete seine Pflanzensammlung. Er lachte, als die Kinder von dem Theater erzählten und ihr Geld brachten. Edith hatte die 86 Rappen zu einem Franken aufgerundet.
     </p>
-    <p xml:id="eco_de_0000141_3620">
+    <p xml:id="eco_de_0000211_3620">
      »Schön, schön!« sagte er, indem er ein langes blaues Heft herholte. »Ein Franken ist immer ein Franken –«
     </p>
-    <p xml:id="eco_de_0000141_3630">
+    <p xml:id="eco_de_0000211_3630">
      Er schlug das Heft auf und lachte noch einmal ein wenig, während er die Feder ergriff.
     </p>
-    <p xml:id="eco_de_0000141_3640">
+    <p xml:id="eco_de_0000211_3640">
      »Jetzt wird's eingeschrieben! jetzt wird's eingeschrieben!« riefen die Kinder sich zu, und dann durfte jedes in das Heft gucken, wo mit schöner Schrift geschrieben stand: »Am 17. Oktober Ertrag der Theatervorstellung im Doktorhaus: Ein Franken.«
     </p>
-    <p xml:id="eco_de_0000141_3650">
+    <p xml:id="eco_de_0000211_3650">
      »Herr Fink«, fragte Trudi. »Könnte man eine Bank machen lassen aus dem Franken?«
     </p>
-    <p xml:id="eco_de_0000141_3660">
+    <p xml:id="eco_de_0000211_3660">
      »Ach, Trudi!« rief Otto. »Für einen Franken bekommt man keine Bank!«
     </p>
-    <p xml:id="eco_de_0000141_3670">
+    <p xml:id="eco_de_0000211_3670">
      »Nein«, sagte Herr Fink; »aber wir wollen sehen, dass es ein junges Ahorn- oder Lindenbäumchen gibt. Das habt ihr dann gestiftet –«
     </p>
-    <p xml:id="eco_de_0000141_3680">
+    <p xml:id="eco_de_0000211_3680">
      »Und da sitzen wir jedesmal drunter!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_3690">
+    <p xml:id="eco_de_0000211_3690">
      »Und wir auch, wenn wir in Larstetten sind!« stimmten Hans, Marianne und Lotti ein.
     </p>
-    <p xml:id="eco_de_0000141_3700">
+    <p xml:id="eco_de_0000211_3700">
      »Wenn es nur recht bald gross und schattig wird! Ja, wir müssen es manchmal begiessen! Ihr schreibt uns dann, wie es wächst! Wir heissen es das Theaterbäumchen! Oder die Siegfriedlinde! Ja, ja! die Siegfriedlinde!« So ging es durcheinander unter den Buben und Mädchen, bis man sehr befriedigt sich trennte.
     </p>
-    <p xml:id="eco_de_0000141_3710">
+    <p xml:id="eco_de_0000211_3710">
      Als Onkel Doktor von der Schenkung und von der Siegfriedlinde hörte, lachte er auch.
     </p>
-    <p xml:id="eco_de_0000141_3720">
+    <p xml:id="eco_de_0000211_3720">
      »Das habt ihr ja ausgezeichnet gemacht!« sagte er.
     </p>
    </div>
@@ -1218,286 +1218,286 @@
     <head>
      Auf der Fähre
     </head>
-    <p xml:id="eco_de_0000141_3730">
+    <p xml:id="eco_de_0000211_3730">
      Am nächsten Nachmittag kamen Marianne, Lotti und Trudi schon wieder ins Pfarrhaus gerannt, Edith solle mitkommen, sie gehen alle zum Eschenweiher hinunter.
     </p>
-    <p xml:id="eco_de_0000141_3740">
+    <p xml:id="eco_de_0000211_3740">
      Der Eschenweiher war ein stilles, langgestrecktes Wasser an der Sägenwiese.
     </p>
-    <p xml:id="eco_de_0000141_3750">
+    <p xml:id="eco_de_0000211_3750">
      Lehrers Bernhard, Hans und Otto waren nach dem Mittagessen daran vorbeispaziert.
     </p>
-    <p xml:id="eco_de_0000141_3760">
+    <p xml:id="eco_de_0000211_3760">
      »Schrecklich schmal!« hatte Hans gesagt.
     </p>
-    <p xml:id="eco_de_0000141_3770">
+    <p xml:id="eco_de_0000211_3770">
      »Aber ziemlich lang!« hatte Bernhard erwidert. »Wenn man von der Bank aus hinuntersieht und den Kopf nicht rechts und links dreht, meint man fast, es sei ein kleiner See.«
     </p>
-    <p xml:id="eco_de_0000141_3780">
+    <p xml:id="eco_de_0000211_3780">
      Hans wollte Bernhard nicht kränken; sonst hätte er laut herausgelacht. Ein See –! Bernhard hatte jedenfalls in seinem Leben noch nie einen See gesehen. Otto guckte Hans von der Seite an; er wusste wohl, was er dachte.
     </p>
-    <p xml:id="eco_de_0000141_3790">
+    <p xml:id="eco_de_0000211_3790">
      »Nein, Bernhard, von einem See kann man da nicht reden. Denk nur, wie tief ein See ist! In unserm Eschenweiher geht einem das Wasser höchstens bis daher –« Otto zeigte an seinen Gürtel.
     </p>
-    <p xml:id="eco_de_0000141_3800">
+    <p xml:id="eco_de_0000211_3800">
      »Da kann man also nicht einmal recht nass werden!« sagte Hans.
     </p>
-    <p xml:id="eco_de_0000141_3810">
+    <p xml:id="eco_de_0000211_3810">
      »Und dann müssten doch Schiffe da sein!« fuhr Otto fort.
     </p>
-    <p xml:id="eco_de_0000141_3820">
+    <p xml:id="eco_de_0000211_3820">
      »Im Sommer bin ich einmal auf einem Brett drauf herumgefahren«, erzählte Bernhard.
     </p>
-    <p xml:id="eco_de_0000141_3830">
+    <p xml:id="eco_de_0000211_3830">
      »Das ist etwas! Auf einem Brett, wo gerade zur Not einer stehen kann!« Hans musste sich Luft machen. »In unserm kleinen Schiff haben sechs Personen Platz. Und in einem ordentlichen Steinschiff etwa dreissig. Und auf einem Dampfschiff – aber natürlich von einem Dampfschiff habt ihr in Larstetten keinen Begriff!«
     </p>
-    <p xml:id="eco_de_0000141_3840">
+    <p xml:id="eco_de_0000211_3840">
      Bernhard schwieg besiegt, und die Knaben trennten sich bald. Bernhard ging den Eschenweiher entlang bis zur Säge, die seinem Vetter gehörte. Man baute da die Scheune um, und das grosse Tor stand angelehnt an der Mauer. Bernhard kam ein Gedanke.
     </p>
-    <p xml:id="eco_de_0000141_3850">
+    <p xml:id="eco_de_0000211_3850">
      Er ging auf des Vetters Sohn zu, der da arbeitete.
     </p>
-    <p xml:id="eco_de_0000141_3860">
+    <p xml:id="eco_de_0000211_3860">
      »Du, Gustav, könnte ich nicht das Tor haben für heut nachmittag?«
     </p>
-    <p xml:id="eco_de_0000141_3870">
+    <p xml:id="eco_de_0000211_3870">
      »Was willst?« rief Gustav, der meinte, nicht recht gehört zu haben.
     </p>
-    <p xml:id="eco_de_0000141_3880">
+    <p xml:id="eco_de_0000211_3880">
      »Das Tor.«
     </p>
-    <p xml:id="eco_de_0000141_3890">
+    <p xml:id="eco_de_0000211_3890">
      »Das Tor? Brauchst du nicht vielleicht noch das Rathausdach und den Kirchturm dazu?«
     </p>
-    <p xml:id="eco_de_0000141_3900">
+    <p xml:id="eco_de_0000211_3900">
      »Ich meine es im Ernst. Es ist nicht wegen mir, sondern wegen Larstetten –«
     </p>
-    <p xml:id="eco_de_0000141_3910">
+    <p xml:id="eco_de_0000211_3910">
      Und Bernhard erzählte von dem Gespräch vorhin und was er nun im Sinn habe.
     </p>
-    <p xml:id="eco_de_0000141_3920">
+    <p xml:id="eco_de_0000211_3920">
      »Ein Schiff soll unser Scheunentor in seinen alten Tagen noch werden –?« sagte Gustav belustigt. »Ja, wenn die Ehre von Larstetten auf dem Spiel steht, so wird es halt sein müssen.«
     </p>
-    <p xml:id="eco_de_0000141_3930">
+    <p xml:id="eco_de_0000211_3930">
      »Was man nicht erlebt!« sagten die zwei Arbeiter, die zugehört hatten. »Jetzt gibt's aus unserer Säge einen Seehafen!«
     </p>
-    <p xml:id="eco_de_0000141_3940">
+    <p xml:id="eco_de_0000211_3940">
      Mit vereinten Kräften schafften die drei Männer das Scheunentor auf den Eschenweiher hinaus, nachdem man auf beiden Seiten noch zwei breite Bretter festgenagelt hatte. Denn je mehr Leute Platz hatten, desto besser war es für Larstetten.
     </p>
-    <p xml:id="eco_de_0000141_3950">
+    <p xml:id="eco_de_0000211_3950">
      Dann rannte Bernhard ins Städtchen hinauf, um Otto und Hans zu holen. Die beiden folgten neugierig. Die Mädchen schlossen sich auch an.
     </p>
-    <p xml:id="eco_de_0000141_3960">
+    <p xml:id="eco_de_0000211_3960">
      »Es ist natürlich kein Dampfschiff!« sagte Bernhard, als man am Eschenweiher anlangte.
     </p>
-    <p xml:id="eco_de_0000141_3970">
+    <p xml:id="eco_de_0000211_3970">
      »Famos ist es! Prachtvoll!« schrien Hans und Otto.
     </p>
-    <p xml:id="eco_de_0000141_3980">
+    <p xml:id="eco_de_0000211_3980">
      Alle sprangen auf das Scheunentor, das breit auf dem Wasser lag. Es schaukelte angenehm und machte kleine Wellen.
     </p>
-    <p xml:id="eco_de_0000141_3990">
+    <p xml:id="eco_de_0000211_3990">
      »In Larstetten schiffahren!« rief Lotti entzückt.
     </p>
-    <p xml:id="eco_de_0000141_4000">
+    <p xml:id="eco_de_0000211_4000">
      »Gelt!« sagte Otto. Er war fast so stolz wie Bernhard.
     </p>
-    <p xml:id="eco_de_0000141_4010">
+    <p xml:id="eco_de_0000211_4010">
      In der Mitte des Schiffes stand ein Schemel, und drei Stangen lagen bereit.
     </p>
-    <p xml:id="eco_de_0000141_4020">
+    <p xml:id="eco_de_0000211_4020">
      »Das ist nun unsere Fähre«, erklärte Hans, indem er eine der Stangen ergriff.
     </p>
-    <p xml:id="eco_de_0000141_4030">
+    <p xml:id="eco_de_0000211_4030">
      »Ja!« rief Marianne. »Wir warten am Ufer und rufen ›Hoiho! Hol über!‹ Wir können auch grosse Leute hinüberfahren, wenn sie vom Stampfenweg kommen oder vom Städtchen herab. Die sind gewiss froh. Es ist eine ziemliche Abkürzung.« Hans stemmte die Stange ein und lehnte sich über den Rand des Fahrzeugs hinaus.
     </p>
-    <p xml:id="eco_de_0000141_4040">
+    <p xml:id="eco_de_0000211_4040">
      »Gib acht, dass du nicht hineinfällst!« warnte Bernhard.
     </p>
-    <p xml:id="eco_de_0000141_4050">
+    <p xml:id="eco_de_0000211_4050">
      »O«, machte Hans. »Das geht nicht so schnell!« Er legte sich noch etwas weiter hinüber. »Den ganzen Sommer sind wir nicht ins Wasser gefallen, keins von uns.«
     </p>
-    <p xml:id="eco_de_0000141_4060">
+    <p xml:id="eco_de_0000211_4060">
      Er lenkte das Schiff in gerader Linie über den Weiher. Die Mädchen standen in der Mitte und spähten zum Stampfenweg hinauf und zurück zum Eschensteig. Niemand wollte sich zeigen, den man hätte können die Annehmlichkeit der Fähre geniessen lassen.
     </p>
-    <p xml:id="eco_de_0000141_4070">
+    <p xml:id="eco_de_0000211_4070">
      Endlich tauchte auf der Stampfenhöhe etwas wie eine Mütze auf.
     </p>
-    <p xml:id="eco_de_0000141_4080">
+    <p xml:id="eco_de_0000211_4080">
      »Dort kommt einer!«
     </p>
-    <p xml:id="eco_de_0000141_4090">
+    <p xml:id="eco_de_0000211_4090">
      »Es ist der Polizeidiener! Der Drehbaum!«
     </p>
-    <p xml:id="eco_de_0000141_4100">
+    <p xml:id="eco_de_0000211_4100">
      Die Mädchen sprangen hinaus.
     </p>
-    <p xml:id="eco_de_0000141_4110">
+    <p xml:id="eco_de_0000211_4110">
      »Herr Drehbaum, wollen Sie sich nicht hinüberfahren lassen zum Eschensteig?« lud Marianne ein.
     </p>
-    <p xml:id="eco_de_0000141_4120">
+    <p xml:id="eco_de_0000211_4120">
      »Sie brauchen nicht machen das weite Umweg!« rief Edith.
     </p>
-    <p xml:id="eco_de_0000141_4130">
+    <p xml:id="eco_de_0000211_4130">
      »Wir tun es umsonst!« fügte Lotti hinzu.
     </p>
-    <p xml:id="eco_de_0000141_4140">
+    <p xml:id="eco_de_0000211_4140">
      »Aber ich tue es nicht umsonst«, sagte Drehbaum schlecht gelaunt. »Und für Geld auch nicht. Das fehlte mir gerade. Überhaupt – wem gehört das Tor?«
     </p>
-    <p xml:id="eco_de_0000141_4150">
+    <p xml:id="eco_de_0000211_4150">
      »Dem Vetter in der Säge!« schrie Bernhard. »Der Gustav hat's uns selber auf den Weiher herausgetan.«
     </p>
-    <p xml:id="eco_de_0000141_4160">
+    <p xml:id="eco_de_0000211_4160">
      »Das war etwas Gescheites!« brummte Drehbaum, indem er sich zum Wege zurückwandte und missbilligend mit seinem Stocke fuchtelte. Im Weitergehen zankte er noch vor sich hin; man hörte etwas von Narreteien und von Verbieten.
     </p>
-    <p xml:id="eco_de_0000141_4170">
+    <p xml:id="eco_de_0000211_4170">
      Die Kinder sahen ihm nach.
     </p>
-    <p xml:id="eco_de_0000141_4180">
+    <p xml:id="eco_de_0000211_4180">
      »Sie sind keine besonders nette Polizeimann!« rief Edith.
     </p>
-    <p xml:id="eco_de_0000141_4190">
+    <p xml:id="eco_de_0000211_4190">
      Der Ärger verging indessen bald. Denn jetzt kam vom Städtchen her langsamen Schrittes mit dem Tragkorb auf dem Rücken die Botenfrau von Rollingen.
     </p>
-    <p xml:id="eco_de_0000141_4200">
+    <p xml:id="eco_de_0000211_4200">
      »Schnell, Hans! schnell –!« Hans, Otto und Bernhard stachelten mit aller Kraft, um rasch das jenseitige Ufer zu erreichen.
     </p>
-    <p xml:id="eco_de_0000141_4210">
+    <p xml:id="eco_de_0000211_4210">
      Die Botenfrau blieb erstaunt stehen, als das Fahrzeug auf sie lossteuerte.
     </p>
-    <p xml:id="eco_de_0000141_4220">
+    <p xml:id="eco_de_0000211_4220">
      »Frau Enzenstein«, riefen sie alle sieben. »Warten Sie, warten Sie! wir fahren Sie hinüber! Sie können sogar sitzen!«
     </p>
-    <p xml:id="eco_de_0000141_4230">
+    <p xml:id="eco_de_0000211_4230">
      Die Botenfrau trat entsetzt zwei Schritte zurück.
     </p>
-    <p xml:id="eco_de_0000141_4240">
+    <p xml:id="eco_de_0000211_4240">
      »Ich da drauf –?«
     </p>
-    <p xml:id="eco_de_0000141_4250">
+    <p xml:id="eco_de_0000211_4250">
      »Es ist ganz fest; sehen Sie –«, ermunterte Lotti und sprang mit beiden Füssen auf und nieder.
     </p>
-    <p xml:id="eco_de_0000141_4260">
+    <p xml:id="eco_de_0000211_4260">
      »Nein, nein, aufs Wasser bringt man mich nicht, Kinder, nicht mit zehn Pferden! Ich hab das von meinem Grossvater. Der hat einmal nach Amerika auswandern wollen, und wie er in Bremen sich das Wasser ansieht, auf dem er hätte hinüber sollen, fällt er hinein; man hat nie recht erfahren wie. Zwei Schiffleute haben ihn gerade noch am Fuss erwischt. Da hat er genug gehabt und ist wieder nach Larstetten zurück. Seither will keines von uns mit Wasser und Schiffahrt zu tun haben.«
     </p>
-    <p xml:id="eco_de_0000141_4270">
+    <p xml:id="eco_de_0000211_4270">
      Die Kinder sahen das ein und liessen die Botenfrau ziehen. Neben ihr aber hatte sich ein kleiner, etwa fünfjähriger Bub hingestellt, um sich das grosse Brett auf dem Weiher zu besehen.
     </p>
-    <p xml:id="eco_de_0000141_4280">
+    <p xml:id="eco_de_0000211_4280">
      »Wo musst du hin, Eduard?« fragte Otto.
     </p>
-    <p xml:id="eco_de_0000141_4290">
+    <p xml:id="eco_de_0000211_4290">
      »Nach Rollingen in die Mühle.«
     </p>
-    <p xml:id="eco_de_0000141_4300">
+    <p xml:id="eco_de_0000211_4300">
      »So, dann darfst du mit uns hinüberfahren zum Stampfenweg.«
     </p>
-    <p xml:id="eco_de_0000141_4310">
+    <p xml:id="eco_de_0000211_4310">
      Der Bub rührte sich nicht. Marianne sprang hinaus, um ihn zu holen.
     </p>
-    <p xml:id="eco_de_0000141_4320">
+    <p xml:id="eco_de_0000211_4320">
      »Nein!« schrie er jetzt und rannte über die Wiese hinauf.
     </p>
-    <p xml:id="eco_de_0000141_4330">
+    <p xml:id="eco_de_0000211_4330">
      »Fang ihn, Marianne«, rief Hans, »und bring ihn! Wenn er auf dem Schiff ist, findet er es dann gewiss nett.«
     </p>
-    <p xml:id="eco_de_0000141_4340">
+    <p xml:id="eco_de_0000211_4340">
      Marianne fasste den kleinen Eduard. Aber der fing an so fürchterlich zu brüllen und sich zu wehren, dass sie ihn wieder losliess. Heulend entfloh er gegen das Städtchen.
     </p>
-    <p xml:id="eco_de_0000141_4350">
+    <p xml:id="eco_de_0000211_4350">
      »Wie man so dumm sein kann!« sagte Hans und stiess das Schiff hinaus.
     </p>
-    <p xml:id="eco_de_0000141_4360">
+    <p xml:id="eco_de_0000211_4360">
      Da bewegte sich drüben hinter den Büschen des Stampfenweges wieder etwas.
     </p>
-    <p xml:id="eco_de_0000141_4370">
+    <p xml:id="eco_de_0000211_4370">
      »Ein Mann!« Man hörte meckern. »Ein Mann mit vier Ziegen – und einem grossen Hund!«
     </p>
-    <p xml:id="eco_de_0000141_4380">
+    <p xml:id="eco_de_0000211_4380">
      Diesmal kam die ganze Schiffsgesellschaft heran, umringte den Mann – es war Bieland, der manchmal im Doktorgarten arbeitete – und redete auf ihn ein, um ihm die Vorteile der Fähre klarzumachen.
     </p>
-    <p xml:id="eco_de_0000141_4390">
+    <p xml:id="eco_de_0000211_4390">
      Bieland schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_4400">
+    <p xml:id="eco_de_0000211_4400">
      »Sie tun doch nicht vielleicht dem Wasser fürchten wie der Familie von Frau Enzenstein?« fragte Edith.
     </p>
-    <p xml:id="eco_de_0000141_4410">
+    <p xml:id="eco_de_0000211_4410">
      »Das nicht gerade. Aber mein besseres Gewand hab ich an, und euere Geschichte da kommt mir etwas wacklig vor. Nein, ich danke.«
     </p>
-    <p xml:id="eco_de_0000141_4420">
+    <p xml:id="eco_de_0000211_4420">
      »Aber die Ziegen doch? Die Ziegen? Wir möchten so schrecklich gern jemand hinüberführen!« riefen die Buben und Mädchen.
     </p>
-    <p xml:id="eco_de_0000141_4430">
+    <p xml:id="eco_de_0000211_4430">
      Bieland überlegte und lachte.
     </p>
-    <p xml:id="eco_de_0000141_4440">
+    <p xml:id="eco_de_0000211_4440">
      »So nehmt sie! Sie können meinetwegen ja zur Abwechslung einmal eine Schiffahrt machen. Da – aber gebt acht!«
     </p>
-    <p xml:id="eco_de_0000141_4450">
+    <p xml:id="eco_de_0000211_4450">
      Mit Freudengeschrei bemächtigten die Kinder sich der Ziegen. Es war ein schweres Stück Arbeit, sie auf das Schiff zu bringen. Glücklicherweise hatte jede einen Strick um. Der Hund Zangger blieb bei seinem Herrn.
     </p>
-    <p xml:id="eco_de_0000141_4460">
+    <p xml:id="eco_de_0000211_4460">
      »Vier Ziegen! das ist doch etwa so viel wie zwei Menschen, gelt, Hans!« rief Trudi und versuchte, eine der Ziegen an sich zu ziehen.
     </p>
-    <p xml:id="eco_de_0000141_4470">
+    <p xml:id="eco_de_0000211_4470">
      Die Tiere aber, besonders als das Schiff nun hinausgestossen wurde, stolperten und drängten sich zusammen. Es gefiel ihnen gar nicht auf dem Wasser; sie hätten viel lieber den Weg um den Eschenweiher herum gemacht; aber es hatte sie niemand gefragt.
     </p>
-    <p xml:id="eco_de_0000141_4480">
+    <p xml:id="eco_de_0000211_4480">
      Mit sechs oder acht Stössen war das Schiff dem andern Ufer nahe. Hans sah nach einer guten Landungsstelle aus für die Ziegen. Derweil kam der Hund Zangger vom untern Ende des Weihers dahergerannt und stellte sich bellend ans Ufer. War es nun, dass ihn reute, nicht mitgefahren zu sein, oder meinte er, er müsse nach den Ziegen sehen, kurz, er tat einen Sprung und schoss auf das Schiff.
     </p>
-    <p xml:id="eco_de_0000141_4490">
+    <p xml:id="eco_de_0000211_4490">
      »Ui –!« Das Schiff schwankte heftig. Die Ziegen fuhren erschreckt zurück und stiessen Trudi um. Die andern Kinder wollten sie in die Höhe ziehen –
     </p>
-    <p xml:id="eco_de_0000141_4500">
+    <p xml:id="eco_de_0000211_4500">
      »Halt!« schrie Hans. »Nicht – nicht alle auf eine Seite –« Er verstummte; denn plötzlich schnappte das Schiff auf, und im Bogen flog Hans in den Weiher. Auf der andern Seite aber rutschte die ganze Gesellschaft in das Wasser, Ziegen und Hund, Buben und Mädchen in einem Knäuel.
     </p>
-    <p xml:id="eco_de_0000141_4510">
+    <p xml:id="eco_de_0000211_4510">
      »Wetter noch einmal! Was ist denn! –« rief Bieland und eilte zur Stelle des Schiffbruches, von wo ihm ein schreckliches Geschrei, Gebell und Gemecker entgegentönte.
     </p>
-    <p xml:id="eco_de_0000141_4520">
+    <p xml:id="eco_de_0000211_4520">
      Der erste, der aus dem Wasser kroch, war Bernhard, triefend und schnaubend wie ein Walross. Otto plätscherte mit seiner Stange herum, die er nicht losgelassen hatte. Edith und Marianne wurden, als sie sich auf die Füsse geholfen, von neuem umgeworfen durch die Ziegen, die einfach über sie hinwegstrampelten. Hans war kopfüber ins Wasser gefallen; als er sich aufrichten wollte, hielt ihn Lotti am Ärmel fest, und er musste sehen, wie er samt der zappelnden Schwester ans Land kam. Der Hund Zangger, der eigentlich schuld an allem war, gab sich die grösste Mühe, den Schemel zu retten, als ob das die Hauptsache wäre. Zuletzt zog Bieland trotz seinem »besseren Gewand« noch Trudi heraus, die hart am Ufer im Wasser sass und sich am Bein einer Ziege hielt; die Ziege und Trudi schrien, wie wenn sie am Spiess stäken.
     </p>
-    <p xml:id="eco_de_0000141_4530">
+    <p xml:id="eco_de_0000211_4530">
      Endlich waren alle sieben Kinder glücklich auf dem Lande. Das Wasser floss in Strömen an ihnen herunter.
     </p>
-    <p xml:id="eco_de_0000141_4540">
+    <p xml:id="eco_de_0000211_4540">
      »Heul doch nicht so grässlich, Trudi!« sagte Otto, als er so weit war, dass er wieder reden konnte.
     </p>
-    <p xml:id="eco_de_0000141_4550">
+    <p xml:id="eco_de_0000211_4550">
      »Ich-h-heule nicht«, weinte Trudi. »Aber ich frier-rrr-re.« Sie schlotterte am ganzen Leib.
     </p>
-    <p xml:id="eco_de_0000141_4560">
+    <p xml:id="eco_de_0000211_4560">
      »Rrr –« zitterten und schnatterten auch die andern. Es war nicht mehr Sommer; das Wasser war kalt gewesen, und es blies ein rauher Wind.
     </p>
-    <p xml:id="eco_de_0000141_4570">
+    <p xml:id="eco_de_0000211_4570">
      »Hört«, sagte Bieland, »das beste ist, ihr rennt heim, so schnell ihr nur könnt. Und ihr da –« er wandte sich zu seinen Ziegen, die kläglich meckerten, »ihr lauft auch, damit ihr mir nicht den Husten bekommt.«
     </p>
-    <p xml:id="eco_de_0000141_4580">
+    <p xml:id="eco_de_0000211_4580">
      »Den Husten!« lachte Lotti, so gut es ging neben dem Zähneklappern, und rannte mit den andern den Eschensteig hinauf. Eine lange Wasserstrasse zog sich hinter ihnen durch das ganze Städtchen, und eine kleinere zweigte zum Pfarrhaus ab.
     </p>
-    <p xml:id="eco_de_0000141_4590">
+    <p xml:id="eco_de_0000211_4590">
      Entsetzt schlug die Tante die Hände zusammen, als die triefenden Kinder ankamen. Wenn sich nun eins erkältet hatte! Und die Kleider –! Sie wusste sich nicht anders zu helfen, als die ganze Mannschaft ins Bett zu schicken.
     </p>
-    <p xml:id="eco_de_0000141_4600">
+    <p xml:id="eco_de_0000211_4600">
      Erst waren die fünf etwas verdutzt, so unversehens am hellen Tag im Bett zu stecken. Aber dann ging bald durch die offene Tür eine lebhafte Unterhaltung an. Jedes schilderte, auf welche besondere Weise es hineingefallen und wieder herausgekommen war; dann gab man sich Rätsel auf, und als Tante Doktor nach einer Weile hereinkam, rief Otto:
     </p>
-    <p xml:id="eco_de_0000141_4610">
+    <p xml:id="eco_de_0000211_4610">
      »Mama, ist es zur Strafe oder nur zur Wärme, dass wir ins Bett mussten? Wir finden es nämlich furchtbar lustig!«
     </p>
-    <p xml:id="eco_de_0000141_4620">
+    <p xml:id="eco_de_0000211_4620">
      Lehrers Bernhard aber war nicht minder vergnügt. Er hatte für gut gefunden, sich zum Trocknen in die Säge zu begeben; seine Mutter verstand in solchen Sachen keinen Spass. Er sass während seine Kleider am Herd hingen, in der Küche der guten Base, eingehüllt in den Winterüberzieher des Vetters.
     </p>
-    <p xml:id="eco_de_0000141_4630">
+    <p xml:id="eco_de_0000211_4630">
      Da kam Gustav herein:
     </p>
-    <p xml:id="eco_de_0000141_4640">
+    <p xml:id="eco_de_0000211_4640">
      »Oha –!«
     </p>
-    <p xml:id="eco_de_0000141_4650">
+    <p xml:id="eco_de_0000211_4650">
      »Ja, wir sind hineingefallen, alle sieben. Und der Hans hat grade vorher erzählt, sie seien den ganzen Sommer nie in ihren See gefallen, in ihren grossen. Und er hat gesagt, im Eschenweiher könne man nicht einmal recht nass werden. Aber du hättest sehen sollen, wie uns das Wasser übers Gesicht und die Haare gelaufen ist, dem Hans auch!«
     </p>
-    <p xml:id="eco_de_0000141_4660">
+    <p xml:id="eco_de_0000211_4660">
      »So? Mehr kann man nicht verlangen«, sagte der Vetter. »Dann hat also der Eschenweiher seine Sache recht gemacht, und die Ehre von Larstetten wäre gerettet.«
     </p>
    </div>
@@ -1505,310 +1505,310 @@
     <head>
      Eine Kaffeegesellschaft
     </head>
-    <p xml:id="eco_de_0000141_4670">
+    <p xml:id="eco_de_0000211_4670">
      Ganz Larstetten bestand bloss aus der langen Hauptgasse und etwa acht oder zehn Nebengassen. Der einen Seite des Städtchens entlang lief eine alte graue Mauer; sie war zerfallen und mit Gras und Holunderbüschen bewachsen. An der Mauer stand ein Turm mit schwerem rotbraunem Dach. Er hiess der Rosenturm. Hier wohnte die Turmsette mit ihrem Raben Peter oben in einer grossen Stube, an deren Fenster vier Kallastöcke mit weissen, tütenförmigen Blüten standen. Die Turmsette bügelte die feine Wäsche für die Leute. Hans, Marianne und Lotti stiegen mit den Doktorskindern oft zur Turmsette hinauf und zu dem Vogel Peter.
     </p>
-    <p xml:id="eco_de_0000141_4680">
+    <p xml:id="eco_de_0000211_4680">
      Der Vogel Peter gehörte zu der Art der Dohlen, war also ein kleiner, netter Rabe mit schwärzlichem Gefieder, schelmischen runden Augen und einem festen Schnabel. Sprechen konnte der Peter nicht. Man habe es ihm nicht gelehrt, wie er jung gewesen sei, erklärte die Turmsette. Er sagte bloss »Kräh!« oder »Kräkräh!« Die Turmsette und der Rabe verstanden sich aber doch sehr gut.
     </p>
-    <p xml:id="eco_de_0000141_4690">
+    <p xml:id="eco_de_0000211_4690">
      »Kräh!« rief Peter begrüssend, als die fünf Kinder eintraten, und ging ihnen höflich entgegen.
     </p>
-    <p xml:id="eco_de_0000141_4700">
+    <p xml:id="eco_de_0000211_4700">
      Die Turmsette stand an ihrem Bügelbrett und gab eben einer blendend weissen Hemdenbrust den letzten Druck. Dann sah sie nach dem Feuer des kleinen Ofens, aus dem die rote Glut herausstrahlte. Der Rabe schlug aufgeregt mit den Flügeln und hüpfte ein paar Schritte zurück. Er war früher einmal mit dem Fuss auf eine brennende Kohle geraten.
     </p>
-    <p xml:id="eco_de_0000141_4710">
+    <p xml:id="eco_de_0000211_4710">
      »Kochen Sie jetzt zu Mittag?« fragte Trudi die Turmsette.
     </p>
-    <p xml:id="eco_de_0000141_4720">
+    <p xml:id="eco_de_0000211_4720">
      Bei der Bereitung des Essens zeigte sich Peter nämlich im vollen Lichte seiner Klugheit.
     </p>
-    <p xml:id="eco_de_0000141_4730">
+    <p xml:id="eco_de_0000211_4730">
      Grade begann es elf Uhr zu läuten. Peter eilte mit freudigem Gekrächz auf die Turmsette zu.
     </p>
-    <p xml:id="eco_de_0000141_4740">
+    <p xml:id="eco_de_0000211_4740">
      »Nun sagt er, es sei Zeit zum Kochen!« riefen die Kinder. »Wie gescheit er ist –!«
     </p>
-    <p xml:id="eco_de_0000141_4750">
+    <p xml:id="eco_de_0000211_4750">
      In der Küche standen die geschnittenen Kartoffeln schon bereit. Peter stellte sich auf den Tisch und verfolgte mit Aufmerksamkeit, wie sie in die heisse Butter kamen und da zu zischen begannen. Dann aber, als sie allmählig gelb wurden, kam er mit einem schnellen Hupf zur Pfanne und erhaschte eine Kartoffelscheibe. Aber er verschluckte sie nicht, sondern flatterte damit zum offenen Fenster und legte sie neben das Schnittlauchglas. Dann kehrte er zurück, um ein neues Stück zu holen. Die Turmsette drohte mit dem Schäufelchen; aber Peter blinzelte mit seinen schelmischen Augen. Das hiess:
     </p>
-    <p xml:id="eco_de_0000141_4760">
+    <p xml:id="eco_de_0000211_4760">
      »Ach was! du meinst es doch nicht ernst!«
     </p>
-    <p xml:id="eco_de_0000141_4770">
+    <p xml:id="eco_de_0000211_4770">
      Auf dem Gesimse entstand eine Reihe von Kartoffelstücken. Und wie nun anzunehmen war, dass das erste erkaltet sei, machte sich der kluge Peter unter vergnügtem Krächzen daran, es zu verzehren.
     </p>
-    <p xml:id="eco_de_0000141_4780">
+    <p xml:id="eco_de_0000211_4780">
      Das war so possierlich, dass es sich wohl lohnte, gegen elf Uhr die fünf Treppen zur Turmsette hinaufzusteigen.
     </p>
-    <p xml:id="eco_de_0000141_4790">
+    <p xml:id="eco_de_0000211_4790">
      Ein wenig musste man den Peter necken. Als er am dritten Stück war, nahm ihm Otto rasch das fünfte weg. Peter wendete sich mit einem Satze und wiegte den Kopf hin und her:
     </p>
-    <p xml:id="eco_de_0000141_4800">
+    <p xml:id="eco_de_0000211_4800">
      »Gibst du es wieder oder nicht –?«
     </p>
-    <p xml:id="eco_de_0000141_4810">
+    <p xml:id="eco_de_0000211_4810">
      Aber Otto steckte es in den Mund. Da wurde Peter sehr zornig. Er zankte: »Kräh, kräh!« und ging mit dem Schnabel auf Otto los, der lachend in die Ofenecke flüchtete.
     </p>
-    <p xml:id="eco_de_0000141_4820">
+    <p xml:id="eco_de_0000211_4820">
      »Er wird doch auch mitkommen morgen?« rief Lotti entzückt.
     </p>
-    <p xml:id="eco_de_0000141_4830">
+    <p xml:id="eco_de_0000211_4830">
      »Wohin?« fragte die Turmsette.
     </p>
-    <p xml:id="eco_de_0000141_4840">
+    <p xml:id="eco_de_0000211_4840">
      »Ja, das hätten wir fast vergessen«, sagten die Kinder. »Wir sollen Sie einladen zu Frau Schnezler; sie gibt eine Kaffeegesellschaft.«
     </p>
-    <p xml:id="eco_de_0000141_4850">
+    <p xml:id="eco_de_0000211_4850">
      »Eine Kaffeegesellschaft?«
     </p>
-    <p xml:id="eco_de_0000141_4860">
+    <p xml:id="eco_de_0000211_4860">
      »Ja, morgen um drei Uhr. Und also der Peter auch! Auf Wiedersehen, Peter!« Die Kinder stiegen polternd die Treppe hinunter.
     </p>
-    <p xml:id="eco_de_0000141_4870">
+    <p xml:id="eco_de_0000211_4870">
      Die Turmsette blieb kopfschüttelnd an der Türe stehen: Eine Kaffeegesellschaft –? Was fällt ihr denn ein!
     </p>
-    <p xml:id="eco_de_0000141_4880">
+    <p xml:id="eco_de_0000211_4880">
      Es war auch der Frau Schnezler gar nicht eingefallen. Diese Kaffeegesellschaft war das Werk der übermütigen Edith.
     </p>
-    <p xml:id="eco_de_0000141_4890">
+    <p xml:id="eco_de_0000211_4890">
      Frau Schnezler wohnte in einem netten kleinen Hause am andern Ende des Städtchens und nähte Weisszeug. Edith hatte zweimal in der Woche bei ihr Unterricht; denn im Handarbeiten war es bei dem Mädchen jämmerlich bestellt, sagte Frau Pfarrer. Wenn Edith bei Frau Schnezler sass und sich in Saum- und Steppstichen übte, so plauderte sie gern.
     </p>
-    <p xml:id="eco_de_0000141_4900">
+    <p xml:id="eco_de_0000211_4900">
      »Es ist viel zu still in Ihrer Stube, Frau Schnezler«, sagte sie eines Nachmittags. »Sie müssen haben eine Hund oder Katze.«
     </p>
-    <p xml:id="eco_de_0000141_4910">
+    <p xml:id="eco_de_0000211_4910">
      »Nimm den Faden nicht so lang!« mahnte Frau Schnezler. »Behüte, nein, so ein Tier, das immer fressen will und meine Sachen herunterwirft.«
     </p>
-    <p xml:id="eco_de_0000141_4920">
+    <p xml:id="eco_de_0000211_4920">
      »Oder Sie können geben einigen Mal Gesellschaft«, schlug Edith vor. »Sie müssen einladen die Turmsette mit ihres fröhliche Vogel oder die Kinder von Doktorhaus.«
     </p>
-    <p xml:id="eco_de_0000141_4930">
+    <p xml:id="eco_de_0000211_4930">
      »Was denkst du! Das ist etwas für reiche Leute, nicht für mich!«
     </p>
-    <p xml:id="eco_de_0000141_4940">
+    <p xml:id="eco_de_0000211_4940">
      »Ich glauben, Sie gar nicht sind arm, Frau Schnezler. Sie haben eine hübsche Sofa und viele Tassen in Ihre Schrank und zwei Zuckerbüchs. Damit Sie können sehr gut geben eine Gesellschaft. Sie nur müssen kochen Kaffee und holen viel Kuchen.«
     </p>
-    <p xml:id="eco_de_0000141_4950">
+    <p xml:id="eco_de_0000211_4950">
      »Lass jetzt die Geschichten und gib acht auf deinen Saum!« sagte Frau Schnezler. »Nein, was sind das für Stiche – greulich!« Sie nahm Edith die Arbeit aus der Hand und begann aufzutrennen.
     </p>
-    <p xml:id="eco_de_0000141_4960">
+    <p xml:id="eco_de_0000211_4960">
      Edith aber setzte sich in den Kopf, Frau Schnezler solle einmal eine Kaffeegesellschaft geben. Man musste ihr nur die Leute einladen; dann würde sie schon sehen, wie nett das sei. So bestellte sie denn die Turnach- und Doktorskinder auf Dienstag zu Frau Schnezler und trug ihnen auf, auch die Turmsette einzuladen. Tante Doktor wunderte sich über die Einladung; aber die Kinder waren sehr dafür, sie anzunehmen. Bei einer Kaffeegesellschaft gab es doch immer etwas Gutes, und dann kamen der Peter und die Edith.
     </p>
-    <p xml:id="eco_de_0000141_4970">
+    <p xml:id="eco_de_0000211_4970">
      Punkt drei Uhr läuteten die Kinder bei Frau Schnezler an.
     </p>
-    <p xml:id="eco_de_0000141_4980">
+    <p xml:id="eco_de_0000211_4980">
      »Ei«, sagte diese, »was kommt denn da für Besuch? Habt ihr die Schuhe abgestreift?«
     </p>
-    <p xml:id="eco_de_0000141_4990">
+    <p xml:id="eco_de_0000211_4990">
      »Einen freundlichen Gruss von Mama«, sagte Otto, »und sie sei so frei und schicke uns.«
     </p>
-    <p xml:id="eco_de_0000141_5000">
+    <p xml:id="eco_de_0000211_5000">
      »Schön«, versetzte Frau Schnezler. »Man putzt wohl bei euch heut und kann euch drum nicht brauchen?«
     </p>
-    <p xml:id="eco_de_0000141_5010">
+    <p xml:id="eco_de_0000211_5010">
      »Nein«, antwortete Trudi. »Wir putzen erst nächste Woche.«
     </p>
-    <p xml:id="eco_de_0000141_5020">
+    <p xml:id="eco_de_0000211_5020">
      »Nun, setzt euch jedenfalls ein wenig!« sagte Frau Schnezler und rückte Stühle zurecht.
     </p>
-    <p xml:id="eco_de_0000141_5030">
+    <p xml:id="eco_de_0000211_5030">
      Die Kinder fanden die Rede sonderbar, wo sie doch zum Kaffee eingeladen waren. Sie setzten sich und sahen einander an. Da überkam sie auf einmal, ohne dass sie recht wussten, warum, ein Lachen. Bei Trudi und Lotti begann es. Sie zogen die Achseln herauf und drehten sich gegen die Wand. Aber je mehr sie sich wehrten, desto stärker kam das Lachen. Natürlich wurden die andern angesteckt. Es war schrecklich. Man konnte gar nicht mehr aufsehen. Hans und Otto drückten die Faust an den Mund; doch das half nichts; immer wieder ging es los:
     </p>
-    <p xml:id="eco_de_0000141_5040">
+    <p xml:id="eco_de_0000211_5040">
      »Dh – dh –!« Marianne wurde rot vor Anstrengung, und es wäre ihr fast gelungen, aufzuhören, wenn nicht Lotti gegenüber solche Grimassen gemacht hätte.
     </p>
-    <p xml:id="eco_de_0000141_5050">
+    <p xml:id="eco_de_0000211_5050">
      Frau Schnezler nahm einen Stoss fertig genähter Bettanzüge vom Tisch.
     </p>
-    <p xml:id="eco_de_0000141_5060">
+    <p xml:id="eco_de_0000211_5060">
      »Ja, ja«, sagte sie. »Wenn man jung ist und es einem gut geht, kann man wohl lachen.«
     </p>
-    <p xml:id="eco_de_0000141_5070">
+    <p xml:id="eco_de_0000211_5070">
      »Dhi – dhi –« kicherte es wieder von links und rechts.
     </p>
-    <p xml:id="eco_de_0000141_5080">
+    <p xml:id="eco_de_0000211_5080">
      »Übrigens weiss ich nicht, was euch hier so lächerlich dünkt«, fuhr Frau Schnezler fort.
     </p>
-    <p xml:id="eco_de_0000141_5090">
+    <p xml:id="eco_de_0000211_5090">
      Die Kinder merkten, dass sie das Lachen nicht sehr nett fand. Aber was konnte man tun? Es wurde immer ärger.
     </p>
-    <p xml:id="eco_de_0000141_5100">
+    <p xml:id="eco_de_0000211_5100">
      Endlich kam Rettung. Es läutete wieder, und die Turmsette trat herein.
     </p>
-    <p xml:id="eco_de_0000141_5110">
+    <p xml:id="eco_de_0000211_5110">
      »Guten Nachmittag, Sette«, sagte Frau Schnezler erstaunt. »Sieht man dich auch wieder einmal?«
     </p>
-    <p xml:id="eco_de_0000141_5120">
+    <p xml:id="eco_de_0000211_5120">
      Die Turmsette hatte am Arm eine Tasche, aus welcher Peter seinen Schnabel herausstreckte.
     </p>
-    <p xml:id="eco_de_0000141_5130">
+    <p xml:id="eco_de_0000211_5130">
      »Wenn du erlaubst – ich habe den mitgebracht«, sagte sie und zog den Vogel aus der Tasche.
     </p>
-    <p xml:id="eco_de_0000141_5140">
+    <p xml:id="eco_de_0000211_5140">
      Die Kinder liefen alle fünf auf den Peter zu. Jetzt konnte man endlich loslachen! Sie nahmen den Vogel zum Fenster und trieben, während die beiden Frauen auf dem Sofa zu plaudern anfingen, ihre Spässe mit ihm. Sie setzten ihm das rote Türkenkäppchen von Frau Schnezlers Lampenzylinder auf und banden es fest. Peter schüttelte den Kopf, so dass die Trottel hin- und herflog. Sie zeigten ihm einen Fingerhut – Peter liebte alles Glänzende – und versteckten diesen dann, damit der Vogel suche.
     </p>
-    <p xml:id="eco_de_0000141_5150">
+    <p xml:id="eco_de_0000211_5150">
      So vergassen sie fast, dass sie zum Kaffee eingeladen waren. Nur einmal sagte Otto, indem er mit der Nase schnupperte:
     </p>
-    <p xml:id="eco_de_0000141_5160">
+    <p xml:id="eco_de_0000211_5160">
      »Ich will sehen, wann es eigentlich angeht. Man riecht gar nichts.«
     </p>
-    <p xml:id="eco_de_0000141_5170">
+    <p xml:id="eco_de_0000211_5170">
      Die Turmsette schien dasselbe zu denken. Sie sah an die Wanduhr:
     </p>
-    <p xml:id="eco_de_0000141_5180">
+    <p xml:id="eco_de_0000211_5180">
      »Schon zwanzig Minuten vor vier Uhr!«
     </p>
-    <p xml:id="eco_de_0000141_5190">
+    <p xml:id="eco_de_0000211_5190">
      »Ja, eher etwas mehr«, sagte Frau Schnezler und dachte, die Turmsette gehe nun wieder und nehme die Kinder vielleicht mit.
     </p>
-    <p xml:id="eco_de_0000141_5200">
+    <p xml:id="eco_de_0000211_5200">
      »Es ist nur wegen dem Kaffee«, fuhr die Turmsette fort. »Ich kann ja mit dir in die Küche gehen und dir ein wenig helfen.«
     </p>
-    <p xml:id="eco_de_0000141_5210">
+    <p xml:id="eco_de_0000211_5210">
      Frau Schnezler sah sie verwundert an.
     </p>
-    <p xml:id="eco_de_0000141_5220">
+    <p xml:id="eco_de_0000211_5220">
      »Mein Kaffee? Der ist nachher schnell gemacht.«
     </p>
-    <p xml:id="eco_de_0000141_5230">
+    <p xml:id="eco_de_0000211_5230">
      »Schnell gemacht? Ein Kaffee und was dazu gehört für sieben Personen? Das ist keine Kleinigkeit. Ich war wirklich erstaunt über die Einladung. Respekt vor dir!«
     </p>
-    <p xml:id="eco_de_0000141_5240">
+    <p xml:id="eco_de_0000211_5240">
      Frau Schnezler sah ganz verständnislos drein.
     </p>
-    <p xml:id="eco_de_0000141_5250">
+    <p xml:id="eco_de_0000211_5250">
      »Was sagst du, Sette –? Ich eine Einladung? Eine Kaffeegesellschaft?«
     </p>
-    <p xml:id="eco_de_0000141_5260">
+    <p xml:id="eco_de_0000211_5260">
      »Treib jetzt keine Spässe, sondern mach vorwärts! Die Kinder möchten gewiss schon lange gern etwas haben.«
     </p>
-    <p xml:id="eco_de_0000141_5270">
+    <p xml:id="eco_de_0000211_5270">
      Frau Schnezler sank entsetzt in ihr Sofa zurück.
     </p>
-    <p xml:id="eco_de_0000141_5280">
+    <p xml:id="eco_de_0000211_5280">
      »Du wirst doch nicht sagen wollen, ich habe dich – ich habe die Kinder eingeladen –!«
     </p>
-    <p xml:id="eco_de_0000141_5290">
+    <p xml:id="eco_de_0000211_5290">
      Nun wurde die Turmsette böse.
     </p>
-    <p xml:id="eco_de_0000141_5300">
+    <p xml:id="eco_de_0000211_5300">
      »Kommt daher, Otto und ihr andern – sind wir zu Frau Schnezler eingeladen oder nicht –?«
     </p>
-    <p xml:id="eco_de_0000141_5310">
+    <p xml:id="eco_de_0000211_5310">
      »Ja«, meldete Otto, »auf heute punkt drei Uhr zum Kaffee, hat Edith gesagt.«
     </p>
-    <p xml:id="eco_de_0000141_5320">
+    <p xml:id="eco_de_0000211_5320">
      »Edith –? diese Edith –? Es – es ist kein Wort wahr – kein Wort! Das ist ja ein grässliches Kind –«
     </p>
-    <p xml:id="eco_de_0000141_5330">
+    <p xml:id="eco_de_0000211_5330">
      Vor Empörung konnte Frau Schnezler nicht weiter sprechen. Die Turmsette und die Kinder waren ebenfalls starr und stumm. Nur der Rabe Peter sagte: »Kräh!« aber weiter wusste er auch nichts.
     </p>
-    <p xml:id="eco_de_0000141_5340">
+    <p xml:id="eco_de_0000211_5340">
      Da läutete die Hausglocke.
     </p>
-    <p xml:id="eco_de_0000141_5350">
+    <p xml:id="eco_de_0000211_5350">
      »Vielleicht noch ein paar Kaffeegäste?« sagte Frau Schnezler grimmig.
     </p>
-    <p xml:id="eco_de_0000141_5360">
+    <p xml:id="eco_de_0000211_5360">
      Als sie jedoch aufmachte, erblickte man den Albert vom Obertorbäcker mit einem Brett, auf dem ein gewaltiger goldbrauner Butterkranz lag. Die Butterkränze vom Obertorbäcker waren berühmt. Am Arm trug Albert einen Korb voll weissgezuckerter Rosinen- und Mandelstengel. Im Nu war Frau Schnezlers Gang und Stube von dem herrlichen Duft durchzogen, den Otto vorhin vermisst hatte.
     </p>
-    <p xml:id="eco_de_0000141_5370">
+    <p xml:id="eco_de_0000211_5370">
      Frau Schnezler aber streckte abwehrend die Hand aus.
     </p>
-    <p xml:id="eco_de_0000141_5380">
+    <p xml:id="eco_de_0000211_5380">
      »Was willst denn du? Du bist nicht am rechten Ort. Ich habe keinen Butterkranz bestellt – behüte!«
     </p>
-    <p xml:id="eco_de_0000141_5390">
+    <p xml:id="eco_de_0000211_5390">
      »O weh!« dachten die Kinder. »Den schönen Butterkranz und die Stengel wieder fortschicken –!«
     </p>
-    <p xml:id="eco_de_0000141_5400">
+    <p xml:id="eco_de_0000211_5400">
      »Der Vater hat gesagt, das gehöre zur Frau Schnezler«, entgegnete Albert und blieb hartnäckig stehen.
     </p>
-    <p xml:id="eco_de_0000141_5410">
+    <p xml:id="eco_de_0000211_5410">
      »Ja, ja, dieses Knabe ist an den rechte Ort!« rief jetzt eine helle Stimme, und durch die offene Haustüre trat Edith herein.
     </p>
-    <p xml:id="eco_de_0000141_5420">
+    <p xml:id="eco_de_0000211_5420">
      »So, da kommt sie noch selber, das unartige, naseweise Kind!« sagte Frau Schnezler. »Wart nur, das will ich deiner Tante erzählen –! Einer rechtschaffenen Frau so etwas anzustellen –!«
     </p>
-    <p xml:id="eco_de_0000141_5430">
+    <p xml:id="eco_de_0000211_5430">
      »Nicht bös sein, Frau Schnezler! Jetzt der Anfang von Gesellschaft ist gemacht. Alle sind da, Frau Turmsette und die Kinder und das Vogel –«
     </p>
-    <p xml:id="eco_de_0000141_5440">
+    <p xml:id="eco_de_0000211_5440">
      Aber Frau Schnezler schüttelte mit der Hand.
     </p>
-    <p xml:id="eco_de_0000141_5450">
+    <p xml:id="eco_de_0000211_5450">
      »Mach dass du gehst! Ich will dich gar nicht mehr sehen! Und die Kinder können grade mit. Und du, Sette, wirst ja wohl so viel Vernunft haben –«
     </p>
-    <p xml:id="eco_de_0000141_5460">
+    <p xml:id="eco_de_0000211_5460">
      »Hör«, sagte die Turmsette. »Es wäre am besten, du nähmest selber Vernunft an. Der Butterkranz und die Stengel sind jetzt einmal da – ich weiss zwar nicht, wie sie herkamen –«
     </p>
-    <p xml:id="eco_de_0000141_5470">
+    <p xml:id="eco_de_0000211_5470">
      »Habe ich bestellt und bezahlt von meines neue Taschengeld«, erklärte Edith.
     </p>
-    <p xml:id="eco_de_0000141_5480">
+    <p xml:id="eco_de_0000211_5480">
      »Siehst du«, nahm Sette wieder das Wort, »nun wird es dir schon wohler. Komm, wir werden doch einen Kaffee zu stand bringen. Die Kinder helfen.«
     </p>
-    <p xml:id="eco_de_0000141_5490">
+    <p xml:id="eco_de_0000211_5490">
      »Ja, ja, wir helfen!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_5500">
+    <p xml:id="eco_de_0000211_5500">
      Frau Schnezler sagte nichts. Ihr Zorn hatte sich noch nicht ganz gelegt; aber sie folgte der Turmsette in die Küche.
     </p>
-    <p xml:id="eco_de_0000141_5510">
+    <p xml:id="eco_de_0000211_5510">
      »Zucker und Kaffee hast du gewiss«, fuhr die Turmsette fort. »Die Milch übernehme ich, damit ich auch meinen Teil habe an dieser merkwürdigen Gesellschaft. Trudi und Edith geht hinüber in den Hirschen. Dort haben sie immer Milch.«
     </p>
-    <p xml:id="eco_de_0000141_5520">
+    <p xml:id="eco_de_0000211_5520">
      Trudi und Edith liefen mit zwei grossen Töpfen. Hans und Otto mahlten Kaffee, dass die Bohnen flogen. Marianne deckte mit Lotti den Tisch. Es ging, wie wenn die Heinzelmännchen lebendig geworden wären im Haus, und nach kurzer Zeit sass gross und klein beim Kaffee. Der Rabe Peter thronte auf Turmsettes Schulter; er bekam von links und rechts Kuchenbrocken und krähte vergnügt mit, wenn die Kinder, die durch die Verwirrung noch übermütiger geworden, lachten und durcheinander schwatzten.
     </p>
-    <p xml:id="eco_de_0000141_5530">
+    <p xml:id="eco_de_0000211_5530">
      »Jetzt machen wir Spiele!« rief Lotti, nachdem alle dem Kaffee, dem Butterkranz und den Stengeln gehörig zugesprochen hatten.
     </p>
-    <p xml:id="eco_de_0000141_5540">
+    <p xml:id="eco_de_0000211_5540">
      »Ja, Kinder! und wir sehen zu«, sagte die Turmsette.
     </p>
-    <p xml:id="eco_de_0000141_5550">
+    <p xml:id="eco_de_0000211_5550">
      Aber bald wurden die beiden Frauen mit hineingezogen; denn es stellte sich heraus, dass die Spiele der Kinder dieselben waren, die man schon vor vierzig Jahren in Larstetten gespielt hatte: Das Tellerspiel, das Kompliment- und das Handwerkerspiel; dann »Wie gefällt dir dein Nachbar?« und »Alle Apothekerbüchsen rühren sich!« Es ging sehr laut und lustig zu in Frau Schnezlers sonst so stiller Stube. Der Rabe, der zuerst munter um den rollenden Teller und zwischen den Komplimenten der Kinder herumgehüpft war, flüchtete auf die Kommode und sah erstaunt auf das Treiben hinunter.
     </p>
-    <p xml:id="eco_de_0000141_5560">
+    <p xml:id="eco_de_0000211_5560">
      Als schöner Schluss kam noch das Nachtwächterspiel. Alle setzten sich auf die in eine Reihe gestellten Stühle; die Lampe wurde ausgelöscht, und Hans ging mit einer Kappe des verstorbenen Herrn Schnezler, einem Laternchen und einem Stock ringsum, indem er mit lauter Stimme verkündete:
     </p>
-    <p xml:id="eco_de_0000141_5570">
+    <p xml:id="eco_de_0000211_5570">
      »Seht die Nachtwach kommt heran Mit einem langen Stocke.
     </p>
-    <p xml:id="eco_de_0000141_5580">
+    <p xml:id="eco_de_0000211_5580">
      Haltet fest und haltet fest, Haltet fest am Rocke!«
     </p>
-    <p xml:id="eco_de_0000141_5590">
+    <p xml:id="eco_de_0000211_5590">
      Die Person, vor der er dreimal mit dem Stocke klopfte, musste hinter ihm herziehen durch den Hausgang oder die Küche. Es war sehr spannend, wenn der Nachtwächter alsbald wieder erschien, um eines zu holen. Je mehr der Schwanz wuchs, desto grösser wurde die Wanderung. Es ging zum Dachboden hinauf und durch das nächtliche Gärtchen, und schliesslich, als die ganze Gesellschaft anhing, hinaus in die Seilergasse.
     </p>
-    <p xml:id="eco_de_0000141_5600">
+    <p xml:id="eco_de_0000211_5600">
      »Kinder, Kinder«, wehrte die Turmsette. »Das geht nicht. Was werden sie im Städtchen sagen!«
     </p>
-    <p xml:id="eco_de_0000141_5610">
+    <p xml:id="eco_de_0000211_5610">
      »Nicht loslassen!« riefen aber die Kinder. »Bitte, nur durch die Seilergasse! Das ist grad das Netteste!«
     </p>
-    <p xml:id="eco_de_0000141_5620">
+    <p xml:id="eco_de_0000211_5620">
      Sie trieben und zogen und fuhren im Chore fort:
     </p>
-    <p xml:id="eco_de_0000141_5630">
+    <p xml:id="eco_de_0000211_5630">
      »Haltet fest und haltet fest, Haltet fest am Rocke!«
     </p>
-    <p xml:id="eco_de_0000141_5640">
+    <p xml:id="eco_de_0000211_5640">
      »Wie das doch in letzter Zeit bei uns zugeht!« sagten die Nachbarn, als die Nachtwache beim Schein des Laternchens daherkam. »Kürzlich der Zusammenlauf an dem Lebkuchenstand, dann bei Doktors das Theater, und die Geschichte mit dem Scheunentor auf dem Eschenweiher. Und jetzt noch ein Umzug – nein, die Turmsette –! Seid ihr beide nicht bei Trost?«
     </p>
-    <p xml:id="eco_de_0000141_5650">
+    <p xml:id="eco_de_0000211_5650">
      »Doch, doch! wir machen ein Spiel. Die Frau Schnezler hat eine Einladung gegeben.«
     </p>
-    <p xml:id="eco_de_0000141_5660">
+    <p xml:id="eco_de_0000211_5660">
      »Potz!« sagten die Nachbarn.
     </p>
-    <p xml:id="eco_de_0000141_5670">
+    <p xml:id="eco_de_0000211_5670">
      Wieder vor dem Hause angelangt, trennte man sich. Die übermütige Edith schüttelte ihrer Nählehrerin die Hand.
     </p>
-    <p xml:id="eco_de_0000141_5680">
+    <p xml:id="eco_de_0000211_5680">
      »Nun Sie sehen, Frau Schnezler, dass ich habe gesagt wahr, Kaffeegesellschaft ist eine sehr hübsche Sache!«
     </p>
    </div>
@@ -1816,166 +1816,166 @@
     <head>
      Im Winterhaus am Kornplatz
     </head>
-    <p xml:id="eco_de_0000141_5690">
+    <p xml:id="eco_de_0000211_5690">
      Es ging mit den Larstetter Ferien, wie es mit denen in der Seeweid gegangen war: Ehe man sich's versah, kam der letzte Tag, und es kam sogar die Abendstunde, wo die Turnachkinder wieder daheim anlangten. Papa hatte sie am Bahnhof abgeholt. Es war ganz seltsam gewesen, nun nicht den Weg zur Seeweid einzuschlagen, sondern rechts abzubiegen zum Kornplatz. Lotti behauptete, sie könne sich die obere Treppe und das Wohnzimmer gar nicht mehr vorstellen.
     </p>
-    <p xml:id="eco_de_0000141_5700">
+    <p xml:id="eco_de_0000211_5700">
      Als sie aber ins Haus traten, sprang ihnen als traulicher Empfang Ulrichs guter alter Schnauzel entgegen. Er umtanzte die Kinder und hüpfte an ihnen empor; er heulte und bellte. Das hiess in seiner Hundesprache: »Endlich, endlich!« Dann schoss er die Treppe hinauf zu Ulrich, um ihm zu sagen: »Sie sind wieder da! die Kinder sind wieder da!«
     </p>
-    <p xml:id="eco_de_0000141_5710">
+    <p xml:id="eco_de_0000211_5710">
      Ulrich stand in der Arbeitsschürze zwischen seinen Garnballen. Er sagte nicht viel: aber man sah, er freute sich auch, dass nach dem stillen Sommer nun Leben ins Haus kam. Hans schlug auf einen der Ballen und atmete den Geruch des Hanftuches ein.
     </p>
-    <p xml:id="eco_de_0000141_5720">
+    <p xml:id="eco_de_0000211_5720">
      »Jetzt fängt der Winter an«, sagte er. »Jetzt sind wir wieder am Kornplatz daheim!«
     </p>
-    <p xml:id="eco_de_0000141_5730">
+    <p xml:id="eco_de_0000211_5730">
      Von droben aber ertönte Werners ungeduldige Stimme:
     </p>
-    <p xml:id="eco_de_0000141_5740">
+    <p xml:id="eco_de_0000211_5740">
      »Kommt doch ganz herauf –! Kommt doch!«
     </p>
-    <p xml:id="eco_de_0000141_5750">
+    <p xml:id="eco_de_0000211_5750">
      Da standen Mama und Wernermann und Sophie mit dem Schwesterlein, das den drei Ankommenden entgegenlachte und ihnen mit seinen Händchen ins Gesicht patschte. Marianne wollte das Schwesterlein auf den Arm nehmen; doch Werner liess ihr keine Zeit:
     </p>
-    <p xml:id="eco_de_0000141_5760">
+    <p xml:id="eco_de_0000211_5760">
      »Zuerst mich anschauen! Bitte, mich anschauen!« rief er und stellte sich dann, so breit er konnte, vor die Geschwister hin.
     </p>
-    <p xml:id="eco_de_0000141_5770">
+    <p xml:id="eco_de_0000211_5770">
      Ja, das war eine Überraschung: Werner in den ersten Hosen! Werner nicht mehr ein kleines Kind, sondern ein grosser Bub!
     </p>
-    <p xml:id="eco_de_0000141_5780">
+    <p xml:id="eco_de_0000211_5780">
      Er stand ganz still mit stolzem Gesicht und liess sich bewundern. Jetzt war endlich der glückliche Moment da! Hundertmal hatte er in den letzten zwei Tagen gefragt:
     </p>
-    <p xml:id="eco_de_0000141_5790">
+    <p xml:id="eco_de_0000211_5790">
      »Mama, wann kommen sie? Mama, wissen sie noch nicht, dass ich Hosen hab? Mama, was sagen sie dann?«
     </p>
-    <p xml:id="eco_de_0000141_5800">
+    <p xml:id="eco_de_0000211_5800">
      »Prachtvoll stehen sie dir!« rief Hans und streckte Werner die Hand hin. »Nun hab ich also einen rechten Bruder! Heulen tust du jetzt natürlich nie mehr?«
     </p>
-    <p xml:id="eco_de_0000141_5810">
+    <p xml:id="eco_de_0000211_5810">
      Werner lachte, sah aber schnell zu Mama hinüber. Heute morgen hatte er noch ganz wacker geheult.
     </p>
-    <p xml:id="eco_de_0000141_5820">
+    <p xml:id="eco_de_0000211_5820">
      Das Begrüssen und Wiedersehen, das sich von den Personen auch auf die Räume und Dinge ausdehnte, nahm kein Ende. Alles schien vertraut und neu zugleich. Marianne und Lotti liefen zum Schrank, um ihre Puppen zu umarmen. Hans sah seine Bücher an; jetzt konnte man sie der Reihe nach von neuem durchlesen. Allerdings unten im Schrank lagen auch die Schulsachen der Kinder. Dieses Wiedersehen stimmte Lotti etwas ernsthaft. Den ganzen Vormittag musste man nun wieder stillsitzen und am Nachmittag meistens noch einmal, und das ging so die lange Woche hindurch –!
     </p>
-    <p xml:id="eco_de_0000141_5830">
+    <p xml:id="eco_de_0000211_5830">
      Aber am Montag fand Lotti es dann doch sehr nett in der Schule. Viele Kinder hatten andere Kleider an, und einige, die vorher offene Haare gehabt, kamen mit Zöpfen. Auch waren die Winterfenster eingehängt, und die Wandtafel war schön schwarz und hatte frische rote Linien. In der vordersten Bank aber sass gar ein ganz neues Kind mit schwarzen Augen, das Nina hiess. Lotti beschloss, eine von ihren Puppen Nina zu taufen.
     </p>
-    <p xml:id="eco_de_0000141_5840">
+    <p xml:id="eco_de_0000211_5840">
      »Das war natürlich die Hauptsache, Lotti«, sagte Hans, als beim Mittagessen vom ersten Schulmorgen gesprochen wurde. »Dieses neue Kind und die roten Linien und der Zopf von der Hedwig Zohner!«
     </p>
-    <p xml:id="eco_de_0000141_5850">
+    <p xml:id="eco_de_0000211_5850">
      »Nein gar nicht!« wehrte sich Lotti. »Wir haben schon stark gerechnet, und zweimal habe ich die Hand zuerst aufgestreckt!«
     </p>
-    <p xml:id="eco_de_0000141_5860">
+    <p xml:id="eco_de_0000211_5860">
      »Uns hat Fräulein Heller eine Rede gehalten«, erzählte Marianne. »Sie hat gesagt, jetzt beginne die Arbeitszeit wieder, und wir sollen uns alle recht zusammennehmen. Es sei auch eine Freude, jeden Tag zu versuchen, wie weit die Kraft reiche.«
     </p>
-    <p xml:id="eco_de_0000141_5870">
+    <p xml:id="eco_de_0000211_5870">
      »Fast das gleiche hat Herr Altschmid gesagt«, rief Hans. »Und er hat uns noch erklärt, dass es mit dem Zusammennehmen und mit dem Rechttun sei wie beim Turnen. Man könne sich üben, und dann gehe es immer leichter. Man werde überhaupt nur ein tüchtiger Mensch, wenn man tapfer an das hingehe, was schwer und mühsam sei.«
     </p>
-    <p xml:id="eco_de_0000141_5880">
+    <p xml:id="eco_de_0000211_5880">
      »Schön«, stimmte Papa zu. »Wir wollen sehen, wie ihr dieses Kopf- und Herzturnen nun betreibt den Winter!« Das klang wie ein Spass; aber die Kinder verstanden, dass Papa es ernst meinte. Sie gaben sich denn auch Mühe, fleissig und brav zu sein in der Schule und zu Hause.
     </p>
-    <p xml:id="eco_de_0000141_5890">
+    <p xml:id="eco_de_0000211_5890">
      Am Abend jedoch nach der Arbeit fand sich immer wieder Zeit zu Spiel und Vergnügen. Schon durch das Fenster auf den Kornplatz hinauszusehen war eine sehr hübsche Unterhaltung. Es dunkelte jetzt früh. Der Laternenanzünder kam, und die Lichter brannten in den Schaufenstern. Drüben beim Pelzhändler hing ein grosses braunes Bärenfell zwischen Müffen und Krägen. Das sah schon sehr winterlich aus. Oben im ersten Stockwerk war ein Kaffeesaal. Die Herren sassen mit Zeitungen bei ihren Tassen. Andere spielten Billard auf grossen grünen Tischen. Man sah, wie sie sich über den Tisch legten, scharf zielten und wie die Kugeln flogen. In dem hohen Hause am Eingang der Schwalbengasse wohnte die Schneiderin Weissenhorn.
     </p>
-    <p xml:id="eco_de_0000141_5900">
+    <p xml:id="eco_de_0000211_5900">
      Die Lehrmädchen nähten fleissig, und Frau Weissenhorn schnitt mit einer langen Schere zu.
     </p>
-    <p xml:id="eco_de_0000141_5910">
+    <p xml:id="eco_de_0000211_5910">
      Unten auf dem Platze eilten die Leute aneinander vorbei, als hätten sie vor der Nacht noch viel zu verrichten. Zwei Herren mit Handkoffern gingen auf eine Droschke zu; der Kutscher nahm schnell die Decke vom Pferd und fuhr mit den Herren davon. Zu dem Kastanienbrater kam eine Dame und kaufte einen grossen Sack Kastanien. Der Kastanienjunge machte ein vergnügtes Gesicht und zählte ihr beim Schein der kleinen Lampe das Geld heraus. Ein Lastwagen hielt vor der Apotheke. Zwei Männer sprangen vom Wagen, um eine schwere Kiste abzuladen.
     </p>
-    <p xml:id="eco_de_0000141_5920">
+    <p xml:id="eco_de_0000211_5920">
      »Das ist fast so lustig wie das Kaleidoskop oder wie das Lebensrad!« sagten die Kinder. »Immer bewegt es sich, und immer gibt's etwas Neues!«
     </p>
-    <p xml:id="eco_de_0000141_5930">
+    <p xml:id="eco_de_0000211_5930">
      In der Seeweid, wenn man abends zum Fenster hinaussah, war alles still und dunkel, und in Larstetten lag das Wohnzimmer gegen den Garten.
     </p>
-    <p xml:id="eco_de_0000141_5940">
+    <p xml:id="eco_de_0000211_5940">
      Oft gingen die Kinder auch hinunter und setzten sich zu Ulrich in die Garnkammer. Plaudern konnte man zwar mit Ulrich nicht viel. Wenn man ihn bat, etwas zu erzählen, so sagte er, es falle ihm auf der Welt nichts ein. Dafür aber wusste er eine Menge Lieder, besonders traurige Soldatenlieder. Es war sehr schön, wenn er mit seiner tiefen Stimme begann:
     </p>
-    <p xml:id="eco_de_0000141_5950">
+    <p xml:id="eco_de_0000211_5950">
      »Zu Strassburg auf der langen Brück, Da stand ich eines Tags …«
     </p>
-    <p xml:id="eco_de_0000141_5960">
+    <p xml:id="eco_de_0000211_5960">
      oder:
     </p>
-    <p xml:id="eco_de_0000141_5970">
+    <p xml:id="eco_de_0000211_5970">
      »Morgenrot, Morgenrot, Leuchtest mir zum frühen Tod …«
     </p>
-    <p xml:id="eco_de_0000141_5980">
+    <p xml:id="eco_de_0000211_5980">
      Oder wenn er das Lied vom alten Feldherrn sang:
     </p>
-    <p xml:id="eco_de_0000141_5990">
+    <p xml:id="eco_de_0000211_5990">
      »Denkst du daran, mein tapfrer Lagienka …«
     </p>
-    <p xml:id="eco_de_0000141_6000">
+    <p xml:id="eco_de_0000211_6000">
      Ulrich konnte sämtliche Strophen, und die Kinder warteten immer mit Spannung auf die prächtige Stelle:
     </p>
-    <p xml:id="eco_de_0000141_6010">
+    <p xml:id="eco_de_0000211_6010">
      »Denkst du daran, dass in des Kampfes Wettern Mein Säbel blitzte stets in deiner Näh, Als du, verlassen von des Sieges Göttern, Noch sinkend riefst: Finis Poloniae! …«
     </p>
-    <p xml:id="eco_de_0000141_6020">
+    <p xml:id="eco_de_0000211_6020">
      Dieses Lied hatte Marianne am liebsten. Es war ihr so seltsam dabei zu Mut, traurig und doch wohl. Einmal stiess Lotti leise Hans an:
     </p>
-    <p xml:id="eco_de_0000141_6030">
+    <p xml:id="eco_de_0000211_6030">
      »Du, die Marianne weint!«
     </p>
-    <p xml:id="eco_de_0000141_6040">
+    <p xml:id="eco_de_0000211_6040">
      »Ach nein«, sagte Marianne und fuhr sich schnell über die Augen.
     </p>
-    <p xml:id="eco_de_0000141_6050">
+    <p xml:id="eco_de_0000211_6050">
      Ulrich aber griff nach seiner Harmonika, die hinten auf dem Gestell lag, und fing unversehens eine rasche lustige Weise an zu spielen, bei der man die Füsse nicht mehr ruhig halten konnte. Lotti wenigstens rutschte von der Kiste, auf der sie sass, herunter und begann in der Garnkammer umher zu hopsen.
     </p>
-    <p xml:id="eco_de_0000141_6060">
+    <p xml:id="eco_de_0000211_6060">
      Es war auch sonst unterhaltend bei Ulrich zu sein und ihm zuzusehen, wenn er auf dem Vorplatz arbeitete. Er schichtete die Garnpakete zusammen in das Hanftuch, nähte dieses zu und schnürte die grossen Ballen dann mit einem starken Seile fest. Das ging alles so flink und ruhig.
     </p>
-    <p xml:id="eco_de_0000141_6070">
+    <p xml:id="eco_de_0000211_6070">
      »Achtung!« oder »Hand vom Zeug!« rief Ulrich bloss von Zeit zu Zeit, wenn er einen Ballen wälzte, oder wenn eins der Kinder Lust bekam, mit der grossen Nadel, in die der Bindfaden eingefädelt war, seine Kunst zu versuchen.
     </p>
-    <p xml:id="eco_de_0000141_6080">
+    <p xml:id="eco_de_0000211_6080">
      Noch mehr als die Packnadel lockte der Farbtopf und der Pinsel, mit dem Ulrich die Buchstaben fest und schön auf die Ballen malte.
     </p>
-    <p xml:id="eco_de_0000141_6090">
+    <p xml:id="eco_de_0000211_6090">
      »F R T 8«, buchstabierte Hans. »Ich möcht's auch einmal probieren.«
     </p>
-    <p xml:id="eco_de_0000141_6100">
+    <p xml:id="eco_de_0000211_6100">
      »Wollt's dir nicht raten«, sagte Ulrich und sah zu Marianne hinüber.
     </p>
-    <p xml:id="eco_de_0000141_6110">
+    <p xml:id="eco_de_0000211_6110">
      Marianne schüttelte lachend den Kopf. Sie hatte letzten Winter eine Erfahrung gemacht. Der Farbtopf und der Pinsel waren dagestanden und kein Ulrich dabei. Da hatte Marianne angefangen, ein F und ein R zu malen; die Buchstaben gerieten gar nicht schön, und eben als ihr noch ein grosser Klecks auf das Hanftuch floss, trat Ulrich hinter sie.
     </p>
-    <p xml:id="eco_de_0000141_6120">
+    <p xml:id="eco_de_0000211_6120">
      »Verdirbst mir den ganzen Ballen!« sagte er ärgerlich, und ehe sie sich's versah. hatte er ihr ein dickes Kreuz auf die Hand gemalt.
     </p>
-    <p xml:id="eco_de_0000141_6130">
+    <p xml:id="eco_de_0000211_6130">
      »So, jetzt bist du auch gezeichnet!«
     </p>
-    <p xml:id="eco_de_0000141_6140">
+    <p xml:id="eco_de_0000211_6140">
      Marianne versuchte, die Farbe wegzureiben; aber diese wich nicht, und es war zehn Minuten vor neun Uhr. Also musste Marianne mit der schwarzen Hand in die Schule laufen, wo alles sie auslachte. –
     </p>
-    <p xml:id="eco_de_0000141_6150">
+    <p xml:id="eco_de_0000211_6150">
      Waren eine Anzahl Ballen fertig, so kam das Rutschbrett. Das Rutschbrett lehnte an der Wand der langen graden Treppe. Wenn man es hinlegte, gab es eine prächtige Rutschbahn, für die Ballen zuerst und dann auch für die Kinder. Das Brett war spiegelglatt von dem vielen Gebrauch. In einem Augenblick sauste man hinunter und stieg an der Seite, wo etwas Raum blieb, wieder die Treppe hinauf, um von neuem hinunterzufahren. Den kleinen Werner nahm Marianne auf den Schoss. Er schrie immer laut auf vor Entzücken.
     </p>
-    <p xml:id="eco_de_0000141_6160">
+    <p xml:id="eco_de_0000211_6160">
      Die grossen Leute allerdings, die auf- und abgehen wollten, fanden die Sache nicht sehr bequem und zankten manchmal ein wenig. Nur Onkel Alfred liess sich zum Ergötzen der Kinder etwa erbitten, ein paar Partien mitzumachen. Er hatte zwar allerlei Einwände.
     </p>
-    <p xml:id="eco_de_0000141_6170">
+    <p xml:id="eco_de_0000211_6170">
      »Kinder, nein! Was mutet ihr mir zu! Es ist unter meiner Würde. Und dann mein Anzug –! Einer Rutschbahn steht der Glanz gut, aber meinen Beinkleidern nicht –!«
     </p>
-    <p xml:id="eco_de_0000141_6180">
+    <p xml:id="eco_de_0000211_6180">
      »Meine glänzen auch schon ein wenig!« rief Hans.
     </p>
-    <p xml:id="eco_de_0000141_6190">
+    <p xml:id="eco_de_0000211_6190">
      »Quod licet Jovi, non licet bovi«, antwortete der Onkel.
     </p>
-    <p xml:id="eco_de_0000141_6200">
+    <p xml:id="eco_de_0000211_6200">
      »Was heisst das?« fragten die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_6210">
+    <p xml:id="eco_de_0000211_6210">
      »Das heisst ungefähr: Was dem Neffen Hans ziemt, das ziemt nicht immer dem Onkel Alfred.«
     </p>
-    <p xml:id="eco_de_0000141_6220">
+    <p xml:id="eco_de_0000211_6220">
      Aber dann gab der Onkel doch nach und rutschte mit den Kindern das Brett hinunter, bis Papa kam und lachend nun etwas Französisches sagte, was aber Onkel Alfred nicht übersetzte.
     </p>
    </div>
@@ -1983,331 +1983,331 @@
     <head>
      Warum der kleine Dieb nicht bestraft wird
     </head>
-    <p xml:id="eco_de_0000141_6230">
+    <p xml:id="eco_de_0000211_6230">
      Im Hintergrunde des grossen Hausflurs standen hoch aufgetürmt kleine und grosse in Hanftuch gepackte Baumwollballen, auf denen man herumklettern konnte. Schon letztes Jahr hatten die Kinder da ihre Burg gehabt, und auch heuer waren die Ballen wieder sehr günstig gelagert. Vorn stand ein schon ziemlich hoher Block, den man nur mit Mühe erstieg. Das war der Zwinger; von ihm führte die aus einem Brett bestehende Brücke zu der noch höheren eigentlichen Burg. Zwischen den Ballen und der Wand ging es tief hinunter. Dieses Loch diente als Burgverlies.
     </p>
-    <p xml:id="eco_de_0000141_6240">
+    <p xml:id="eco_de_0000211_6240">
      Die Nachbarskinder Rudolf und Sylvia Lorez machten auch wieder mit. Rudolf war etwas jünger als Hans, und Sylvia ging in die erste Klasse.
     </p>
-    <p xml:id="eco_de_0000141_6250">
+    <p xml:id="eco_de_0000211_6250">
      Wenn Rudolf und Sylvia vor die Burg kamen, war zuerst immer die Zugbrücke aufgezogen.
     </p>
-    <p xml:id="eco_de_0000141_6260">
+    <p xml:id="eco_de_0000211_6260">
      »Freund oder Feind?« rief dann Hans hinunter.
     </p>
-    <p xml:id="eco_de_0000141_6270">
+    <p xml:id="eco_de_0000211_6270">
      »Freund!« antwortete Rudolf.
     </p>
-    <p xml:id="eco_de_0000141_6280">
+    <p xml:id="eco_de_0000211_6280">
      »Das Wort?« fragte Hans.
     </p>
-    <p xml:id="eco_de_0000141_6290">
+    <p xml:id="eco_de_0000211_6290">
      Dann rief Rudolf, zum Beweis, dass er ein Vertrauter der Burg war, das Wort hinauf, das man tags zuvor ausgemacht hatte. Es war irgend etwas Kühnes: Falkenhorst! oder: Rache! oder: Ritterehre!
     </p>
-    <p xml:id="eco_de_0000141_6300">
+    <p xml:id="eco_de_0000211_6300">
      Hierauf wurde die Zugbrücke hinuntergelassen, und der Ritter Rudolf erklomm mit dem Edelfräulein Sylvia den Zwinger und von da die Burg.
     </p>
-    <p xml:id="eco_de_0000141_6310">
+    <p xml:id="eco_de_0000211_6310">
      Oft unternahmen die Ritter und die Frauen von der Burg aus eine Jagdpartie und kehrten mit Beute heim. Der gute Schnauzel musste abwechselnd ein Wildschwein oder einen Hirsch darstellen. Er liebte das gar nicht, und zog sich jedesmal im Hofe hinter eine Kiste zurück, wenn die Jagd sich näherte. Aber die Kinder drangen mit Hussa! auf ihn ein und schleppten ihn unter grossen Schwierigkeiten auf den Zwinger und über die Zugbrücke.
     </p>
-    <p xml:id="eco_de_0000141_6320">
+    <p xml:id="eco_de_0000211_6320">
      An einem Samstag nachmittag nach der Rückkehr von der Jagd sahen die Kinder an der Haustüre einen Buben stehen. Er schaute ihnen eine Weile zu und trat dann näher.
     </p>
-    <p xml:id="eco_de_0000141_6330">
+    <p xml:id="eco_de_0000211_6330">
      Hans und Rudolf zogen die Zugbrücke auf.
     </p>
-    <p xml:id="eco_de_0000141_6340">
+    <p xml:id="eco_de_0000211_6340">
      »Das Wort?« rief Lotti von der stolzen Höhe herab.
     </p>
-    <p xml:id="eco_de_0000141_6350">
+    <p xml:id="eco_de_0000211_6350">
      Der Bub wusste kein Wort.
     </p>
-    <p xml:id="eco_de_0000141_6360">
+    <p xml:id="eco_de_0000211_6360">
      »Kann ich auch mitmachen?« fragte er und sah verlangend hinauf. Er war etwa im Alter von Rudolf, sah aber etwas struppig aus. Er sagte, er heisse Theodor Hahn.
     </p>
-    <p xml:id="eco_de_0000141_6370">
+    <p xml:id="eco_de_0000211_6370">
      Die Kinder überlegten.
     </p>
-    <p xml:id="eco_de_0000141_6380">
+    <p xml:id="eco_de_0000211_6380">
      »Hans, ich weiss etwas«, flüsterte Rudolf. »Er könnte ein Gefangener sein. Es wäre fein, einen gefesselten Feind im Burgverlies zu haben! Wir würden ihn bewachen –«
     </p>
-    <p xml:id="eco_de_0000141_6390">
+    <p xml:id="eco_de_0000211_6390">
      »Und ihm Speise und Trank hinunterlassen!« rief Marianne, die eben Brot und Äpfel zur Vesper geholt hatte.
     </p>
-    <p xml:id="eco_de_0000141_6400">
+    <p xml:id="eco_de_0000211_6400">
      »Ja, ja!« stimmten alle zu.
     </p>
-    <p xml:id="eco_de_0000141_6410">
+    <p xml:id="eco_de_0000211_6410">
      Man machte dem Buben den Vorschlag, und er kletterte vergnügt zur Burg hinauf, um allerdings an der andern Seite wieder hinunterbefördert zu werden in den Kerker.
     </p>
-    <p xml:id="eco_de_0000141_6420">
+    <p xml:id="eco_de_0000211_6420">
      »Da unten, wo weder Sonne noch Mond dich bescheinen, wirst du büssen für deine Missetaten!« rief ihm Rudolf nach, der eben ganz in einem Rittergeschichtenbuch lebte.
     </p>
-    <p xml:id="eco_de_0000141_6430">
+    <p xml:id="eco_de_0000211_6430">
      »Ich glaube, ich würde mich fürchten«, flüsterte die ängstliche Sylvia und sah in das Verlies hinunter.
     </p>
-    <p xml:id="eco_de_0000141_6440">
+    <p xml:id="eco_de_0000211_6440">
      »Du musst von Zeit zu Zeit stöhnen und über Hunger und Durst klagen!« ermahnte Hans den Gefangenen.
     </p>
-    <p xml:id="eco_de_0000141_6450">
+    <p xml:id="eco_de_0000211_6450">
      Dieser liess ein undeutliches Gebrumm vernehmen.
     </p>
-    <p xml:id="eco_de_0000141_6460">
+    <p xml:id="eco_de_0000211_6460">
      Währenddessen hatte Marianne einen kleinen Korb und eine grosse Medizinflasche gebracht. Diese wurde im Hofe mit Wasser gefüllt und samt einem Stück Brot und einem grossen Apfel in dem Körbchen zu dem Gefangenen hinuntergelassen. Der Gefangene griff nach dem Brot und dem Apfel und hatte beides in wenig Augenblicken aufgegessen.
     </p>
-    <p xml:id="eco_de_0000141_6470">
+    <p xml:id="eco_de_0000211_6470">
      »Das Wasser brauche ich nicht«, sagte er und goss es ohne weiteres auf das Steinpflaster aus.
     </p>
-    <p xml:id="eco_de_0000141_6480">
+    <p xml:id="eco_de_0000211_6480">
      »Das gilt nicht!« riefen die Kinder; sie waren empört.
     </p>
-    <p xml:id="eco_de_0000141_6490">
+    <p xml:id="eco_de_0000211_6490">
      »Wenn du nicht recht spielst, so darfst du nicht mehr mitmachen!« erklärte Hans. »Grade an Durst litten sie im Kerker manchmal sehr.«
     </p>
-    <p xml:id="eco_de_0000141_6500">
+    <p xml:id="eco_de_0000211_6500">
      »Ja«, bestätigte Rudolf. »In meinem Buche sagt der Gefangene einmal: ›Mich quält der Hunger, und ich verschmachte vor Durst!‹«
     </p>
-    <p xml:id="eco_de_0000141_6510">
+    <p xml:id="eco_de_0000211_6510">
      Eine Weile blieb es still unten; der Gefangene schien zu überlegen. Dann rief er mit richtig jämmerlicher Stimme:
     </p>
-    <p xml:id="eco_de_0000141_6520">
+    <p xml:id="eco_de_0000211_6520">
      »Mich quält der Hunger, und ich verschmachte vor Durst!«
     </p>
-    <p xml:id="eco_de_0000141_6530">
+    <p xml:id="eco_de_0000211_6530">
      »Also, wenn du das Wasser trinkst, bekommst du noch einmal Brot und einen Apfel!« riefen Hans und Rudolf.
     </p>
-    <p xml:id="eco_de_0000141_6540">
+    <p xml:id="eco_de_0000211_6540">
      Theodor Hahn versprach es, und der Korb wurde aufs neue mit Speise und Trank hinuntergelassen. Theodor hielt sein Wort; ja er sagte, für einen dritten Apfel mit Brot trinke er die ganze Flasche noch zweimal aus.
     </p>
-    <p xml:id="eco_de_0000141_6550">
+    <p xml:id="eco_de_0000211_6550">
      Das ging nun nicht; denn die Kinder hatten das Vesperbrot selber aufgegessen. Hingegen begannen sie ein anderes Spiel mit ihrem Gefangenen. Er musste entwischen durch eine Spalte des Kerkers und versteckte sich im Hofe oder suchte über den Kornplatz zu fliehen. Dann wurde er verfolgt von den Rittern und wieder eingebracht. Er wehrte sich dabei so natürlich, dass man ihn kaum bewältigen konnte.
     </p>
-    <p xml:id="eco_de_0000141_6560">
+    <p xml:id="eco_de_0000211_6560">
      Als es dunkel wurde, trennte man sich. Theodor war sehr vergnügt, dass Hans und Rudolf ihm sagten, er solle am nächsten freien Nachmittag wieder kommen.
     </p>
-    <p xml:id="eco_de_0000141_6570">
+    <p xml:id="eco_de_0000211_6570">
      Das Ritterspiel gestaltete sich jetzt noch in anderer Weise besonders hübsch. Hans und Rudolf erinnerten sich, wie in alten Zeiten die Burgen manchmal belagert wurden und wie dann die Ritter und ihre Leute anfingen Mangel zu leiden, wenn sie nicht, bevor der Feind kam, Nahrungsmittel, Vieh und Mehl auf die Burg gebracht hatten. Die Kinder beschlossen, neben dem Zwinger an der Mauer ebenfalls einen Vorratskeller einzurichten. Und am folgenden Tage brachte jedes, was es an Lebensmitteln hatte auftreiben können. Rudolf kam mit einer Schokoladetafel und Sylvia mit einer Stange Süssholzsaft aus der Apotheke. Lotti hatte ihre Schürze voll gedörrter Langbirnen, und Marianne besass noch einen Lebkuchen vom Larstetter Markt. Hans aber zeigte triumphierend eine kleine geräucherte Wurst; Grossmama, der er von der Burg erzählt, hatte sie ihm geschenkt.
     </p>
-    <p xml:id="eco_de_0000141_6580">
+    <p xml:id="eco_de_0000211_6580">
      Alle rochen an der Wurst. Dann wurde sie mit den andern Nahrungsmitteln in eine Schachtel gelegt und diese in der Nische hinter dem Zwinger versteckt. Fast jeden Tag wurde nachgesehen, ob im Vorratskeller alles in Ordnung sei. Genascht wurde nicht; man hatte sich das Ehrenwort gegeben.
     </p>
-    <p xml:id="eco_de_0000141_6590">
+    <p xml:id="eco_de_0000211_6590">
      Um so grösser war die Bestürzung, als man eines Mittags nach der Schule die Schachtel leer fand –! Halb offen stand sie in der Ecke, gänzlich ausgeplündert. Die schönen Lebensmittel alle fort!
     </p>
-    <p xml:id="eco_de_0000141_6600">
+    <p xml:id="eco_de_0000211_6600">
      Die Kinder waren sprachlos. Wer konnte das getan haben! Rudolf und Sylvia standen auch dabei; man ass bei ihnen wie bei Turnachs erst um ein Uhr. Alle sahen sich gegenseitig an; aber jedes schaute dem andern fest ins Gesicht, weil es ein gutes Gewissen hatte.
     </p>
-    <p xml:id="eco_de_0000141_6610">
+    <p xml:id="eco_de_0000211_6610">
      »Ist's am Ende der Schnauzel –?« meinte Marianne. »Letzthin hat er der Balbine ein Stück Fleisch gestohlen –«
     </p>
-    <p xml:id="eco_de_0000141_6620">
+    <p xml:id="eco_de_0000211_6620">
      Die Kinder liefen in den Hof, wo der Schnauzel unter dem Vordach lag, jetzt aber schleunigst hinter den Brunnen schlüpfte; denn er meinte, man wolle ihn wieder als Wildschwein auf die Burg schleppen.
     </p>
-    <p xml:id="eco_de_0000141_6630">
+    <p xml:id="eco_de_0000211_6630">
      »Halt, mein Freund!« rief Hans und zog ihn hervor. »Bist du über unsere Sachen gekommen? Du –!« Er schüttelte ihn drohend.
     </p>
-    <p xml:id="eco_de_0000141_6640">
+    <p xml:id="eco_de_0000211_6640">
      Schnauzel wedelte mit dem kurzen Schwanz und gab Hans die Pfote, um zu sagen, dass er diesmal wirklich unschuldig sei.
     </p>
-    <p xml:id="eco_de_0000141_6650">
+    <p xml:id="eco_de_0000211_6650">
      »Nein«, rief Lotti. »Er hat's nicht getan. Langbirnen und Süssholzsaft frisst er nicht!«
     </p>
-    <p xml:id="eco_de_0000141_6660">
+    <p xml:id="eco_de_0000211_6660">
      Der kluge Schnauzel sprang dankbar an ihr auf.
     </p>
-    <p xml:id="eco_de_0000141_6670">
+    <p xml:id="eco_de_0000211_6670">
      Wer aber war der Dieb –?
     </p>
-    <p xml:id="eco_de_0000141_6680">
+    <p xml:id="eco_de_0000211_6680">
      »Hans«, sagte Rudolf Lorez. »Es wäre zu arg; aber es könnte sein, dass der Theodor uns die Sachen gestohlen hat!«
     </p>
-    <p xml:id="eco_de_0000141_6690">
+    <p xml:id="eco_de_0000211_6690">
      »O! Der –!« riefen die andern entrüstet.
     </p>
-    <p xml:id="eco_de_0000141_6700">
+    <p xml:id="eco_de_0000211_6700">
      »Wir werden es bald herauskriegen. Ich weiss, wo er wohnt.« Rudolf lief hinaus, und die andern folgten ihm über den Kornplatz in die Schwalbengasse und dann um die Ecke in das Wintergässchen. Es ging durch einen engen Hausgang vier steile Treppen hinauf. Schneller als die Kinder gedacht hatten, fanden sie den Gesuchten. Er stand mit der Mütze und der Schultasche oben. Als die Schar heranstürmte, erschrak er sichtlich und drückte sich in die Ecke.
     </p>
-    <p xml:id="eco_de_0000141_6710">
+    <p xml:id="eco_de_0000211_6710">
      »Aha! da bist du! Komm mit uns hinüber! wir wollen dir etwas zeigen! Ja – und dich etwas fragen! Komm nur –«
     </p>
-    <p xml:id="eco_de_0000141_6720">
+    <p xml:id="eco_de_0000211_6720">
      Damit zogen Hans und Rudolf den Buben die Treppe hinunter. Er leistete übrigens jetzt, da es Ernst galt, lange nicht so viel Widerstand als sonst im Spiele auf seinen Fluchtversuchen.
     </p>
-    <p xml:id="eco_de_0000141_6730">
+    <p xml:id="eco_de_0000211_6730">
      Man langte bei der Burg an, und Hans hielt Theodor die leere Schachtel vors Gesicht. Theodor drehte den Kopf weg. Aber Rudolf liess ihn nicht los.
     </p>
-    <p xml:id="eco_de_0000141_6740">
+    <p xml:id="eco_de_0000211_6740">
      »Hast du unsern Vorrat gestohlen? Die Wurst und die Schokolade und das andere –? Bekenne!«
     </p>
-    <p xml:id="eco_de_0000141_6750">
+    <p xml:id="eco_de_0000211_6750">
      Theodor gab keine Antwort. In der Verlegenheit griff er nach seinem Taschentuch; dabei fiel eine kurze Schnur mit einem Endchen Haut auf den Boden.
     </p>
-    <p xml:id="eco_de_0000141_6760">
+    <p xml:id="eco_de_0000211_6760">
      »O«, riefen alle und bückten sich darnach. »Das ist von der Wurst! Von unserer Wurst! Jetzt weiss man, dass du es gewesen bist! Wo hast du die Sachen hingetan? Sag!«
     </p>
-    <p xml:id="eco_de_0000141_6770">
+    <p xml:id="eco_de_0000211_6770">
      Theodor drückte die Hand vor die Augen.
     </p>
-    <p xml:id="eco_de_0000141_6780">
+    <p xml:id="eco_de_0000211_6780">
      »Du hast doch nicht etwa alles aufgegessen?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_6790">
+    <p xml:id="eco_de_0000211_6790">
      Theodor nickte und fing an zu weinen.
     </p>
-    <p xml:id="eco_de_0000141_6800">
+    <p xml:id="eco_de_0000211_6800">
      »Alles –?« drangen die Kinder in ihn. »Man kann doch eine Stange Süssholzsaft nicht auf einmal essen!«
     </p>
-    <p xml:id="eco_de_0000141_6810">
+    <p xml:id="eco_de_0000211_6810">
      »Doch«, schluchzte Theodor und versteckte sein Gesicht schnell wieder hinter dem Ellbogen.
     </p>
-    <p xml:id="eco_de_0000141_6820">
+    <p xml:id="eco_de_0000211_6820">
      »Und die ganze Wurst –?« fragte Lotti schmerzlich.
     </p>
-    <p xml:id="eco_de_0000141_6830">
+    <p xml:id="eco_de_0000211_6830">
      »Das ist gemein –!« rief Rudolf. »Dass du's nur weisst, Theodor: du bist ein Dieb!«
     </p>
-    <p xml:id="eco_de_0000141_6840">
+    <p xml:id="eco_de_0000211_6840">
      »Ja, ein Dieb!« wiederholten die andern und sahen ihn böse an.
     </p>
-    <p xml:id="eco_de_0000141_6850">
+    <p xml:id="eco_de_0000211_6850">
      Marianne hatte wohl einen Augenblick Mitleid mit Theodor, wie er gar so jämmerlich dastand. Aber Stehlen war doch etwas sehr Hässliches. Und Theodor hatte ja auch sein Ehrenwort gegeben.
     </p>
-    <p xml:id="eco_de_0000141_6860">
+    <p xml:id="eco_de_0000211_6860">
      In diesem Augenblick kam Mama vom Keller herauf.
     </p>
-    <p xml:id="eco_de_0000141_6870">
+    <p xml:id="eco_de_0000211_6870">
      »Was habt ihr denn?« fragte sie.
     </p>
-    <p xml:id="eco_de_0000141_6880">
+    <p xml:id="eco_de_0000211_6880">
      »Mama, er hat alles genommen, was in der Schachtel war! Das ist doch schlecht! Man hatte ausgemacht, dass keines etwas anrühre. Später hätten wir dann einmal ein Festessen gehalten auf der Burg –«
     </p>
-    <p xml:id="eco_de_0000141_6890">
+    <p xml:id="eco_de_0000211_6890">
      Mama betrachtete den unglückseligen Theodor, dem die Tränen über das Gesicht liefen. Sie hatte von dem neuen Spielkameraden der Kinder gehört und sich vorgenommen, ihn einmal heraufkommen zu lassen.
     </p>
-    <p xml:id="eco_de_0000141_6900">
+    <p xml:id="eco_de_0000211_6900">
      »Führt ihn in die Stube!« sagte sie nach kurzem Besinnen. »Rudolf und Sylvia, ihr müsst wohl jetzt heim.«
     </p>
-    <p xml:id="eco_de_0000141_6910">
+    <p xml:id="eco_de_0000211_6910">
      Droben in der hellen Stube fiel es erst recht auf, wie ärmlich Theodor aussah. Seine Kleidung war für das rauhe Herbstwetter viel zu dünn; die zerrissenen Zeugschuhe schienen durchnässt. Und was für ein blasses, mageres Gesicht hatte Theodor!
     </p>
-    <p xml:id="eco_de_0000141_6920">
+    <p xml:id="eco_de_0000211_6920">
      »Was ist dein Vater?« fragte Frau Turnach den Buben.
     </p>
-    <p xml:id="eco_de_0000141_6930">
+    <p xml:id="eco_de_0000211_6930">
      »Er ist gestorben, schon lang«, antwortete Theodor.
     </p>
-    <p xml:id="eco_de_0000141_6940">
+    <p xml:id="eco_de_0000211_6940">
      »Und die Mutter?«
     </p>
-    <p xml:id="eco_de_0000141_6950">
+    <p xml:id="eco_de_0000211_6950">
      Da fing der kleine Tropf an stärker zu schluchzen und wühlte in der Hosentasche, bis er sein sehr schmutziges Taschentuch erwischte.
     </p>
-    <p xml:id="eco_de_0000141_6960">
+    <p xml:id="eco_de_0000211_6960">
      Frau Turnach musste dreimal fragen; endlich verstand man, dass Theodors Mutter seit sechs Wochen im Krankenhaus liege, und mit vieler Mühe brachte Frau Turnach aus dem kleinen Sünder weiter heraus, dass jetzt niemand für ihn sorge als eine alte Frau, die im gleichen Hause wohne, aber jeden Tag zum Putzen gehe. Am Morgen hatte er oft nichts zum Frühstück, gestern auch nicht –
     </p>
-    <p xml:id="eco_de_0000141_6970">
+    <p xml:id="eco_de_0000211_6970">
      »Und da ist dir die Schachtel mit den Esswaren eingefallen?« fragte Frau Turnach.
     </p>
-    <p xml:id="eco_de_0000141_6980">
+    <p xml:id="eco_de_0000211_6980">
      Theodor schluchzte und warf einen kläglichen Blick auf die drei Kinder. Eine Weile konnte er gar nicht mehr reden; dann erfuhr man, dass er gestern um elf Uhr in den Hausflur geschlichen sei und die Sachen genommen habe. Ulrich sei gekommen; da habe er ihm gesagt, er suche sein Lineal –
     </p>
-    <p xml:id="eco_de_0000141_6990">
+    <p xml:id="eco_de_0000211_6990">
      Frau Turnach schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_7000">
+    <p xml:id="eco_de_0000211_7000">
      »Und das war gar nicht wahr. Siehst du, zum ersten Schlimmen kommt meist schnell das zweite.«
     </p>
-    <p xml:id="eco_de_0000141_7010">
+    <p xml:id="eco_de_0000211_7010">
      Theodor sah zerknirscht zu Boden, gewärtig, was für eine Strafe nun über ihn verhängt werde.
     </p>
-    <p xml:id="eco_de_0000141_7020">
+    <p xml:id="eco_de_0000211_7020">
      »Marianne«, sagte Mama. »Geh in die Küche und lass dir einen Teller Suppe geben.«
     </p>
-    <p xml:id="eco_de_0000141_7030">
+    <p xml:id="eco_de_0000211_7030">
      Marianne sah Mama überrascht an, brachte dann aber rasch einen vollen Teller Erbsensuppe mit Reis.
     </p>
-    <p xml:id="eco_de_0000141_7040">
+    <p xml:id="eco_de_0000211_7040">
      »So«, sagte Mama, während sie ein grosses Stück Brot herunterschnitt. »Nachher reden wir noch weiter miteinander. Iss einmal die Suppe!«
     </p>
-    <p xml:id="eco_de_0000141_7050">
+    <p xml:id="eco_de_0000211_7050">
      Theodor sah mit grossen Augen auf. Was sagte die Frau? Suppe sollte er bekommen, wo er gemeint hatte, es gebe Schläge? So schöne goldgelbe Suppe?
     </p>
-    <p xml:id="eco_de_0000141_7060">
+    <p xml:id="eco_de_0000211_7060">
      Ein Ausdruck grössten Behagens breitete sich über Theodors verweintes Gesicht, als Frau Turnach ihm den Stuhl zurecht rückte und er darauf den Löffel in die Suppe tauchte. Er vergass alle seine Not und versenkte sich ganz in das Essen.
     </p>
-    <p xml:id="eco_de_0000141_7070">
+    <p xml:id="eco_de_0000211_7070">
      Mama winkte den Kindern, dass sie vom Tische wegtreten.
     </p>
-    <p xml:id="eco_de_0000141_7080">
+    <p xml:id="eco_de_0000211_7080">
      »Mama«, fing Hans nach einer Weile flüsternd an. »Du hast aber doch immer gesagt, du findest es sehr unartig, wenn wir heimlich etwas nehmen. Letzthin, als Lotti von dem Eingemachten naschte –«
     </p>
-    <p xml:id="eco_de_0000141_7090">
+    <p xml:id="eco_de_0000211_7090">
      »Ja, da ist sie tüchtig gezankt worden und hat ohne Abendessen zu Bett gehen müssen. Wenn sie wieder so etwas tut, wird sie noch stärker bestraft.«
     </p>
-    <p xml:id="eco_de_0000141_7100">
+    <p xml:id="eco_de_0000211_7100">
      Lotti war es unangenehm, dass Hans mit der Geschichte kam. Sie lief sehr bereitwillig, als Mama sie in die Küche schickte, für Theodor ein Stück Fleisch und Gemüse zu holen.
     </p>
-    <p xml:id="eco_de_0000141_7110">
+    <p xml:id="eco_de_0000211_7110">
      »Aber Mama«, fuhr Hans fort, »was Theodor getan hat, ist doch viel ärger: So ins Haus schleichen und Ulrich anlügen und alles wegstehlen –«
     </p>
-    <p xml:id="eco_de_0000141_7120">
+    <p xml:id="eco_de_0000211_7120">
      »Hans«, antwortete Mama. »Eigentlich meine ich, es wäre nicht nötig, viel über die Sache zu sprechen. Denk selber nach! Dann siehst du hoffentlich ein, warum man den armen kleinen Burschen nicht so strafen kann. Ist das etwa ein Verdienst, wenn ihr nichts nehmt? Jeden Tag könnt ihr euch an den gedeckten Tisch setzen und sattessen. Dieser Theodor aber hat niemand im Hause, der für ihn sorgt. Er hat vielleicht seit ein paar Wochen nicht mehr so recht gehörig gegessen. Da ist die Schachtel für ihn eine grosse Versuchung gewesen. Er wird schon einsehen, dass er nicht recht getan hat. Wir aber wollen ihm verzeihen, nicht wahr?«
     </p>
-    <p xml:id="eco_de_0000141_7130">
+    <p xml:id="eco_de_0000211_7130">
      »Ja, Mama, natürlich!« riefen Marianne und Lotti, und Hans stimmte auch ein; er sah jetzt die Sache auf einmal ganz anders an.
     </p>
-    <p xml:id="eco_de_0000141_7140">
+    <p xml:id="eco_de_0000211_7140">
      Theodor hatte auf das Gespräch nicht acht gegeben. Als er mit seiner Mahlzeit fertig war, stand er auf. Sein Gesicht trübte sich plötzlich. Es fiel ihm wieder ein, dass er ein Dieb sei und jedenfalls doch noch bestraft werden müsse.
     </p>
-    <p xml:id="eco_de_0000141_7150">
+    <p xml:id="eco_de_0000211_7150">
      Scheu sah er von einem zum andern, als Frau Turnach ihn herrief. Aber sie redete ihm freundlich zu, dass er nie mehr etwas nehme, was ihm nicht gehöre, und sagte, sie werde seine Mutter besuchen und auch sorgen, dass er ordentlich zu essen bekomme.
     </p>
-    <p xml:id="eco_de_0000141_7160">
+    <p xml:id="eco_de_0000211_7160">
      Theodor horchte und begriff nach und nach, dass es wirklich keine Strafe gebe. Da tat er einen starken Atemzug wie zu einer Anstrengung.
     </p>
-    <p xml:id="eco_de_0000141_7170">
+    <p xml:id="eco_de_0000211_7170">
      »Ich will's nicht mehr tun!« sagte er laut und sah Frau Turnach ehrlich an.
     </p>
-    <p xml:id="eco_de_0000141_7180">
+    <p xml:id="eco_de_0000211_7180">
      Frau Turnach gab ihm die Hand.
     </p>
-    <p xml:id="eco_de_0000141_7190">
+    <p xml:id="eco_de_0000211_7190">
      »Also, du hast mir's versprochen, Theodor. Und jetzt lauf ins Krankenhaus zu deiner Mutter! Um ein Uhr dürfest du sie sehen, hast du gesagt.«
     </p>
-    <p xml:id="eco_de_0000141_7200">
+    <p xml:id="eco_de_0000211_7200">
      Theodor aber blieb stehen. Er hatte das Bedürfnis, sich mit Hans, Marianne und Lotti auszusöhnen.
     </p>
-    <p xml:id="eco_de_0000141_7210">
+    <p xml:id="eco_de_0000211_7210">
      »Darf ich doch wieder der Gefangene sein?« fragte er zögernd. »Ich mache es dann ohne Brot und Äpfel«, fügte er hinzu.
     </p>
-    <p xml:id="eco_de_0000141_7220">
+    <p xml:id="eco_de_0000211_7220">
      »Ja, darüber wollte ich auch noch ein Wort sagen«, wendete Mama sich zu den Kindern. »Was ist das für eine Art zu spielen! Heute morgen erzählte mir Lotti davon. Warum soll Theodor beständig in dem Loche sitzen? Bei so etwas wechselt man doch ab!«
     </p>
-    <p xml:id="eco_de_0000141_7230">
+    <p xml:id="eco_de_0000211_7230">
      Hans schämte sich sehr. Nun wurde man noch gezankt vor Theodor und musste sich sagen, dass Mama recht hatte.
     </p>
-    <p xml:id="eco_de_0000141_7240">
+    <p xml:id="eco_de_0000211_7240">
      »Mama«, warf Lotti ein. »Er hat's immer gern getan, weil wir ihm den Nahrungskorb hinunterliessen.«
     </p>
-    <p xml:id="eco_de_0000141_7250">
+    <p xml:id="eco_de_0000211_7250">
      »Euer Vesperbrot konntet ihr auch so mit ihm teilen. Gewiss hätte Theodor einmal etwas anderes sein wollen als immer nur Gefangener.«
     </p>
-    <p xml:id="eco_de_0000141_7260">
+    <p xml:id="eco_de_0000211_7260">
      Theodor, der nach und nach zutraulicher wurde, nickte:
     </p>
-    <p xml:id="eco_de_0000141_7270">
+    <p xml:id="eco_de_0000211_7270">
      »Der Rudolf Lorez hat vorgestern gesagt, wir sollten einen Torwächter haben. Ich wüsste ein Horn. Es gehört der Frau Kroller. Sie gibt mir's manchmal, wenn ich ihr Wasser und Holz trage.«
     </p>
-    <p xml:id="eco_de_0000141_7280">
+    <p xml:id="eco_de_0000211_7280">
      »Also«, sagte Hans, froh, dass durch das Horn das Gespräch eine Wendung nahm. »Dann bist du der Torwächter und gibst jedesmal ein Zeichen, wenn jemand zur Burg kommt!«
     </p>
-    <p xml:id="eco_de_0000141_7290">
+    <p xml:id="eco_de_0000211_7290">
      Schon am Nachmittag stellte sich Theodor mit dem Blasinstrument ein. Es war ein altes Posthorn, an dem eine weiss und rote Troddel hing. Wenn man fest hineinblies, gab es gewaltige Töne von sich, die im ganzen Hause widerhallten. Papa und hinter ihm die beiden Herren aus dem Bureau, sowie Ulrich kamen herbei, um zu sehen, was denn los sei.
     </p>
-    <p xml:id="eco_de_0000141_7300">
+    <p xml:id="eco_de_0000211_7300">
      Mama aber besuchte am nächsten Tage Frau Hahn im Krankenhause und wählte unter dem Schuhwerk der Kinder ein paar feste Stiefel aus für Theodor; auch eine warme Bluse von Hans legte sie dazu. Sie sprach mit Frau Kroller, dass diese besser für Theodors Frühstück und Abendessen sorge. Zum Mittagsmahl kam Theodor nun jeden Tag ins Turnachhaus.
     </p>
-    <p xml:id="eco_de_0000141_7310">
+    <p xml:id="eco_de_0000211_7310">
      Das beste für ihn war aber, dass seine Mutter bald gesund wurde und selbst wieder zum Rechten sehen konnte.
     </p>
    </div>
@@ -2315,337 +2315,337 @@
     <head>
      Marianne und Lotti gehen auf die Universität
     </head>
-    <p xml:id="eco_de_0000141_7320">
+    <p xml:id="eco_de_0000211_7320">
      »Heute hab ich's gut«, sagte Marianne und streckte sich nach dem Frühstück behaglich auf ihrem Stuhl. »Ich muss statt um acht Uhr erst um halb zehn in der Schule sein. Fräulein Heller ist verreist; wir haben bloss zwei Stunden mit der andern dritten Klasse.«
     </p>
-    <p xml:id="eco_de_0000141_7330">
+    <p xml:id="eco_de_0000211_7330">
      »Dann gehen wir zusammen«, erklärte Lotti, deren Unterricht um neun Uhr begann.
     </p>
-    <p xml:id="eco_de_0000141_7340">
+    <p xml:id="eco_de_0000211_7340">
      »Und jetzt tut ihr noch mit mir Schule spielen!« rief Werner und klatschte in die Hände.
     </p>
-    <p xml:id="eco_de_0000141_7350">
+    <p xml:id="eco_de_0000211_7350">
      Er liebte dieses Spiel sehr. Sofort schleppte er einen Stuhl in die Mitte des Zimmers und einen Schemel davor. Das war Schulbank und Tisch. Er brachte auch eine alte Schiefertafel und einen langen Stock. Weder Fräulein Heller noch Fräulein Matthias brauchten einen solchen in ihrer Klasse; aber ohne Stock hätten Marianne, Lotti und Werner das Schulspiel lange nicht so nett gefunden.
     </p>
-    <p xml:id="eco_de_0000141_7360">
+    <p xml:id="eco_de_0000211_7360">
      »Zuerst rechnen wir!« sagte Marianne mit strengem Gesicht, indem sie sich vor Werner stellte, der hinter dem Stuhl auf dem Schemel sass und erwartungsvoll mit den Beinen strampelte.
     </p>
-    <p xml:id="eco_de_0000141_7370">
+    <p xml:id="eco_de_0000211_7370">
      »Nicht strampeln!« rief Marianne und gab dem Schüler einen kleinen Klaps, so dass er hellauf lachte, wofür er einen zweiten Klaps bekam.
     </p>
-    <p xml:id="eco_de_0000141_7380">
+    <p xml:id="eco_de_0000211_7380">
      Lotti sass, ebenfalls ernst dreinsehend, als Vorsteherin der Klasse gegenüber. Sie hatte auf den Kopf ein schwarzes Täschchen gebunden, das einen Damenhut vorstellte.
     </p>
-    <p xml:id="eco_de_0000141_7390">
+    <p xml:id="eco_de_0000211_7390">
      »Achtung, Werner Turnach!« begann die Lehrerin. »Wieviel ist vier und vier?«
     </p>
-    <p xml:id="eco_de_0000141_7400">
+    <p xml:id="eco_de_0000211_7400">
      »Drei«, sagte der Kleine, ohne sich zu besinnen.
     </p>
-    <p xml:id="eco_de_0000141_7410">
+    <p xml:id="eco_de_0000211_7410">
      »Falsch!« rief Marianne und bemühte sich, dem dummen Wernerlein zu zeigen, wie man an den Fingern zusammenzähle.
     </p>
-    <p xml:id="eco_de_0000141_7420">
+    <p xml:id="eco_de_0000211_7420">
      »Das ist der Dieter und das der Käpper!« sagte Werner voll Übermut. Die Finger erinnerten ihn an die lustige Geschichte von der Frau Vrene und ihren vier faulen Knechten.
     </p>
-    <p xml:id="eco_de_0000141_7430">
+    <p xml:id="eco_de_0000211_7430">
      Für diese Zerstreutheit erhielt er viele Schläge von der Lehrerin, so dass er aus dem Lachen gar nicht herauskam.
     </p>
-    <p xml:id="eco_de_0000141_7440">
+    <p xml:id="eco_de_0000211_7440">
      »Aber das ist ja ein schrecklich unartiger und ungeschickter Schüler«, sagte die Vorsteherin mit gerunzelter Stirne.
     </p>
-    <p xml:id="eco_de_0000141_7450">
+    <p xml:id="eco_de_0000211_7450">
      Endlich waren die acht Finger in der Höhe.
     </p>
-    <p xml:id="eco_de_0000141_7460">
+    <p xml:id="eco_de_0000211_7460">
      »Also wieviel ist nun vier und vier?«
     </p>
-    <p xml:id="eco_de_0000141_7470">
+    <p xml:id="eco_de_0000211_7470">
      »Fünfundsiebzig«, sagte Werner stolz. Er hatte die Zahl gestern gehört, als er mit Sophie im Butterladen gewesen war.
     </p>
-    <p xml:id="eco_de_0000141_7480">
+    <p xml:id="eco_de_0000211_7480">
      Die Lehrerin und die Vorsteherin schlugen entsetzt die Hände zusammen.
     </p>
-    <p xml:id="eco_de_0000141_7490">
+    <p xml:id="eco_de_0000211_7490">
      »Nein, rechnen kann er gar nicht. Wir wollen es jetzt mit dem Schreiben versuchen.«
     </p>
-    <p xml:id="eco_de_0000141_7500">
+    <p xml:id="eco_de_0000211_7500">
      Nun kritzelte Werner auf seine Tafel ein paar Reihen wilder Zacken und streckte das Geschriebene Marianne hin, dass sie lese. Er war immer sehr gespannt zu hören, was er geschrieben hatte. Die Vorsteherin besichtigte die Tafel ebenfalls und sagte, die Sätze seien nicht so übel. Marianne aber las langsam:
     </p>
-    <p xml:id="eco_de_0000141_7510">
+    <p xml:id="eco_de_0000211_7510">
      »Ich heisse Werner Turnach. Ich bin ein dummer kleiner Bub. Ich kann nicht einmal vier und vier zusammenzählen. Aber ich kann viel essen und tüchtig schreien …«
     </p>
-    <p xml:id="eco_de_0000141_7520">
+    <p xml:id="eco_de_0000211_7520">
      Dann kam eine Turnstunde. Werner sollte im Takte gehen und das Rumpfbeugen üben und auf einem Bein stehen. Es war sehr schwierig. Die Lehrerin musste vorn halten und die Vorsteherin hinten. Aber der Schüler tat so ungebärdig, dass zuletzt alle drei am Boden lagen.
     </p>
-    <p xml:id="eco_de_0000141_7530">
+    <p xml:id="eco_de_0000211_7530">
      Grade als man wieder nach dem Stocke greifen wollte, läutete die Hausglocke. Es waren Karoline Rupprecht und Hedwig Zohner, die Lotti abholten. Den Wernermann aber, der ein Mäulchen machen wollte, rief Mama, um ihm die Schürze, die sie für ihn nähte, anzuprobieren, und voll Eifer, dass doch ja eine Tasche hinkomme, vergass er die unterbrochene Turnstunde.
     </p>
-    <p xml:id="eco_de_0000141_7540">
+    <p xml:id="eco_de_0000211_7540">
      Es war noch nicht halb neun; die vier Mädchen schlenderten über die Brücke die Gassen hinauf und machten einen Umweg durch die Baumstrasse.
     </p>
-    <p xml:id="eco_de_0000141_7550">
+    <p xml:id="eco_de_0000211_7550">
      »Soll ich euch etwas zeigen?« sagte Karoline, als man oben an den Gärten und kleinen Häusern vorbeikam. »Dort vorn wohnt eine Hippenbäckerin; wir können durchs Fenster zusehen.«
     </p>
-    <p xml:id="eco_de_0000141_7560">
+    <p xml:id="eco_de_0000211_7560">
      Karoline ging voraus und machte ein Hoftor auf. Die andern fanden es etwas keck, so einzudringen, besonders da eine Frau im Hofe stand und Wäsche aufhängte.
     </p>
-    <p xml:id="eco_de_0000141_7570">
+    <p xml:id="eco_de_0000211_7570">
      Die Küche der Hippenbäckerin war zu ebener Erde. Ein helles Feuer loderte im Herd, und davor sass eine ältere Frau mit einem grossen schwarzen Schirm über den Augen. Neben ihr stand ein Korb mit den fertigen Hippen. Ein süsser Duft von Zucker und gebrannten Mandeln drang oben durch eine runde Öffnung heraus. Die Kinder drängten sich aneinander, um recht zu sehen.
     </p>
-    <p xml:id="eco_de_0000141_7580">
+    <p xml:id="eco_de_0000211_7580">
      »Rück doch ein wenig, Karoline!« sagte Hedwig Zohner, und weil Karoline nicht hörte, gab sie ihr einen kleinen Puff. Karoline stiess an Lotti, die aber auch nicht nachgab. Da, in diesem Drängen und Stemmen, brach plötzlich mit lautem Klirren eine Scheibe. Hatte Karoline sie eingedrückt oder die feste Kante von Lottis Schultasche oder Hedwigs Lineal? Die vier Mädchen sahen einander erschrocken an. Aber schon kam die Frau mit dem grossen Augenschirm daher gelaufen.
     </p>
-    <p xml:id="eco_de_0000141_7590">
+    <p xml:id="eco_de_0000211_7590">
      »Ich will euch! Was habt ihr da zu tun? Die Scheibe müsst ihr bezahlen. hört ihr's!«
     </p>
-    <p xml:id="eco_de_0000141_7600">
+    <p xml:id="eco_de_0000211_7600">
      »Wir rennen davon!« flüsterte Karoline.
     </p>
-    <p xml:id="eco_de_0000141_7610">
+    <p xml:id="eco_de_0000211_7610">
      »Das ist nicht recht«, sagte Marianne, die am wenigsten schuld war. Lotti fand es auch. Aber die Frau sah sehr zornig aus mit ihrem langen Eisen. So fingen denn die Mädchen doch an wegzulaufen, eins hinter dem andern. Man konnte es ja zu Hause erzählen; dann gab Mama –
     </p>
-    <p xml:id="eco_de_0000141_7620">
+    <p xml:id="eco_de_0000211_7620">
      Aber bevor Marianne ausgedacht hatte, wurden sie angehalten durch die andere Frau im Hofe. Sie hatte das Tor zugeschlagen, so dass keines der Mädchen entweichen konnte.
     </p>
-    <p xml:id="eco_de_0000141_7630">
+    <p xml:id="eco_de_0000211_7630">
      »Was habt ihr dahinten angestellt? Dem Geklirr nach eine Scheibe zerbrochen? Frau Hamberger wird eine Freude haben! Wartet jetzt nur, bis sie kommt. Man rennt nicht bloss so weg!«
     </p>
-    <p xml:id="eco_de_0000141_7640">
+    <p xml:id="eco_de_0000211_7640">
      Und fest hielt sie das Tor zu, trotz den unglücklichen Gesichtern der Kinder. Von hinten aber kam die Hippenbäckerin mit ihrem grossen Augenschirm.
     </p>
-    <p xml:id="eco_de_0000141_7650">
+    <p xml:id="eco_de_0000211_7650">
      »Ihr unverschämten Kinder!« rief sie. »Auf der Stelle zahlt ihr mir die Scheibe! Unter 95 Rappen macht mir der Glaser sie nicht. Hättet ihr wenigstens die linke eingeschlagen, wo schon ein Sprung ist!«
     </p>
-    <p xml:id="eco_de_0000141_7660">
+    <p xml:id="eco_de_0000211_7660">
      Die Kinder waren in der schrecklichsten Verlegenheit.
     </p>
-    <p xml:id="eco_de_0000141_7670">
+    <p xml:id="eco_de_0000211_7670">
      »Wir haben kein Geld«, sagte Marianne, während Lotti in die Tasche fuhr und ausser dem Taschentuch einen Tannzapfen, ein paar Nüsse, ein Knäulchen Bindfaden, einen Permutterknopf und ein zusammengefaltetes blaues Seidenpapier herauszog. Darin waren Geldstücke eingewickelt. Sie streckte sie der Frau hin.
     </p>
-    <p xml:id="eco_de_0000141_7680">
+    <p xml:id="eco_de_0000211_7680">
      »Es sind zwölf Rappen«, sagte sie.
     </p>
-    <p xml:id="eco_de_0000141_7690">
+    <p xml:id="eco_de_0000211_7690">
      »Die kannst du behalten«, erwiderte die Frau. »Ich will nicht mehr und nicht weniger als 95.«
     </p>
-    <p xml:id="eco_de_0000141_7700">
+    <p xml:id="eco_de_0000211_7700">
      »Heute abend kommen wir und bringen Ihnen das Geld«, versprach Marianne.
     </p>
-    <p xml:id="eco_de_0000141_7710">
+    <p xml:id="eco_de_0000211_7710">
      »Das kann wahr sein oder nicht. Wenn man immer glauben wollte, was so Kinder schwatzen!« erwiderte die Frau.
     </p>
-    <p xml:id="eco_de_0000141_7720">
+    <p xml:id="eco_de_0000211_7720">
      Nun wurde Marianne ganz aufgebracht.
     </p>
-    <p xml:id="eco_de_0000141_7730">
+    <p xml:id="eco_de_0000211_7730">
      »Ich lüge nicht!« sagte sie.
     </p>
-    <p xml:id="eco_de_0000141_7740">
+    <p xml:id="eco_de_0000211_7740">
      »Nein, wir lügen nicht«, bestätigte Lotti. »Wenn wir etwas versprechen, so halten wir es. Unsere Mama sagt immer, das müsse man tun, und Hans auch. Wir geben Ihnen unser Ehrenwort –«
     </p>
-    <p xml:id="eco_de_0000141_7750">
+    <p xml:id="eco_de_0000211_7750">
      Aber die Frau schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_7760">
+    <p xml:id="eco_de_0000211_7760">
      »Weisst du was«, sagte sie zu Lotti. »Wenn du so gut laufen kannst wie reden, dann geh heim und hol das Geld. Eins kann mit, und die andern bleiben bei mir, bis ihr wieder kommt.« Damit packte sie aufs Geratewohl mit der einen Hand Karoline, mit der andern Hedwig Zohner. Beide Mädchen fingen an zu weinen. Es war aber auch schlimm.
     </p>
-    <p xml:id="eco_de_0000141_7770">
+    <p xml:id="eco_de_0000211_7770">
      »Wir haben so weit nach Hause«, versuchte Lotti noch einmal einzuwenden. »Und wenn die Neunuhrpause vorbei ist, müssen wir in der Arbeitsstunde sein, sonst straft uns Fräulein Lips –«
     </p>
-    <p xml:id="eco_de_0000141_7780">
+    <p xml:id="eco_de_0000211_7780">
      »Da hat sie recht«, sagte ungerührt die böse Hippenbäckerin. »Verliert also keine Zeit! Bevor ihr wieder da seid, lasse ich die zwei nicht fort.«
     </p>
-    <p xml:id="eco_de_0000141_7790">
+    <p xml:id="eco_de_0000211_7790">
      Sie zog die laut weinenden Kinder mit sich in ihre Küche.
     </p>
-    <p xml:id="eco_de_0000141_7800">
+    <p xml:id="eco_de_0000211_7800">
      »Das ist grässlich!« sagte Lotti, als sie mit Marianne zum Tore hinausging. »Hättest du geglaubt, dass es auf der Welt eine so böse Frau geben könne wie diese!«
     </p>
-    <p xml:id="eco_de_0000141_7810">
+    <p xml:id="eco_de_0000211_7810">
      »Nein«, sagte Marianne. »Es ist wie ein Hexenmärchen. Oder wie in einer Geschichte von Seeräubern. Die nahmen die Leute gefangen, und dann musste man Lösegeld bezahlen.«
     </p>
-    <p xml:id="eco_de_0000141_7820">
+    <p xml:id="eco_de_0000211_7820">
      »Was tun wir jetzt?« überlegte Lotti. »Wenn wir heimgehen, kommen wir viel zu spät, und Fräulein Lips ist so streng –« Lotti sah sich um. Ja, wenn Grossmama noch in der Kronengasse wohnen würde!
     </p>
-    <p xml:id="eco_de_0000141_7830">
+    <p xml:id="eco_de_0000211_7830">
      »Marianne«, rief Lotti. »Mir fällt etwas ein. Wir gehen in die Universität. Das ist ja grad dort um die Ecke. Wir sagen Onkel Alfred, er solle uns die 95 Rappen geben!«
     </p>
-    <p xml:id="eco_de_0000141_7840">
+    <p xml:id="eco_de_0000211_7840">
      »Wenn wir ihn nur gleich finden!« entgegnete Marianne.
     </p>
-    <p xml:id="eco_de_0000141_7850">
+    <p xml:id="eco_de_0000211_7850">
      »O, einmal hat er uns doch sein Schulzimmer gezeigt. Weisst du noch? Er hat gesagt: ›Hier Lotti, habe ich heute morgen auf die Finger bekommen!‹ Das war nur ein Spass von ihm; aber das Zimmer weiss ich gut. Die Treppe hinauf und dann gleich die erste Türe. Wenn es neun Uhr schlägt, kommt er natürlich heraus.«
     </p>
-    <p xml:id="eco_de_0000141_7860">
+    <p xml:id="eco_de_0000211_7860">
      Dass es in der Universität verschiedene Treppen gebe und dass Onkel Alfred nicht wie eine Zweitklässlerin immer im selben Zimmer sitze, konnte Lotti nicht wissen und Marianne ebensowenig.
     </p>
-    <p xml:id="eco_de_0000141_7870">
+    <p xml:id="eco_de_0000211_7870">
      So stiegen denn die beiden vertrauensvoll die breiten Stufen hinauf, die zu dem grossen Universitätsgebäude führten. Zufällig war der Pedell, der sonst ein Auge hatte auf alles, was aus- und einging, nicht in seiner Stube, und die zwei Mädchen konnten ungehindert vorbeihuschen. Es war still und fast feierlich in dem hohen weiten Vorplatz. Zu beiden Seiten sah man schöne steinerne Treppen. Auf welcher aber ging es zu Onkel Alfreds Zimmer? Marianne meinte auf der linken, Lotti auf der rechten.
     </p>
-    <p xml:id="eco_de_0000141_7880">
+    <p xml:id="eco_de_0000211_7880">
      »Es ist am besten, wir warten da«, entschied Marianne. »Gleich ist es neun Uhr; dann kommt Onkel Alfred herab und spaziert unter den Bäumen.«
     </p>
-    <p xml:id="eco_de_0000141_7890">
+    <p xml:id="eco_de_0000211_7890">
      Sie blieben vor einer hohen Glastüre stehen.
     </p>
-    <p xml:id="eco_de_0000141_7900">
+    <p xml:id="eco_de_0000211_7900">
      »Da sind Totengerippe drin«, flüsterten sie geheimnisvoll und sahen sich an, ob dem andern nicht graue.
     </p>
-    <p xml:id="eco_de_0000141_7910">
+    <p xml:id="eco_de_0000211_7910">
      Sie guckten hinein. Der grüne Vorhang war etwas verschoben; man konnte grade vorn auf dem ersten Gestell ein Gürteltier sehen das eine kleine dünne Schnauze aus seinem Panzer herausstreckte. Daneben hing an einem Aste etwas wie ein Affe, aber mit langen gebogenen Klauen. Weiter links ragte ein kühn geschwungener buschiger Schwanz hervor. Wenn man nur hätte entdecken können, zu was für einem Tier der schöne Schwanz gehörte! Marianne und Lotti vergassen einen Augenblick die böse Hippenbäckerin und den Onkel Alfred und streckten sich vor der Türe; es hätte grade gefehlt, dass sie diese Scheibe auch noch eindrückten.
     </p>
-    <p xml:id="eco_de_0000141_7920">
+    <p xml:id="eco_de_0000211_7920">
      Da fuhren sie erschrocken zusammen. Eine laute, schrille Glocke fing an zu klingeln, und fast gleichzeitig mit diesem gellenden Ton wurde es in dem grossen Hause lebendig: Türen öffneten sich, Schritte erschallten, Stimmen erklangen.
     </p>
-    <p xml:id="eco_de_0000141_7930">
+    <p xml:id="eco_de_0000211_7930">
      Marianne wurde es bang. Sie hätte gute Lust gehabt, wegzulaufen. Aber man konnte die zwei doch nicht im Stiche lassen bei der bösen Frau. Da stiess Lotti die Schwester an.
     </p>
-    <p xml:id="eco_de_0000141_7940">
+    <p xml:id="eco_de_0000211_7940">
      »Marianne! jene Treppe ist's! Dort kommen ein paar mit weissen Mützen; die sind aus Onkel Alfreds Klasse –!«
     </p>
-    <p xml:id="eco_de_0000141_7950">
+    <p xml:id="eco_de_0000211_7950">
      Aber wie die beiden Mädchen tapfer die Treppe hinaufstiegen, begegneten ihnen ganze Scharen junger Männer. Die einen der Herren sprangen in grossen Sätzen über die Stufen hinunter. Die andern blieben stehen, sprachen miteinander und schwangen ihre Stöcke. Alle machten sie einen tüchtigen Lärm. Indessen kamen Marianne und Lotti ziemlich unbehelligt hindurch. Einige von den Studenten sahen ihnen verwundert lachend ins Gesicht, zogen Marianne am Zopf oder klopften mit dem Stock auf Lottis Schultasche.
     </p>
-    <p xml:id="eco_de_0000141_7960">
+    <p xml:id="eco_de_0000211_7960">
      Oben standen die Kinder still. Welches war nun die Türe, die Lotti so gut zu kennen meinte? Eine von jenen beiden oder die dort gegenüber? Und immer mehr und mehr Studenten! Auch Lotti entsank jetzt der Mut. Sie fasste Marianne am Kleid.
     </p>
-    <p xml:id="eco_de_0000141_7970">
+    <p xml:id="eco_de_0000211_7970">
      Da kam langsam ein alter Herr daher mit vielen Büchern unter dem Arm. Die Studenten machten ihm grüssend Platz, und er nickte so freundlich, dass Marianne dachte, das sei gewiss ein guter Herr, den dürfe man schon anreden. Eben als sie sich ein Herz fassen wollte, glitten zwei der Bücher unter dem Arm des alten Herrn heraus und fielen zu Boden. Der alte Herr wollte sich bücken.
     </p>
-    <p xml:id="eco_de_0000141_7980">
+    <p xml:id="eco_de_0000211_7980">
      Aber Marianne hatte die Bücher schon aufgehoben und reichte sie dem Herrn.
     </p>
-    <p xml:id="eco_de_0000141_7990">
+    <p xml:id="eco_de_0000211_7990">
      »Ei!« sagte er, indem er die Brille zurechtrückte und die beiden Kinder ansah. »Was wünscht ihr hier?«
     </p>
-    <p xml:id="eco_de_0000141_8000">
+    <p xml:id="eco_de_0000211_8000">
      Das klang sehr höflich.
     </p>
-    <p xml:id="eco_de_0000141_8010">
+    <p xml:id="eco_de_0000211_8010">
      »Wir suchen unsern Onkel, den Onkel Alfred.« In der Aufregung vergass Marianne den vollen Namen des Onkels zu nennen.
     </p>
-    <p xml:id="eco_de_0000141_8020">
+    <p xml:id="eco_de_0000211_8020">
      »Onkel Alfred?« sagte der Herr Professor und sah herum. »Hm – also wir suchen einen Onkel, der Alfred heisst, oder wenn wir den Fall umdrehen, einen Alfred, der zugleich Onkel ist –«
     </p>
-    <p xml:id="eco_de_0000141_8030">
+    <p xml:id="eco_de_0000211_8030">
      Lotti sah erwartungsvoll zu dem alten Herrn auf. Marianne aber bückte sich noch einmal, um ein gelbes Zeichen aufzuheben, das aus einem Buche gefallen war.
     </p>
-    <p xml:id="eco_de_0000141_8040">
+    <p xml:id="eco_de_0000211_8040">
      »O, o!« sagte der Herr Professor bekümmert, indem er das Zeichen nahm und eines der Bücher öffnete. »Fatal! Wartet einen Augenblick –«
     </p>
-    <p xml:id="eco_de_0000141_8050">
+    <p xml:id="eco_de_0000211_8050">
      Er legte die Bücher auf das Fenstersims und fing an zu blättern und zu blättern.
     </p>
-    <p xml:id="eco_de_0000141_8060">
+    <p xml:id="eco_de_0000211_8060">
      Da räusperte Lotti sich. Es war schrecklich, so zu warten. Gewiss kam man zu spät in die Schule!
     </p>
-    <p xml:id="eco_de_0000141_8070">
+    <p xml:id="eco_de_0000211_8070">
      Der Herr Professor sah sich um und fuhr über die Stirne.
     </p>
-    <p xml:id="eco_de_0000141_8080">
+    <p xml:id="eco_de_0000211_8080">
      »Aha«, sagte er und wendete sich zu zwei vorbeigehenden Studenten. »Meine Herren, möchten Sie nicht die Güte haben, sich dieser Sache anzunehmen? Die Kinder suchen – wen sucht ihr –?«
     </p>
-    <p xml:id="eco_de_0000141_8090">
+    <p xml:id="eco_de_0000211_8090">
      »Unsern Onkel, den Onkel Alfred«, erklärte Lotti, sich an die Studenten wendend. »Wir brauchen Geld.«
     </p>
-    <p xml:id="eco_de_0000141_8100">
+    <p xml:id="eco_de_0000211_8100">
      »So! wir auch!« lachten die jungen Herren, zu denen sich noch ein paar andere gesellten. Keiner wusste etwas von einem Onkel Alfred. Aber alle fingen sie an mit absichtlich ganz hohen Kinderstimmen durch den langen Korridor zu rufen:
     </p>
-    <p xml:id="eco_de_0000141_8110">
+    <p xml:id="eco_de_0000211_8110">
      »Onkel Alfred!«
     </p>
-    <p xml:id="eco_de_0000141_8120">
+    <p xml:id="eco_de_0000211_8120">
      Und von allen Seiten tönte es jetzt:
     </p>
-    <p xml:id="eco_de_0000141_8130">
+    <p xml:id="eco_de_0000211_8130">
      »Onkel Alfred! Onkel Alfred!«
     </p>
-    <p xml:id="eco_de_0000141_8140">
+    <p xml:id="eco_de_0000211_8140">
      Jedem, der es hörte, machte es Vergnügen, mitzurufen, ohne zu wissen warum. Die beiden Studenten hatten die Kinder an die Hand genommen und schritten an den Türen vorbei und um die Ecke, wo ein neuer Korridor begann.
     </p>
-    <p xml:id="eco_de_0000141_8150">
+    <p xml:id="eco_de_0000211_8150">
      »Onkel Alfred!« krähten die übermütigen jungen Herren. »Wo bist du –?«
     </p>
-    <p xml:id="eco_de_0000141_8160">
+    <p xml:id="eco_de_0000211_8160">
      Einige taten, als ob sie weinten:
     </p>
-    <p xml:id="eco_de_0000141_8170">
+    <p xml:id="eco_de_0000211_8170">
      »Onkel Alfred! wir brauchen Geld!«
     </p>
-    <p xml:id="eco_de_0000141_8180">
+    <p xml:id="eco_de_0000211_8180">
      Marianne schämte sich so, dass sie gar nicht mehr aufzusehen wagte. Und Lotti, die sonst Freude hatte, wenn die Dinge recht drunter und drüber gingen, fand das nun doch zu arg. So hatte sie sich Onkel Alfreds Schulhaus nicht vorgestellt.
     </p>
-    <p xml:id="eco_de_0000141_8190">
+    <p xml:id="eco_de_0000211_8190">
      Auf einmal erblickte sie unter einer offenen Türe Onkel Alfred, wirklich Onkel Alfred! Sie machte sich los:
     </p>
-    <p xml:id="eco_de_0000141_8200">
+    <p xml:id="eco_de_0000211_8200">
      »Onkel, Onkel!« schrie sie und rannte auf ihn zu.
     </p>
-    <p xml:id="eco_de_0000141_8210">
+    <p xml:id="eco_de_0000211_8210">
      Onkel Alfred erkannte sie.
     </p>
-    <p xml:id="eco_de_0000141_8220">
+    <p xml:id="eco_de_0000211_8220">
      »Lotti – Marianne – nein, das ist zu toll! Wir haben doch keine Kinderbewahranstalt hier oben –« Er machte ein unwilliges Gesicht.
     </p>
-    <p xml:id="eco_de_0000141_8230">
+    <p xml:id="eco_de_0000211_8230">
      Aber Lotti fasste den glücklich entdeckten Onkel an der Hand.
     </p>
-    <p xml:id="eco_de_0000141_8240">
+    <p xml:id="eco_de_0000211_8240">
      »Onkel«, bat sie. »Wir brauchen 95 Rappen! Es eilt schrecklich. Karoline und Hedwig warten schon lang; sie lässt sie nicht los –«
     </p>
-    <p xml:id="eco_de_0000141_8250">
+    <p xml:id="eco_de_0000211_8250">
      »Wer, wen, was, warum –?« fragte der Onkel, schon wieder halb belustigt. »Bevor ich mein gutes Geld hergebe, muss ich wissen, wofür!«
     </p>
-    <p xml:id="eco_de_0000141_8260">
+    <p xml:id="eco_de_0000211_8260">
      »Also Onkel, wir haben bloss wollen zusehen, wie sie Hippen macht. Weisst du, sie hat so einen Schirm vorn am Kopf, und auf einmal ist die Scheibe zerbrochen –« erzählte Lotti und zog den Onkel zur Treppe.
     </p>
-    <p xml:id="eco_de_0000141_8270">
+    <p xml:id="eco_de_0000211_8270">
      Onkel Alfred folgte rasch, um aus dem Bereich der lachenden Herren zu kommen. Marianne trabte nebenher und ergänzte Lottis Bericht.
     </p>
-    <p xml:id="eco_de_0000141_8280">
+    <p xml:id="eco_de_0000211_8280">
      »Das ist allerdings schauderhaft«, sagte der Onkel. »Wenn wir die zwei nur noch lebend finden. Ich soll also wieder so eine Art Drachentöter sein, Marianne? Wollen wir die Hippenbäckerin aufspiessen?« Er machte mit seinem Stocke eine Bewegung.
     </p>
-    <p xml:id="eco_de_0000141_8290">
+    <p xml:id="eco_de_0000211_8290">
      Marianne lachte.
     </p>
-    <p xml:id="eco_de_0000141_8300">
+    <p xml:id="eco_de_0000211_8300">
      »Nein, aber du musst ihr sagen, dass ich nicht lüge!«
     </p>
-    <p xml:id="eco_de_0000141_8310">
+    <p xml:id="eco_de_0000211_8310">
      Schon waren sie bei dem Hause angelangt. Die Hippenbäckerin machte ein sehr überraschtes Gesicht, als sie die beiden Mädchen in Begleitung des jungen Herrn erblickte. Karoline stand trotzig in der einen Ecke der Küche, Hedwig weinend in der andern.
     </p>
-    <p xml:id="eco_de_0000141_8320">
+    <p xml:id="eco_de_0000211_8320">
      »Ach, Sie kommen vielleicht wegen der Scheibe?« sagte die Hippenbäckerin mit freundlichster Stimme. »Ja, so Kinder – unversehens schlagen sie etwas zusammen. Ich sass vor meinem Feuer und dachte an nichts. Auf einmal –«
     </p>
-    <p xml:id="eco_de_0000141_8330">
+    <p xml:id="eco_de_0000211_8330">
      »Hier«, unterbrach sie Onkel Alfred, indem er Geld aus seinem Beutel nahm. »Aber etwas scharf haben Sie's gemacht! Eigentlich könnten wir Sie verklagen wegen Freiheitsentziehung, nach Paragraph so und so des Gesetzbuches. Jawohl.« Onkel Alfred verbiss das Lachen; aber wie er so aufrecht dastand mit dem Stöckchen, sah er doch aus, als ob er auch einmal ernst machen könnte.
     </p>
-    <p xml:id="eco_de_0000141_8340">
+    <p xml:id="eco_de_0000211_8340">
      »So, jetzt kann sie sich fürchten!« dachte Lotti und stellte sich neben den Onkel.
     </p>
-    <p xml:id="eco_de_0000141_8350">
+    <p xml:id="eco_de_0000211_8350">
      »Und meine Nichte haben Sie schwer in ihrer Ehre gekränkt –« Onkel Alfred gab sich Mühe, ein strenges Gesicht zu machen. »Bereuen Sie! sonst – sonst lasse ich Ihnen von diesen Kindern und ihren Kameraden eine Katzenmusik bringen.«
     </p>
-    <p xml:id="eco_de_0000141_8360">
+    <p xml:id="eco_de_0000211_8360">
      »Ja, Onkel! Gelt mit Pfanndeckeln und Ratschen«, rief Lotti. »Ein Posthorn hätten wir auch!«
     </p>
-    <p xml:id="eco_de_0000141_8370">
+    <p xml:id="eco_de_0000211_8370">
      Die Frau rieb verlegen die Hände. Sie wurde nicht recht klug aus dem jungen Herrn.
     </p>
-    <p xml:id="eco_de_0000141_8380">
+    <p xml:id="eco_de_0000211_8380">
      »Ich zweifle keinen Augenblick an deinem guten Willen, Lotti«, lachte der Onkel. »Jetzt aber macht, dass ihr in euere Schule kommt! Sagt der Lehrerin einen schönen Gruss von Onkel Alfred und sie solle heut eine Ausnahme machen. Straft sie euch jedoch, so ertragt's als Philosophen. Da –«
     </p>
-    <p xml:id="eco_de_0000141_8390">
+    <p xml:id="eco_de_0000211_8390">
      Er nahm aus dem Korbe für jedes der Mädchen eine Handvoll Hippen und griff noch einmal in die Tasche.
     </p>
-    <p xml:id="eco_de_0000141_8400">
+    <p xml:id="eco_de_0000211_8400">
      Die vier machten sich davon; aber als sie ins Schulhaus kamen, hatte der Unterricht in allen Klassen, die von Marianne ausgenommen, längst begonnen. Fräulein Lips empfing die drei Verspäteten sehr ungehalten.
     </p>
-    <p xml:id="eco_de_0000141_8410">
+    <p xml:id="eco_de_0000211_8410">
      »Und auch noch mit Hippen in den Händen! Schickt sich das –? Ihr werdet um elf Uhr da bleiben! Nehmt sofort euer Strickzeug und seid fleissig und mäuschenstill!«
     </p>
-    <p xml:id="eco_de_0000141_8420">
+    <p xml:id="eco_de_0000211_8420">
      Das hielt aber Lotti nicht aus. Sie streckte und streckte die Hand, bis Fräulein Lips ein Einsehen hatte und Lotti die ganze merkwürdige Geschichte erzählen liess. Die Klasse hörte mit Verwunderung und Vergnügen zu, und als Lotti zum Schlusse den Gruss von Onkel Alfred ausrichtete, da machte Fräulein Lips wirklich eine Ausnahme: Sie lachte und erliess den drei kleinen Abenteurerinnen die Strafe.
     </p>
    </div>
@@ -2653,373 +2653,373 @@
     <head>
      Eine Dachpartie
     </head>
-    <p xml:id="eco_de_0000141_8430">
+    <p xml:id="eco_de_0000211_8430">
      »Hier im Winterhaus ist es gerade umgekehrt als in der Seeweid«, sagte Marianne, als sie mit Hans und Lotti die Treppen hinauf zur Zinne stieg. »Dort geht alles in die Breite und hier in die Höhe.«
     </p>
-    <p xml:id="eco_de_0000141_8440">
+    <p xml:id="eco_de_0000211_8440">
      Das Haus am Kornplatz war sehr schmal; aber eingeengt fühlten sich die Kinder doch nicht. Sie waren in jedem der fünf Stockwerke heimisch und trieben ihr Wesen droben auf dem Dachboden so gut wie unten bei den Baumwollballen. Über der vierten Treppe waren die Kammern. Ein kleiner dunkler Seitengang führte zum Holz- und Torfverschlag, und diese Ecke hiess unter den Kindern »Beim Werwolf«. Schon als Grosspapa Turnach ein Knabe gewesen war, hatte der Winkel den Namen getragen, und er und seine Geschwister hatten sich, so lange sie klein waren, vor dem Ungeheuer gefürchtet, von dem man sagte, es sehe halb wie ein Wolf aus, halb wie ein Mensch. Diese Spukgeschichte blieb an dem Winkel hängen, man wusste nicht wie. Hans und Marianne glaubten zwar nicht mehr an den Werwolf, auch Lotti nicht.
     </p>
-    <p xml:id="eco_de_0000141_8450">
+    <p xml:id="eco_de_0000211_8450">
      »In Häusern wohnen keine Wölfe«, erklärte sie weise dem kleinen Werner, der sich nie allein auf den obern Boden wagte. »Und Werwölfe gibt es überhaupt nicht.«
     </p>
-    <p xml:id="eco_de_0000141_8460">
+    <p xml:id="eco_de_0000211_8460">
      Aber es war doch ein angenehm gruseliges Spiel, an dem sogar Hans noch teilnahm, auf den Zehen in die Nähe des Wolfswinkels zu schleichen und auf einmal zu schreien:
     </p>
-    <p xml:id="eco_de_0000141_8470">
+    <p xml:id="eco_de_0000211_8470">
      »Er kommt, er kommt!« worauf man dann die Treppe hinunter schoss, als ob einem das Ungetüm schon im Rücken wäre.
     </p>
-    <p xml:id="eco_de_0000141_8480">
+    <p xml:id="eco_de_0000211_8480">
      Auf demselben Boden gab es noch etwas. Da war die Apfelkammer; auf breiten Laden in Stroh gebettet lagen die Winteräpfel schön gesondert, die sossen und die sauren, die grossen gelben Reinetten, die dunkelroten Stromer, die bräunlichen Lederäpfel, daneben die kleinen Kugelbirnen und in Säcken die Nüsse und die getrockneten Zwetschgen. Das Vornehmste aber in der Kammer war die Weinlaube. Sie bestand aus zwei langen weiss und blau geringelten Fahnenstangen, die quer von einer Wand zur andern gingen. Hier hingen an Bindfaden befestigt die Trauben. Prächtig goldene lockere Markgräfler Trauben, die Mama jedes Jahr geschickt bekam und die bis gegen Weihnacht sich hielten. Es war nun zwar nicht erlaubt, da Trauben zu pflücken wie in einem Weinberg. Aber am Boden fanden sich immer Beeren, und wenn man zufällig an eine Stange stiess, so fielen noch ein paar mehr herunter. Die Beeren schmeckten zuckersüss.
     </p>
-    <p xml:id="eco_de_0000141_8490">
+    <p xml:id="eco_de_0000211_8490">
      Heute gingen die Kinder an der Apfelkammer und dem Werwolf vorbei und erklommen vom Dachboden aus die letzten Stufen des Hauses, die zur Zinne führten. Schnell noch vor dem Mittagessen hatten sie da hinauf müssen. Am Morgen war nämlich der erste Schnee gefallen.
     </p>
-    <p xml:id="eco_de_0000141_8500">
+    <p xml:id="eco_de_0000211_8500">
      »Es schneit!« hatte Mama gerufen, und die Kinder waren schnell aus den Betten ans Fenster gesprungen.
     </p>
-    <p xml:id="eco_de_0000141_8510">
+    <p xml:id="eco_de_0000211_8510">
      Da wirbelten und tanzten die Flocken; alles war weiss bedeckt, der Kornplatz, die Flussmauer und die Wagen, die vorbeifahren.
     </p>
-    <p xml:id="eco_de_0000141_8520">
+    <p xml:id="eco_de_0000211_8520">
      »O, Mama!« jauchzten die Kinder. »Wie lustig! wie schön! Nun kommt bald Weihnacht, Mama! Und heut nachmittag nehmen wir den Schlitten heraus –«
     </p>
-    <p xml:id="eco_de_0000141_8530">
+    <p xml:id="eco_de_0000211_8530">
      In der Schule konnte man fast nicht aufmerken, sogar Marianne nicht, die doch sonst sehr fleissig war. Sie hielt die Hand auf und schaute hinaus in das fröhliche Schneien, und als Fräulein Heller sie rief, wusste sie nicht einmal mehr, was gefragt war. Die andern Mädchen waren ebenso zerstreut, bis Fräulein Heller sagte:
     </p>
-    <p xml:id="eco_de_0000141_8540">
+    <p xml:id="eco_de_0000211_8540">
      »Jetzt geht alle zum Fenster und seht euch fünf Minuten den Schnee recht an! Vielleicht bringen wir dann nachher unsere Sätze vernünftig zu Ende.«
     </p>
-    <p xml:id="eco_de_0000141_8550">
+    <p xml:id="eco_de_0000211_8550">
      Doch in der zweiten Stunde hörte es zu schneien auf, und beim Heimgehen war aller Schnee weggeschmolzen.
     </p>
-    <p xml:id="eco_de_0000141_8560">
+    <p xml:id="eco_de_0000211_8560">
      »Er kommt schon wieder, der Schnee, noch früh genug«, tröstete Ulrich.
     </p>
-    <p xml:id="eco_de_0000141_8570">
+    <p xml:id="eco_de_0000211_8570">
      Aber Lotti hatte einen grossen Jammer. Da war dem Hans eingefallen, dass droben auf dem Hause der Schnee jedenfalls noch liege. Und richtig, wie die Kinder auf die Zinne hinaustraten, war sie mit einer blendend weissen Schneeschicht bedeckt. Die Kinder traten behutsam auf und betrachteten die Fussspuren. Dann guckten sie sich um; überall sah man beschneite Dächer. Die Mittagssonne schien hell. Aus der Lucke eines Nachbarhauses stieg eine Katze und spazierte, als ob das nichts wäre, über die steilen Dächer weg, hart an die Kante; sie sah zu den Kindern hinüber und gähnte.
     </p>
-    <p xml:id="eco_de_0000141_8580">
+    <p xml:id="eco_de_0000211_8580">
      »Du«, rief Marianne, »gib du acht auf deinen Weg!«
     </p>
-    <p xml:id="eco_de_0000141_8590">
+    <p xml:id="eco_de_0000211_8590">
      »Katzen fallen fast nie, hat Ulrich gesagt, und wenn sie fallen, so tut es ihnen nicht weh«, erwiderte Hans.
     </p>
-    <p xml:id="eco_de_0000141_8600">
+    <p xml:id="eco_de_0000211_8600">
      »Das ist bequem«, meinte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_8610">
+    <p xml:id="eco_de_0000211_8610">
      »Eigentlich könnten wir auch einmal probieren über die Dächer zu steigen. Dort hinüber –« Hans zeigte nach der grossen Zinne des Gasthofs zum Goldenen Degen.
     </p>
-    <p xml:id="eco_de_0000141_8620">
+    <p xml:id="eco_de_0000211_8620">
      Diese war durch mehrere andere Zinnen und durch ein breites Dach vom Turnachhause getrennt.
     </p>
-    <p xml:id="eco_de_0000141_8630">
+    <p xml:id="eco_de_0000211_8630">
      »Du meinst doch nicht, dass wir da hinüber könnten?« fragten Marianne und Lotti ungläubig, aber gelockt durch den Gedanken.
     </p>
-    <p xml:id="eco_de_0000141_8640">
+    <p xml:id="eco_de_0000211_8640">
      »Doch. Man muss es nur recht anstellen. Ich wollte auch schon lange einmal auf das graue Türmchen.«
     </p>
-    <p xml:id="eco_de_0000141_8650">
+    <p xml:id="eco_de_0000211_8650">
      Das »graue Türmchen« ragte über dem Dache des drittnächsten Hauses auf. Es war ein aus Steinen gemauertes Bauwerklein. Fünf oder sechs hohe schmale Stufen führten von aussen zur Plattform des Türmchens, auf der zur Not Platz war für drei Personen. Zu den Stufen konnte man nur über das Dach gelangen. Im Hause selbst wohnten ältere Leute, die nie auch nur auf dem Dachboden, geschweige denn auf das Türmchen kamen. Man hatte überhaupt noch nie gehört, dass jemand da oben gewesen sei.
     </p>
-    <p xml:id="eco_de_0000141_8660">
+    <p xml:id="eco_de_0000211_8660">
      Um so ruhmvoller schien es Hans, das graue Türmchen einmal zu besteigen. Er setzte sich rittlings auf das Geländer, das die Zinne von der benachbarten trennte und sah prüfend hinüber.
     </p>
-    <p xml:id="eco_de_0000141_8670">
+    <p xml:id="eco_de_0000211_8670">
      »Es wird fein! Es wird wie eine Bergtour! Wir brauchen ein Seil, um das Dach vom Goldenen Degen zu queren –«
     </p>
-    <p xml:id="eco_de_0000141_8680">
+    <p xml:id="eco_de_0000211_8680">
      »Queren?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_8690">
+    <p xml:id="eco_de_0000211_8690">
      »So sagen die Bergsteiger, wenn sie über einen Gletscher gehen. Wir müssen uns mit allem Nötigen ausrüsten. Mein Fernrohr nehme ich auch mit –«
     </p>
-    <p xml:id="eco_de_0000141_8700">
+    <p xml:id="eco_de_0000211_8700">
      Gleich nach Tisch begann die Vorbereitung zu der Berg- oder vielmehr Dachpartie, von der Papa und Mama vorläufig nichts vernahmen, weil Grossmama sie zum Essen eingeladen hatte.
     </p>
-    <p xml:id="eco_de_0000141_8710">
+    <p xml:id="eco_de_0000211_8710">
      Hans suchte bei Ulrich ein starkes langes Seil, das er aufwand und über die Schulter legte. Marianne beschaffte eine Stange mit Flagge, die auf das Türmchen gepflanzt werden sollte zum Zeichen, dass es bestiegen worden war.
     </p>
-    <p xml:id="eco_de_0000141_8720">
+    <p xml:id="eco_de_0000211_8720">
      »Lotti, du darfst die Feldflasche umhängen. Wir brauchen etwas Stärkung –«
     </p>
-    <p xml:id="eco_de_0000141_8730">
+    <p xml:id="eco_de_0000211_8730">
      Lotti hüpfte von einem Fuss auf den andern vor Vergnügen, als Hans eine grosse in Leder genähte Feldflasche brachte, die früher Papa gehört hatte. Sie ging mit der Flasche in die Küche.
     </p>
-    <p xml:id="eco_de_0000141_8740">
+    <p xml:id="eco_de_0000211_8740">
      »Balbine, wir sollten schwarzen Kaffee haben.«
     </p>
-    <p xml:id="eco_de_0000141_8750">
+    <p xml:id="eco_de_0000211_8750">
      »Du liebe Güte! Wo doch Mama nicht will, dass ihr Kaffee trinkt!«
     </p>
-    <p xml:id="eco_de_0000141_8760">
+    <p xml:id="eco_de_0000211_8760">
      »Nur ein wenig! Wir machen eine Bergtour.«
     </p>
-    <p xml:id="eco_de_0000141_8770">
+    <p xml:id="eco_de_0000211_8770">
      »So. Wohl hier im Hause?« brummte Balbine, tat dann aber doch etwas verdünnten Kaffee und gestossenen Zucker in die Flasche.
     </p>
-    <p xml:id="eco_de_0000141_8780">
+    <p xml:id="eco_de_0000211_8780">
      Lotti stieg, ihre Feldflasche schüttelnd, hinter den andern die Treppen hinauf.
     </p>
-    <p xml:id="eco_de_0000141_8790">
+    <p xml:id="eco_de_0000211_8790">
      Die drei überkletterten das Lattengeländer und kamen auf die Nachbarzinne, deren Blechboden klirrte, als die Kinder rasch weiter schritten zur zweiten Zinne, die Herrn Lorez gehörte; da fühlte man sich schon eher heimisch.
     </p>
-    <p xml:id="eco_de_0000141_8800">
+    <p xml:id="eco_de_0000211_8800">
      »Sylvia, Rudolf!« rief Lotti zum Spass im Vorbeigehen und guckte durch das Dachfenster, hinter dem aufgeschichtete weisse Seifenstücke und eine Menge leerer Medizinflaschen zu sehen waren.
     </p>
-    <p xml:id="eco_de_0000141_8810">
+    <p xml:id="eco_de_0000211_8810">
      Von der Apothekerzinne nun ging es zum Dach hinauf. Etwas Schlimmes konnte nicht begegnen; höchstens rutschte man wieder auf die Zinne zurück. Immerhin war es ein steiler und mühsamer Weg – .
     </p>
-    <p xml:id="eco_de_0000141_8820">
+    <p xml:id="eco_de_0000211_8820">
      »Eben gerade wie in den Bergen!« sagte Hans, der voran ging und den Schwestern die besten Stellen zeigte.
     </p>
-    <p xml:id="eco_de_0000141_8830">
+    <p xml:id="eco_de_0000211_8830">
      Drüben sass die schwarze Katze vom Vormittag wieder und sah aufmerksam her, als ob sie dächte: Jetzt will ich doch sehen, wie die Turnachkinder das Dach hinaufkommen! So gut wie die Katze konnten sie es nicht; aber sie gelangten doch glücklich zu den Stufen, indem sie, wenn es nicht anders ging, auf Händen und Füssen krochen. Die Stufen waren etwas wackelig; ein paar Eisenstäbe dienten als Halt. Das ganze Türmchen war wie in die Luft gebaut. Aber die Turnachkinder kannten keinen Schwindel. Und als sie zusammengedrängt auf der kleinen Plattform standen, fanden sie es prachtvoll.
     </p>
-    <p xml:id="eco_de_0000141_8840">
+    <p xml:id="eco_de_0000211_8840">
      »Juhu!« schrien sie in die helle Luft hinaus.
     </p>
-    <p xml:id="eco_de_0000141_8850">
+    <p xml:id="eco_de_0000211_8850">
      Der Blick war weit und frei nach allen Seiten. Man sah den Kreuzberg, ganz beschneit, und die Höhen des Buchenberges mit seinen vielen Häusern, die in der Sonne lagen. Über dem See wallte ein weisser Dunst. Hans zog sein Fernrohr heraus, das aus der Hälfte eines alten Feldstechers bestand. Ob man wohl die Seeweid sehen konnte –? Hans fuhr dem Ufer entlang; doch schon beim Neugut verlor es sich im Nebel. Lotti wollte auch durchs Fernrohr gucken; zuerst behauptete sie, das Glas sei trüb; dann aber schrie sie plötzlich:
     </p>
-    <p xml:id="eco_de_0000141_8860">
+    <p xml:id="eco_de_0000211_8860">
      »Ich sehe die Seeweid – eine Pappel von der Seeweid – ganz gross –!«
     </p>
-    <p xml:id="eco_de_0000141_8870">
+    <p xml:id="eco_de_0000211_8870">
      Da lachten Hans und Marianne sie tüchtig aus. Denn die Pappel war Hansens Zeigfinger, den er, um Lotti zu necken, vor das Fernrohr gehalten hatte.
     </p>
-    <p xml:id="eco_de_0000141_8880">
+    <p xml:id="eco_de_0000211_8880">
      Hierauf wurde die Flaggenstange auf dem Türmchen befestigt. Marianne hauchte in die Hände.
     </p>
-    <p xml:id="eco_de_0000141_8890">
+    <p xml:id="eco_de_0000211_8890">
      »Ja, auf den Höhen ist es immer kalt«, sagte Hans.
     </p>
-    <p xml:id="eco_de_0000141_8900">
+    <p xml:id="eco_de_0000211_8900">
      »Also wollen wir uns jetzt stärken«, schlug Lotti vor und griff zur Feldflasche.
     </p>
-    <p xml:id="eco_de_0000141_8910">
+    <p xml:id="eco_de_0000211_8910">
      Der süsse Kaffee mundete sehr gut und machte die Runde, bis die Flasche leer war.
     </p>
-    <p xml:id="eco_de_0000141_8920">
+    <p xml:id="eco_de_0000211_8920">
      Dann trat man den Abstieg an. Ohne Unfall gelangte man wieder zur Apothekerzinne. Von da aus sollte nun der wichtigste Teil der Partie beginnen, die Querung des breiten Daches vom Goldenen Degen. Hans knüpfte das Ende seines Seiles drei-, viermal fest um das Gitter und trat dann hinaus, das Seil auf der Schulter. Der Weg war gerade so, dass ein gewandter Bub wie Hans ihn ohne Gefahr machen konnte. Die Schwestern sahen ihm nach. Er glitt nicht ein einziges Mal aus.
     </p>
-    <p xml:id="eco_de_0000141_8930">
+    <p xml:id="eco_de_0000211_8930">
      »Bravo!« riefen sie. Hans sah stolz zufrieden zurück. Dann zog er das Seil an und band es am Geländer fest.
     </p>
-    <p xml:id="eco_de_0000141_8940">
+    <p xml:id="eco_de_0000211_8940">
      »So, jetzt habt ihr einen sichern Übergang.«
     </p>
-    <p xml:id="eco_de_0000141_8950">
+    <p xml:id="eco_de_0000211_8950">
      Marianne meinte zuerst, es wäre verdienstlicher, wie Hans ohne Halt hinüberzugehen. Aber Hans, der bei allem Wagemut doch vorsichtig war, wollte nichts davon wissen.
     </p>
-    <p xml:id="eco_de_0000141_8960">
+    <p xml:id="eco_de_0000211_8960">
      »Nächstes Jahr machst du's dann frei«, sagte er.
     </p>
-    <p xml:id="eco_de_0000141_8970">
+    <p xml:id="eco_de_0000211_8970">
      Lotti natürlich ging so sorglos an die Sache, dass sie mitten auf dem Dach ausrutschte. Es war wirklich gut, dass sie an dem Seil einen festen Halt hatte. So, noch einmal –
     </p>
-    <p xml:id="eco_de_0000141_8980">
+    <p xml:id="eco_de_0000211_8980">
      Da ertönte plötzlich ein lauter Schrei:
     </p>
-    <p xml:id="eco_de_0000141_8990">
+    <p xml:id="eco_de_0000211_8990">
      »Um Gotteswillen – um Gotteswillen –!«
     </p>
-    <p xml:id="eco_de_0000141_9000">
+    <p xml:id="eco_de_0000211_9000">
      Lotti, die wieder aufgestanden war, sah sich um und erblickte drüben am Dachfenster, wo die schwarze Katze gewesen war, eine Frau mit einem violetten, gestrickten Tuch um. Sie hielt die Hände in die Höhe.
     </p>
-    <p xml:id="eco_de_0000141_9010">
+    <p xml:id="eco_de_0000211_9010">
      »Ein Kind auf dem Dach –! Eins von den Turnachkindern auf dem Dach –! Um Gotteswillen –!«
     </p>
-    <p xml:id="eco_de_0000141_9020">
+    <p xml:id="eco_de_0000211_9020">
      Lotti erkannte jetzt die Frau. Sie hatte einen Wolladen in der Märzengasse, gleich um die Ecke vom Kornplatz. Sie hiess Frau Vellacker und war sonst freundlich.
     </p>
-    <p xml:id="eco_de_0000141_9030">
+    <p xml:id="eco_de_0000211_9030">
      »Frau Vellacker«, schrie Lotti hinüber, »ich halte mich ja am Seil!« Mit drei Schritten war sie auf der Zinne vom Goldenen Degen.
     </p>
-    <p xml:id="eco_de_0000141_9040">
+    <p xml:id="eco_de_0000211_9040">
      »Frau Vellacker, es sieht nur so aus! Aber es ist nicht gefährlich!« riefen nun auch Hans und Marianne.
     </p>
-    <p xml:id="eco_de_0000141_9050">
+    <p xml:id="eco_de_0000211_9050">
      Doch Frau Vellacker beruhigte sich nicht.
     </p>
-    <p xml:id="eco_de_0000141_9060">
+    <p xml:id="eco_de_0000211_9060">
      »Nein, Kinder!« jammerte sie und schlug ein über das anderemal die Hände zusammen. »Das kann man nicht mit ansehen! Auf dem hohen steilen Dach! Das Seil hätte reissen können, und dann läge das Kind im Hofe unten – mein Gott!«
     </p>
-    <p xml:id="eco_de_0000141_9070">
+    <p xml:id="eco_de_0000211_9070">
      »Aber es ist ein ganz starkes Seil. Ich habe es vorher probiert!« rief Hans wieder hinüber, und als jetzt Frau Vellacker sich einen Augenblick zurückwandte zu ihrer Magd, die im Dachboden Wäsche abnahm, hielten die Kinder die Sache für erledigt und liefen rasch der ängstlichen Frau Vellacker aus den Augen.
     </p>
-    <p xml:id="eco_de_0000141_9080">
+    <p xml:id="eco_de_0000211_9080">
      Wie gross die Zinne war! Wohl viermal so gross als die eigene. Die Kinder schauten über das schöne eiserne Gitter hinunter. Man sah grade auf die Brücke, wo die Obstfrauen vor ihren Körben sassen. Sie schienen wie aus einer Spielzeugschachtel aufgestellt, so klein. In einer Ecke der Zinne stand ein kleiner runder Pavillon. Die Kinder traten hinein und entdeckten etwas Wundervolles. Lotti schrie laut auf: Das Glas der Fenster war bunt, hier rot, dort gelb und das dritte blau. Durch das rote sah die Stadt mit der Brücke und den Obstfrauen wie in einer Feuersbrunst aus, durch das gelbe, als ob die Sonne nach einem Gewitter hellstrahlend unterginge; durch das blaue aber entstand eine ganz zauberhafte Mondbeleuchtung. Die Kinder konnten nicht fertig werden mit Gucken.
     </p>
-    <p xml:id="eco_de_0000141_9090">
+    <p xml:id="eco_de_0000211_9090">
      »Hans, dass es so schön da oben sei, hast du auch nicht gewusst! Wir machen die Partie noch einmal, und Onkel Alfred muss mitkommen!« sagte Marianne, als man endlich den Rückweg antrat. Sie schwang sich als Erste über das Gitter.
     </p>
-    <p xml:id="eco_de_0000141_9100">
+    <p xml:id="eco_de_0000211_9100">
      An Frau Vellacker dachten die Kinder längst nicht mehr. Aber o weh! da stand sie an ihrem Dachfenster und erhob, als sie der Kinder wieder ansichtig wurde, aufs neue ihr Jammergeschrei.
     </p>
-    <p xml:id="eco_de_0000141_9110">
+    <p xml:id="eco_de_0000211_9110">
      »Was –! Noch einmal –? Seid ihr von Sinnen? Nein, das tut ihr mir nicht!«
     </p>
-    <p xml:id="eco_de_0000141_9120">
+    <p xml:id="eco_de_0000211_9120">
      »Wir müssen doch wieder auf unsere Zinne!« rief Hans.
     </p>
-    <p xml:id="eco_de_0000141_9130">
+    <p xml:id="eco_de_0000211_9130">
      Aber Frau Vellacker war so erregt, dass sich nicht mit ihr reden liess.
     </p>
-    <p xml:id="eco_de_0000141_9140">
+    <p xml:id="eco_de_0000211_9140">
      »Ihr dürft in keinem Fall noch einmal auf das Dach hinaus! Halt! Zurück, sage ich euch! Wenn das euere Mama wüsste und euer Papa –! Regine, Regine!« rief sie hinter sich in den Dachboden.
     </p>
-    <p xml:id="eco_de_0000141_9150">
+    <p xml:id="eco_de_0000211_9150">
      Da und dort in den Nachbarhäusern wurden Fenster geöffnet. Die Leute schauten heraus, zeigten sich die Kinder und riefen einander zu. Dieses Aufsehen war den dreien höchst unangenehm.
     </p>
-    <p xml:id="eco_de_0000141_9160">
+    <p xml:id="eco_de_0000211_9160">
      »Wir müssen warten, bis sie wieder von den Fenstern weg sind«, sagte Hans und trat mit den Schwestern zurück.
     </p>
-    <p xml:id="eco_de_0000141_9170">
+    <p xml:id="eco_de_0000211_9170">
      Doch Frau Vellacker blieb auf ihrem Posten. Da sah Hans sich auf der Zinne um und entdeckte eine Falltüre. Sie liess sich heben. Irgend jemand hatte vielleicht beim Teppichklopfen zu schliessen vergessen.
     </p>
-    <p xml:id="eco_de_0000141_9180">
+    <p xml:id="eco_de_0000211_9180">
      »Kommt!« rief Hans entschlossen. »Wir müssen da hinunter!«
     </p>
-    <p xml:id="eco_de_0000141_9190">
+    <p xml:id="eco_de_0000211_9190">
      »Hans – durch das fremde Haus!« warf Marianne ein. »Mama will nicht, dass wir in fremde Häuser gehen –«
     </p>
-    <p xml:id="eco_de_0000141_9200">
+    <p xml:id="eco_de_0000211_9200">
      »Wenn wir aber nun schon da sind und keinen andern Weg haben –! Hilf doch –«
     </p>
-    <p xml:id="eco_de_0000141_9210">
+    <p xml:id="eco_de_0000211_9210">
      Sie hoben zusammen die Türe und schlüpften hinein. Von dem weiten Bodenraum huschten sie ohne zu sprechen die nächsten zwei Treppen hinunter. Da sah es sehr vornehm aus: Am Boden des grossen Korridors lagen rote Teppiche; die Türen waren weiss bemalt, und in den Ecken standen dunkelgrüne Bäumchen. Auf der folgenden Treppe lag ebenfalls ein Teppich; man ging völlig geräuschlos.
     </p>
-    <p xml:id="eco_de_0000141_9220">
+    <p xml:id="eco_de_0000211_9220">
      »Hans, wenn wir nur hinauskommen, ohne dass man uns sieht«, flüsterte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_9230">
+    <p xml:id="eco_de_0000211_9230">
      In dem Augenblick erschien ein Stubenmädchen mit kleiner weisser Haube.
     </p>
-    <p xml:id="eco_de_0000141_9240">
+    <p xml:id="eco_de_0000211_9240">
      »Was wollt ihr?« fragte sie; aber da klingelte es; sie lief zurück und verschwand in einem Zimmer.
     </p>
-    <p xml:id="eco_de_0000141_9250">
+    <p xml:id="eco_de_0000211_9250">
      Ohne Hindernis gelangten die Turnachkinder wieder ein Stockwerk tiefer; denn die zwei Damen, die ihnen auf der Treppe begegneten, kümmerten sich nicht um sie.
     </p>
-    <p xml:id="eco_de_0000141_9260">
+    <p xml:id="eco_de_0000211_9260">
      »Jetzt sind wir gewiss bald unten«, sagte Lotti, indem sie sich umsah.
     </p>
-    <p xml:id="eco_de_0000141_9270">
+    <p xml:id="eco_de_0000211_9270">
      An den Wänden standen grüngepolsterte Sofas, und in der Mitte war eine hohe Doppeltüre mit Vergoldung. Aber aus dieser prächtigen Doppeltüre trat ein grosser, breitschultriger Herr mit rötlichem Gesicht und weissen Haaren. Die Turnachkinder standen bestürzt still. Es war der Besitzer des Goldenen Degens, Herr Zurbuchen; die Kinder kannten ihn nur vom Sehen.
     </p>
-    <p xml:id="eco_de_0000141_9280">
+    <p xml:id="eco_de_0000211_9280">
      »Oho, oho!« rief Herr Zurbuchen mit lauter Stimme. »Was wollt ihr da? Woher kommt ihr? Von oben, wie mir scheint? Das Haus besichtigt? Wie, meine Herrschaften?« Herr Zurbuchen sprach so rasch nacheinander fort, dass man nicht zu einer Antwort kam, besonders wenn man ein etwas schlechtes Gewissen hatte.
     </p>
-    <p xml:id="eco_de_0000141_9290">
+    <p xml:id="eco_de_0000211_9290">
      »Heh, redet! Wer führt das Wort? Wie kommt ihr zum Portal herein, ohne dass euch ein Mensch sieht?«
     </p>
-    <p xml:id="eco_de_0000141_9300">
+    <p xml:id="eco_de_0000211_9300">
      »Wir sind nicht hineingekommen; wir wollen nur hinaus«, begann endlich Lotti.
     </p>
-    <p xml:id="eco_de_0000141_9310">
+    <p xml:id="eco_de_0000211_9310">
      »Wa – was?« machte Herr Zurbuchen. »Nicht hereingekommen –? Also vom Himmel geschneit –? Heut morgen, natürlich! Sonderbare Schneeflocken!« Herr Zurbuchen setzte sich lachend auf die grüne Polsterbank und zog Hans am Arm her.
     </p>
-    <p xml:id="eco_de_0000141_9320">
+    <p xml:id="eco_de_0000211_9320">
      »Ja, was!« rief er. »Das sind ja die Nachbarsleute von drüben, die Turnachs! Also, wie seid ihr in den Goldenen Degen gekommen? Geflogen?«
     </p>
-    <p xml:id="eco_de_0000141_9330">
+    <p xml:id="eco_de_0000211_9330">
      »Nein, nicht geflogen«, antwortete Lotti. »Es war ziemlich schwer. Aber wir hatten ein Seil. Wir konnten nicht wieder über das Dach zurück wegen Frau Vellacker –«
     </p>
-    <p xml:id="eco_de_0000141_9340">
+    <p xml:id="eco_de_0000211_9340">
      »Lotti, erzähl doch der Reihe nach!« unterbrach Hans die Schwester und fing nun von vorn an mit den Zinnen und dem grauen Türmchen –
     </p>
-    <p xml:id="eco_de_0000141_9350">
+    <p xml:id="eco_de_0000211_9350">
      »Auf dem grauen Türmchen –? Da seid ihr gewesen? Famos, famos! Ihr seid Prachtskerle –! Eine kühne Tour! Und was sagst du, Bürschlein? Es sei noch niemand droben gewesen? Lang ist's allerdings her, so gut 55 Jahre – da stand der Kaspar Zurbuchen an einem Sommerabend auf dem grauen Türmchen mit Pfarrers Arnold und mit Fritz Turnach, euerem Grossonkel. Die beiden sind längst tot, und der Kaspar Zurbuchen steigt auch nicht mehr auf die Dächer; damals war er jung und behend; jetzt ist er alt und lässt andere klettern. – Ja, Kinder, es lebe die Jugend –!« Herr Zurbuchen sah einen Augenblick grade aus wie in die Weite. Dann stand er auf.
     </p>
-    <p xml:id="eco_de_0000141_9360">
+    <p xml:id="eco_de_0000211_9360">
      »Ich lasse euern Papa grüssen. Er habe da eine wackere kleine Schar! Sapperment!« Herr Zurbuchen klopfte den Kindern auf die Achsel und begleitete sie bis vors Haus.
     </p>
-    <p xml:id="eco_de_0000141_9370">
+    <p xml:id="eco_de_0000211_9370">
      »Das ist ein artiger Herr!« rühmten sie. »Und ein gescheiter! Der versteht es besser als Frau Vellacker! Steht sie wohl noch droben –?«
     </p>
-    <p xml:id="eco_de_0000141_9380">
+    <p xml:id="eco_de_0000211_9380">
      Aber vor der Stubentüre hielt Hans plötzlich an.
     </p>
-    <p xml:id="eco_de_0000141_9390">
+    <p xml:id="eco_de_0000211_9390">
      »Marianne, Lotti«, flüsterte er. »Da ist sie! Sie ist drin bei Mama –«
     </p>
-    <p xml:id="eco_de_0000141_9400">
+    <p xml:id="eco_de_0000211_9400">
      Die Türe ging auf, und Frau Vellackers klagende Stimme tönte jetzt deutlich heraus.
     </p>
-    <p xml:id="eco_de_0000141_9410">
+    <p xml:id="eco_de_0000211_9410">
      »Wie gesagt, Frau Turnach, es war fürchterlich, schauderhaft! Mir ist schwarz vor den Augen geworden. Die Kleine ist zweimal ausgerutscht und bei einem Haar –«
     </p>
-    <p xml:id="eco_de_0000141_9420">
+    <p xml:id="eco_de_0000211_9420">
      »Nein, gar nicht bei einem Haar! Ich hab mich am Seil gehalten, Mama!« rief Lotti in die Stube hinein.
     </p>
-    <p xml:id="eco_de_0000141_9430">
+    <p xml:id="eco_de_0000211_9430">
      »Gott! da sind sie ja! Danken Sie dem Himmel, Frau Turnach, dass Sie sie wieder haben. Ich sah sie im Geiste schon mit zerschmetterten Gliedern liegen! So leichtsinnig –«
     </p>
-    <p xml:id="eco_de_0000141_9440">
+    <p xml:id="eco_de_0000211_9440">
      »Mama, es war nicht leichtsinnig«, entgegnete Hans. »Ich habe alles genau –«
     </p>
-    <p xml:id="eco_de_0000141_9450">
+    <p xml:id="eco_de_0000211_9450">
      »Hans, sei ruhig!« verwies ihn Mama. »Man redet nicht drein, wenn grosse Leute sprechen. Frau Vellacker meint es gut mit ihrer Warnung.«
     </p>
-    <p xml:id="eco_de_0000141_9460">
+    <p xml:id="eco_de_0000211_9460">
      »Aber wenn doch –« versuchte Lotti noch einmal.
     </p>
-    <p xml:id="eco_de_0000141_9470">
+    <p xml:id="eco_de_0000211_9470">
      »Lotti!« rief Mama streng.
     </p>
-    <p xml:id="eco_de_0000141_9480">
+    <p xml:id="eco_de_0000211_9480">
      Lotti drückte die Faust an den Mund und machte mit den Augen Zeichen. Das tat sie immer, wenn sie schweigen musste.
     </p>
-    <p xml:id="eco_de_0000141_9490">
+    <p xml:id="eco_de_0000211_9490">
      »Und ob ich's gut meine!« fuhr Frau Vellacker fort. »Die längste Zeit stand ich in der Kälte am Fenster, bis mir der Schneider Moosbach zurief, die Kinder seien durch die Zinnentüre vom Goldenen Degen hinunter –«
     </p>
-    <p xml:id="eco_de_0000141_9500">
+    <p xml:id="eco_de_0000211_9500">
      »Ja, und Herr Zurbuchen war sehr nett«, wollte Lotti hinzufügen; aber man durfte ja nicht reden.
     </p>
-    <p xml:id="eco_de_0000141_9510">
+    <p xml:id="eco_de_0000211_9510">
      »Ich danke Ihnen, Frau Vellacker«, sagte Mama, »dass Sie sich herbemüht haben. Die Kinder haben Ihnen einen rechten Schrecken gemacht; das tut mir leid.«
     </p>
-    <p xml:id="eco_de_0000141_9520">
+    <p xml:id="eco_de_0000211_9520">
      »Es sind ja sonst liebe Kinder. Aber diesmal gehörte ihnen fast etwas Strafe. So sich in Gefahr begeben –! Von meiner Angst nicht zu reden! Adieu, Frau Turnach! adieu, Kinder!«
     </p>
-    <p xml:id="eco_de_0000141_9530">
+    <p xml:id="eco_de_0000211_9530">
      Als Frau Vellacker fort war, atmeten die Kinder auf.
     </p>
-    <p xml:id="eco_de_0000141_9540">
+    <p xml:id="eco_de_0000211_9540">
      »Mama – also hör', Mama –« fingen alle drei an.
     </p>
-    <p xml:id="eco_de_0000141_9550">
+    <p xml:id="eco_de_0000211_9550">
      Aber Mama hatte. auch etwas zu sagen.
     </p>
-    <p xml:id="eco_de_0000141_9560">
+    <p xml:id="eco_de_0000211_9560">
      »Hans, ihr treibt es wirklich toll! Im Sommer denke ich immer, es ist eben der See und der weite Garten und die Scheune mit dem Heuboden; aber hier geht es ja kein bisschen besser! Auf das Dach steigen, dass die Nachbarn kommen, einen zu warnen –«
     </p>
-    <p xml:id="eco_de_0000141_9570">
+    <p xml:id="eco_de_0000211_9570">
      »Mama, Herr Zurbuchen war aber auch schon droben! Vor 55 Jahren, und er hat gelacht und uns gelobt, und unser Grossonkel sei mit gewesen! Hast du ihn gekannt, den Grossonkel Fritz –?«
     </p>
-    <p xml:id="eco_de_0000141_9580">
+    <p xml:id="eco_de_0000211_9580">
      Mama wusste nicht, was sie sagen sollte. Wer hatte recht, Frau Vellacker oder Herr Zurbuchen –? Aber als sie auf das Betteln der Kinder mit auf die Zinne ging, um den interessanten Weg in Augenschein zu nehmen, schüttelte sie denn doch den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_9590">
+    <p xml:id="eco_de_0000211_9590">
      »Hans, Hans«, sagte sie, »strafen will ich euch nicht; aber ebensowenig will ich, dass ihr die Tour noch einmal macht!«
     </p>
-    <p xml:id="eco_de_0000141_9600">
+    <p xml:id="eco_de_0000211_9600">
      Und Papa schüttelte am Abend auch den Kopf:
     </p>
-    <p xml:id="eco_de_0000141_9610">
+    <p xml:id="eco_de_0000211_9610">
      »Furchtlosigkeit und Unternehmungslust sind gute Dinge, und wer nicht wagt, gewinnt nicht. Aber im ganzen merkt euch: Tollkühn darf man nicht sein. Etwas anderes ist's, wenn es sich um grosse Dinge handelt, etwa um die Rettung eines Menschen oder um eine sehr wichtige Entdeckung.«
     </p>
-    <p xml:id="eco_de_0000141_9620">
+    <p xml:id="eco_de_0000211_9620">
      An der Erzählung jedoch, wie die Kinder Herrn Zurbuchen in die Hände gelaufen waren, hatte Papa seinen Spass.
     </p>
-    <p xml:id="eco_de_0000141_9630">
+    <p xml:id="eco_de_0000211_9630">
      »Papa«, berichtete Werner, der die Geschichte nun schon viermal gehört hatte, »er hat gesagt: ›Famos, famos!‹«
     </p>
-    <p xml:id="eco_de_0000141_9640">
+    <p xml:id="eco_de_0000211_9640">
      »Ja«, bestätigte Marianne, »und zuletzt hat er noch gesagt: ›Es lebe die Jugend!‹«
     </p>
-    <p xml:id="eco_de_0000141_9650">
+    <p xml:id="eco_de_0000211_9650">
      »So!« schloss Papa und sah Mama und die Kinder lachend an. »Er hat recht: sie lebe!«
     </p>
    </div>
@@ -3027,340 +3027,340 @@
     <head>
      Noch einmal auf dem Dach
     </head>
-    <p xml:id="eco_de_0000141_9660">
+    <p xml:id="eco_de_0000211_9660">
      Marianne und Lotti holten Obst in der Apfelkammer. Hans turnte währenddessen draussen an einem Dachbalken, bald den Kopf, bald die Füsse nach unten hängend. Werner rannte auf und ab und versuchte, wie weit er gegen den Wolfswinkel vordringen könne, ohne sich zu fürchten.
     </p>
-    <p xml:id="eco_de_0000141_9670">
+    <p xml:id="eco_de_0000211_9670">
      Als die zwei Körbe gefüllt waren, trugen Hans und Marianne sie hinunter. Lotti jagte noch mit Werner umher, hinein in die Apfelkammer und wieder heraus. Einen Augenblick schloss Lotti Werner in die Kammer ein; er erhob aber ein solches Geschrei, dass sie sofort wieder aufmachte.
     </p>
-    <p xml:id="eco_de_0000141_9680">
+    <p xml:id="eco_de_0000211_9680">
      »Sei doch still«, sagte sie. »Wart, jetzt darfst du mich einschliessen.«
     </p>
-    <p xml:id="eco_de_0000141_9690">
+    <p xml:id="eco_de_0000211_9690">
      Sie lief vor bis zum Fenster; wie aber Werner den Riegel schieben wollte, schoss sie daher und drängte sich durch. Werner krähte vor Eifer, Lotti einzusperren; zuletzt gelang es ihm wirklich.
     </p>
-    <p xml:id="eco_de_0000141_9700">
+    <p xml:id="eco_de_0000211_9700">
      »So, jetzt lass ich dich nicht mehr heraus, gar nicht mehr!« rief er triumphierend und horchte an der Türe.
     </p>
-    <p xml:id="eco_de_0000141_9710">
+    <p xml:id="eco_de_0000211_9710">
      Lotti blieb ganz still; hingegen hörte der Kleine von unten Stimmen – Onkel Alfred! Da musste Werner dabei sein. Er trabte die Treppen hinunter.
     </p>
-    <p xml:id="eco_de_0000141_9720">
+    <p xml:id="eco_de_0000211_9720">
      »Ein Papagei, Onkel? Der reden kann? Was sagt er? Gibt er Antwort, wenn man ihn etwas frägt?« bestürmten Hans und Marianne den Onkel.
     </p>
-    <p xml:id="eco_de_0000141_9730">
+    <p xml:id="eco_de_0000211_9730">
      Werner verstand nicht ganz, um was es sich handelte; aber für jeden Fall schrie er sein: »Ich auch, ich auch!« hinein.
     </p>
-    <p xml:id="eco_de_0000141_9740">
+    <p xml:id="eco_de_0000211_9740">
      »Vor allem macht rasch, wenn ihr den gelehrten Vogel sehen wollt!« sagte der Onkel. »Es ist weit zu meinem Freund, und nach sechs müssen wir beide im Kolleg sein!«
     </p>
-    <p xml:id="eco_de_0000141_9750">
+    <p xml:id="eco_de_0000211_9750">
      »Ich auch, Onkel!« bettelte Werner.
     </p>
-    <p xml:id="eco_de_0000141_9760">
+    <p xml:id="eco_de_0000211_9760">
      »Nein, mein teurer Neffe. Dich können wir nicht brauchen. Draussen regnet und stürmt es und wird bald dunkel. Wir müssen furchtbar laufen; sieh, so –« Onkel Alfred tat ein paar ungeheuerliche Schritte im Korridor.
     </p>
-    <p xml:id="eco_de_0000141_9770">
+    <p xml:id="eco_de_0000211_9770">
      Aber Werner wollte die Schritte nicht sehen; er fing so jämmerlich an zu weinen, dass Sophie erschien und den kleinen Buben in das hintere Zimmer zog.
     </p>
-    <p xml:id="eco_de_0000141_9780">
+    <p xml:id="eco_de_0000211_9780">
      Hans und Marianne kamen eilig mit Mantel und Mütze aus dem Wohnzimmer.
     </p>
-    <p xml:id="eco_de_0000141_9790">
+    <p xml:id="eco_de_0000211_9790">
      »Nehmt alle drei die Schirme!« rief Mama ihnen nach.
     </p>
-    <p xml:id="eco_de_0000141_9800">
+    <p xml:id="eco_de_0000211_9800">
      Der Onkel wandte sich zur Treppe.
     </p>
-    <p xml:id="eco_de_0000141_9810">
+    <p xml:id="eco_de_0000211_9810">
      »Vorwärts, ihr Spatzen! Wo ist denn der dritte?«
     </p>
-    <p xml:id="eco_de_0000141_9820">
+    <p xml:id="eco_de_0000211_9820">
      Ja, wo war der dritte Spatz?
     </p>
-    <p xml:id="eco_de_0000141_9830">
+    <p xml:id="eco_de_0000211_9830">
      »Lotti, Lotti!« riefen Hans und Marianne. »So komm doch –!«
     </p>
-    <p xml:id="eco_de_0000141_9840">
+    <p xml:id="eco_de_0000211_9840">
      War sie vielleicht noch droben? Manchmal turnte sie auch am Balken. Oder war sie bei Sophie?
     </p>
-    <p xml:id="eco_de_0000141_9850">
+    <p xml:id="eco_de_0000211_9850">
      Marianne rief hinauf und hinüber. Aber der Onkel zog seine Uhr heraus.
     </p>
-    <p xml:id="eco_de_0000141_9860">
+    <p xml:id="eco_de_0000211_9860">
      »Komm, Marianne!« sagte er. »Ich nehme Lotti und Werner ein anderes Mal mit. Heute eilt es.«
     </p>
-    <p xml:id="eco_de_0000141_9870">
+    <p xml:id="eco_de_0000211_9870">
      Die drei verliessen das Haus. Der kleine Werner aber sass schluchzend an seinem Tischchen. Dorthin zog er sich jedesmal zurück, wenn er unglücklich war. An Lotti und an die zugeriegelte Türe dachte er nicht mehr. Auch dann nicht, als Mama hereinkam und zu ihm sagte:
     </p>
-    <p xml:id="eco_de_0000141_9880">
+    <p xml:id="eco_de_0000211_9880">
      »So, mein armes Wernerlein, sind dir Hans, Marianne und Lotti wieder einmal davongelaufen?«
     </p>
-    <p xml:id="eco_de_0000141_9890">
+    <p xml:id="eco_de_0000211_9890">
      Vielleicht meinte er, die beiden Grossen hätten Lotti geholt. Wahrscheinlich aber dachte er überhaupt nichts; denn er war noch ein recht törichter kleiner Bub.
     </p>
-    <p xml:id="eco_de_0000141_9900">
+    <p xml:id="eco_de_0000211_9900">
      Lotti hatte in ihrer Apfelkammer von all dem keinen Ton gehört. Die Kammer lag drei Stockwerke höher, und die oberste Treppe hatte eine Türe, die hinter Werner zugeschlagen war. Dass der Kleine sich wegbegeben, hatte Lotti gemerkt; aber was schadete das? Drunten erzählte er natürlich seine Heldentat, und dann kamen Hans und Marianne und liessen Lotti nach einigem Necken heraus. Vielleicht waren sie schon vor der Türe. Um zu zeigen, dass sie sich aus der Gefangenschaft gar nichts mache, fing Lotti an zu singen:
     </p>
-    <p xml:id="eco_de_0000141_9910">
+    <p xml:id="eco_de_0000211_9910">
      »Als unser Mops ein Möpschen war, Da konnt' er freundlich sein …«
     </p>
-    <p xml:id="eco_de_0000141_9920">
+    <p xml:id="eco_de_0000211_9920">
      Dann spazierte sie in der Weinlaube auf und ab und schaute nach gefallenen Beeren. Sie zupfte auch ein wenig an der äussersten Traube. Wenn man da so eingesperrt war, durfte man das schon …
     </p>
-    <p xml:id="eco_de_0000141_9930">
+    <p xml:id="eco_de_0000211_9930">
      Der dumme Werner. Warum kam denn keins? Lotti trat an die Türe. Dann ging sie zurück und las eine schöne Reinette aus, setzte sich auf eine Kiste und ass den Apfel, während sie mit den Füssen schlenkerte. Als sie den Apfel verzehrt hatte, stand sie wieder auf. Es war langweilig da oben so allein, und es fing an zu dunkeln. Lotti wollte hinaus. Sie rief an der Türe, so laut sie konnte:
     </p>
-    <p xml:id="eco_de_0000141_9940">
+    <p xml:id="eco_de_0000211_9940">
      »Hans, Marianne! macht doch auf!«
     </p>
-    <p xml:id="eco_de_0000141_9950">
+    <p xml:id="eco_de_0000211_9950">
      Oder vielleicht hörte Mama sie. Lotti rief und rief; dann rüttelte sie am Schlosse und horchte wieder; aber es blieb draussen alles still. Lotti sah ringsum und fand es auf einmal unheimlich in der grossen tiefen Kammer, besonders dort hinten, wo man die Dinge schon nicht mehr recht erkennen konnte. Das Gestell mit dem Tuch drüber sah so seltsam aus, fast zum Fürchten. Lotti ging vor zum Fenster; da war es heller. Wenn sie aufmachen würde, um zu rufen? Unten waren die Fenster vom Wohnzimmer, unten waren Mama und die andern – Lotti stieg auf den Stuhl und öffnete das Fenster.
     </p>
-    <p xml:id="eco_de_0000141_9960">
+    <p xml:id="eco_de_0000211_9960">
      »Mama, Mama –!« rief sie. Aber niemand hörte sie, und sie sah nichts als die Dächer drüben über dem Kornplatz.
     </p>
-    <p xml:id="eco_de_0000141_9970">
+    <p xml:id="eco_de_0000211_9970">
      Sie stieg vom Stuhl hinunter und begann leise zu weinen. Aber nein, das half nichts! Sie musste sehen, dass sie etwas recht Festes fand, um an die Tür zu klopfen. Dort hinter dem Gestell war ein Stock, das wusste sie. Aber sie traute sich nicht hin. Wenn es – wenn es doch so etwas Schreckliches gäbe wie den Werwolf –? Er konnte gerade so gut hier sein wie drüben beim Holzverschlag! Vorhin hatte sich etwas bewegt hinter dem Tuche. Wenn er nun auf einmal hervorschaute mit glühenden Augen –! Lotti drückte die Hände an die Brust … Doch Hans sagte immer, man solle mutig sein. Sie tat rasch ein paar Schritte vorwärts. Da fasste etwas sie am Kleide. Sie stiess einen Schrei aus. Es war nur ein Nagel der Kiste gewesen. Aber Lotti kam ganz ausser sich vor Entsetzen und weinte laut auf:
     </p>
-    <p xml:id="eco_de_0000141_9980">
+    <p xml:id="eco_de_0000211_9980">
      »Mama, Mama! ich will hinaus –!«
     </p>
-    <p xml:id="eco_de_0000141_9990">
+    <p xml:id="eco_de_0000211_9990">
      Plötzlich kam ihr ein rettender Gedanke. Von dem grauen Türmchen kürzlich hatten sie auf alle Dächer ringsum gesehen. »Dort, wenn man von unserer Zinne rechts hinaufstiege zum First«, hatte Hans gesagt, »so käme man auf der andern Seite hinunter zur Apfelkammer.« Also musste es umgekehrt auch gehen, und die Zinnentüre liess sich vielleicht schieben, wenn Lotti alle Kraft zusammennahm, und dann war sie befreit! Mama wollte zwar nicht, dass man noch einmal aufs Dach hinausgehe. Aber jetzt musste Lotti. Das würde Mama schon einsehen.
     </p>
-    <p xml:id="eco_de_0000141_10000">
+    <p xml:id="eco_de_0000211_10000">
      Schnell stieg Lotti auf den Stuhl und reckte sich zum Fenster hinaus. Im Sommer hatte man doch das Klettern ordentlich gelernt. Nun war sie draussen auf dem Dache. Sie erkannte die Richtung, die sie nehmen musste, um den First zu erreichen. Aber es war ein steiler, böser Weg. Zitternd vor Angst und Schrecken kroch Lotti aufwärts. Jetzt konnte sie den Blitzableiter sehen. Halt – ins Rutschen durfte man nicht kommen! Hinter sich hörte Lotti von tief unten das Wagengerassel auf dem Kornplatz. Frau Vellacker kam ihr in den Sinn. »Tot und zerschlagen –« hatte sie gesagt –! Lotti griff mit den Händen aus. Wieder kam sie ein Stück vorwärts und noch eins. Jetzt hatte sie den Blitzableiter erreicht!
     </p>
-    <p xml:id="eco_de_0000141_10010">
+    <p xml:id="eco_de_0000211_10010">
      O, das war gut, sich fest an etwas halten zu können! Lotti war ausser Atem; der Regen schlug ihr ins Gesicht; die Hände brannten sie. Auf dem First sitzend, die Arme um den Blitzableiter geschlungen, spähte Lotti nun hinunter nach der Zinne. Undeutlich konnte sie schräg dort unten etwas vom Geländer erkennen; aber grade vor ihr ging es in eine unheimliche dunkle Tiefe.
     </p>
-    <p xml:id="eco_de_0000141_10020">
+    <p xml:id="eco_de_0000211_10020">
      Lotti hatte aufgeatmet, wie der Blitzableiter erreicht war. Nun fing ihr Herz von neuem an angstvoll zu klopfen. Wenn nur Hans da wäre, um ihr zu zeigen, wie man hinabkletterte! Vielleicht war er unten im Hof.
     </p>
-    <p xml:id="eco_de_0000141_10030">
+    <p xml:id="eco_de_0000211_10030">
      »Hans! Hans!« schrie sie.
     </p>
-    <p xml:id="eco_de_0000141_10040">
+    <p xml:id="eco_de_0000211_10040">
      Aber der Wind heulte; es rasselte und knarrte auf den alten Dächern. Lottis Stimme, die ganz heiser geworden vor Weinen, reichte nicht weit.
     </p>
-    <p xml:id="eco_de_0000141_10050">
+    <p xml:id="eco_de_0000211_10050">
      Lotti versuchte, sich zusammenzunehmen und es zu wagen. Sie liess mit einer Hand den Blitzableiter los und machte einen Schritt. Doch erschien ihr, als ob das Dach hier noch steiler sei als drüben. Erschrocken zog sie sich wieder hinauf. Nach einer Weile machte sie einen zweiten Versuch. Aber nein, es war unmöglich. Sie weinte laut auf und klammerte sich an den Blitzableiter. Wenn sie in die dunkle Tiefe sah, schüttelte es sie vor Grauen …
     </p>
-    <p xml:id="eco_de_0000141_10060">
+    <p xml:id="eco_de_0000211_10060">
      Daniel, der Hausknecht vom Goldenen Degen, trat an das Fenster seiner Kammer, die im obersten Stockwerk nach dem Hofe lag. Er hatte in seinem alten Lehnstuhl etwas geschlafen. Morgens musste er immer um halb vier Uhr aufstehen, um vor den Türen der Fremden die Stiefel zu holen und sie zu putzen. Er schaute in den Regensturm hinaus.
     </p>
-    <p xml:id="eco_de_0000141_10070">
+    <p xml:id="eco_de_0000211_10070">
      »Das ist ja ein greuliches Wetter!« sagte er vor sich hin.
     </p>
-    <p xml:id="eco_de_0000141_10080">
+    <p xml:id="eco_de_0000211_10080">
      Auf einmal machte er das Fenster auf und sah starr über den Hof hinweg hinauf nach einer Stelle.
     </p>
-    <p xml:id="eco_de_0000141_10090">
+    <p xml:id="eco_de_0000211_10090">
      »Ist das eine Katze dort –? Eine grosse müsste es sein – eine seltsame –«
     </p>
-    <p xml:id="eco_de_0000141_10100">
+    <p xml:id="eco_de_0000211_10100">
      Er rieb sich die Augen und sah wieder hin. Plötzlich schlug er das Fenster zu, nahm die Mütze und ging hinaus.
     </p>
-    <p xml:id="eco_de_0000141_10110">
+    <p xml:id="eco_de_0000211_10110">
      Im Flur des Turnachhauses stand Ulrich und klopfte Nägel aus einem Kistendeckel. Da trat Daniel zu ihm.
     </p>
-    <p xml:id="eco_de_0000141_10120">
+    <p xml:id="eco_de_0000211_10120">
      »Ulrich«, sagte er rasch und leise, »ich möchte wissen, was das ist auf euerm Dache. Zuerst hab' ich an eine Katze gedacht. Dann aber hat sich's in die Höhe gestreckt. Da kam's mir wahrhaftig vor wie ein Kind! Ulrich, die euern machen ja so Geschichten! Zwar im Dunkeln und an der abschüssigen Stelle – Jedenfalls muss man sehen!«
     </p>
-    <p xml:id="eco_de_0000141_10130">
+    <p xml:id="eco_de_0000211_10130">
      Ulrich sah Daniel bestürzt an; dann griff er nach seiner Laterne. Im Vorbeigehen nahm er ein Seil.
     </p>
-    <p xml:id="eco_de_0000141_10140">
+    <p xml:id="eco_de_0000211_10140">
      »Ich gehe mit«, sagte Daniel.
     </p>
-    <p xml:id="eco_de_0000141_10150">
+    <p xml:id="eco_de_0000211_10150">
      »Ja. Es wäre am besten, sie merkten droben nichts. Sonst gibt es ein Wesen und eine Angst – vielleicht umsonst. Denn du hast dich am Ende doch getäuscht, Daniel.«
     </p>
-    <p xml:id="eco_de_0000141_10160">
+    <p xml:id="eco_de_0000211_10160">
      »Nein, es ist ein Kind. So etwa in der Grösse von euerm Dritten – wie heisst's? Das immer lacht –«
     </p>
-    <p xml:id="eco_de_0000141_10170">
+    <p xml:id="eco_de_0000211_10170">
      Die beiden Männer stiegen leise die Treppen hinauf. Da trat ihnen Balbine entgegen.
     </p>
-    <p xml:id="eco_de_0000141_10180">
+    <p xml:id="eco_de_0000211_10180">
      »Was wollen Sie denn miteinander?« fragte sie verwundert.
     </p>
-    <p xml:id="eco_de_0000141_10190">
+    <p xml:id="eco_de_0000211_10190">
      »Wir – der Ulrich will mir etwas zeigen«, antwortet Daniel. »Das muss etwas Wichtiges sein, dass man nicht warten kann bis zum Feierabend«, sagte Balbine ein wenig spöttisch und ging weiter.
     </p>
-    <p xml:id="eco_de_0000141_10200">
+    <p xml:id="eco_de_0000211_10200">
      »Balbine«, fragte Ulrich, wie so nebenbei, »ist Lotti im Zimmer? Sie hat ihre Puppe in der Garnkammer liegen lassen.«
     </p>
-    <p xml:id="eco_de_0000141_10210">
+    <p xml:id="eco_de_0000211_10210">
      »Nein, sie ist fort mit Herrn Alfred und den zwei Grossen.«
     </p>
-    <p xml:id="eco_de_0000141_10220">
+    <p xml:id="eco_de_0000211_10220">
      »So«, sagte Ulrich nur; aber er ging rascher. Herrn Alfred hatte er mit Hans und Marianne gesehen; Lotti war nicht dabei gewesen.
     </p>
-    <p xml:id="eco_de_0000141_10230">
+    <p xml:id="eco_de_0000211_10230">
      Als die beiden Männer zur Zinnentüre kamen, hörten sie den Wind heulen und den Regen auf die Ziegel klatschen. Schnauzel, der Ulrich nachgelaufen war, sprang als erster auf die Zinne.
     </p>
-    <p xml:id="eco_de_0000141_10240">
+    <p xml:id="eco_de_0000211_10240">
      Ulrich und Daniel traten zum Geländer und sahen hinauf. Es war nun fast vollständig dunkel geworden. Grade konnte man noch erkennen, dass da oben beim Blitzableiter eine Gestalt kauerte. Schwache, vom Wind verwehte Jammerlaute tönten herunter.
     </p>
-    <p xml:id="eco_de_0000141_10250">
+    <p xml:id="eco_de_0000211_10250">
      »Lotti –!« rief Ulrich entsetzt. »Wie bist du da hinaufgeraten!« wollte er hinzufügen; aber es war jetzt keine Zeit für unnötige Fragen. »Lotti!« rief er nur. »Halt noch ein paar Augenblicke fest!«
     </p>
-    <p xml:id="eco_de_0000141_10260">
+    <p xml:id="eco_de_0000211_10260">
      Er band sich die kleine Laterne vor die Brust und hängte die Seilschlinge an den Arm.
     </p>
-    <p xml:id="eco_de_0000141_10270">
+    <p xml:id="eco_de_0000211_10270">
      Schnauzel winselte und versuchte, an dem Dach emporzuspringen. Doch das ging nicht für Hundepfoten. Helfen konnte Schnauzel nicht; aber er konnte laut hinaufbellen und damit Lotti sagen:
     </p>
-    <p xml:id="eco_de_0000141_10280">
+    <p xml:id="eco_de_0000211_10280">
      »Sei nur getrost! Wein' nicht mehr! Sie holen dich! sie bringen dich herunter!«
     </p>
-    <p xml:id="eco_de_0000141_10290">
+    <p xml:id="eco_de_0000211_10290">
      »Du hast gut bellen«, sagte Daniel. »So einfach ist die Sache nicht! Ulrich, ich fürchte, es sei zu steil und zu schlüpfrig – Wär es nicht besser, ich holte schnell den Dachdecker –«
     </p>
-    <p xml:id="eco_de_0000141_10300">
+    <p xml:id="eco_de_0000211_10300">
      »Nein, so lang darf mir die Kleine nicht mehr da oben in der Angst bleiben«, antwortete Ulrich. »Ich bring es schon zustand.«
     </p>
-    <p xml:id="eco_de_0000141_10310">
+    <p xml:id="eco_de_0000211_10310">
      »Lass mich hinauf«, fing Daniel noch einmal an. »Ich bin neun Jahre jünger als du und gehe in den Turnverein –«
     </p>
-    <p xml:id="eco_de_0000141_10320">
+    <p xml:id="eco_de_0000211_10320">
      »Dafür aber ist es das Kind von meinem Herrn«, sagte Ulrich und zog die Schuhe aus.
     </p>
-    <p xml:id="eco_de_0000141_10330">
+    <p xml:id="eco_de_0000211_10330">
      Er trat auf das Dach. Die Laterne warf ihren Schein auf die nassen Ziegel. Es waren etwa fünfzehn Schritte gefährlichen Weges; denn über das niedrigere Dach des Hinterhauses hinauf bis zum vordern First gab es keinen Halt.
     </p>
-    <p xml:id="eco_de_0000141_10340">
+    <p xml:id="eco_de_0000211_10340">
      »Langsam, langsam!« rief Daniel. »Halt mehr rechts, Ulrich – Es geht nicht! Lass mich's versuchen –!«
     </p>
-    <p xml:id="eco_de_0000141_10350">
+    <p xml:id="eco_de_0000211_10350">
      Ulrich kam indessen doch vorwärts. Er hatte sich auf die Knie niedergelassen. Das lange Seil, dessen Ende Daniel hielt, zog er hinter sich drein. Das Dach wurde nach oben steiler. Aber nur noch eine kurze Strecke, eine kurze Strecke der äussersten Anstrengung und Vorsicht, und Ulrich konnte mit der einen Hand den First erreichen. Jetzt – er tat einen starken Atemzug und hielt einen Augenblick an.
     </p>
-    <p xml:id="eco_de_0000141_10360">
+    <p xml:id="eco_de_0000211_10360">
      »Was ist –?« rief Daniel ängstlich von unten.
     </p>
-    <p xml:id="eco_de_0000141_10370">
+    <p xml:id="eco_de_0000211_10370">
      »Droben bin ich!« antwortete Ulrich und setzte sich wieder in Bewegung. Rasch ging es nun dem First entlang.
     </p>
-    <p xml:id="eco_de_0000141_10380">
+    <p xml:id="eco_de_0000211_10380">
      »Jetzt gib acht, Lotti!« rief er, als er bei dem Kinde ankam.
     </p>
-    <p xml:id="eco_de_0000141_10390">
+    <p xml:id="eco_de_0000211_10390">
      Aber Lotti war ganz erschöpft vor Angst und Weinen und Kälte. Sie wusste nicht recht, was vorging. Sie fürchtete sich, den Blitzableiter loszulassen, und schrie laut auf, als Ulrich sie anfasste. Dann aber klammerte sie sich fest um seinen Hals.
     </p>
-    <p xml:id="eco_de_0000141_10400">
+    <p xml:id="eco_de_0000211_10400">
      »So, Lotti, so – schnaufen musst mich noch lassen«, sagte er zu dem bebenden Kind. Das Seil hatte er von sich losgelöst und um den Blitzableiter geschlungen.
     </p>
-    <p xml:id="eco_de_0000141_10410">
+    <p xml:id="eco_de_0000211_10410">
      »Er wird doch halten«, sagte er für sich und rief dann Daniel zu, straff zu ziehen. Lotti im einen Arm, mit der andern Hand am Seil sich haltend, begann Ulrich nun sitzend, rutschend, sich stemmend den Rückweg. Jeden Augenblick glitt er aus auf dem nassen Dach; aber nun hatte er ja das Seil, und der Blitzableiter, der schon Lottis Zuflucht gewesen, hielt sich noch einmal wacker. Glücklich kam Ulrich am Zinnengeländer an.
     </p>
-    <p xml:id="eco_de_0000141_10420">
+    <p xml:id="eco_de_0000211_10420">
      »Gut ist's gegangen!« rief Daniel fröhlich und streckte die Hände aus, um Lotti herüberzuheben, was einige Mühe kostete; denn die hielt sich zitternd an Ulrich fest. Sie vermochte noch nicht zu fassen, dass nun alle Gefahr und Not vorüber war, sondern schluchzte fort und fort.
     </p>
-    <p xml:id="eco_de_0000141_10430">
+    <p xml:id="eco_de_0000211_10430">
      »Jetzt bringen wir dich der Mama, Lotti, der Mama! Die tröstet dich dann«, sprach Ulrich auf das Kind ein. »Sieh, der Schnauzel freut sich auch, dass wir dich heruntergeholt haben.«
     </p>
-    <p xml:id="eco_de_0000141_10440">
+    <p xml:id="eco_de_0000211_10440">
      Der Schnauzel war aber gar nicht zur Stelle, sondern stand heulend auf dem Dach draussen. In seinem Eifer hatte er Ulrich entgegenspringen wollen und wagte sich nun nicht mehr zurück auf dem abschüssigen Weg.
     </p>
-    <p xml:id="eco_de_0000141_10450">
+    <p xml:id="eco_de_0000211_10450">
      »Du Tropf!« sagte Daniel und stieg über das Geländer. »Gelt, damit ich mir an dir meine Rettungsmedaille verdiene –«
     </p>
-    <p xml:id="eco_de_0000141_10460">
+    <p xml:id="eco_de_0000211_10460">
      Er zog den Hund herab und beförderte ihn etwas unsanft auf die Zinne. Dann ging's die Treppen hinunter.
     </p>
-    <p xml:id="eco_de_0000141_10470">
+    <p xml:id="eco_de_0000211_10470">
      »Frau Turnach«, sagte Ulrich, indem er die Wohnzimmertüre öffnete. »Erschrecken Sie nicht. Es ist ihr nichts geschehen. Sie ist bloss ein wenig nass und kalt geworden auf dem Dach. Wie sie hinaufgekommen ist, wissen wir nicht; aber wir haben sie Glücklich heruntergebracht.«
     </p>
-    <p xml:id="eco_de_0000141_10480">
+    <p xml:id="eco_de_0000211_10480">
      Das klang so ungefährlich als möglich. Aber Frau Turnach wurde doch blass vor Schrecken, als sie das krampfhaft weinende, vom Regen triefende Kind in Empfang nahm. Vom Dache geholt? Lotti war ja doch mit Marianne und Hans weggegangen –!
     </p>
-    <p xml:id="eco_de_0000141_10490">
+    <p xml:id="eco_de_0000211_10490">
      Und es dauerte eine lange Zeit, bis man zu dem Ende der Geschichte, die Daniel und Ulrich erzählten, von Lotti endlich auch den Anfang vernahm.
     </p>
-    <p xml:id="eco_de_0000141_10500">
+    <p xml:id="eco_de_0000211_10500">
      »Es – es war ganz steil und so d – dunkel und nass –« war alles, was Lotti immer wieder hervorschluchzte.
     </p>
-    <p xml:id="eco_de_0000141_10510">
+    <p xml:id="eco_de_0000211_10510">
      Erst als Werner hereinkam und Lotti ihn erblickte, klärte sich die Sache nach und nach auf.
     </p>
-    <p xml:id="eco_de_0000141_10520">
+    <p xml:id="eco_de_0000211_10520">
      »Er braucht einen nicht einschliessen –« weinte Lotti, »und dann f – fortlaufen –«
     </p>
-    <p xml:id="eco_de_0000141_10530">
+    <p xml:id="eco_de_0000211_10530">
      Mama zog Werner her, dem jetzt das Spiel droben an der Türe wieder aufdämmerte. Aber es war schwer, ihn zu überzeugen, dass er etwas sehr Schlimmes angestellt habe. Als Papa hereinkam, lief Werner wichtig auf ihn zu:
     </p>
-    <p xml:id="eco_de_0000141_10540">
+    <p xml:id="eco_de_0000211_10540">
      »Papa, Lotti hat auf dem Dach ganz nasse Haare bekommen!«
     </p>
-    <p xml:id="eco_de_0000141_10550">
+    <p xml:id="eco_de_0000211_10550">
      Papa hatte unten von Ulrich und Daniel die Sache vernommen. Er war auch heftig erschrocken.
     </p>
-    <p xml:id="eco_de_0000141_10560">
+    <p xml:id="eco_de_0000211_10560">
      »Mein Gott!« sagte er, »da sitzt man bei seiner Lampe und rechnet und schreibt, und währenddessen geschehen über unserm Kopf solche Dinge!«
     </p>
-    <p xml:id="eco_de_0000141_10570">
+    <p xml:id="eco_de_0000211_10570">
      Er schüttelte den beiden Männern immer wieder die Hände.
     </p>
-    <p xml:id="eco_de_0000141_10580">
+    <p xml:id="eco_de_0000211_10580">
      »Herr Turnach, Ulrich hat's allein getan«, wies Daniel den Dank zurück.
     </p>
-    <p xml:id="eco_de_0000141_10590">
+    <p xml:id="eco_de_0000211_10590">
      »Ich musste doch auch einmal eine Dachpartie machen«, sagte Ulrich. »Wetter und Aussicht waren zwar nicht besonders!«
     </p>
-    <p xml:id="eco_de_0000141_10600">
+    <p xml:id="eco_de_0000211_10600">
      Bald kehrten Hans und Marianne heim. Sie waren ganz erfüllt von den Sprechkünsten des Papageis, der »Guten Abend« sagte und: »Ich wollt, es wäre Nacht und die Preussen wären da!« und sogar etwas Lateinisches: »O jemine, o jerum, o quae mutatio rerum!« Aber sie kamen nicht zum Erzählen. Lotti lag zitternd und mit verweintem Gesicht im Bett und hatte Furchtbares erlebt.
     </p>
-    <p xml:id="eco_de_0000141_10610">
+    <p xml:id="eco_de_0000211_10610">
      Hans regte die Geschichte sehr auf. »Lotti allein – diesen gefährlichen Weg! In der Dunkelheit!«
     </p>
-    <p xml:id="eco_de_0000141_10620">
+    <p xml:id="eco_de_0000211_10620">
      »Lotti«, wollte er anfangen. »Vielleicht wenn man mehr links –«
     </p>
-    <p xml:id="eco_de_0000141_10630">
+    <p xml:id="eco_de_0000211_10630">
      »Lass, Hans!« sagte aber Mama. »Du siehst, wie Lotti mitgenommen ist. Sprich nicht mehr von dem schrecklichen Dach!«
     </p>
-    <p xml:id="eco_de_0000141_10640">
+    <p xml:id="eco_de_0000211_10640">
      Lotti fing indessen selbst immer wieder an. Sie schilderte, wie sie ausgerutscht sei und wie sie vom Blitzableiter hinunter in die dunkle Tiefe gesehen. Es war entsetzlich für Mama zu hören.
     </p>
-    <p xml:id="eco_de_0000141_10650">
+    <p xml:id="eco_de_0000211_10650">
      »Kind, Kind«, sagte sie, »sei jetzt ruhig! Versuche zu schlafen!« Sie strich Lotti das Haar aus der Stirne.
     </p>
-    <p xml:id="eco_de_0000141_10660">
+    <p xml:id="eco_de_0000211_10660">
      »Mama, es war aber doch gut, dass Hans etwas von dem Weg gesagt hat. Sonst wäre ich nicht aus der Apfelkammer gekommen!«
     </p>
-    <p xml:id="eco_de_0000141_10670">
+    <p xml:id="eco_de_0000211_10670">
      »Zuletzt hätten wir dich doch dort gesucht, Lotti.«
     </p>
-    <p xml:id="eco_de_0000141_10680">
+    <p xml:id="eco_de_0000211_10680">
      »Aber vorher wäre ich ganz gewiss gestorben aus Angst!«
     </p>
-    <p xml:id="eco_de_0000141_10690">
+    <p xml:id="eco_de_0000211_10690">
      Lotti besann sich und seufzte.
     </p>
-    <p xml:id="eco_de_0000141_10700">
+    <p xml:id="eco_de_0000211_10700">
      »Mama«, begann sie noch einmal. »Und droben am Blitzableiter wäre ich auch fast gestorben aus Angst!«
     </p>
-    <p xml:id="eco_de_0000141_10710">
+    <p xml:id="eco_de_0000211_10710">
      »Ja, Kind, und nun hat's der liebe Gott gnädig gefügt, dass du da unten sicher und warm in deinem Bett liegst.«
     </p>
-    <p xml:id="eco_de_0000141_10720">
+    <p xml:id="eco_de_0000211_10720">
      Lotti nickte.
     </p>
-    <p xml:id="eco_de_0000141_10730">
+    <p xml:id="eco_de_0000211_10730">
      »Mama«, sagte sie dann, »ich hab noch nicht gebetet«, und setzte sich auf, um ihr kleines Nachtgebet zu sprechen.
     </p>
-    <p xml:id="eco_de_0000141_10740">
+    <p xml:id="eco_de_0000211_10740">
      Endlich wurde sie ruhiger; nur noch einmal drehte sie sich:
     </p>
-    <p xml:id="eco_de_0000141_10750">
+    <p xml:id="eco_de_0000211_10750">
      »Mama, ich stricke dem Ulrich Pulswärmer. Und dem Daniel näh ich ein Buchzeichen.«
     </p>
-    <p xml:id="eco_de_0000141_10760">
+    <p xml:id="eco_de_0000211_10760">
      »Ja, Lotti.«
     </p>
-    <p xml:id="eco_de_0000141_10770">
+    <p xml:id="eco_de_0000211_10770">
      Als nach einer Weile Papa, der immer noch im Wohnzimmer auf und ab gegangen war, leise hereinkam, um nach seinem Lotti zu sehen, war das Kind fest eingeschlafen.
     </p>
    </div>
@@ -3368,295 +3368,295 @@
     <head>
      Bald kommt das Christkind
     </head>
-    <p xml:id="eco_de_0000141_10780">
+    <p xml:id="eco_de_0000211_10780">
      Draussen blies ein kalter Wind. In der Kinderstube war es warm und gemütlich. Das Schwesterlein schlief im Korbwagen; Werner stand daneben und guckte zu. Von Zeit zu Zeit lachte er auf. Marianne, die mit Lotti Kleider für die Papierpüppchen schnitt, winkte ihm, dass er das Schwesterlein nicht wecke.
     </p>
-    <p xml:id="eco_de_0000141_10790">
+    <p xml:id="eco_de_0000211_10790">
      »Ich tu es nicht wecken«, flüsterte Wernermann. »Ich lach nur ein bisschen, wenn die Fliege wieder kommt. Sieh einmal, Marianne!«
     </p>
-    <p xml:id="eco_de_0000141_10800">
+    <p xml:id="eco_de_0000211_10800">
      Um des Schwesterleins Gesicht summte eine grosse Fliege und setzte sich auf das winzige Näschen; das zog sich kraus, als ob das Schwesterlein niesen müsste. Dann fuhr die kleine Faust über das Näschen, und die Fliege flog ärgerlich brummend fort. Das Schwesterlein aber schlief ruhig weiter.
     </p>
-    <p xml:id="eco_de_0000141_10810">
+    <p xml:id="eco_de_0000211_10810">
      Wie die drei dastanden und in den Korbwagen guckten, stürmte Hans zur Türe herein.
     </p>
-    <p xml:id="eco_de_0000141_10820">
+    <p xml:id="eco_de_0000211_10820">
      »Wisst ihr etwas –? Etwas Wundervolles? In 23 Tagen ist Weihnacht! In 23 Tagen!«
     </p>
-    <p xml:id="eco_de_0000141_10830">
+    <p xml:id="eco_de_0000211_10830">
      Marianne und Lotti sahen sich an. Seit man hier im Winterhause wohnte, hatte man ja schon immer das heimliche frohe Gefühl von Weihnacht. Aber wie nun Hans sagte: »In 23 Tagen!« da war's, als käme man der Herrlichkeit um einen ganzen Ruck näher.
     </p>
-    <p xml:id="eco_de_0000141_10840">
+    <p xml:id="eco_de_0000211_10840">
      Lotti fasste Werner und tanzte jauchzend mit ihm in der Stube herum. So musste das Schwesterlein denn doch erwachen. Es machte die Augen weit auf und zappelte mit den Armen.
     </p>
-    <p xml:id="eco_de_0000141_10850">
+    <p xml:id="eco_de_0000211_10850">
      »Du! In 23 Tagen ist Weihnacht!« rief Werner in den Korbwagen hinein. »Verstehst du?«
     </p>
-    <p xml:id="eco_de_0000141_10860">
+    <p xml:id="eco_de_0000211_10860">
      Hans lachte.
     </p>
-    <p xml:id="eco_de_0000141_10870">
+    <p xml:id="eco_de_0000211_10870">
      »Wernermann, tu du nicht so grossartig. Du weisst ja selber nicht, wieviel 23 Tage sind!«
     </p>
-    <p xml:id="eco_de_0000141_10880">
+    <p xml:id="eco_de_0000211_10880">
      »Doch, das weiss ich gut! Ein Tag ist, wenn man aufsteht, und 23 Tage ist, wenn man vielmal aufsteht, und dann kommt Weihnacht!«
     </p>
-    <p xml:id="eco_de_0000141_10890">
+    <p xml:id="eco_de_0000211_10890">
      Lotti aber lief ins Schlafzimmer, um an ihr und an Mariannes Bett mit Kreide 23 lange Striche zu zeichnen.
     </p>
-    <p xml:id="eco_de_0000141_10900">
+    <p xml:id="eco_de_0000211_10900">
      »Oder ich mach mir 24, Sophie! Dann kann ich heute abend schon einen auswischen.«
     </p>
-    <p xml:id="eco_de_0000141_10910">
+    <p xml:id="eco_de_0000211_10910">
      Marianne war am Wagen des Schwesterleins stehen geblieben. Es hatte seinen wollenen Hasen erwischt und schlug ihn auf das Deckbettchen, dass die kleine Schelle klingelte. Wie sonderbar, dachte Marianne, gar nichts weiss es noch von Weihnachten und kann sich kein bisschen darauf freuen! Dann aber kamen ihr selber so viel Weihnachtsgedanken, dass sie rasch an den Tisch ging und ihre Papierpuppen zusammenpackte.
     </p>
-    <p xml:id="eco_de_0000141_10920">
+    <p xml:id="eco_de_0000211_10920">
      »Zum Spielen habe ich jetzt keine Zeit mehr«, sagte sie zu Lotti, als diese wieder eintrat. »Denk, bis alle Weihnachtsarbeiten fertig sind!«
     </p>
-    <p xml:id="eco_de_0000141_10930">
+    <p xml:id="eco_de_0000211_10930">
      Die Turnachkinder hatten immer sehr viele Leute zu beschenken. So wurde jetzt am Abend bei der Lampe mit aller Macht gestrickt und gestickt, geschnitten und gekleistert. Hans, der an einem Nebentische hübsche Schachteln pappte, hatte um seine Arbeit eine ganze Mauer von Büchern gebaut. Jedesmal, wenn Mama vorbeiging, erhob er einen Lärm:
     </p>
-    <p xml:id="eco_de_0000141_10940">
+    <p xml:id="eco_de_0000211_10940">
      »Mama, Mama, nicht! Bitte, tu den Kopf weg!«
     </p>
-    <p xml:id="eco_de_0000141_10950">
+    <p xml:id="eco_de_0000211_10950">
      Die arme Mama wusste gar nicht mehr, wohin sich wenden. Denn Marianne arbeitete ebenfalls hinter einer Schanze aus zwei aufgestellten Teebrettern, die jeden Augenblick umstürzten:
     </p>
-    <p xml:id="eco_de_0000141_10960">
+    <p xml:id="eco_de_0000211_10960">
      »O, Mama, nicht hersehen –!«
     </p>
-    <p xml:id="eco_de_0000141_10970">
+    <p xml:id="eco_de_0000211_10970">
      Und Lotti schrie zum Vergnügen mit, obgleich sie an den Pulswärmern für Ulrich war. Das Buchzeichen für Daniel hatte ihr Marianne auch schon zugeschnitten.
     </p>
-    <p xml:id="eco_de_0000141_10980">
+    <p xml:id="eco_de_0000211_10980">
      Onkel Alfred hatte sich ausdrücklich ein Geschenk von den beiden Nichten erbeten.
     </p>
-    <p xml:id="eco_de_0000141_10990">
+    <p xml:id="eco_de_0000211_10990">
      »Hört«, hatte er gesagt, »für den Ritterdienst, den ich euch tat bei der fürchterlichen Hippenbäckerin, erwarte ich irgend etwas Gesticktes, etwa eine Schärpe, die ich Sonntags tragen könnte.«
     </p>
-    <p xml:id="eco_de_0000141_11000">
+    <p xml:id="eco_de_0000211_11000">
      »Ach, Onkel!« lachte Lotti; aber sie machte sich dann mit Eifer an den Tintenwischer, dessen Zeichnung Marianne entworfen hatte und der nun mit Blau und Gold ausgenäht wurde.
     </p>
-    <p xml:id="eco_de_0000141_11010">
+    <p xml:id="eco_de_0000211_11010">
      Das war das Hübscheste und Interessanteste bei den Weihnachtsarbeiten, sich die Stoffe und Farben, die Muster und Verzierungen selber auszudenken. Hans suchte in drei Läden, bis er das richtige mattgraue starke Papier fand, aus dem er für Marianne zwei Büchereinbände machen wollte. Sie wurden zugeschnitten und gefaltet; dann besann sich Hans über die Ausschmückung und kam auf die hübsche Idee, einen Kreis zu ziehen und da hinein ein Steinschiff zu malen mit grossem weissem Segel, rotem Steuer und blauem Wasser. Das wurde sorgfältig mit Tusch und Farbe ausgeführt und dann gefirnisst. Für Lotti hatte er eine kleine Wandtafel mit Gestell gearbeitet, die sie vor ihre Papierpuppenschule stellen konnte.
     </p>
-    <p xml:id="eco_de_0000141_11020">
+    <p xml:id="eco_de_0000211_11020">
      »Nobel!« sagte Ulrich, als Hans ihm den Einband zeigte, und Hans nahm sich vor, Ulrich ein Notizbuch zu schenken mit ähnlicher Ausstattung: Ringsum eine farbige Borte und in der Mitte die Namenszüge in Schwarz und Gold.
     </p>
-    <p xml:id="eco_de_0000141_11030">
+    <p xml:id="eco_de_0000211_11030">
      Marianne war auch mit beim Buchbinder gewesen und hatte weisse Karten gekauft, die sie geschickt mit kleinen Kränzen und Sträussen aus winzigen Blümchen beklebte. Sie hatte im Sommer allerlei gesammelt: Augentrost, Vergissmeinnicht, Guldenkraut, Klee, feine Gräser und Moose. Den verblichenen Blumen gab sie mit dem Pinsel wieder etwas Farbe. Die Karten sahen sehr niedlich aus und waren für Grossmama bestimmt, welche kurze Briefe darauf schreiben konnte.
     </p>
-    <p xml:id="eco_de_0000141_11040">
+    <p xml:id="eco_de_0000211_11040">
      So herrschte eine grosse Geschäftigkeit unter den Turnachkindern, ein Hin und Her mit Stickgarn und Farbkasten, mit Leim und Schere. Werner wollte auch etwas tun. Er warf das Leimglas um und zerschnitt Lottis Seidenfäden. Da gab ihm Mama einen mit Wachs gesteiften Bindfaden und grosse Glasperlen, damit er für Balbine ein Armband mache. Aber der ungeschickte Bub liess die Perlen fallen und lief immer wieder zu Marianne, dass sie ihm helfe.
     </p>
-    <p xml:id="eco_de_0000141_11050">
+    <p xml:id="eco_de_0000211_11050">
      »Wenn ich doch gar keine Zeit habe!« wehrte sich Marianne.
     </p>
-    <p xml:id="eco_de_0000141_11060">
+    <p xml:id="eco_de_0000211_11060">
      Sie hatte ein Täschchen für Mama angefangen, eine etwas zu grosse Arbeit. Wann sollte sie fertig werden? Um halb acht Uhr musste man immer ins Bett.
     </p>
-    <p xml:id="eco_de_0000141_11070">
+    <p xml:id="eco_de_0000211_11070">
      »Weisst du, Lotti«, flüsterte Marianne leise, damit der kleine Werner nichts ausplaudern könne, »heut abend geht Mama ins Konzert, und da bleib ich auf. Ich glaube, das darf man schon einmal, weil es eine Weihnachtsarbeit ist.«
     </p>
-    <p xml:id="eco_de_0000141_11080">
+    <p xml:id="eco_de_0000211_11080">
      Wirklich zog sich Marianne, als sie abends mit Lotti ins Schlafzimmer kam, nicht aus. Sie hatte, ohne dass es Sophie und Balbine bemerkten, statt dem Wachslicht die alte kleine Küchenlampe mitgenommen und setzte sich mit ihrer Stickerei hin.
     </p>
-    <p xml:id="eco_de_0000141_11090">
+    <p xml:id="eco_de_0000211_11090">
      »Du hättest eigentlich auch zu tun«, sagte sie. »Du könntest an dem Nadelbüchlein für Sophie weitersticken.«
     </p>
-    <p xml:id="eco_de_0000141_11100">
+    <p xml:id="eco_de_0000211_11100">
      »O«, gähnte Lotti in ihrem Bett, »das wird schon noch fertig. Arbeiten mag ich nicht mehr; aber ich will dir eine Geschichte erzählen.« Sie besann sich. »Ich will dir Jorinde und Joringel erzählen.«
     </p>
-    <p xml:id="eco_de_0000141_11110">
+    <p xml:id="eco_de_0000211_11110">
      »Nein«, sagte Marianne, »das ist so schrecklich traurig.«
     </p>
-    <p xml:id="eco_de_0000141_11120">
+    <p xml:id="eco_de_0000211_11120">
      »Ja, und eigentlich weiss ich es auch gar nicht mehr recht. Aber das Rumpelstilzchen?«
     </p>
-    <p xml:id="eco_de_0000141_11130">
+    <p xml:id="eco_de_0000211_11130">
      »Also!« sagte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_11140">
+    <p xml:id="eco_de_0000211_11140">
      »Es war einmal ein Müller«, fing Lotti an. »Der sagte zum König, er habe eine Tochter, die Gold spinnen könne aus Stroh. Da liess der König die Tochter auf das Schloss holen und gab ihr einen Bund Stroh, dass sie daraus Gold spinne. Aber die Müllerstochter weinte – weil – – sie das gar nicht konnte – –«
     </p>
-    <p xml:id="eco_de_0000141_11150">
+    <p xml:id="eco_de_0000211_11150">
      »Und da?« fragte Marianne. »Weiter! Du wirst doch nicht schon einschlafen?«
     </p>
-    <p xml:id="eco_de_0000141_11160">
+    <p xml:id="eco_de_0000211_11160">
      »Nein, bewahre!« versicherte Lotti. »Ich bin noch ganz wach. Und da kam ein graues Männlein und fragte die Tochter, warum sie weine, und sagte, er wolle ihr das Stroh zu Gold spinnen, wenn sie ihm ihr Halsband gebe. Und da spann das – da spann das –«.
     </p>
-    <p xml:id="eco_de_0000141_11170">
+    <p xml:id="eco_de_0000211_11170">
      »Das Männlein!« half Marianne, während sie einen neuen Faden nahm.
     </p>
-    <p xml:id="eco_de_0000141_11180">
+    <p xml:id="eco_de_0000211_11180">
      »Das Männlein«, sagte Lotti nach; aber weiter fuhr sie nicht.
     </p>
-    <p xml:id="eco_de_0000141_11190">
+    <p xml:id="eco_de_0000211_11190">
      »Lotti, das soll jetzt die ganze Geschichte vom Rumpelstilzchen sein?« rief Marianne.
     </p>
-    <p xml:id="eco_de_0000141_11200">
+    <p xml:id="eco_de_0000211_11200">
      Da drehte sich Lotti noch einmal und sagte:
     </p>
-    <p xml:id="eco_de_0000141_11210">
+    <p xml:id="eco_de_0000211_11210">
      »O, wie gut, dass niemand weiss, Dass ich Rumpelstilzchen heiss'.«
     </p>
-    <p xml:id="eco_de_0000141_11220">
+    <p xml:id="eco_de_0000211_11220">
      »Ach Lotti«, erwiderte Marianne. »Du machst alles durcheinander. Das gehört ja erst an den Schluss!«
     </p>
-    <p xml:id="eco_de_0000141_11230">
+    <p xml:id="eco_de_0000211_11230">
      Aber Lotti war bereits eingeschlafen.
     </p>
-    <p xml:id="eco_de_0000141_11240">
+    <p xml:id="eco_de_0000211_11240">
      Da erzählte sich Marianne in Gedanken selber weiter, wie der König immer mehr Gold wollte und wie er die Müllerstochter heiratete und diese dem grauen Männlein ihr erstes Kind geben sollte, wenn sie nicht erraten konnte, wie das Männlein hiess. Aber ihr Bote hörte dann im Walde, wie das Männlein den Spruch sang, und sie durfte ihr Kind behalten.
     </p>
-    <p xml:id="eco_de_0000141_11250">
+    <p xml:id="eco_de_0000211_11250">
      Es war jetzt ganz still im Zimmer. Marianne stickte fleissig; die eine Ecke wollte sie fertig bringen, durchaus. Sie konnte ihre Augen schon zwingen, offen zu bleiben. Jetzt schlug es draussen auf der Turmuhr halb neun. Drüben überm Hof in dem grossen Hause brannten Lichter; andere Leute arbeiteten also auch noch …
     </p>
-    <p xml:id="eco_de_0000141_11260">
+    <p xml:id="eco_de_0000211_11260">
      Marianne fuhr zusammen. War sie jetzt eingeschlafen? Nein, das durfte sie nicht. Sie rückte zurecht und stichelte weiter. Die Lampe leuchtete aber auch schlecht. Marianne schraubte den Docht höher. Sie dachte, um sich wach zu halten, an das Rumpelstilzchen, wie es nachts in dem Walde beim Feuer auf und ab tanzte:
     </p>
-    <p xml:id="eco_de_0000141_11270">
+    <p xml:id="eco_de_0000211_11270">
      »O, wie gut, dass niemand weiss, Dass ich Rumpelstilzchen heiss'.«
     </p>
-    <p xml:id="eco_de_0000141_11280">
+    <p xml:id="eco_de_0000211_11280">
      Marianne sah das Feuer … Ein grauer Dunst stieg davon auf und erfüllte alles … Und Marianne hatte nicht mehr das Täschchen in der Hand, sondern Stroh, und das sollte zu Gold werden. Aber Marianne konnte die Hände nicht bewegen, und vor ihr das Rumpelstilzchen hörte nicht auf, seine seltsamen Sprünge zu machen. Dann kam auch die Müllerstochter und nahm Marianne das Stroh aus den Händen … Oder war es Sophie, die ihr half sich ausziehen –? Marianne strengte sich an, die Augen aufzumachen, um zu sehen, wo sie eigentlich war, im Walde bei dem Rumpelstilzchen oder in ihrem Zimmer. Aber als sie fühlte, dass sie im Bette lag, vergingen ihr alle Gedanken.
     </p>
-    <p xml:id="eco_de_0000141_11290">
+    <p xml:id="eco_de_0000211_11290">
      Am andern Morgen wusste sie gar nicht, wie das gestern zugegangen war.
     </p>
-    <p xml:id="eco_de_0000141_11300">
+    <p xml:id="eco_de_0000211_11300">
      »Ja, Marianne«, sagte Mama, »seltsam ist es zugegangen. Wie Sophie hereinkam um neun Uhr, war das ganze Zimmer erfüllt von dickem greulichem Lampenrauch, und du lagst eingeschlafen am Tisch. Wenn du die Lampe umgestossen hättest! Sophie hat dich dann ins Bett gebracht. Du hast es gut gemeint, Marianne. Aber tu so etwas nicht wieder! Du sollst schlafen nachts, nicht sticken. Weit bist du doch nicht gekommen, wie mir scheint.«
     </p>
-    <p xml:id="eco_de_0000141_11310">
+    <p xml:id="eco_de_0000211_11310">
      »Nein, Mama!« gestand Marianne beschämt.
     </p>
-    <p xml:id="eco_de_0000141_11320">
+    <p xml:id="eco_de_0000211_11320">
      Aber wie freudig überrascht war sie am Abend, als sie die beiden unteren Ecken an ihrer Arbeit fertig fand. Wer hatte geholfen –?
     </p>
-    <p xml:id="eco_de_0000141_11330">
+    <p xml:id="eco_de_0000211_11330">
      »Das Rumpelstilzchen vielleicht«, sagte Sophie. »Wenn es versteht, aus Stroh Gold zu spinnen, wird es wohl auch den Kreuzstich können.«
     </p>
-    <p xml:id="eco_de_0000141_11340">
+    <p xml:id="eco_de_0000211_11340">
      Marianne erfuhr nie, wer sich der Arbeit angenommen; aber mit dem Rumpelstilzchen wurde sie oft noch geneckt, und das Täschchen hiess, so lange es Mama hatte, das Rumpelstilzchen.
     </p>
-    <p xml:id="eco_de_0000141_11350">
+    <p xml:id="eco_de_0000211_11350">
      Am Tage nach Mariannes verunglücktem Aufbleiben war Sankt Nikolaus. In der Gegend, wo Grossmama aufgewachsen, feierte man den Nikolaustag; Grossmama hatte diese Sitte beibehalten und bereitete jedes Jahr den Turnachkindern eine kleine Festfreude, einen Vorgeschmack von Weihnacht.
     </p>
-    <p xml:id="eco_de_0000141_11360">
+    <p xml:id="eco_de_0000211_11360">
      Lotti und Werner standen erwartend am Fenster und sprachen vom Christkind. Werner hatte heute auf der Schwelle einen Faden Goldflitter gefunden. »Werner, da ist das Christkind vorbeigegangen!« hatte Sophie gesagt. »Sei nur ja ganz brav. Es ist jetzt oft in der Nähe!«
     </p>
-    <p xml:id="eco_de_0000141_11370">
+    <p xml:id="eco_de_0000211_11370">
      Der Kleine sah mit Lotti hinaus.
     </p>
-    <p xml:id="eco_de_0000141_11380">
+    <p xml:id="eco_de_0000211_11380">
      »Ich guck recht, Lotti. Dann seh ich es vielleicht fliegen. Es hat ein silbernes Kleid, gelt? und goldene Haare?«
     </p>
-    <p xml:id="eco_de_0000141_11390">
+    <p xml:id="eco_de_0000211_11390">
      Lotti nickte. Wenn man es wirklich einmal sehen könnte mit seinen schimmernden Flügeln und dem Stern auf der Stirne! Nur einen Augenblick –! In der Schule hatten gestern ein paar Kinder gesagt, es gebe kein Christkind.
     </p>
-    <p xml:id="eco_de_0000141_11400">
+    <p xml:id="eco_de_0000211_11400">
      »Mama«, war Lotti heimgekommen. »Es ist aber so schön, das vom Christkind! Ich glaube doch, dass es eines gibt.«
     </p>
-    <p xml:id="eco_de_0000141_11410">
+    <p xml:id="eco_de_0000211_11410">
      »Ja, Lotti, glaub du das nur«, hatte Mama geantwortet.
     </p>
-    <p xml:id="eco_de_0000141_11420">
+    <p xml:id="eco_de_0000211_11420">
      So spähte denn Lotti mit dem kleinen Bruder zum dunkeln Himmel hinauf.
     </p>
-    <p xml:id="eco_de_0000141_11430">
+    <p xml:id="eco_de_0000211_11430">
      Plötzlich aber läutete es draussen. Es war Grossmamas Friederike, die den »Nikolaus« brachte; auf einem mit weissem Tuch bedeckten Brette lagen vier schöne, braungelbe Nikolausmänner aus mürbem Teig gebacken, mit Rosinenaugen und einer Rute aus weissem Zucker. Und über den Nikolausmännern lagen vier grüne Tannenzweige.
     </p>
-    <p xml:id="eco_de_0000141_11440">
+    <p xml:id="eco_de_0000211_11440">
      Jedes Jahr wurden die gebackenen Männer mit Jubel empfangen; Mama musste immer wieder erzählen, wie einst bei Grossmama, als diese noch klein war, ein wirklicher lebendiger Nikolaus gekommen sei mit langem Bart und Pelzrock und einer grossen Rute, über dem Rücken einen Sack mit Nüssen und Äpfeln. Aber die kleinen Mädchen und Buben im Haus hätten sich so gefürchtet und so entsetzlich geschrien, dass das nächste Mal dann statt des lebendigen Nikolaus kleine Nikolausmänner aus Kuchenteig gekommen seien.
     </p>
-    <p xml:id="eco_de_0000141_11450">
+    <p xml:id="eco_de_0000211_11450">
      »Ich mag auch lieber nur einen kleinen«, sagte Werner und sah seinen Nikolaus zärtlich an, nachdem er ihm ein Stück vom Bein abgebissen und das rechte Rosinenauge herausgeklaubt hatte.
     </p>
-    <p xml:id="eco_de_0000141_11460">
+    <p xml:id="eco_de_0000211_11460">
      Hans aber hielt die Tannenzweige über die Lampe, so dass die Nadeln leise zu knistern begannen und durch den ganzen Raum ein feiner, lieblicher Duft zog, der Duft des Christbaumes –!
     </p>
-    <p xml:id="eco_de_0000141_11470">
+    <p xml:id="eco_de_0000211_11470">
      »Weihnacht, Weihnacht!« riefen die Kinder und liefen, ihre Tannenzweige schwingend, durch das Haus, zu Ulrich hinunter, zu Papa und wieder hinauf.
     </p>
-    <p xml:id="eco_de_0000141_11480">
+    <p xml:id="eco_de_0000211_11480">
      »Weihnacht, Weihnacht!« drangen sie zum Schwesterlein ins Zimmer, damit die Kleine ebenfalls den Tannenduft atme.
     </p>
-    <p xml:id="eco_de_0000141_11490">
+    <p xml:id="eco_de_0000211_11490">
      »Nächstes Jahr bekommst du auch einen Nikolaus!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000141_11500">
+    <p xml:id="eco_de_0000211_11500">
      »Mum, mambam«, machte die Kleine und lachte die Geschwister zufrieden an, als ob sie sagen wollte: »Ja, ja, ich kann schon noch warten.«
     </p>
-    <p xml:id="eco_de_0000141_11510">
+    <p xml:id="eco_de_0000211_11510">
      Näher und näher rückte Weihnacht heran. Bereits fünfzehn Striche hatten Marianne und Lotti an ihren Betten ausgewischt. Die Tage waren jetzt ganz mit Weihnachtsgedanken erfüllt. Schon früh am Morgen, wenn es fast noch dunkel war, begannen die Kinder ihre Lieder zu lernen. Mama nebenan hörte zu und half. Marianne war immer die erste.
     </p>
-    <p xml:id="eco_de_0000141_11520">
+    <p xml:id="eco_de_0000211_11520">
      »Mama«, rief sie leise. »Schläfst du noch?«
     </p>
-    <p xml:id="eco_de_0000141_11530">
+    <p xml:id="eco_de_0000211_11530">
      »Nein«, antwortete Mama.
     </p>
-    <p xml:id="eco_de_0000141_11540">
+    <p xml:id="eco_de_0000211_11540">
      »Dann kann ich aufsagen?« Und sie begann:
     </p>
-    <p xml:id="eco_de_0000141_11550">
+    <p xml:id="eco_de_0000211_11550">
      »Du lieber, heil'ger, frommer Christ, Der für uns Kinder kommen ist, Damit wir sollen gut und rein Und rechte Kinder Gottes sein …«
     </p>
-    <p xml:id="eco_de_0000141_11560">
+    <p xml:id="eco_de_0000211_11560">
      Die zwei ersten Strophen konnte sie schon. Nun sprach Mama ihr die schöne dritte vor:
     </p>
-    <p xml:id="eco_de_0000141_11570">
+    <p xml:id="eco_de_0000211_11570">
      »Du lieber, heil'ger, frommer Christ, Weil heute dein Geburtstag ist, Drum ist auf Erden weit und breit Bei allen Kindern frohe Zeit.«
     </p>
-    <p xml:id="eco_de_0000141_11580">
+    <p xml:id="eco_de_0000211_11580">
      Dann kam Lotti an die Reihe. Während sie ihr Lied aufsagte, blieb Marianne aufrecht sitzen und sprach leise mit:
     </p>
-    <p xml:id="eco_de_0000141_11590">
+    <p xml:id="eco_de_0000211_11590">
      »Wenn die Weihnachtsglocken klingen, Wenn die Engel Gottes singen …«
     </p>
-    <p xml:id="eco_de_0000141_11600">
+    <p xml:id="eco_de_0000211_11600">
      Wie ahnungsvoll das war! – Draussen fing der Strassenlärm an; man hörte die Wagen rasseln; der Bäckerjunge und der Briefträger läuteten am Hause. Es ging wie alle Tage im Jahr. Und doch fühlte man in sich innen, dass jetzt eine besondere Zeit war, eine ganz einzig schöne Zeit!
     </p>
-    <p xml:id="eco_de_0000141_11610">
+    <p xml:id="eco_de_0000211_11610">
      Hans, der oben schlief, sagte seine Weihnachtsverse am Abend, bevor man die Lampe anzündete. Mama lehrte ihn ein Stück aus dem Weihnachtsevangelium:
     </p>
-    <p xml:id="eco_de_0000141_11620">
+    <p xml:id="eco_de_0000211_11620">
      »Und es waren Hirten auf dem Felde bei den Hürden, die hüteten des Nachts ihre Herde. Und siehe, des Herrn Engel trat zu ihnen, und die Klarheit des Herrn leuchtete um sie, und sie fürchteten sich sehr. Und der Engel sprach zu ihnen: Fürchtet euch nicht, siehe ich verkündige euch grosse Freude, die allem Volke widerfahren wird. Denn euch ist heute der Heiland geboren, welcher ist Christus der Herr, in der Stadt Davids. Und das habt zum Zeichen, ihr werdet finden das Kind in Windeln gewickelt und in einer Krippe liegend.
     </p>
-    <p xml:id="eco_de_0000141_11630">
+    <p xml:id="eco_de_0000211_11630">
      Und alsobald war da bei dem Engel die Menge der himmlischen Heerscharen, die lobten Gott und sprachen: Ehre sei Gott in der Höhe und Friede auf Erden und den Menschen ein Wohlgefallen …«
     </p>
-    <p xml:id="eco_de_0000141_11640">
+    <p xml:id="eco_de_0000211_11640">
      Mama erzählte den Kindern dann noch weiter, wie die Hirten das Jesuskind gefunden im Stall zu Bethlehem, und wie die Könige kamen, ihm Geschenke zu bringen. Das hörte sich so schön und feierlich an in der Abenddämmerung.
     </p>
-    <p xml:id="eco_de_0000141_11650">
+    <p xml:id="eco_de_0000211_11650">
      Am Mittwoch der letzten Woche kam das Backen. Mama und Balbine hatten schon am Abend vorher Mehl, Zucker und Eier, Zitronat, Zimmet und Mandeln abgewogen.
     </p>
-    <p xml:id="eco_de_0000141_11660">
+    <p xml:id="eco_de_0000211_11660">
      »Heut nachmittag dürft ihr helfen!« rief Sophie den Kindern nach, als sie zur Schule gingen.
     </p>
-    <p xml:id="eco_de_0000141_11670">
+    <p xml:id="eco_de_0000211_11670">
      Der würzige Geruch aus der Küche und die freudige Ungeduld verfolgte die drei bis in die Unterrichtsstunden hinein. Dass Lotti nicht recht aufpasste und nach allen Seiten mitteilte, es werde heute zu Haus gebacken, war nicht erstaunlich. Sie musste sogar ein bisschen in den Winkel stehen. Aber Hans – ein Bub und ein Fünftklässler –! Zweimal gab er im Rechnen eine ganz falsche Antwort, weil er an die Verzierung seiner Lebkuchen dachte. Herr Altschmid runzelte die Stirne.
     </p>
-    <p xml:id="eco_de_0000141_11680">
+    <p xml:id="eco_de_0000211_11680">
      »Was ist denn heut mit dem Turnach! Erst behauptet er, wenn neun Maurer zu einer Arbeit drei Tage brauchen, so müssten achtzehn Maurer sechs Tage haben! Und jetzt kann er nicht einmal mehr 135 durch 15 teilen! Ich möchte wirklich wissen, wo seine Gedanken sind.«
     </p>
-    <p xml:id="eco_de_0000141_11690">
+    <p xml:id="eco_de_0000211_11690">
      Hans wurde feuerrot. Es wäre doch geradezu entsetzlich, wenn Herr Altschmid und die Buben errieten, an was er gedacht hatte! Das ganze Jahr müsste er in der Klasse »der Zuckerbäcker« heissen –! Mit Gewalt verscheuchte er den Zitronat und die Mandeln aus dem Kopfe und strengte sich an, die folgenden Rechnungsaufgaben richtig zu lösen.
     </p>
-    <p xml:id="eco_de_0000141_11700">
+    <p xml:id="eco_de_0000211_11700">
      Die ganze Familie, Papa ausgenommen, war nachmittags in der Küche beschäftigt. Lotti stand mit aufgestülpten Ärmeln an einer Schüssel mit warmem Wasser, in dem die Mandeln geschält wurden. Hoppla! da sprang wieder eine über Lotti weg, eine ganz kleine, krumme; die durfte man essen.
     </p>
-    <p xml:id="eco_de_0000141_11710">
+    <p xml:id="eco_de_0000211_11710">
      »Mama, der Backtag ist doch zu nett!« rief Lotti einmal über das andere.
     </p>
-    <p xml:id="eco_de_0000141_11720">
+    <p xml:id="eco_de_0000211_11720">
      Mama strich mit Balbine den Lebkuchenteig auf grosse Oblaten, worauf Hans und Marianne die Ausschmückung vornahmen. Es wurden aus Zitronat und geschnittenen Mandeln Sterne, Halbmonde, Buchstaben und Blumen gebildet, immer künstlicher, bis Mama zur Eile trieb. Die Springerlein mussten auch noch gemacht werden. Da kamen die hübschen Formen, in die man den Teig drückte: die Ente, der Hase und das Obstkörbchen, das Dampfschiff und die Windmühle. Auch ein Kaiser Karl war da mit Krone, ein Tiroler und eine Frau, die ein Taufkind trug. Es ging sehr munter und laut zu mit Rühren und Klopfen, mit: »Ei, wie fein!« und »O weh! jetzt ist dem Kaiser Karl der Kopf weg –!«
     </p>
-    <p xml:id="eco_de_0000141_11730">
+    <p xml:id="eco_de_0000211_11730">
      Werner arbeitete an einem niedrigen Stuhl; er war voll Mehlstaub wie ein Müller, und schrecklich viel Mehl knetete er auch in seinen Teig, der allmählich zu einem grauen festen Klumpen wurde. Höchst befriedigt drückte ihn aber Werner zuletzt in die Schwanenform hinein.
     </p>
-    <p xml:id="eco_de_0000141_11740">
+    <p xml:id="eco_de_0000211_11740">
      »Den hab ich gemacht!« rief er strahlend. »Den schenk ich Sophie, und dem Papa mach ich ein Dampfschiff!«
     </p>
    </div>
@@ -3664,409 +3664,409 @@
     <head>
      Der Weihnachtstag
     </head>
-    <p xml:id="eco_de_0000141_11750">
+    <p xml:id="eco_de_0000211_11750">
      Endlich, endlich war der Weihnachtsmorgen da. Marianne leuchtete und Lotti wischte den letzten Strich aus, den allerletzten! Kaum waren die beiden imstande, sich anzuziehen vor Wonne. Und es gab doch noch so viel zu tun. Im Wohnzimmer brannte die Lampe; ringsum auf Tischen und Stühlen war eine prächtige Unordnung von Schuhen, Spielzeug und Kleidern, von Körben mit Äpfeln, Kuchen und allerlei andern Esswaren. Mama richtete Pakete für verschiedene Leute, die sie beschenken wollte. So bekam Theodor Hahn ein paar neue Stiefel, ein Märchenbuch und eine grosse Tüte voll Backwerk. Für Mischa Zritschek, der immer noch alles Schuhwerk der Familie Turnach sohlte und flickte, hatte Mama Taschentücher und ein Schreibzeug, für seine Mutter Wollenstoff und Kaffee bereit.
     </p>
-    <p xml:id="eco_de_0000141_11760">
+    <p xml:id="eco_de_0000211_11760">
      »Guten Morgen, Mama –! Mama, Weihnacht!« kamen die Kinder hereingesprungen und machten sich eilig auch an ihre Pakete. Das war die letzte schöne Arbeit! Marianne hatte für ihre Geschenke weisses Seidenpapier mit Rosabändchen; Lottis Sachen wurden in Blau gewickelt mit silberner Schnur; Hans aber brachte hellgrüne Bogen und steckte auf alle seine Päckchen kleine Stechpalmenzweige voll roter Beeren; er hatte die Zweige von Balbines Bruder, dem Gärtner, erhalten.
     </p>
-    <p xml:id="eco_de_0000141_11770">
+    <p xml:id="eco_de_0000211_11770">
      Jedes der Kinder war in einer Ecke beschäftigt und schrie laut auf, wenn ein anderes in die Nähe kam. Lotti legte sich immer mit der ganzen Länge auf ihre Herrlichkeiten, um sie zu verbergen.
     </p>
-    <p xml:id="eco_de_0000141_11780">
+    <p xml:id="eco_de_0000211_11780">
      Der kleine Werner erschien nun ebenfalls und lief mit seinen dicken grauen Springerlein von einem zum andern, dass man ihm auch schöne Pakete daraus mache, was die gute Marianne dann tat.
     </p>
-    <p xml:id="eco_de_0000141_11790">
+    <p xml:id="eco_de_0000211_11790">
      Gegen Mittag wurde es immer geheimnisvoller im Hause. Mama schloss die Wohnstube ab, und ins Schlafzimmer durfte man auch nicht mehr. Man ass droben in der blauen Stube; doch niemand hatte Zeit, lange am Tisch zu sitzen. Die Kinder wurden hinaufgeschickt auf den Boden, wo sie oft nach dem Essen spielten; aber heute hielten sie es nicht aus da droben.
     </p>
-    <p xml:id="eco_de_0000141_11800">
+    <p xml:id="eco_de_0000211_11800">
      »Geht hinunter zu Papa«, sagte Mama, »und fragt, ob er Zeit habe, mit euch spazieren zu gehen!«
     </p>
-    <p xml:id="eco_de_0000141_11810">
+    <p xml:id="eco_de_0000211_11810">
      »Ja, Mama, ja! und wenn wir heimkommen, ist Weihnacht da!«
     </p>
-    <p xml:id="eco_de_0000141_11820">
+    <p xml:id="eco_de_0000211_11820">
      Jedes Jahr machte Papa mit den Kindern vor der Bescherung einen weiten Spaziergang hinauf durch den Wald und dann hinunter in die Seeweid zu Frau Völklein. Es mochte noch so kalt sein, dieser Spaziergang wurde gemacht, und die Kinder sagten, er sei der allerschönste im ganzen Jahr.
     </p>
-    <p xml:id="eco_de_0000141_11830">
+    <p xml:id="eco_de_0000211_11830">
      Als die vier Kinder – Werner war diesmal auch dabei – mit Papa das Haus verliessen, kam Theodor Hahn mit glücklichem Gesicht über den Kornplatz, um sein Paket bei Frau Turnach zu holen.
     </p>
-    <p xml:id="eco_de_0000141_11840">
+    <p xml:id="eco_de_0000211_11840">
      »Aber noch nicht aufmachen, gelt?« mahnte ihn Marianne.
     </p>
-    <p xml:id="eco_de_0000141_11850">
+    <p xml:id="eco_de_0000211_11850">
      »Nein, erst am Abend!« versicherte Theodor. »Ich bekomme ein Christbäumchen!«
     </p>
-    <p xml:id="eco_de_0000141_11860">
+    <p xml:id="eco_de_0000211_11860">
      Unter der Türe der Apotheke standen Rudolf und Sylvia.
     </p>
-    <p xml:id="eco_de_0000141_11870">
+    <p xml:id="eco_de_0000211_11870">
      »Freut ihr euch auch so schrecklich?« rief ihnen Hans zu.
     </p>
-    <p xml:id="eco_de_0000141_11880">
+    <p xml:id="eco_de_0000211_11880">
      »Ja, furchtbar!« antwortete Sylvia, die mit dem ganzen Gesicht lachte. »Bei uns kommt das Christkind schon um fünf Uhr!«
     </p>
-    <p xml:id="eco_de_0000141_11890">
+    <p xml:id="eco_de_0000211_11890">
      Auf der Brücke liefen die Leute rasch und geschäftig aneinander vorbei, Frauen mit Körben, Männer und Knaben mit grünen Christbäumen auf den Schultern, neu lackierten Puppenwagen oder Schlitten. Jedesmal, wenn Lotti so etwas Ahnungsvolles erblickte, stampfte sie vor Vergnügen mit beiden Füssen.
     </p>
-    <p xml:id="eco_de_0000141_11900">
+    <p xml:id="eco_de_0000211_11900">
      »Die friert auch«, sagte ein Bäcker an der Kramgasse, der mit einem Blech voll frischgebackener Stollen aus dem Laden trat.
     </p>
-    <p xml:id="eco_de_0000141_11910">
+    <p xml:id="eco_de_0000211_11910">
      »Nein, ich freu mich bloss so!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000141_11920">
+    <p xml:id="eco_de_0000211_11920">
      Als man aus der Stadt heraus auf die Höhe kam, wurde es stiller. In dem tiefen Schnee sah man nur einzelne Fusstapfen. Es war das prächtigste Weihnachtswetter. Am Himmel zogen leichte weisse Wolken daher, aus denen der Schnee in feinen Flocken oder einzelnen Sternchen herniederflog. Dazwischen war wieder der blaue Himmel sichtbar, und die Sonne schien auf die beschneiten Abhänge. Die ganze Luft war wie silbern.
     </p>
-    <p xml:id="eco_de_0000141_11930">
+    <p xml:id="eco_de_0000211_11930">
      Am Waldeingange standen hohe Tannen, deren Äste sich senkten unter der Last des Schnees.
     </p>
-    <p xml:id="eco_de_0000141_11940">
+    <p xml:id="eco_de_0000211_11940">
      »Papa«, sagte Marianne, »wie das schön ist, durch den prächtigen Wald zu gehen und dabei an das andere Schöne zu denken, das am Abend kommt!«
     </p>
-    <p xml:id="eco_de_0000141_11950">
+    <p xml:id="eco_de_0000211_11950">
      Lotti war ein Stück voraus und sagte mit lauter Stimme ihr Weihnachtslied in die glitzernde Luft hinaus.
     </p>
-    <p xml:id="eco_de_0000141_11960">
+    <p xml:id="eco_de_0000211_11960">
      In den Tannen piepten die Meisen. Auf einem Aste sass ein Eichhörnchen und guckte neugierig zu den Kindern herunter. Werner, der so ein Schwanztier, wie er es nannte, noch nie gesehen, hatte seine helle Freude.
     </p>
-    <p xml:id="eco_de_0000141_11970">
+    <p xml:id="eco_de_0000211_11970">
      »Komm! Komm! ich schenk dir etwas!« rief er und streckte ein Anisspringerlein zu der Tanne hinauf.
     </p>
-    <p xml:id="eco_de_0000141_11980">
+    <p xml:id="eco_de_0000211_11980">
      Papa aber zog seine Uhr.
     </p>
-    <p xml:id="eco_de_0000141_11990">
+    <p xml:id="eco_de_0000211_11990">
      »Vorwärts, Kinder! In drei Stunden brennt schon der Christbaum!«
     </p>
-    <p xml:id="eco_de_0000141_12000">
+    <p xml:id="eco_de_0000211_12000">
      Da liessen die Kinder Meisen und Eichhorn und fingen auf einmal an so zu eilen, dass Papa kaum nachkam und Werner Trab laufen musste.
     </p>
-    <p xml:id="eco_de_0000141_12010">
+    <p xml:id="eco_de_0000211_12010">
      Die Seeweid lag einsam und verschneit. Aber als Frau Völklein die Turnachkinder die Treppe heraufstampfen hörte, kam sie aus ihrer Türe.
     </p>
-    <p xml:id="eco_de_0000141_12020">
+    <p xml:id="eco_de_0000211_12020">
      »Grüss Gott, grüss Gott, Kinderlein! So kalt und in dem tiefen Schnee! Ja, und das Wernermännchen auch –! Mit ganz rotem Näschen! Gewiss habt ihr nasse Füsse bekommen! Grite soll euch die warmen Schuhe bringen!«
     </p>
-    <p xml:id="eco_de_0000141_12030">
+    <p xml:id="eco_de_0000211_12030">
      Die Kinder zogen bereitwillig ihre Schnürstiefel aus. Sie wussten das vom vergangenen Jahr. Es war sehr lustig, in den viel zu weiten Hausschuhen herumzufahren wie in Kähnen. Dann aber setzte man sich an den Tisch zu einem warmen Tee und Bretzeln; es schmeckte prächtig nach dem langen Spaziergang. Der Tee bei Frau Völklein gehörte durchaus zu den Weihnachtsfreuden der Turnachkinder. Fritz war nicht da; aber er wurde eingeladen, sich an einem der Feiertage die Bescherung anzusehen. Die Bescherung –! Die Kinder standen vom Tische auf. Sie konnten heute nirgends lang ruhig bleiben; sie schifften in ihren Hausschuhen auf den Gang hinaus zum Fenster.
     </p>
-    <p xml:id="eco_de_0000141_12040">
+    <p xml:id="eco_de_0000211_12040">
      Unter weisser Decke lag der Garten, die Seemauer und der Landungssteg; das Schiff war aufs Ufer gezogen unter ein Bretterdach. Alles sah aus, als ob es schlafe in dem tiefen Schnee.
     </p>
-    <p xml:id="eco_de_0000141_12050">
+    <p xml:id="eco_de_0000211_12050">
      In der Küche sass Jakob bei seinem Abendbrot.
     </p>
-    <p xml:id="eco_de_0000141_12060">
+    <p xml:id="eco_de_0000211_12060">
      »Jakob, heut ist Weihnacht!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_12070">
+    <p xml:id="eco_de_0000211_12070">
      »Ja«, sagte er und steckte das letzte Stück Brot in den Mund.
     </p>
-    <p xml:id="eco_de_0000141_12080">
+    <p xml:id="eco_de_0000211_12080">
      »Hast du dich auch so schrecklich gefreut, als du ein Bub warst?«
     </p>
-    <p xml:id="eco_de_0000141_12090">
+    <p xml:id="eco_de_0000211_12090">
      »Ja, ja, schon. Christbäume waren zwar bei uns im Dorf nicht Brauch.«
     </p>
-    <p xml:id="eco_de_0000141_12100">
+    <p xml:id="eco_de_0000211_12100">
      »Aber du hast doch etwas bekommen? Was hast du bekommen?«
     </p>
-    <p xml:id="eco_de_0000141_12110">
+    <p xml:id="eco_de_0000211_12110">
      Jakob besann sich.
     </p>
-    <p xml:id="eco_de_0000141_12120">
+    <p xml:id="eco_de_0000211_12120">
      »Eine kleine Stadt hat's einmal gegeben zum Aufstellen. Und dann jedes Jahr ein paar Winterstrümpfe und einen grossen Birnenweggen.«
     </p>
-    <p xml:id="eco_de_0000141_12130">
+    <p xml:id="eco_de_0000211_12130">
      Jakob klappte sein Taschenmesser zusammen.
     </p>
-    <p xml:id="eco_de_0000141_12140">
+    <p xml:id="eco_de_0000211_12140">
      »Du, Jakob«, fing Lotti die Unterhaltung wieder an, »ich finde es schrecklich traurig, eine Kuh zu sein.«
     </p>
-    <p xml:id="eco_de_0000141_12150">
+    <p xml:id="eco_de_0000211_12150">
      »Lotti, du sagst doch Sachen!« riefen Hans und Marianne.
     </p>
-    <p xml:id="eco_de_0000141_12160">
+    <p xml:id="eco_de_0000211_12160">
      »Ja, ich meine es im Ernst. Jetzt stehen die Kühe im Stall und wissen gar nichts von Weihnacht. Und heut abend bekommen sie bloss Heu, wie wenn es ein gewöhnlicher Tag wäre.«
     </p>
-    <p xml:id="eco_de_0000141_12170">
+    <p xml:id="eco_de_0000211_12170">
      »Das ist auch am besten für sie«, versetzte Jakob. »Und dann – etwas haben die Kühe vielleicht doch. Sie hatten vor acht Tagen die Thomasnacht.«
     </p>
-    <p xml:id="eco_de_0000141_12180">
+    <p xml:id="eco_de_0000211_12180">
      »Die Thomasnacht?« fragten die Kinder. »Was ist in der Thomasnacht?«
     </p>
-    <p xml:id="eco_de_0000141_12190">
+    <p xml:id="eco_de_0000211_12190">
      Jakob zögerte ein wenig.
     </p>
-    <p xml:id="eco_de_0000141_12200">
+    <p xml:id="eco_de_0000211_12200">
      »Bei uns daheim sagen manche Leute, in der Thomasnacht können die Tiere sprechen.«
     </p>
-    <p xml:id="eco_de_0000141_12210">
+    <p xml:id="eco_de_0000211_12210">
      »Jakob«, rief Hans. »Das glaubst du aber doch nicht!«
     </p>
-    <p xml:id="eco_de_0000141_12220">
+    <p xml:id="eco_de_0000211_12220">
      »Nein, natürlich – eigentlich nicht. Aber für die Thomasnacht richt' ich den Stall doch immer besonders schön her – man weiss nicht – . Und ich möcht's den Kühen gönnen, wenn sie auch einmal im Jahr das Maul auftun dürften!«
     </p>
-    <p xml:id="eco_de_0000141_12230">
+    <p xml:id="eco_de_0000211_12230">
      »Ja, das wäre nett für sie«, rief Lotti. »Und es könnte doch wahr sein! Jakob, geh' in der Thomasnacht einmal in den Stall und hör zu!«
     </p>
-    <p xml:id="eco_de_0000141_12240">
+    <p xml:id="eco_de_0000211_12240">
      »Nein, das darf man nicht! Der Grossvater hat immer gesagt, er glaube, der heilige Thomas gehe dann durch die Ställe und höre, was die Tiere zu erzählen haben, und wenn sie klagen, dass man schlecht mit ihnen umgehe, so sage der heilige Thomas es nachher dem lieben Herrgott –«
     </p>
-    <p xml:id="eco_de_0000141_12250">
+    <p xml:id="eco_de_0000211_12250">
      »Und dann?« fragte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_12260">
+    <p xml:id="eco_de_0000211_12260">
      Aber nun brachte Grite die Stiefel, die sie mit heissem Sand getrocknet hatte. Eilig und freudig schlüpften die Kinder hinein.
     </p>
-    <p xml:id="eco_de_0000141_12270">
+    <p xml:id="eco_de_0000211_12270">
      Als man unter den kahlen beschneiten Birnbäumen den Weg hinaufging, fing es an zu dunkeln. Droben an der Strasse brannten schon die Laternen. Werner marschierte tapfer neben Papa her und hüpfte von Zeit zu Zeit an ihm auf:
     </p>
-    <p xml:id="eco_de_0000141_12280">
+    <p xml:id="eco_de_0000211_12280">
      »Papa, ich schenk dir auch etwas!«
     </p>
-    <p xml:id="eco_de_0000141_12290">
+    <p xml:id="eco_de_0000211_12290">
      »Ja, wenn ich doch wüsste, was das ist!« sagte Papa.
     </p>
-    <p xml:id="eco_de_0000141_12300">
+    <p xml:id="eco_de_0000211_12300">
      »Tu raten, Papa!«
     </p>
-    <p xml:id="eco_de_0000141_12310">
+    <p xml:id="eco_de_0000211_12310">
      Dann fing der gute Papa an zu raten:
     </p>
-    <p xml:id="eco_de_0000141_12320">
+    <p xml:id="eco_de_0000211_12320">
      »Einen Schlafrock? Einen Zylinderhut? Eine Kutsche? – Aha, jetzt weiss ich: Einen Luftballon –?«
     </p>
-    <p xml:id="eco_de_0000141_12330">
+    <p xml:id="eco_de_0000211_12330">
      Und der kleine Bursche lachte jedesmal laut auf:
     </p>
-    <p xml:id="eco_de_0000141_12340">
+    <p xml:id="eco_de_0000211_12340">
      »Nein, Papa! Nein!« und kam auf diese Weise vorwärts, ohne etwas von Müdigkeit und Kälte zu fühlen.
     </p>
-    <p xml:id="eco_de_0000141_12350">
+    <p xml:id="eco_de_0000211_12350">
      Die drei Grossen gingen hinterdrein.
     </p>
-    <p xml:id="eco_de_0000141_12360">
+    <p xml:id="eco_de_0000211_12360">
      »Was ist denn?« rief Papa zurück, als er einen lauten Schrei hörte.
     </p>
-    <p xml:id="eco_de_0000141_12370">
+    <p xml:id="eco_de_0000211_12370">
      »Nichts, Papa!« antwortete Marianne. »Wir mussten bloss ein bisschen schreien, weil wir es fast nicht mehr aushalten!«
     </p>
-    <p xml:id="eco_de_0000141_12380">
+    <p xml:id="eco_de_0000211_12380">
      Zu Hause sass Grossmama schon in der blauen Stube. Onkel Alfred war auch da und ging auf und ab.
     </p>
-    <p xml:id="eco_de_0000141_12390">
+    <p xml:id="eco_de_0000211_12390">
      »Gelt, Onkel, man kann es fast nicht erwarten«, sagte Lotti. »Um sechs Uhr läutet's. Wie lang dauert das noch?«
     </p>
-    <p xml:id="eco_de_0000141_12400">
+    <p xml:id="eco_de_0000211_12400">
      »49 Minuten 37 und eine halbe Sekunde«, sagte der Onkel auf die Uhr schauend.
     </p>
-    <p xml:id="eco_de_0000141_12410">
+    <p xml:id="eco_de_0000211_12410">
      Dann aber setzte er sich ans Klavier und spielte schöne Akkorde. Es klang, als ob Weihnachtsglocken läuteten.
     </p>
-    <p xml:id="eco_de_0000141_12420">
+    <p xml:id="eco_de_0000211_12420">
      Endlich kam auch Mama mit dem Schwesterlein auf dem Arm und Papa.
     </p>
-    <p xml:id="eco_de_0000141_12430">
+    <p xml:id="eco_de_0000211_12430">
      Nun sollte Marianne mit ihrem Lied beginnen. Sie drückte die Hände einen Augenblick ineinander und spürte ihr Herz klopfen. Es war so feierlich, wie alle da still im Kreis sassen. Aber dann fing sie an:
     </p>
-    <p xml:id="eco_de_0000141_12440">
+    <p xml:id="eco_de_0000211_12440">
      »Du lieber, heil'ger, frommer Christ …«
     </p>
-    <p xml:id="eco_de_0000141_12450">
+    <p xml:id="eco_de_0000211_12450">
      und sprach die Verse gut und ohne Stocken.
     </p>
-    <p xml:id="eco_de_0000141_12460">
+    <p xml:id="eco_de_0000211_12460">
      Lotti auch. Nur einmal mahnte Mama leise:
     </p>
-    <p xml:id="eco_de_0000141_12470">
+    <p xml:id="eco_de_0000211_12470">
      »Nicht so schnell, Lotti!«
     </p>
-    <p xml:id="eco_de_0000141_12480">
+    <p xml:id="eco_de_0000211_12480">
      Als Hans das schöne Weihnachtsevangelium von den Hirten und dem Lobgesang der Engel aufgesagt hatte, stimmte Onkel Alfred am Klavier das liebe alte Lied an:
     </p>
-    <p xml:id="eco_de_0000141_12490">
+    <p xml:id="eco_de_0000211_12490">
      »O du fröhliche, o du selige, Gnadenbringende Weihnachtszeit …«
     </p>
-    <p xml:id="eco_de_0000141_12500">
+    <p xml:id="eco_de_0000211_12500">
      Alle sangen mit. Papas und Onkel Alfreds Stimmen klangen wie Orgeltöne.
     </p>
-    <p xml:id="eco_de_0000141_12510">
+    <p xml:id="eco_de_0000211_12510">
      Dann aber vernahm man plötzlich einen andern Ton: Das helle Weihnachtsglöcklein läutete unten, so stark es vermochte.
     </p>
-    <p xml:id="eco_de_0000141_12520">
+    <p xml:id="eco_de_0000211_12520">
      »Mama, jetzt – jetzt –!«
     </p>
-    <p xml:id="eco_de_0000141_12530">
+    <p xml:id="eco_de_0000211_12530">
      Mama nickte lächelnd. »Ja, jetzt!« Die Kinder stürzten hinaus und die Treppe hinunter. Die Türe des Weihnachtszimmers war weit offen. Einen Augenblick blieben alle vier wie geblendet stehen. Strahlend stand der hohe Christbaum da mit seinen Lichtern, seinen farbigen Kugeln, goldenen Nüssen und dem funkelnden Flitter, der über den Ästen hing. So vertraut und doch so zauberhaft, so unbegreiflich schön!
     </p>
-    <p xml:id="eco_de_0000141_12540">
+    <p xml:id="eco_de_0000211_12540">
      Dann aber machte sich Werner von Mariannes Hand los.
     </p>
-    <p xml:id="eco_de_0000141_12550">
+    <p xml:id="eco_de_0000211_12550">
      »O, o, Kühe!« rief er in höchstem Jubel und lief in die Ecke, wo man auf einem niedrigen Tischchen seine Sachen aufgebaut hatte.
     </p>
-    <p xml:id="eco_de_0000141_12560">
+    <p xml:id="eco_de_0000211_12560">
      Und nun war der Bann gebrochen. Hans erblickte seinen Platz rechts vom Christbaum.
     </p>
-    <p xml:id="eco_de_0000141_12570">
+    <p xml:id="eco_de_0000211_12570">
      »O, o!« rief auch er und zog einen Schlitten heraus, einen festen Schlitten aus schönem glattem Holz, genau wie er sich ihn gewünscht hatte!
     </p>
-    <p xml:id="eco_de_0000141_12580">
+    <p xml:id="eco_de_0000211_12580">
      »Marianne, sieh wie lang! Da können wir zu dritt sitzen!« Doch Marianne hörte nicht; sie hatte schon ihre Schlittschuhe in der Hand, ein Paar prächtige Schlittschuhe, ganz wie die von Lily Rabus! Marianne wollte sich gleich hinsetzen, um sie an ihrem Fuss zu messen; aber ihre Augen überflogen den Tisch und erblickten neben allerlei Paketen einen Muff und Pelzkragen, und dahinter stand die Puppenstube neu hergerichtet, mit weissen Vorhängen und grünem Tischteppich, drei neuen Puppenkindern und einem Papa in brauner Hausjoppe mit einer Zeitung, und am Fenster war ein Blumentisch. Nein, diese Seligkeit –!
     </p>
-    <p xml:id="eco_de_0000141_12590">
+    <p xml:id="eco_de_0000211_12590">
      »Lotti, sieh doch!«
     </p>
-    <p xml:id="eco_de_0000141_12600">
+    <p xml:id="eco_de_0000211_12600">
      Lotti kniete indessen in lautem Entzücken vor einer Wiege, in der ein Wickelkind schlief, mit blonden Härchen und weissem Kittelchen.
     </p>
-    <p xml:id="eco_de_0000141_12610">
+    <p xml:id="eco_de_0000211_12610">
      »Es macht die Augen auf und zu! O, du Schatz!« rief sie und küsste die Puppe und sah dann hinten über der Wiege den Kramladen! Frisch gestrichen und lockend stand er da mit Quittenwürstchen und Schokoladeschinken, mit Glasbüchsen voll Zuckererbsen, mit kleinen Brotlaiben und einer Menge weisser Tüten. Das Wickelkind im Arm, machte sich Lotti jauchzend an den Laden.
     </p>
-    <p xml:id="eco_de_0000141_12620">
+    <p xml:id="eco_de_0000211_12620">
      Am lautesten aber ging es in Werners Ecke her. Er kreischte geradezu vor Wonne über seine Kühe und riss an Onkel Alfred, bis dieser sich zu ihm auf den Boden setzte, um die Tiere anzusehen.
     </p>
-    <p xml:id="eco_de_0000141_12630">
+    <p xml:id="eco_de_0000211_12630">
      »Die heisst – Dachs!« schrie Werner. »Und die ist die böse, die heisst Bär! Und das ist der Bless –«
     </p>
-    <p xml:id="eco_de_0000141_12640">
+    <p xml:id="eco_de_0000211_12640">
      Dann lief er hinter den Ofen und erklärte dort dem Pferd, dass es Platz machen müsse, weil jetzt Kühe kommen. Es war auch ein Heubündel da. Werner hatte so zu tun, dass er die Schachtel mit dem Dorf und das Bilderbuch noch gar nicht betrachten konnte.
     </p>
-    <p xml:id="eco_de_0000141_12650">
+    <p xml:id="eco_de_0000211_12650">
      Hans wusste ebenfalls nicht, wohin sich wenden. Da war ein Buch, das hiess »Das Wunderland der Pyramiden« und hatte eine Menge Bilder von Kriegern, Denkmälern, seltsamen Göttern und Felsengräbern. Das andere Buch trug den Titel »Sigismund Rüstig« –
     </p>
-    <p xml:id="eco_de_0000141_12660">
+    <p xml:id="eco_de_0000211_12660">
      »Marianne, das ist ja die prächtige Geschichte, aus der Papa uns schon erzählt hat!«
     </p>
-    <p xml:id="eco_de_0000141_12670">
+    <p xml:id="eco_de_0000211_12670">
      Aber im selben Augenblick rief Marianne: »Hans, Lotti! seht doch den Christbaum wieder an, wie schön er ist!«
     </p>
-    <p xml:id="eco_de_0000141_12680">
+    <p xml:id="eco_de_0000211_12680">
      Ja, wenn man nur alles zugleich hätte bewundern können!
     </p>
-    <p xml:id="eco_de_0000141_12690">
+    <p xml:id="eco_de_0000211_12690">
      Das Schwesterlein nahm sich am meisten Zeit für den Christbaum. Auf Mamas Arm guckte es mit weit offenen Augen unverwandt in die Lichter und fuhr mit den kleinen Fäusten auf und ab vor Erstaunen und Freude.
     </p>
-    <p xml:id="eco_de_0000141_12700">
+    <p xml:id="eco_de_0000211_12700">
      Balbine, Sophie und Ulrich waren auch hinzugetreten, und da sah man erst, dass Ulrich etwas in der Hand hielt, ein Geschenk für die Kinder, ein Schiff, das er an den Abenden und Sonntagen aus Holz geschnitzt hatte.
     </p>
-    <p xml:id="eco_de_0000141_12710">
+    <p xml:id="eco_de_0000211_12710">
      »Nein, so etwas Feines, Ulrich!« jubelten die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_12720">
+    <p xml:id="eco_de_0000211_12720">
      Es war weiss, blau und rot gestrichen und hatte ein Segel und ein bewegliches Steuerruder. Das Ganze war so kunstvoll und sauber gemacht, dass auch die Grossen es bewunderten.
     </p>
-    <p xml:id="eco_de_0000141_12730">
+    <p xml:id="eco_de_0000211_12730">
      »Ulrich, Sie sind ja ein Schiffbauer erster Güte«, sagte Onkel Alfred. »Sie gehören auf eine Werft und nicht in die Garnkammer!«
     </p>
-    <p xml:id="eco_de_0000141_12740">
+    <p xml:id="eco_de_0000211_12740">
      Ulrich lachte verlegen. Er hatte auch einen Gabentisch und freute sich besonders über Lottis Pulswärmer. Aber vergnügt sah er immer wieder hinüber zu Hans, der das schöne Schiff auf seinen Tisch stellte, mitten unter die Herrlichkeiten, die noch gar nicht alle entdeckt waren. Da gab es ein Taschenmesser, warme Winterhandschuhe, ein Reisszeug, mit dunkelblauem Sammet ausgeschlagen, einen Rucksack mit allerlei nützlichen Nebentaschen. Es war fast zu viel. Hans zog Marianne mit Gewalt herüber, dass sie ihm helfe bewundern.
     </p>
-    <p xml:id="eco_de_0000141_12750">
+    <p xml:id="eco_de_0000211_12750">
      »Ja, Hans, prachtvoll! Reizend!« stimmte Marianne ein. »Aber komm, sieh meinen Malkasten an! Bitte, nur den! Es sind fünfzehn Farben und vier Pinsel!«
     </p>
-    <p xml:id="eco_de_0000141_12760">
+    <p xml:id="eco_de_0000211_12760">
      Hans besichtigte den Malkasten; als er aber gleich wieder zu seiner Bescherung hinüberlief, holte sich Marianne Balbine, damit sie helfe, das Kommödchen von Grossmama betrachten, und die hübsche Schürze, die Zopfbänder, die Gamaschen und das Buch, das »Roland und Elisabeth« hiess, und gewiss wunderschön zu lesen war.
     </p>
-    <p xml:id="eco_de_0000141_12770">
+    <p xml:id="eco_de_0000211_12770">
      Lotti hatte sich Ulrichs bemächtigt; er musste das Wickelkind besehen, die gefüllte Federschachtel, den kleinen Pumpbrunnen, den Baukasten und den Regenschirm mit einer Troddel wie der von Mama!
     </p>
-    <p xml:id="eco_de_0000141_12780">
+    <p xml:id="eco_de_0000211_12780">
      Der fröhliche Lärm wurde immer grösser, da nun Papa und Mama, Grossmama und Onkel Alfred auch an ihre Tische getreten waren und mit Ausrufen der Freude und Überraschung ihre Geschenke entgegennahmen. Die Kinder liefen von einem zum andern und standen gespannt dabei, wenn ihre kleinen Pakete aufgemacht wurden.
     </p>
-    <p xml:id="eco_de_0000141_12790">
+    <p xml:id="eco_de_0000211_12790">
      »Alles Blaue mit Silberschnur ist also von mir!« verkündete Lotti.
     </p>
-    <p xml:id="eco_de_0000141_12800">
+    <p xml:id="eco_de_0000211_12800">
      Mama wickelte das Rumpelstilzchen aus. Grossmama war entzückt über Hansens rosa Pappschachtel, in der Mariannes Blumenkarten lagen. Papa aber entdeckte Werners grossartiges Geschenk.
     </p>
-    <p xml:id="eco_de_0000141_12810">
+    <p xml:id="eco_de_0000211_12810">
      »Gelt, Papa, das hast du nicht erraten können!« triumphierte der Kleine, und ruhte nicht, bis der arme Papa ein Stück von dem dicken grauen Springerlein versuchte.
     </p>
-    <p xml:id="eco_de_0000141_12820">
+    <p xml:id="eco_de_0000211_12820">
      Dann machte Onkel Alfred mit vielen Umständen Mariannes und Lottis Päckchen auf und hob behutsam den Tintenwischer heraus.
     </p>
-    <p xml:id="eco_de_0000141_12830">
+    <p xml:id="eco_de_0000211_12830">
      »Reizend –!«
     </p>
-    <p xml:id="eco_de_0000141_12840">
+    <p xml:id="eco_de_0000211_12840">
      »Für die Tinte!« sagte Lotti und sah den Onkel stolz an.
     </p>
-    <p xml:id="eco_de_0000141_12850">
+    <p xml:id="eco_de_0000211_12850">
      »Tinte –!« wehrte dieser. »Nein, dafür ist dieses Kunstwerk zu kostbar! Höchstens meine Tränen wische ich damit ab –«
     </p>
-    <p xml:id="eco_de_0000141_12860">
+    <p xml:id="eco_de_0000211_12860">
      »Ach, Onkel, du weinst ja nie!« riefen Marianne und Lotti belustigt.
     </p>
-    <p xml:id="eco_de_0000141_12870">
+    <p xml:id="eco_de_0000211_12870">
      »Nie –! Wo ihr mir grade jetzt Tränen der Freude und Rührung entlockt!«
     </p>
-    <p xml:id="eco_de_0000141_12880">
+    <p xml:id="eco_de_0000211_12880">
      Und Onkel Alfred fuhr sich mit dem Tintenwischer über die Augen; dann aber befestigte er ihn an seinem Knopfloch und erklärte, er werde ihn als Verdienstorden tragen.
     </p>
-    <p xml:id="eco_de_0000141_12890">
+    <p xml:id="eco_de_0000211_12890">
      In dem Getümmel schoss auch noch Schnauzel hin und her, aufgeregt durch die Lichter, den Lärm und die Wurst, die er geschenkt bekommen hatte. Papa hatte ihm die Hälfte davon gegeben und die andere in die Höhe gehalten.
     </p>
-    <p xml:id="eco_de_0000141_12900">
+    <p xml:id="eco_de_0000211_12900">
      »Du begreifst, Schnauzel«, hatte er gesagt, »wenn du sie jetzt frissest, so hast du morgen nichts mehr.«
     </p>
-    <p xml:id="eco_de_0000141_12910">
+    <p xml:id="eco_de_0000211_12910">
      »Wau!« bellte Schnauzel und wedelte heftig mit dem kurzen Schwanze, was jedenfalls heissen sollte:
     </p>
-    <p xml:id="eco_de_0000141_12920">
+    <p xml:id="eco_de_0000211_12920">
      Ja, ich begreife; aber ich will sie doch gern heut noch! worauf Papa ihm das zweite Stück aushändigte, damit auch er an diesem Abend seine ganze Freude habe.
     </p>
-    <p xml:id="eco_de_0000141_12930">
+    <p xml:id="eco_de_0000211_12930">
      Die gute Mama und Sophie machten es möglich, dass man im Weihnachtszimmer zu Nacht essen konnte. Man liess sich's gut schmecken; aber das Beste war doch, dass man hinter sich alle die wunderschönen Sachen wusste. Ja, man durfte, was sonst verboten war, mitten vom Essen weglaufen, zur Puppenstube, zum Schlitten und Schiff, zum Wickelkind, zu den Kühen und zu den Körbchen mit Backwerk, die auf den Gabentischen standen und aus denen man sich ein paar recht feine Stücke zum Nachtisch aussuchte.
     </p>
-    <p xml:id="eco_de_0000141_12940">
+    <p xml:id="eco_de_0000211_12940">
      Schrecklich aber war es, als Mama anfing, vom Schlafengehen zu sprechen.
     </p>
-    <p xml:id="eco_de_0000141_12950">
+    <p xml:id="eco_de_0000211_12950">
      »Mama, wenn man doch die Betten da heraus zum Christbaum stellen könnte!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000141_12960">
+    <p xml:id="eco_de_0000211_12960">
      Zum Glück hielt das Gutnachtsagen und das Danken die Kinder noch ein Weilchen im Zimmer zurück. Man hatte für soviel zu danken!
     </p>
-    <p xml:id="eco_de_0000141_12970">
+    <p xml:id="eco_de_0000211_12970">
      Werner lief auf Papa zu.
     </p>
-    <p xml:id="eco_de_0000141_12980">
+    <p xml:id="eco_de_0000211_12980">
      »Papa, hast du dem Christkind gesagt, dass es mir die Kühe schenken soll?«
     </p>
-    <p xml:id="eco_de_0000141_12990">
+    <p xml:id="eco_de_0000211_12990">
      »Ja, Wernermann.«
     </p>
-    <p xml:id="eco_de_0000141_13000">
+    <p xml:id="eco_de_0000211_13000">
      »Dann geb ich dir für jede einen Kuss!«
     </p>
-    <p xml:id="eco_de_0000141_13010">
+    <p xml:id="eco_de_0000211_13010">
      Und der Kleine rannte eifrig hin und her zwischen Papa und seinen Kühen, damit es nur ja richtig werde mit den Küssen. Er wäre nie fertig geworden, wenn Sophie ihn nicht endlich gepackt hätte. Glücklich erwischte er aber noch den »Dachs« und behielt ihn fest im Arm bis in den Schlaf hinein. Lotti stellte ihr »Schatzkind« mit der Wiege neben ihr Bett. Hans legte sein »Land der Pyramiden« und den »Sigismund Rüstig« unter das Kopfkissen, damit er auch im Schlafe die beiden Bücher spüre, und Marianne hängte ihre Schlittschuhe an den Bettpfosten, wo man sie bei jeder Bewegung konnte klirren hören.
     </p>
-    <p xml:id="eco_de_0000141_13020">
+    <p xml:id="eco_de_0000211_13020">
      Nach der Spannung und der Freude des Tages schlummerten die Kinder bald ein. Aber in der Nacht, als es im Hause ganz still geworden, erwachte Marianne, und es überkam sie eine unbezwingliche Lust nach dem Weihnachtszimmer.
     </p>
-    <p xml:id="eco_de_0000141_13030">
+    <p xml:id="eco_de_0000211_13030">
      »Lotti«, flüsterte sie, »Lotti, ich muss hinübergehen und den Christbaum ansehen!«
     </p>
-    <p xml:id="eco_de_0000141_13040">
+    <p xml:id="eco_de_0000211_13040">
      »Ich auch«, sagte Lotti, und beide stiegen aus ihren Betten und schlüpften hinaus ins Wohnzimmer.
     </p>
-    <p xml:id="eco_de_0000141_13050">
+    <p xml:id="eco_de_0000211_13050">
      Es war nicht ganz dunkel. Das Laternenlicht vom Kornplatz fiel auf den Christbaum, von dem ein feiner Tannenduft ausströmte. Zwischen den Zweigen leuchteten die vergoldeten Nüsse und die kleinen weissen Zuckerherzen. Die feinen Silberfäden, die über den Ästen hingen, zitterten leise. Hoch oben an der Spitze des Christbaums aber glänzte der grosse Stern.
     </p>
-    <p xml:id="eco_de_0000141_13060">
+    <p xml:id="eco_de_0000211_13060">
      Marianne und Lotti hielten sich an der Hand.
     </p>
-    <p xml:id="eco_de_0000141_13070">
+    <p xml:id="eco_de_0000211_13070">
      »Marianne«, flüsterte Lotti. »Es ist ganz sicher, dass es ein Christkind gibt. Wer könnte sonst so etwas Wundervolles wie einen Christbaum ausdenken!«
     </p>
-    <p xml:id="eco_de_0000141_13080">
+    <p xml:id="eco_de_0000211_13080">
      »Kinder, Kinder!« rief jetzt auf einmal Mama aus ihrem Zimmer. »Meint ihr, ich hätte euch nicht gehört? Seid vernünftig und geht nun schnell in euere warmen Betten!«
     </p>
-    <p xml:id="eco_de_0000141_13090">
+    <p xml:id="eco_de_0000211_13090">
      Mamas Stimme tönte aber sehr freundlich und fröhlich. Gewiss war Mama einst als Kind auch hinausgehuscht ins Weihnachtszimmer, um zu sehen, wie schön und geheimnisvoll der Christbaum bei Nacht sei.
     </p>
    </div>
@@ -4074,337 +4074,337 @@
     <head>
      Das alte Jahr geht zu Ende
     </head>
-    <p xml:id="eco_de_0000141_13100">
+    <p xml:id="eco_de_0000211_13100">
      Am folgenden Morgen wurde im Tageslicht alles aufs neue mit Jubel begrüsst und bewundert, probiert und ringsum gezeigt. Dann aber begannen Marianne und Lotti gleich mit der Puppenstube zu spielen. Die Familie wurde zum Frühstück an den Tisch gesetzt. Die Puppenmama aber hörte nebenan schreien und ging, um das Kleinste aus dem Schlafzimmer zu holen. Dann kam Besuch: Die drei Badepuppen, die im Winter Kleider trugen wie andere Leute, erschienen, um die neue Wohnung zu betrachten.
     </p>
-    <p xml:id="eco_de_0000141_13110">
+    <p xml:id="eco_de_0000211_13110">
      »Einen Garten haben Sie wohl nicht?« fragte die Älteste der Badepuppen.
     </p>
-    <p xml:id="eco_de_0000141_13120">
+    <p xml:id="eco_de_0000211_13120">
      »Nein«, antwortete der Familienvater. »Im Sommer ziehen wir immer aufs Land –«
     </p>
-    <p xml:id="eco_de_0000141_13130">
+    <p xml:id="eco_de_0000211_13130">
      »Lotti«, unterbrach Marianne das Spiel, »wir könnten das wirklich machen! Wir machen den Umzug in die Seeweid – .« Sie lief zu Haus. »Hans, wir brauchen das Schiff! Es muss alles aufgeladen werden!«
     </p>
-    <p xml:id="eco_de_0000141_13140">
+    <p xml:id="eco_de_0000211_13140">
      Hans sass auf seinem Schlitten, vertieft in »Sigismund Rüstig«»»Stör' mich nicht immer!« sagte er und las die Stelle fertig, wo der treue Steuermann von dem Wilden tödlich verwundet wurde, als er für die belagerte Familie Seagrave Wasser holte. Dann aber sah Hans hinüber zu der Puppenstube und klappte das Buch zu.
     </p>
-    <p xml:id="eco_de_0000141_13150">
+    <p xml:id="eco_de_0000211_13150">
      »Ihr müsst es richtig machen«, sagte er. »Ihr braucht den langen blauen Teppich, der den See vorstellt, und dann sollte eine Treppe gebaut werden –«
     </p>
-    <p xml:id="eco_de_0000141_13160">
+    <p xml:id="eco_de_0000211_13160">
      Marianne brachte den Teppich, während Hans eine breite Treppe herstellte, die vom Fenstertritt herunterführte. Hier landete das Schiff, das einen flachen Boden hatte, und nun wurde der sämtliche Hausrat die Treppe hinunter auf das Schiff geschafft. Als alles hochgetürmt aufgeladen war, setzte sich die Familie oben auf das Sofa und den quergelegten Schrank, und das Schiff fuhr, von Hans an einer Schnur gezogen, ab. Zuerst ging es friedlich und in gerader Linie nach dem Moosgärtchen unter dem Christbaum, das die Seeweid vorstellte. Dann aber geschah, was noch nie begegnet war, so oft man in Wirklichkeit schon zur Seeweid gezogen war: Es erhob sich ein starker Sturm und Wellenschlag, verursacht durch Marianne und Lotti, welche anfingen, an dem Teppich zu ziehen und zu schütteln. Hans liess die Schnur los, so dass das Schiff nicht mehr vorwärts kam, sondern, ganz den Wellen preisgegeben, immer stärker hin- und herschwankte.
     </p>
-    <p xml:id="eco_de_0000141_13170">
+    <p xml:id="eco_de_0000211_13170">
      »Jetzt kommt eine furchtbare –!« rief Marianne, indem sie den Teppich aufwarf.
     </p>
-    <p xml:id="eco_de_0000141_13180">
+    <p xml:id="eco_de_0000211_13180">
      »O!« schrie Werner, der auch dabei stand, und im selben Augenblick schlug das Schiff auf die Seite. Alle Habe und, was noch schlimmer war, die ganze Familie stürzte ins Wasser. Es gab ein lautes Jammergeschrei.
     </p>
-    <p xml:id="eco_de_0000141_13190">
+    <p xml:id="eco_de_0000211_13190">
      Der Puppenvater benahm sich heldenhaft. Er rettete die drei kleinen Mädchen, während die Mutter, obgleich sie in ihrem langen Kleid nicht so gut schwimmen konnte, das jüngste Kind ans Land brachte. Die zwei Ältesten mussten sich selber heraushelfen. Endlich war die ganze Familie auf dem Trockenen und konnte daran denken, die Möbel zu retten. Unter Hallo und mit langen Stangen – Hans und Marianne holten ihre Lineale – wurde alles aufgefischt und wieder aufgeladen. Der See hatte sich beruhigt, so dass die Fahrt fortgesetzt werden konnte.
     </p>
-    <p xml:id="eco_de_0000141_13200">
+    <p xml:id="eco_de_0000211_13200">
      Da klopfte es: Rudolf und Sylvia traten ein.
     </p>
-    <p xml:id="eco_de_0000141_13210">
+    <p xml:id="eco_de_0000211_13210">
      »Ah – ein Schiff!« rief Rudolf. »Famos, der Schlitten! Zeig, was für Bücher – ich habe Gullivers Reisen bekommen! Ha – der feine Baukasten!«
     </p>
-    <p xml:id="eco_de_0000141_13220">
+    <p xml:id="eco_de_0000211_13220">
      Sylvia geriet in Entzücken über das Wickelkind. Die ausgeräumte Puppenstube nahm sich gerade nicht sehr vorteilhaft aus, der Kaufladen um so mehr. Bei ihm blieben die Mädchen stecken. Marianne war die Verkäuferin; Lotti und Sylvia verlangten Zuckerstöcke, getrocknete Kirschen und Butter, der durch kleine Marzipanstücke dargestellt war.
     </p>
-    <p xml:id="eco_de_0000141_13230">
+    <p xml:id="eco_de_0000211_13230">
      Erst ging es ganz hübsch und vernünftig zu. Marianne fragte mit höflicher hoher Stimme nach den Wünschen von Frau Lorez und Frau Turnach und gab jedesmal für die Kinder zu Hause ein paar Zuckererbsen mit. Dann aber, als die Herren Hans und Rudolf auch kamen, wurde es sehr lebhaft. Lotti musste als Ladenfräulein mithelfen, um so mehr, als es sich herausstellte, dass der kleine Gehilfe Werner schrecklich stahl. Marianne und Lotti hatten alle Hände voll zu tun; das Ladenglöcklein schellte beständig. Nach und nach wurden die beiden Herren immer unbescheidener; sie zogen selber die Rosinenschublade auf und nahmen Schokoladezigarren von den Gestellen, so dass Marianne sich zuletzt breit vor den Laden stellte und rief:
     </p>
-    <p xml:id="eco_de_0000141_13240">
+    <p xml:id="eco_de_0000211_13240">
      »Jetzt kriegt überhaupt niemand mehr etwas! Es ist zwölf Uhr und der Laden wird geschlossen!«
     </p>
-    <p xml:id="eco_de_0000141_13250">
+    <p xml:id="eco_de_0000211_13250">
      »Ja, und wir müssen eigentlich heim«, erwiderte Rudolf. »Wir wollten nur abreden für den Nachmittag. Also um zwei Uhr, Hans, am Breitenbergweg! Da saust's nur so!«
     </p>
-    <p xml:id="eco_de_0000141_13260">
+    <p xml:id="eco_de_0000211_13260">
      Als Hans, Marianne und Lotti nach dem Essen mit dem neuen Schlitten und dem kleinen alten auszogen und zum Breitenberg kamen, tönte ihnen schon von weitem der laute, langgezogene Ruf: »Aa – b!« entgegen, ohne den keiner den Weg herunterfuhr.
     </p>
-    <p xml:id="eco_de_0000141_13270">
+    <p xml:id="eco_de_0000211_13270">
      Eine Menge bekannter Buben und Mädchen waren da. Hansens Freunde liefen auf ihn zu. Die neuen Schlitten wurden besichtigt und verglichen, und rasch ging's den Berg hinauf.
     </p>
-    <p xml:id="eco_de_0000141_13280">
+    <p xml:id="eco_de_0000211_13280">
      Die Mädchen folgten mit Sylvia, Lily Rabus und andern. Man hatte sich schrecklich viel zu erzählen und zu zeigen.
     </p>
-    <p xml:id="eco_de_0000141_13290">
+    <p xml:id="eco_de_0000211_13290">
      »Aa – b! aa – b!« schrie es beständig. Nur mit Mühe kam man vorbei an den Dahersausenden.
     </p>
-    <p xml:id="eco_de_0000141_13300">
+    <p xml:id="eco_de_0000211_13300">
      Aber dann setzte man sich selber auf den Schlitten. Hui! wie das schoss! wie das flog –!
     </p>
-    <p xml:id="eco_de_0000141_13310">
+    <p xml:id="eco_de_0000211_13310">
      »Aa – b!« schrie Lotti aus vollem Halse, während Hans lenkte.
     </p>
-    <p xml:id="eco_de_0000141_13320">
+    <p xml:id="eco_de_0000211_13320">
      Der ängstlichen kleinen Sylvia ging es fast zu wild.
     </p>
-    <p xml:id="eco_de_0000141_13330">
+    <p xml:id="eco_de_0000211_13330">
      »Nicht so schnell, Rudolf!« rief sie, als sie sich hinter den Bruder setzte.
     </p>
-    <p xml:id="eco_de_0000141_13340">
+    <p xml:id="eco_de_0000211_13340">
      »Das ist grade gut für dich. Jetzt kannst du lernen, ein wenig mutig sein!« entgegnete aber der Bruder und steuerte drauflos.
     </p>
-    <p xml:id="eco_de_0000141_13350">
+    <p xml:id="eco_de_0000211_13350">
      Sowie man unten war, ging's von neuem hinauf und wieder in einem Schuss talwärts – oder auch einmal auf die Seite in den tiefen Schnee, oder gar in einen andern Schlitten hinein, worauf gewöhnlich eine von beiden Parteien den Rain hinunterkollerte.
     </p>
-    <p xml:id="eco_de_0000141_13360">
+    <p xml:id="eco_de_0000211_13360">
      Ein paarmal wäre aus solch einem Zusammenstoss fast Streit entstanden.
     </p>
-    <p xml:id="eco_de_0000141_13370">
+    <p xml:id="eco_de_0000211_13370">
      »Heh da! gebt doch acht, wo ihr hinfahrt!« riefen ein paar Buben, die mit Lotti und mit Hedwig Zohner zusammengeprallt waren.
     </p>
-    <p xml:id="eco_de_0000141_13380">
+    <p xml:id="eco_de_0000211_13380">
      »Gebt ihr selber acht!« erwiderte Lotti, indem sie aus dem Schnee herauskroch. Wenn sie im Recht war, liess sie nichts auf sich sitzen.
     </p>
-    <p xml:id="eco_de_0000141_13390">
+    <p xml:id="eco_de_0000211_13390">
      Aber als sie den einen der Buben ansah, lachte sie. Das war ja der Haubinger aus Hansens Klasse, dem sie im Herbst die Rübenlaterne geschnitzt hatte.
     </p>
-    <p xml:id="eco_de_0000141_13400">
+    <p xml:id="eco_de_0000211_13400">
      »Ja so!« sagte Haubinger und lachte auch, und nach einer Weile, als Lotti grade weder auf Hansens noch auf Mariannes Schlitten Platz fand, lud er sie ein, einmal mit ihm links den noch steileren Rotackerweg hinunterzufahren.
     </p>
-    <p xml:id="eco_de_0000141_13410">
+    <p xml:id="eco_de_0000211_13410">
      »Aber du heulst dann nicht, wenn es uns an der Ecke über den Wegrand hinausnimmt«, machte Haubinger zur Bedingung.
     </p>
-    <p xml:id="eco_de_0000141_13420">
+    <p xml:id="eco_de_0000211_13420">
      »Nein, ich heul' nicht!« versicherte Lotti. »Aber wenn es recht rasch geht, so schrei ich, weil's so lustig ist!« womit Haubinger einverstanden war.
     </p>
-    <p xml:id="eco_de_0000141_13430">
+    <p xml:id="eco_de_0000211_13430">
      An gewöhnlichen Tagen kostete es immer eine Überwindung, sich, wie Mama es wollte, um halb fünf Uhr von der Schlittbahn zu trennen. Heute aber, als es auf dem Kirchturm halb schlug, fiel den Turnachkindern die ganze Herrlichkeit zu Hause ein, und eilig kehrten sie zu ihren Weihnachtstischen zurück. –
     </p>
-    <p xml:id="eco_de_0000141_13440">
+    <p xml:id="eco_de_0000211_13440">
      Diesem ersten schönen Feiertage folgte eine ganze schöne Woche. Es gab so viel zu spielen, zu hantieren, zu lesen, dass man gar nicht zu allem Zeit fand. Am zweiten Feiertag liess Papa sich erbitten, mit den Kindern zu bauen. Papa baute prachtvoll. Zu dem grossen Baukasten, den die Kinder schon besassen, war dies Jahr ein neuer hinzugekommen mit einer Menge Hölzer, vom längsten zehnteiligen bis hinunter zum Einerwürfel. Dann waren auch Bogen da, abgeschrägte Stücke und sogar einige Säulen.
     </p>
-    <p xml:id="eco_de_0000141_13450">
+    <p xml:id="eco_de_0000211_13450">
      Papa nahm ein Buch, blätterte eine kurze Weile darin und sagte dann entschlossen:
     </p>
-    <p xml:id="eco_de_0000141_13460">
+    <p xml:id="eco_de_0000211_13460">
      »Heute bauen wir das Grabmal des Theodorich!«
     </p>
-    <p xml:id="eco_de_0000141_13470">
+    <p xml:id="eco_de_0000211_13470">
      »Ja, Papa! das Grabmal des Theodorich!« stimmten die Kinder zu, überzeugt, dass das etwas sehr Schönes werde. Das Bild zeigte ein grosses tempelartiges Gebäude.
     </p>
-    <p xml:id="eco_de_0000141_13480">
+    <p xml:id="eco_de_0000211_13480">
      Und nun ging die Arbeit an. Es wurden acht Grundpfeiler erstellt.
     </p>
-    <p xml:id="eco_de_0000141_13490">
+    <p xml:id="eco_de_0000211_13490">
      »Sorgfältig, Hans! Fest gefügt, damit nichts einstürzt!« sagte Papa, während er die Rundbogen auswählte.
     </p>
-    <p xml:id="eco_de_0000141_13500">
+    <p xml:id="eco_de_0000211_13500">
      Marianne und Lotti mussten die Bauhölzer zutragen.
     </p>
-    <p xml:id="eco_de_0000141_13510">
+    <p xml:id="eco_de_0000211_13510">
      »Einen Zehner –! zwei Achter –! drei Vierer –! vorwärts!« befahlen Papa und Hans. »Einen Siebener, Lotti! Soll das ein Siebener sein –!«
     </p>
-    <p xml:id="eco_de_0000141_13520">
+    <p xml:id="eco_de_0000211_13520">
      Die Mädchen kamen kaum nach mit Zählen und Herbringen. Werner rannte auch hin und her als Maurerbub und trug dem Papa immer grade die Hölzer zu, die er nicht brauchte.
     </p>
-    <p xml:id="eco_de_0000141_13530">
+    <p xml:id="eco_de_0000211_13530">
      Der Bau wuchs indessen stolz heran. Ringsum über den Rundbogen gab es einen Umgang.
     </p>
-    <p xml:id="eco_de_0000141_13540">
+    <p xml:id="eco_de_0000211_13540">
      »Da konnte Theodorich spazieren«, sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_13550">
+    <p xml:id="eco_de_0000211_13550">
      »Ach, Lotti«, entgegnete Hans, »als König Theodorich in das Grabmal kam, war er doch tot.«
     </p>
-    <p xml:id="eco_de_0000141_13560">
+    <p xml:id="eco_de_0000211_13560">
      »Schade!« sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_13570">
+    <p xml:id="eco_de_0000211_13570">
      »Ist er eigentlich schon lange tot, Papa? Hatte er ein grosses Reich? Führte er viele Kriege?« fing nun Hans an zu tragen.
     </p>
-    <p xml:id="eco_de_0000141_13580">
+    <p xml:id="eco_de_0000211_13580">
      »War er ein guter König? Hatte er auch Kinder? Wie hiessen sie?« wollte Marianne wissen.
     </p>
-    <p xml:id="eco_de_0000141_13590">
+    <p xml:id="eco_de_0000211_13590">
      »Halt, halt!« rief Papa und griff sich an den Kopf; denn das waren etwas viel Fragen auf einmal.
     </p>
-    <p xml:id="eco_de_0000141_13600">
+    <p xml:id="eco_de_0000211_13600">
      Aber dann erzählte Papa, während er weiterbaute, was für ein weiser und mächtiger König dieser Theodorich gewesen sei.
     </p>
-    <p xml:id="eco_de_0000141_13610">
+    <p xml:id="eco_de_0000211_13610">
      »Und auch ein guter König war er, Marianne, wenngleich es zu seiner Zeit nicht ohne Gewalt und Grausamkeit abging …«
     </p>
-    <p xml:id="eco_de_0000141_13620">
+    <p xml:id="eco_de_0000211_13620">
      Jetzt kam das Dach. Das war die grösste Schwierigkeit; aber Papa brachte alles zustande. Statt der Kuppel, die mit den eckigen Hölzern nicht zu bauen war, liess Papa das Dach in flachen Stufen auslaufen. Oben errichtete Hans ein Kreuz. Das vollendete Gebäude, das auf der grossen umgestürzten Kiste wie auf einem Felsen stand, sah prächtig aus.
     </p>
-    <p xml:id="eco_de_0000141_13630">
+    <p xml:id="eco_de_0000211_13630">
      »Hans«, rief Marianne, als die drei immer wieder durch die Bogen in das dunkle Innere guckten, »wir müssen einen wirklichen König Theodorich hineinlegen!«
     </p>
-    <p xml:id="eco_de_0000141_13640">
+    <p xml:id="eco_de_0000211_13640">
      Sie lief zur Puppenstube und holte den Puppenvater, der mit seiner winzigen Zeitung friedlich auf dem Sofa sass. In seiner braunen Joppe konnte er zwar natürlich nicht den König Theodorich vorstellen. Aber Marianne besass in ihrem Kommödchen, das Grossmama mit allerlei Stoffen für Puppenkleider angefüllt hatte, ein Stückchen dunkelroten Samt. Das gab den Königsmantel. Aus einem Goldbörtchen machte Marianne eine kleine Krone, und so wurde der Puppenvater seiner Familie entrissen und in die Gruft gelegt auf das Totenlager, das Hans aus vier Bauhölzern hergestellt hatte.
     </p>
-    <p xml:id="eco_de_0000141_13650">
+    <p xml:id="eco_de_0000211_13650">
      »Wie feierlich!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_13660">
+    <p xml:id="eco_de_0000211_13660">
      »Jetzt sollten wir es noch von innen beleuchten!« sagte Hans. »Mama, wenn wir das Nachtlicht haben könnten mit dem blauen Glas!«
     </p>
-    <p xml:id="eco_de_0000141_13670">
+    <p xml:id="eco_de_0000211_13670">
      Das Nachtlicht wurde geholt und in die Gruft gestellt, wo es die Nacht hindurch brennen sollte. Damit man aber wisse, wie das in der Dunkelheit aussehe, musste die gute Mama auf ein Weilchen die Lampe löschen. Es war geheimnisvoll wie ein schönes Märchen, wenn man in das Grabgewölbe schaute: Das bläuliche Licht fiel auf die Pfeiler der Gruft und auf die Krone des Theodorich, der still dalag, bedeckt von seinem langen roten Königsmantel.
     </p>
-    <p xml:id="eco_de_0000141_13680">
+    <p xml:id="eco_de_0000211_13680">
      »Mama, ich wollte, der Tag hätte hundert Stunden!« rief Marianne. »Wir haben gar nicht gewusst, wie nett das ist, das Kneten –«
     </p>
-    <p xml:id="eco_de_0000141_13690">
+    <p xml:id="eco_de_0000211_13690">
      Auf Mariannes Tisch war eine Schachtel mit Modellierwachs gestanden, und heute hatten die Kinder sich darüber gemacht. Sie kneteten Wecken, Hörnchen, Bretzeln, ganze Bäckerauslagen, dann Pilze, Äpfel und Zwetschgen. Hans wurde unternehmend und ging an ein Pferd; aber das war nicht leicht. Immer wenn er zur Probe die Schwestern fragte, erklärte Lotti:
     </p>
-    <p xml:id="eco_de_0000141_13700">
+    <p xml:id="eco_de_0000211_13700">
      »Das ist eine Ziege!« oder »ein Tiger!« oder »ein Hase!« Fast wäre Hans ärgerlich geworden.
     </p>
-    <p xml:id="eco_de_0000141_13710">
+    <p xml:id="eco_de_0000211_13710">
      »Aber dass das ein Elefant ist, siehst du vielleicht!« sagte er nach einer Weile neuer Bemühung und zeigte eine Gestalt, die man. an dem langen Rüssel, an den mächtigen Beinen und den Schlappohren sofort erkannte, und die Lotti denn auch geziemend bewunderte.
     </p>
-    <p xml:id="eco_de_0000141_13720">
+    <p xml:id="eco_de_0000211_13720">
      Marianne hielt sich an die niedrigern Tiere und brachte eine Schlange zustande mit gehobenem Kopf und aufgesperrtem Rachen, auch einen Molch und eine nette Schildkröte.
     </p>
-    <p xml:id="eco_de_0000141_13730">
+    <p xml:id="eco_de_0000211_13730">
      Lotti vertiefte sich nun ebenfalls in die Arbeit.
     </p>
-    <p xml:id="eco_de_0000141_13740">
+    <p xml:id="eco_de_0000211_13740">
      »Ich will euch etwas sagen«, erklärte sie. »Ich mache Menschen; das geht am leichtesten.«
     </p>
-    <p xml:id="eco_de_0000141_13750">
+    <p xml:id="eco_de_0000211_13750">
      Und kühn nudelte sie Arme und Beine zurecht; eine dickere Nudel gab den Leib, eine Kugel den Kopf –
     </p>
-    <p xml:id="eco_de_0000141_13760">
+    <p xml:id="eco_de_0000211_13760">
      »Haha, er steht!« lachte Lotti zufrieden, bog dem Burschen den Arm und gab ihm einen Schneeball in die Hand.
     </p>
-    <p xml:id="eco_de_0000141_13770">
+    <p xml:id="eco_de_0000211_13770">
      »Greulich!« sagten Hans und Marianne.
     </p>
-    <p xml:id="eco_de_0000141_13780">
+    <p xml:id="eco_de_0000211_13780">
      Aber dann bekamen sie auf einmal auch Lust, solche Buben zu kneten. Eine ganze Schar entstand allmählich. Marianne formte einen, der sich weit vorlegte mit gebeugtem Knie; er hatte kurze Hosen und eine Mütze. Hans fabrizierte zwei, die sich in die Haare kamen. Daneben brachte Lotti einen an, der auf dem Boden lag und die Beine in die Höhe streckte. Es ging immer hitziger:
     </p>
-    <p xml:id="eco_de_0000141_13790">
+    <p xml:id="eco_de_0000211_13790">
      »Ich mach einen auf einem Schlitten – so – er muss recht nach hinten liegen. – Und ich einen, der einen grossen Schneeball rollt – zu einem Schneemann –!«
     </p>
-    <p xml:id="eco_de_0000141_13800">
+    <p xml:id="eco_de_0000211_13800">
      Marianne verlegte sich auf Mädchen, die zwar wegen der Röckchen etwas beschwerlicher waren. Am liebsten hätten die Kinder den ganzen Tag geknetet. Aber anderes lockte auch wieder. Darum hatte Marianne ausgerufen:
     </p>
-    <p xml:id="eco_de_0000141_13810">
+    <p xml:id="eco_de_0000211_13810">
      »Mama, ich wollte, der Tag hätte hundert Stunden!«
     </p>
-    <p xml:id="eco_de_0000141_13820">
+    <p xml:id="eco_de_0000211_13820">
      Doch die schöne Zeit flog unaufhaltsam dahin. Nicht einmal mehr das Jahr hatte hundert Stunden. Übermorgen war schon Silvester.
     </p>
-    <p xml:id="eco_de_0000141_13830">
+    <p xml:id="eco_de_0000211_13830">
      Der Silvester war ein ganz besonderer Tag bei den Turnachkindern. Da musste man sehr früh aufstehen, noch bei stockdunkler Nacht. Wer zuletzt war, hiess Silvester und bekam eine Musik vor seiner Türe. Die Kinder flehten am Abend, dass man sie doch ja wecke. Keins wollte Silvester sein. Diese Rolle übernahm auch dies Jahr wieder Papa, der sonst so früh aufstand.
     </p>
-    <p xml:id="eco_de_0000141_13840">
+    <p xml:id="eco_de_0000211_13840">
      »Ssst – ssst!« flüsterte Hans, als die Schwestern die Treppe heraufkamen. Man verständigte sich durch Gebärden. Werner zwar, der auch dabei war, wollte alle Augenblicke etwas sagen, so dass Marianne ihm den Mund zuhalten musste. Sie stellten sich vor Papas Türe auf.
     </p>
-    <p xml:id="eco_de_0000141_13850">
+    <p xml:id="eco_de_0000211_13850">
      »Jetzt!« flüsterte Hans, und nun hub ein ganz schreckliches Konzert an:
     </p>
-    <p xml:id="eco_de_0000141_13860">
+    <p xml:id="eco_de_0000211_13860">
      Hans hatte Theodor Hahns Posthorn: »Tetteretäng! tetteretäng!« schmetterte er drauflos. Marianne benutzte zwei blecherne Pfannendeckel als Cinellen: »Ratatschin, ratatschin!« Lotti schlug die Trommel, so fest sie nur konnte, und Werner blies auf einer kleinen Pfeife, die in den höchsten Tönen quiekte. Es war ein Spektakel, der bis in den Hof hinausdrang.
     </p>
-    <p xml:id="eco_de_0000141_13870">
+    <p xml:id="eco_de_0000211_13870">
      »Wie geht's denn bei euch zu?« rief der Koch vom Goldenen Degen herüber.
     </p>
-    <p xml:id="eco_de_0000141_13880">
+    <p xml:id="eco_de_0000211_13880">
      »Unsere Kinder machen Silvester!« gab Ulrich zurück, indem er vor sich hinlachte.
     </p>
-    <p xml:id="eco_de_0000141_13890">
+    <p xml:id="eco_de_0000211_13890">
      Die fürchterliche Musik dauerte ein gutes Weilchen. Dann hielten die Kinder inne und sahen einander sehr befriedigt an.
     </p>
-    <p xml:id="eco_de_0000141_13900">
+    <p xml:id="eco_de_0000211_13900">
      »Jetzt aber noch etwas Nettes!« schlug Marianne vor. »Jetzt singen wir das Guggulied!«
     </p>
-    <p xml:id="eco_de_0000141_13910">
+    <p xml:id="eco_de_0000211_13910">
      Das Guggulied hatte Mama den Kindern gelehrt, und das Besondere daran war, dass eines nach dem andern einsetzen musste. Marianne begann:
     </p>
-    <p xml:id="eco_de_0000141_13920">
+    <p xml:id="eco_de_0000211_13920">
      »Erwacht ihr Schläfer drinnen! Der Kuckuck rufet laut Hoch von den Bergeszinnen Die helle Sonne schaut …«
     </p>
-    <p xml:id="eco_de_0000141_13930">
+    <p xml:id="eco_de_0000211_13930">
      Dann kam Lotti, und als Marianne nur noch »Guggu, Guggu …« zu singen hatte, fing Hans an. Es klang sehr hübsch ineinander und ging immer wieder von vorn an, bis Papa herauskam und in die Hände seiner wilden Kinder fiel, die ihn unter lautem: »Silvester! Silvester!« die Treppe hinunterzogen.
     </p>
-    <p xml:id="eco_de_0000141_13940">
+    <p xml:id="eco_de_0000211_13940">
      Auf dem Frühstückstische lagen viele Glückwunschkarten und Briefe, auch einer von Otto aus Larstetten.
     </p>
-    <p xml:id="eco_de_0000141_13950">
+    <p xml:id="eco_de_0000211_13950">
      »Lieber Freund und Vetter«, schrieb Otto. »Ich habe ein Vergrösserungsglas bekommen und ein Tivolispiel und einen prachtvollen Werkzeugkasten und einen Wettermantel und noch vieles. Wenn ich die Farbenstifte aus dem Etui einzeln zähle, so sind es neunzehn Sachen. Edith gibt dem Peter Stunden. Er soll lernen sagen: Guten Morgen Turmsette. Aber er kann es nicht. Er sagt bloss: Korokikoh. Am letzten Dienstag ist es ihm ganz verleidet, und er hat Edith in die Nase gebissen. Jetzt trägt Edith ein Stückchen Heiltaffet auf der Nase, extra ein schwarzes. Sie hat gesagt, damit man es besser sehe. Die Turmsette geht vielleicht im Frühling nach Amerika. Es grüsst dich freundlich Dein Dich liebender Vetter Otto.
     </p>
-    <p xml:id="eco_de_0000141_13960">
+    <p xml:id="eco_de_0000211_13960">
      Mama hat gesagt, ich hätte gratulieren sollen. Also, ich wünsche euch allen viel Glück zum neuen Jahr.«
     </p>
-    <p xml:id="eco_de_0000141_13970">
+    <p xml:id="eco_de_0000211_13970">
      Hans setzte sich sofort zur Antwort hin, während Marianne und Lotti auf Mamas Geheiss die Weihnachtssachen aufräumten. Nur der Christbaum, an dem allerdings kein einziges Zuckerherz, kein Quittenring oder Schokoladestern mehr hing, blieb da; er war noch so schön grün und duftete so gut.
     </p>
-    <p xml:id="eco_de_0000141_13980">
+    <p xml:id="eco_de_0000211_13980">
      Und das Grabmal des Theodorich, das nebenan stand, musste nun wirklich abgetragen werden? Mama sagte, es nehme zu viel Platz weg. Aber Marianne und Lotti konnten sich gar nicht entschliessen, den prächtigen Bau zu zerstören. Vielleicht doch bis zum Abend durfte er bleiben; oder bis morgen –?
     </p>
-    <p xml:id="eco_de_0000141_13990">
+    <p xml:id="eco_de_0000211_13990">
      Da führten Werner und Schnauzel zusammen unversehens die Entscheidung herbei. Schnauzel war ein gutmütiger Hund; er konnte jedoch nicht leiden, wenn man ihm eine lange Nase machte, wie es eben jetzt der kleine Werner tat, der hinter dem Grabmal stand. Ärgerlich schoss Schnauzel heran, stellte die Vorderfüsse auf die Galerie – und im selben Augenblick stürzte das ganze Gebäude mit grossem Gepolter zusammen, Dach, Rundbogen, Säulen und alles!
     </p>
-    <p xml:id="eco_de_0000141_14000">
+    <p xml:id="eco_de_0000211_14000">
      »Hallo!« schrie Hans und fuhr von seinem Briefe auf.
     </p>
-    <p xml:id="eco_de_0000141_14010">
+    <p xml:id="eco_de_0000211_14010">
      Schnauzel schaute sehr bestürzt drein und bewegte reumütig seinen Schwanz. Plötzlich aber erblickte er den kleinen König zwischen den Trümmern, packte ihn am Sammetmantel und brachte ihn Hans. Wenn er apportierte, wurde er immer gelobt. Die Kinder lachten.
     </p>
-    <p xml:id="eco_de_0000141_14020">
+    <p xml:id="eco_de_0000211_14020">
      »Eigentlich hat der Schnauzel es ganz richtig gemacht!« rief Hans. »Papa hat ja gesagt, es sei damals sehr wild und gewalttätig zugegangen. Wo hast denn du Geschichte studiert, Schnauzel?«
     </p>
-    <p xml:id="eco_de_0000141_14030">
+    <p xml:id="eco_de_0000211_14030">
      Marianne aber nahm den Puppenvater und brachte ihn wieder in seinen Familienkreis zurück, wo er erschöpft auf dem Sofa liegen blieb. Was hatte er nicht alles erlebt in der kurzen Zeit! Erst das Schiffsunglück, dann die einsamen Nächte in der Gruft, jetzt den fürchterlichen Zusammensturz und schliesslich den Schrecken, als das Riesentier ihn packte!
     </p>
-    <p xml:id="eco_de_0000141_14040">
+    <p xml:id="eco_de_0000211_14040">
      Am Abend durften die Kinder mit Grossmama in die Kirche. Als man eintrat, sassen schon viele Leute rechts und links in den Bänken. Es war so still und ernst, dass die Kinder auf den Fussspitzen hinter Grossmama hergingen. Die Säulen der Kirche waren mit Tannengirlanden umwunden; überall brannten Lichter, aber so hoch war die Kirche, dass der Schein nicht bis zur Decke drang; die mächtigen Säulen verloren sich oben im Dunkel.
     </p>
-    <p xml:id="eco_de_0000141_14050">
+    <p xml:id="eco_de_0000211_14050">
      Marianne sass andächtig da und versuchte zu verstehen, was der Herr Pfarrer sagte. Er sprach von den Leiden des Lebens. Marianne hörte hinter sich eine Frau leise schluchzen, und als sie zur Seite sah, bemerkte sie eine andere, der auch die Tränen herunterliefen. Da wurde es Marianne fast bang. Sie dachte, ob sie wohl auch einmal, wenn sie gross und alt sei, so in der Kirche weinen müsse über die Leiden des Lebens.
     </p>
-    <p xml:id="eco_de_0000141_14060">
+    <p xml:id="eco_de_0000211_14060">
      Hans sass drüben bei den Männern in einem Stuhl mit sehr hoher Lehne. Auch er sah unverwandt hinauf zur Kanzel und fragte sich, ob es nicht schön wäre, statt einem Doktor ein Pfarrer zu werden und in schwarzem Talar mit so ernster tiefer Stimme den Leuten zu predigen, die aufmerksam zuhörten. Da fiel ihm aber ein, dass er selber jetzt ja nicht acht gebe. Er rückte zurecht und horchte, wie der Herr Pfarrer mahnte, man solle auf Gott vertrauen und tapfer, furchtlos und fröhlich sein. Das gefiel Hans gut.
     </p>
-    <p xml:id="eco_de_0000141_14070">
+    <p xml:id="eco_de_0000211_14070">
      Lotti hatte etwas Mühe, so ganz still zu sitzen. Noch viel stiller als in der Schule sass man da. Aber auf einmal, als der Herr Pfarrer aufhörte zu sprechen, erklang von hoch oben, wo die Orgel war, ein wunderschöner Gesang, tiefe Stimmen und hohe Stimmen, die ineinander jubelten, dann leise wurden und plötzlich wieder laut und mächtig erschallten. Lotti lauschte.
     </p>
-    <p xml:id="eco_de_0000141_14080">
+    <p xml:id="eco_de_0000211_14080">
      »Gelt, Grossmama, das gefällt dem lieben Gott auch?« flüsterte sie und Grossmama nickte.
     </p>
-    <p xml:id="eco_de_0000141_14090">
+    <p xml:id="eco_de_0000211_14090">
      »Was ist Kinder! Ihr wolltet mir doch punkt zwölf Uhr ein gutes neues Jahr wünschen –!« rief Onkel Alfred ins hintere Zimmer, wo Marianne und Lotti im Schlafe lagen.
     </p>
-    <p xml:id="eco_de_0000141_14100">
+    <p xml:id="eco_de_0000211_14100">
      Mama hatte ihn abhalten wollen, die Kinder zu wecken. Aber sie hatten alle drei dem Onkel das Versprechen abgenommen.
     </p>
-    <p xml:id="eco_de_0000141_14110">
+    <p xml:id="eco_de_0000211_14110">
      »Und dann, Luise«, sagte der Onkel lachend, »sind deine Kinder nicht so zimperlich! Sie schlafen und springen heraus und schlafen wieder weiter – wie's eben grad am Platz ist!«
     </p>
-    <p xml:id="eco_de_0000141_14120">
+    <p xml:id="eco_de_0000211_14120">
      Der Onkel hatte recht. Die Kinder kamen in Kleider und Decken eingehüllt vergnügt ans Fenster gelaufen, um das Neujahrläuten zu hören, das eben begann. Alle Glocken der Stadt schlugen in brausendem Klange zusammen. Die ganze Luft war erfüllt von den gewaltigen Tönen. Hell hallte es vom Münster her über den Fluss; dumpf dröhnte die tiefe Glocke von der Kirche hinter dem Kornplatz. In allen Häusern brannten Lichter, und auf dem Kornplatz war eine Menge fröhlicher Menschen, die einander zuriefen.
     </p>
-    <p xml:id="eco_de_0000141_14130">
+    <p xml:id="eco_de_0000211_14130">
      Lotti sah immer zum Himmel auf; sie dachte, in dem Augenblick, wo das Jahr zu Ende sei, müsste da oben irgend etwas vorgehen. Doch die Sterne standen hoch und ruhig wie sonst an dem dunkeln Himmel. Da begannen aber plötzlich von unten Lichtkugeln aufzusteigen; wie Blitze fuhren sie empor und fielen in blauen, roten und grünen Sternen oder in einem prächtigen Funkenregen herab.
     </p>
-    <p xml:id="eco_de_0000141_14140">
+    <p xml:id="eco_de_0000211_14140">
      Jetzt schlug es zwölf Uhr.
     </p>
-    <p xml:id="eco_de_0000141_14150">
+    <p xml:id="eco_de_0000211_14150">
      »Viel Glück! viel Glück!« riefen die Kinder und die Erwachsenen und stiessen mit den Punschgläsern an, in die Mama den Kindern warme Limonade gegossen hatte.
     </p>
-    <p xml:id="eco_de_0000141_14160">
+    <p xml:id="eco_de_0000211_14160">
      Werner in der Hinterstube war auch wach geworden.
     </p>
-    <p xml:id="eco_de_0000141_14170">
+    <p xml:id="eco_de_0000211_14170">
      »Wernermann«, rief Hans ihm zu. »Nun ist das alte Jahr fort und davon! Was tun wir jetzt?«
     </p>
-    <p xml:id="eco_de_0000141_14180">
+    <p xml:id="eco_de_0000211_14180">
      Wernermann sah mit verwunderten Augen drein und besann sich.
     </p>
-    <p xml:id="eco_de_0000141_14190">
+    <p xml:id="eco_de_0000211_14190">
      »Aber es kommt wieder ein anderes, gelt, Mama?« fragte er.
     </p>
-    <p xml:id="eco_de_0000141_14200">
+    <p xml:id="eco_de_0000211_14200">
      »Ja, mein Wernermännchen, es kommt ein anderes, hoffentlich ein recht gutes, gesegnetes!« sagte Mama, worauf der Kleine befriedigt sich wieder zum Schlafen hinlegte.
     </p>
    </div>
@@ -4412,184 +4412,184 @@
     <head>
      Im kalten Monat Januar
     </head>
-    <p xml:id="eco_de_0000141_14210">
+    <p xml:id="eco_de_0000211_14210">
      Gleich nach Neujahr wurde es sehr kalt. Es fiel kein Schnee. Jeden Tag stand die Sonne am klaren Himmel; aber mit allem Scheinen brachte sie keine Wärme zustande.
     </p>
-    <p xml:id="eco_de_0000141_14220">
+    <p xml:id="eco_de_0000211_14220">
      »Brrr –! Frisch, frisch!« sagten die Leute auf der Strasse zu einander statt des Morgengrusses und eilten rasch weiter. Die Gemüsefrauen auf der Brücke steckten bis über die Nase in Mänteln und Tüchern; sie hatten ihre Füsse auf Kästchen, in denen Kohlen glühten, und rieben die Hände, die kalt wurden trotz der dicken Handschuhe.
     </p>
-    <p xml:id="eco_de_0000141_14230">
+    <p xml:id="eco_de_0000211_14230">
      Es war gar nicht angenehm, am Morgen aufzustehen. Lotti streckte dreimal den Fuss heraus und zog ihn wieder zurück. Marianne wollte tapfer sein und war schon bis zum Waschtisch gekommen. Aber da fand sie es so schrecklich kalt, dass sie noch einmal ins Bett zurückschlüpfte –
     </p>
-    <p xml:id="eco_de_0000141_14240">
+    <p xml:id="eco_de_0000211_14240">
      »Nur ein bisschen mich noch einmal anwärmen –!«
     </p>
-    <p xml:id="eco_de_0000141_14250">
+    <p xml:id="eco_de_0000211_14250">
      Lotti hauchte, um zuzusehen, wie ihr Atem als weisse Dampfwolke durch die Luft ging.
     </p>
-    <p xml:id="eco_de_0000141_14260">
+    <p xml:id="eco_de_0000211_14260">
      »Sophie, wir können nicht aufstehen! Es ist zu grässlich kalt!« rief sie, als Sophie warmes Wasser brachte. Gestern hatte Lottis und Mariannes Krug eine dünne Eisschicht gehabt.
     </p>
-    <p xml:id="eco_de_0000141_14270">
+    <p xml:id="eco_de_0000211_14270">
      »Das ist noch gar nichts«, sagte Sophie. »Bei mir zu Hause war das Wasser in der Waschschüssel oft ein einziger Eisklumpen, und am Morgen, wenn ich erwachte, war mir die Bettdecke an den Mund gefroren. Und einmal bin ich auf dem weiten Schulweg abends hingesessen und eingeschlafen; grad dass der Vater mich noch gefunden hat mit der Laterne. Er hat schon gemeint, ich sei erfroren, so steif war ich. Ich weiss noch gut, ich habe immer geträumt von drei braunen Enten, die um einen Ofen herumliefen –«
     </p>
-    <p xml:id="eco_de_0000141_14280">
+    <p xml:id="eco_de_0000211_14280">
      »Um einen geheizten?« fragte Lotti, die während dieser interessanten Erzählung in die Strümpfe gekommen war.
     </p>
-    <p xml:id="eco_de_0000141_14290">
+    <p xml:id="eco_de_0000211_14290">
      »Hattest du auch Frostbeulen, Sophie?« fragte Marianne, indem sie einen Fuss an dem andern rieb.
     </p>
-    <p xml:id="eco_de_0000141_14300">
+    <p xml:id="eco_de_0000211_14300">
      Am ärgsten war es mit den Frostbeulen in der Schule, wo man stillsitzen sollte.
     </p>
-    <p xml:id="eco_de_0000141_14310">
+    <p xml:id="eco_de_0000211_14310">
      »Ist ein Rösslein dort hinten, das scharrt, oder ist's die Marianne Turnach?« hatte gestern Fräulein Heller gerufen.
     </p>
-    <p xml:id="eco_de_0000141_14320">
+    <p xml:id="eco_de_0000211_14320">
      Es war noch ein Trost, dass Lily Rabus und Berta Strobel auch Frostbeulen hatten, und dass man einander, indem man die Augen einkniff und mit den Zähnen in die Lippen biss, andeuten konnte, was man auszustehen habe.
     </p>
-    <p xml:id="eco_de_0000141_14330">
+    <p xml:id="eco_de_0000211_14330">
      Aber der Januar brachte neben den Frostbeulen und dem zugefrorenen Waschwasser auch sehr Hübsches.
     </p>
-    <p xml:id="eco_de_0000141_14340">
+    <p xml:id="eco_de_0000211_14340">
      »Sie sind da! Heut sind sie gekommen!« sagte Grossmama eines Abends, als die Kinder von der Schule heimgekehrt waren.
     </p>
-    <p xml:id="eco_de_0000141_14350">
+    <p xml:id="eco_de_0000211_14350">
      »O! sind's recht viele? Können wir sie morgen sehen?« riefen die Kinder. Sie wussten alle, dass es die Bergfinken und die Grünfinken waren, die sich bei Grossmama eingestellt hatten.
     </p>
-    <p xml:id="eco_de_0000141_14360">
+    <p xml:id="eco_de_0000211_14360">
      Grossmamas Wohnzimmer ging auch jetzt, wie früher an der Kronengasse, gegen lauter Gärten, und so wie der Dezember gekommen war, hatte sie aussen am Fenster ein Futterbrettchen festgemacht mit einem kleinen Tännchen in der Mitte. Kaum war das Brettchen da, so flog wie jedes Jahr als erster Gast eine Spechtmeise herbei. Mit ihrem langen Schnabel, ihrem grauen Rücken und rostroten Bäuchlein, das vom reichlichen Herbstfutter noch artig rund war, hüpfte sie auf dem Brettchen hin und her: Aha, das scheint für unsereinen eingerichtet! Zutraulich guckte sie zum Fenster herein: Guten Nachmittag! Der Sommer ist schön gewesen. Wir wollen hoffen, dass der Winter es nicht zu bös mache!
     </p>
-    <p xml:id="eco_de_0000141_14370">
+    <p xml:id="eco_de_0000211_14370">
      Sehr possierlich war die Spechtmeise wenn sie frass. Wie ein kleiner Holzhacker klopfte sie mit dem spitzen Schnabel auf den Hanf los, den sie in den Krallen hielt, verschluckte den öligen Inhalt und drehte sich blitzschnell um nach einem neuen Korn.
     </p>
-    <p xml:id="eco_de_0000141_14380">
+    <p xml:id="eco_de_0000211_14380">
      Ihre Vettern, die Spiegelmeisen, kamen auch, fein angezogen in grünem Frack, gelber Weste und langer schwarzer Krawatte. Die niedlichsten aber waren die Blaumeisen. Es war wundernett, wenn die winzigen blauschillernden Vögel sich mit dem Rücken nach unten an die Nussäckchen der kleinen Tanne hängten und sorglos hin- und herwiegend die Körner herauspickten. Die Spechtmeise guckte dann erstaunt hinauf; so sich anhängen, das konnte sie nicht.
     </p>
-    <p xml:id="eco_de_0000141_14390">
+    <p xml:id="eco_de_0000211_14390">
      Wild und laut aber wurde es auf dem Vogelbrettchen, wenn im Januar das ungebärdige, trotzige Volk der Bergfinken und Grünfinken anlangte. In ganzen Scharen kamen sie dahergeschwirrt. Fast war das Brettchen zu klein.
     </p>
-    <p xml:id="eco_de_0000141_14400">
+    <p xml:id="eco_de_0000211_14400">
      »Grossmama, jetzt sind siebzehn da –! Nein, zwanzig!« riefen die Kinder, die entzückt dem Getümmel unter dem Bäumchen zusahen. »Wie sie streiten und sich stossen und übereinander hüpfen! Und wie sie piepen und schreien! O – jetzt hat ein Spatz kommen wollen; aber sie lassen ihn nicht! Nur die Spechtmeise traut sich von der Seite her und holt schnell ein Korn – . Es ist zu lustig, Grossmama!«
     </p>
-    <p xml:id="eco_de_0000141_14410">
+    <p xml:id="eco_de_0000211_14410">
      Die Kinder standen, so oft sie konnten, an Grossmamas Fenster. Man musste behutsam herankommen. Der kleine Werner vergass das immer und drückte im Eifer seine kleine runde Nase an die Scheibe, so dass die Vögel – uitt –! davonflogen. Da war Grossmamas Kater fast vernünftiger. Grossmamas Kater hatte ein weisses Fell, einen dicken Kopf und ein sehr ernsthaftes Gesicht. Er hiess Aristoteles nach einem alten griechischen Gelehrten. Tagsüber war er bei Grossmama und nach dem Nachtessen hinten bei Onkel Alfred auf dem Schreibtisch; Onkel Alfred behauptete, er helfe ihm studieren.
     </p>
-    <p xml:id="eco_de_0000141_14420">
+    <p xml:id="eco_de_0000211_14420">
      Aristoteles sass stundenlang regungslos am Fenster und sah dem Treiben der Vögel zu. Nur manchmal krümmte er begehrlich seinen langen Schwanz, als ob er dächte: Wenn die widerwärtige Scheibe nicht wäre, wollt ich mir schnell genug den Fettesten von euch geholt haben!
     </p>
-    <p xml:id="eco_de_0000141_14430">
+    <p xml:id="eco_de_0000211_14430">
      Bald nachdem Grossmamas Finken angelangt waren, kamen die Kinder mit einer neuen fröhlichen Kunde nach Haus.
     </p>
-    <p xml:id="eco_de_0000141_14440">
+    <p xml:id="eco_de_0000211_14440">
      »Er ist zu, Mama!« meldeten sie. »Er hat furchtbar lang gebraucht; aber jetzt ist er fest!«
     </p>
-    <p xml:id="eco_de_0000141_14450">
+    <p xml:id="eco_de_0000211_14450">
      Der so furchtbar lang gebraucht hatte, war der Stadtgraben. Ungeduldig hatte man darauf gewartet, dass er zufriere, und dann ging es noch einmal mehrere Tage, bis der Polizeidiener die Buben nicht mehr fortjagte, die hinauswollten, um die Dicke des Eises zu erproben.
     </p>
-    <p xml:id="eco_de_0000141_14460">
+    <p xml:id="eco_de_0000211_14460">
      Die Turnachkinder liefen am Mittwoch gleich nach dem Essen zum Stadtgraben. Lotti hatte auch ein Paar Schlittschuhe erbeutet und bemühte sich, sie recht laut klappern zu lassen, als sie mit Hans und Marianne durch die Schwalbengasse ging.
     </p>
-    <p xml:id="eco_de_0000141_14470">
+    <p xml:id="eco_de_0000211_14470">
      Hans hatte im Nu seine Schlittschuhe an.
     </p>
-    <p xml:id="eco_de_0000141_14480">
+    <p xml:id="eco_de_0000211_14480">
      »Ich will sehen, ob ich noch holländern kann«, sagte er. Holländern nannten es die Buben in Hansens Klasse, wenn einer den andern an der Achsel hielt und den Fuss nach jedem Zuge so kühn als möglich vornüber schlenkerte.
     </p>
-    <p xml:id="eco_de_0000141_14490">
+    <p xml:id="eco_de_0000211_14490">
      »Wer gut holländert, kann schon fast Bogen fahren«, erklärte Hans, indem er vor Marianne und Lotti einen Halbkreis versuchte, wobei er allerdings in einen Herrn hineinschoss, der ihn ärgerlich wegschob.
     </p>
-    <p xml:id="eco_de_0000141_14500">
+    <p xml:id="eco_de_0000211_14500">
      »Die Buben –! alle Augenblicke hat man einen zwischen den Füssen –«
     </p>
-    <p xml:id="eco_de_0000141_14510">
+    <p xml:id="eco_de_0000211_14510">
      Ja, überall schossen die Buben herum, kreuz und quer wie Bremsen. Und die Mädchen nicht minder. Beständig kamen neue Scharen die Treppe herunter, und das lustige Gewimmel wurde immer grösser.
     </p>
-    <p xml:id="eco_de_0000141_14520">
+    <p xml:id="eco_de_0000211_14520">
      Marianne und Lotti hatten ihre Schlittschuhe endlich auch angeschraubt.
     </p>
-    <p xml:id="eco_de_0000141_14530">
+    <p xml:id="eco_de_0000211_14530">
      »So, Hans«, rief Lotti, als der Bruder an ihnen vorbeifuhr. »Jetzt hilf uns nur aufstehen. Lernen können wir's dann allein.«
     </p>
-    <p xml:id="eco_de_0000141_14540">
+    <p xml:id="eco_de_0000211_14540">
      »Ja, ja, Lotti, du wirst schon sehen –« sagte Hans, indem er den Schwestern half. »So – da hast du's –«
     </p>
-    <p xml:id="eco_de_0000141_14550">
+    <p xml:id="eco_de_0000211_14550">
      Lotti hatte sich kaum von der Bank erhoben, als sie zu ihrem Erstaunen schon wieder sass, diesmal aber auf dem Boden. Hans stellte sie mit einiger Mühe auf. Marianne tat mutig einen Zug und fiel ebenfalls hin. Hans nahm auf jede Seite eine der Schwestern und zog sie vorwärts.
     </p>
-    <p xml:id="eco_de_0000141_14560">
+    <p xml:id="eco_de_0000211_14560">
      »Jetzt geht es schon ein wenig!« sagte Lotti vergnügt. Aber Hans entdeckte, dass Lotti und Marianne gar nicht auf dem Eisen des Schlittschuhs standen, sondern bloss auf dem umgekippten Stiefel.
     </p>
-    <p xml:id="eco_de_0000141_14570">
+    <p xml:id="eco_de_0000211_14570">
      »Das ist nichts«, sagte er und liess sie los. »Seht einmal, so steht man –«
     </p>
-    <p xml:id="eco_de_0000141_14580">
+    <p xml:id="eco_de_0000211_14580">
      »Ich glaube, meine Schlittschuhe sind schlecht; sie halten gar nicht«, erklärte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_14590">
+    <p xml:id="eco_de_0000211_14590">
      »Das sagt jeder am Anfang«, belehrte sie Hans. »Ihr müsst versuchen, das Gleichgewicht zu halten und dann einen festen Anlauf nehmen.«
     </p>
-    <p xml:id="eco_de_0000141_14600">
+    <p xml:id="eco_de_0000211_14600">
      Marianne und Lotti versuchten das Gleichgewicht zu halten und nahmen einen festen Anlauf, worauf sie nach links hinausfielen. Sie nahmen einen zweiten Anlauf der sie sofort wieder zu Fall brachte, aber auf die rechte Seite. Sie krabbelten auf, und Lotti schaute umher.
     </p>
-    <p xml:id="eco_de_0000141_14610">
+    <p xml:id="eco_de_0000211_14610">
      »Das ist merkwürdig«, sagte sie. »Man fällt hin und weiss gar nicht warum!«
     </p>
-    <p xml:id="eco_de_0000141_14620">
+    <p xml:id="eco_de_0000211_14620">
      Und nun ging es fort mit Fallen und Aufstehen und wieder Hinfallen. Bald zog Hans von vorn, bald schob er von hinten.
     </p>
-    <p xml:id="eco_de_0000141_14630">
+    <p xml:id="eco_de_0000211_14630">
      »So! haltet euch jetzt ein wenig aneinander und zählt im Takt! Ich komm dann wieder«, sagte Hans und verliess sie, um für ein Weilchen seinen eigenen Weg zu fahren, was man ihm nicht übelnehmen konnte.
     </p>
-    <p xml:id="eco_de_0000141_14640">
+    <p xml:id="eco_de_0000211_14640">
      Marianne und Lotti befolgten Hansens Rat. Das Halten bestand allerdings bloss darin, dass immer die eine die andere wieder umriss, wenn sie sich gerade erhoben hatte. Manchmal konnten beide vor Lachen gar nicht mehr aufstehen.
     </p>
-    <p xml:id="eco_de_0000141_14650">
+    <p xml:id="eco_de_0000211_14650">
      So – jetzt – das ging ja fein: links, rechts, links – wie Hans gesagt hatte. Plumps – da lag man wieder! Aha, eine Spalte! Vor denen musste man sich in acht nehmen. Dort drüben hatte es eine schöne, glatte Stelle – plumps –! Nein, so ganz glatt, das war auch nichts!
     </p>
-    <p xml:id="eco_de_0000141_14660">
+    <p xml:id="eco_de_0000211_14660">
      »Jetzt probieren wir es einmal jedes für sich allein!« sagte Marianne und steuerte mit ausgestreckten Armen drauf los. Lotti wackelte hinterdrein. Die beiden waren gefährlich, wenn sie einem nahe kamen; denn sie hielten sich, wo sie nur gerade konnten – Marianne hier an zwei Mädchen, die paarweise vorbeifuhren, – Lotti dort an einer Reihe Buben, die sie aber bloss abschüttelten und liegen liessen. Hierauf fasste Marianne in der Not einen Herrn am Pelzrock und dann einen andern, der sich zu einem kunstvollen Bogen schief hinüberlegte, am Ellbogen. Die Mütze flog dem Herrn ab, und als Marianne sie aufheben wollte, kam sie unversehens darauf zu sitzen.
     </p>
-    <p xml:id="eco_de_0000141_14670">
+    <p xml:id="eco_de_0000211_14670">
      Lotti ergriff den Muff einer Dame, und zwar so kräftig, dass die Dame ein Stock weit ohne Muff davonfuhr und sich erstaunt umsah. Gleich darauf packte Lotti im Stolpern den Besenstiel eines Eiskehrers; beinahe wäre dieser hingefallen.
     </p>
-    <p xml:id="eco_de_0000141_14680">
+    <p xml:id="eco_de_0000211_14680">
      »Das sind doch Manieren!« brummte er.
     </p>
-    <p xml:id="eco_de_0000141_14690">
+    <p xml:id="eco_de_0000211_14690">
      Nun versuchten die Schwestern ihr Glück wieder zusammen. Plötzlich aber stiessen sie einen Freudenschrei aus. Sie hatten Onkel Alfred entdeckt.
     </p>
-    <p xml:id="eco_de_0000141_14700">
+    <p xml:id="eco_de_0000211_14700">
      »Onkel Alfred!« riefen sie. »Wir sind auch da! Wir können es schon ziemlich!« Und der Länge nach fielen die beiden vor den Onkel hin.
     </p>
-    <p xml:id="eco_de_0000141_14710">
+    <p xml:id="eco_de_0000211_14710">
      »Ihr seid auch da! Natürlich! wo seid ihr nicht!« rief der Onkel, indem er Marianne und Lotti in die Höhe zog. »Schrecklich – solche Nichten!« wendete er sich zu der jungen Dame und dem Herrn, mit denen er gelaufen war. »Haben Sie auch welche?«
     </p>
-    <p xml:id="eco_de_0000141_14720">
+    <p xml:id="eco_de_0000211_14720">
      Die beiden schüttelten lachend den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_14730">
+    <p xml:id="eco_de_0000211_14730">
      »Dann danken Sie dem Schicksal und haben Sie Mitleid mit mir!«
     </p>
-    <p xml:id="eco_de_0000141_14740">
+    <p xml:id="eco_de_0000211_14740">
      »Sollen wir Sie in Ihren Onkelpflichten etwas unterstützen?« sagte die junge Dame und nahm an jede Hand eines der Kinder. Die beiden Herren machten links und rechts den Abschloss.
     </p>
-    <p xml:id="eco_de_0000141_14750">
+    <p xml:id="eco_de_0000211_14750">
      Und nun ging es zu fünft schön im Takte, einen Schwung links, einen Schwung rechts, unter den Brücken durch, den ganzen Graben hinauf und wieder hinunter. Es war unmöglich zu stolpern, unmöglich zu fallen; wie getragen ging's, wie im Fluge …
     </p>
-    <p xml:id="eco_de_0000141_14760">
+    <p xml:id="eco_de_0000211_14760">
      »Mama, das Schlittschuhlaufen ist prachtvoll!« rief Lotti die Treppe hinauf. »Ich bin etwa siebenundzwanzigmal hingefallen und Marianne auch. Aber zuletzt haben wir noch mit Onkel Alfred Bogen gefahren!«
     </p>
-    <p xml:id="eco_de_0000141_14770">
+    <p xml:id="eco_de_0000211_14770">
      In den nächsten zwei Wochen waren die Turnachkinder jeden Tag auf dem Eise und sprachen von nichts als vom Schlittschuhlaufen. Und damit Balbine, die nicht gern in der Kälte an den Stadtgraben spazieren ging, auch einen Begriff bekomme, nahmen Marianne und Lotti den Werner zwischen sich und zeigten Balbine in der Küche das Holländern, das sie nun schon loshatten. Hans aber machte ihr vor, wie man vorwärts und rückwärts kreisle, bis es Balbine angst und bang wurde und die Teller und Schüsseln zu klirren begannen.
     </p>
-    <p xml:id="eco_de_0000141_14780">
+    <p xml:id="eco_de_0000211_14780">
      Das erste am Morgen war immer, dass man nach dem Thermometer sah und am Barometer klopfte.
     </p>
-    <p xml:id="eco_de_0000141_14790">
+    <p xml:id="eco_de_0000211_14790">
      »Wenn es nur noch recht lang kalt bliebe!« war der sehnlichste Wunsch der Turnachkinder.
     </p>
-    <p xml:id="eco_de_0000141_14800">
+    <p xml:id="eco_de_0000211_14800">
      Und alle Buben und Mädchen in der Stadt wünschten dasselbe. Aber die armen und die alten Leute und die Gemüsefrauen, die Droschkenkutscher und die Weichenwärter an der Eisenbahn, die den ganzen Tag oder gar die ganze Nacht draussen sein mussten, dachten jeden Morgen: Wenn doch nur der Wind sich bald drehen wollte! Und da die Kinder ja sonst viel Vergnügen hatten, nahm das Wetter diesmal die Partei der andern Leute: In der letzten Januarwoche schlug es um; der Westwind wehte und es fing an zu schneien. Die Oberfläche des Eises verwandelte sich in eine weiche Sulze, und eines Nachmittags stand wieder ein Polizeidiener an der Treppe des Stadtgrabens, und die ganze Herrlichkeit hatte für einmal ein Ende.
     </p>
    </div>
@@ -4597,250 +4597,250 @@
     <head>
      Hans zeigt sich als Held
     </head>
-    <p xml:id="eco_de_0000141_14810">
+    <p xml:id="eco_de_0000211_14810">
      Lotti machte eine schreckliche Grimasse und zog den Fuss in die Höhe. Der heisse Siegellack, von dem ihr ein Tropfen auf den Finger gefallen war, brannte tüchtig; aber schreien durfte man nicht, sonst wurde man aus dem Bureau weggeschickt. Man gehörte da eigentlich überhaupt nicht hin. Doch wenn die Kinder für Mama Briefe zu Papa hinuntergetragen hatten, blieben sie womöglich noch ein wenig im äussern Zimmer, wo Herr Oberauer und Herr Frei sassen. Man konnte da zusehen, wie Herr Frei mit der Kopierpresse die Briefe kopierte. Das ging im Hui: Es wurde ein Blatt in dem grossen Buche mit dem Pinsel feucht gemacht; dann kam der Brief unter das Blatt und das Buch unter die Presse. Herr Frei schraubte zu, wieder auf und wenn er das Buch herausnahm, stand der Brief darin, Wort für Wort.
     </p>
-    <p xml:id="eco_de_0000141_14820">
+    <p xml:id="eco_de_0000211_14820">
      Manchmal bemächtigte man sich auch des Kerzenstockes, in dem Siegellack und Petschaft lagen. Die Herren am Schreibtisch sagten nichts; ja, Herr Oberauer gab einem sogar, wenn man ihn bat, einen Bogen Papier; darauf konnte man den brennenden Siegellack tropfen lassen und das Petschaft hindrücken, das mit den drei Buchstaben oder das schöne mit dem Türmchen und den Sternen; das war Papas Wappen.
     </p>
-    <p xml:id="eco_de_0000141_14830">
+    <p xml:id="eco_de_0000211_14830">
      Aber eben acht geben musste man. Lotti steckte den Finger in die Wasserschale, worin der Pinsel lag. Da klopfte es leise an die Türe, so leise, dass nur Lotti es hörte, die neben der Türe stand. Lotti machte auf. Es war Sylvia, der Ulrich gesagt hatte, dass Lotti da drinnen sei. Die schüchterne Sylvia war sehr froh, als Lotti heraustrat und nicht einer von den Herren.
     </p>
-    <p xml:id="eco_de_0000141_14840">
+    <p xml:id="eco_de_0000211_14840">
      »Lotti, du sollst zur Schneeburg kommen. Marianne und Hans sind schon da. Wir machen ein Fest, ein Einweihungsfest. Wir haben Kissen und Tee und Gläser, und Zwieback hat uns die Tante auch gegeben.« Rudolf und Sylvia hatten keine Mutter mehr.
     </p>
-    <p xml:id="eco_de_0000141_14850">
+    <p xml:id="eco_de_0000211_14850">
      Lotti lief mit Sylvia hinüber in den Hof der Apotheke, wo eine stattliche Schneeburg stand, an der die Lorez- und die Turnachkinder die letzten Tage gearbeitet hatten. Es hatte sehr stark geschneit und der Schnee war weich und liess sich gut ballen und formen. Die Schneeburg hatte einen Eingang, zwei Fenster und ein gewölbtes Dach; das war der Hauptstolz.
     </p>
-    <p xml:id="eco_de_0000141_14860">
+    <p xml:id="eco_de_0000211_14860">
      Herr Lorez kam auch einen Augenblick heraus, um den Bau zu bewundern und nannte ihn eine ganz famose Eskimohütte.
     </p>
-    <p xml:id="eco_de_0000141_14870">
+    <p xml:id="eco_de_0000211_14870">
      »Dann sind wir also jetzt Eskimos!« rief Lotti und tanzte mit Sylvia um das Schneehaus, während Hans zum Schlusse noch ein kunstvolles Schneehorn über dem Eingange anbrachte.
     </p>
-    <p xml:id="eco_de_0000141_14880">
+    <p xml:id="eco_de_0000211_14880">
      Rudolf kam mit zwei rot und grünen Papierlaternen.
     </p>
-    <p xml:id="eco_de_0000141_14890">
+    <p xml:id="eco_de_0000211_14890">
      »Die zünden wir nachher an. Ihr werdet sehen, wie das fein aussieht!« sagte er vergnügt. Seine Tante allerdings, die sich eben zum Ausgehen richtete, wusste nichts von den Laternen.
     </p>
-    <p xml:id="eco_de_0000141_14900">
+    <p xml:id="eco_de_0000211_14900">
      Der kleine Werner durfte, weil es gar nicht kalt war, auch an dem Einweihungsfeste teilnehmen. Marianne bekam den Teekessel zur Verwaltung, in den Fräulein Lorez leichten Tee mit Milch und Zucker gegossen hatte.
     </p>
-    <p xml:id="eco_de_0000141_14910">
+    <p xml:id="eco_de_0000211_14910">
      In der Mitte des Schneehauses stand ein Tisch, aus einem Schneepfosten und einem darübergelegten Brett hergestellt. Ringsum ging eine Schneebank, auf der die Kissen lagen. Es war gerade Platz für sechs Personen, wenn man sich recht zusammendrückte. Das taten die Kinder und trommelten mit ihren Teegläsern auf den Tisch. Den Zwieback nannten sie Kerzen; denn Hans erzählte, die Eskimos ässen Talglichter; er nannte Marianne, die austeilte, die alte Eskimomutter; Schnauzel war ein Seehund und bekam auch von den Kerzen.
     </p>
-    <p xml:id="eco_de_0000141_14920">
+    <p xml:id="eco_de_0000211_14920">
      »Entweder muss jetzt jedes eine Rede halten«, sagte Hans, »oder ein lustiges Lied aufsagen!«
     </p>
-    <p xml:id="eco_de_0000141_14930">
+    <p xml:id="eco_de_0000211_14930">
      Die Mehrzahl der Eskimos war für lustige Lieder.
     </p>
-    <p xml:id="eco_de_0000141_14940">
+    <p xml:id="eco_de_0000211_14940">
      »Ich weiss ein furchtbar lustiges!« rief Lotti, »und es passt zu jedem Namen: Sylvia, Widilvia«, hob sie an, indem sie Sylvia hin- und herzog:
     </p>
-    <p xml:id="eco_de_0000141_14950">
+    <p xml:id="eco_de_0000211_14950">
      »Sylvia, Widilvia, Widewitzundkatilvia, Widehops und Katops, Widewanischer Mops.«
     </p>
-    <p xml:id="eco_de_0000141_14960">
+    <p xml:id="eco_de_0000211_14960">
      »Nein Lotti«, wehrte Hans, »das ist zu dumm! So ganz dumme wollen wir nicht!«
     </p>
-    <p xml:id="eco_de_0000141_14970">
+    <p xml:id="eco_de_0000211_14970">
      »Also, dann weiss ich ein anderes; das ist auch zum Lachen«, rief Lotti. »Jedes der Reihe nach muss eine Strophe sagen!« Und Lotti begann den Reim von der Gans:
     </p>
-    <p xml:id="eco_de_0000141_14980">
+    <p xml:id="eco_de_0000211_14980">
      »Was trägt die Gans auf ihrem Schnabel Einen Kriegsmann mit dem Sabel Trägt die Gans auf ihrem Schnabel. Da seht ihr sie, die brave Gans! Reden tut sie gickelgackel, Gehen tut sie wickelwackel, Fliegen tut sie fliflaflederwisch …«
     </p>
-    <p xml:id="eco_de_0000141_14990">
+    <p xml:id="eco_de_0000211_14990">
      Das ging so weiter. Auf ihrem Kopfe trug die Gans einen Koch mit samt dem Topfe, auf den Flügeln einen Reiter mit den Bügeln, auf dem Rücken einen Greis mit seinen Krücken, auf dem Schwanze eine Jungfer mit dem Kranze. Und nach jeder Strophe kam wieder:
     </p>
-    <p xml:id="eco_de_0000141_15000">
+    <p xml:id="eco_de_0000211_15000">
      »Da seht ihr sie, die brave Gans Reden tut sie gickelgackel, Gehen tut sie wickelwackel, Fliegen tut sie fliflaflederwisch …«
     </p>
-    <p xml:id="eco_de_0000141_15010">
+    <p xml:id="eco_de_0000211_15010">
      was die ganze Gesellschaft im Schneehaus unter Jubel mitsprach. Werner, der sich in dem Fliflaflederwisch allemal verwickelte, goss vor lauter Vergnügen sein ganzes Teeglas um.
     </p>
-    <p xml:id="eco_de_0000141_15020">
+    <p xml:id="eco_de_0000211_15020">
      »Jetzt der Werner! der Werner muss etwas aufsagen!« riefen alle.
     </p>
-    <p xml:id="eco_de_0000141_15030">
+    <p xml:id="eco_de_0000211_15030">
      Marianne rückte zu ihm hinüber, um ihm zu helfen. Aber Werner sah stolz im Kreise herum und sagte:
     </p>
-    <p xml:id="eco_de_0000141_15040">
+    <p xml:id="eco_de_0000211_15040">
      »Ich – ich kann: Adam hatte sieben Söhne –«
     </p>
-    <p xml:id="eco_de_0000141_15050">
+    <p xml:id="eco_de_0000211_15050">
      Weiter wusste er nicht; aber es war auch nicht nötig.
     </p>
-    <p xml:id="eco_de_0000141_15060">
+    <p xml:id="eco_de_0000211_15060">
      »Ja, ja! Werner hat recht! Wir machen, ›Adam hatte sieben Söhne‹! Wer fängt an? Ich –« riefen die fünf durcheinander.
     </p>
-    <p xml:id="eco_de_0000141_15070">
+    <p xml:id="eco_de_0000211_15070">
      »Wartet! zuerst kommt noch etwas –« sagte Rudolf und stieg auf die Bank, um die Papierlaternen anzuzünden, obgleich es noch nicht dunkel war.
     </p>
-    <p xml:id="eco_de_0000141_15080">
+    <p xml:id="eco_de_0000211_15080">
      »Und die Mützen, Rudolf, die Mützen!« rief Sylvia.
     </p>
-    <p xml:id="eco_de_0000141_15090">
+    <p xml:id="eco_de_0000211_15090">
      Sie nahm aus dem Korbe sechs bunte Papiermützen, die an Neujahr in den Knallbonbons gesteckt hatten.
     </p>
-    <p xml:id="eco_de_0000141_15100">
+    <p xml:id="eco_de_0000211_15100">
      »O, Sylvia«, schrie Lotti, »bitte, mir die weisse Haube!« Sie setzte rasch eine Altfrauenhaube auf, an deren Seiten lange lila Bänder flatterten.
     </p>
-    <p xml:id="eco_de_0000141_15110">
+    <p xml:id="eco_de_0000211_15110">
      Marianne bekam eine rote Jakobinermütze, Hans einen Zweispitz, den er quer auf den Kopf setzte wie Napoleon. Rudolf hatte ein gelbes Chinesenhütchen, und dem Werner setzte man ein viereckiges englisches Doktorbarett auf. Sylvia aber prangte in einer weissen Narrenkappe. Um den Hals hatte sie sich noch eine breite papierne Krause gebunden. Die Kinder lachten hell auf, als sie einander ansahen.
     </p>
-    <p xml:id="eco_de_0000141_15120">
+    <p xml:id="eco_de_0000211_15120">
      Dann begannen sie alle recht laut und übermütig:
     </p>
-    <p xml:id="eco_de_0000141_15130">
+    <p xml:id="eco_de_0000211_15130">
      »Adam hatte sieben Söhne, Sieben Söhne hatt' Adam. Die assen nicht und tranken nicht Und machten all ein schief Gesicht Und machte alle so –«
     </p>
-    <p xml:id="eco_de_0000141_15140">
+    <p xml:id="eco_de_0000211_15140">
      Bei dem So –! musste jedes der Reihe nach irgendeine Gebärde oder Hantierung vormachen, die von der ganzen Gesellschaft nachgeahmt wurde, so lange das wiederbegonnene Lied dauerte.
     </p>
-    <p xml:id="eco_de_0000141_15150">
+    <p xml:id="eco_de_0000211_15150">
      Marianne, die zuerst dran kam, hielt Arme und Hand, als ob sie Geige spielte. Mit der Rechten musste man auf und niederfahren, mit der Linken fingern und dazu den Kopf auf die Seite legen.
     </p>
-    <p xml:id="eco_de_0000141_15160">
+    <p xml:id="eco_de_0000211_15160">
      Als die Reihe an Hans war, drückte er beide Fäuste in die Augen wie ein kleines Kind und fing mit weinender Stimme den Adam an, und alle schluchzten das Lied mit.
     </p>
-    <p xml:id="eco_de_0000141_15170">
+    <p xml:id="eco_de_0000211_15170">
      Immer übermütiger wurden die Kinder. Rudolf stieg auf die Schneebank und fing an, in gebückter Stellung auf und abzuhüpfen, wie ein Kobold, und die andern hüpften lachend mit. Bei Lotti aber musste man tun, als ob man schliefe; eins lehnte sich ans andere und nickte mit dem Kopf.
     </p>
-    <p xml:id="eco_de_0000141_15180">
+    <p xml:id="eco_de_0000211_15180">
      Keines merkte, dass es auf einmal heller wurde in der Schneehütte. Die eine der Lampen, die an der Decke befestigt waren, hatte einen Stoss bekommen. Sie hing schief, und das Papier fing an zu brennen. Schnauzel als einziger Vernünftiger sah, dass da oben etwas nicht in Ordnung war. Er hatte sich aus dem Tumult heraus an den Eingang der Hütte geflüchtet und bellte jetzt heftig gegen die Flamme hinauf; aber die Kinder in ihrer Ausgelassenheit achteten nicht auf Schnauzel.
     </p>
-    <p xml:id="eco_de_0000141_15190">
+    <p xml:id="eco_de_0000211_15190">
      Plötzlich fiel die ganze brennende Lampe herunter. Sie fiel gerade auf Sylvias Kappe und von da auf ihren breiten Kragen; beides loderte hell empor. Die Kinder schrien laut auf; Lotti, die neben Sylvia sass, stiess die brennende Lampe weg, die nun aber gegen Werner flog, so dass sein Barett ebenfalls zu brennen anfing. Ausser sich vor Entsetzen drängten die Kinder hinaus aus der Hütte.
     </p>
-    <p xml:id="eco_de_0000141_15200">
+    <p xml:id="eco_de_0000211_15200">
      Marianne hatte so viel Besinnung, dass sie Werner das Barett herunterriss und ihn mitzog. Rudolf hatte Sylvias Kappe fortgeschleudert; aber schon brannten ihre Haare und das Tuch, das sie um die Schultern geschlungen hatte.
     </p>
-    <p xml:id="eco_de_0000141_15210">
+    <p xml:id="eco_de_0000211_15210">
      Wie wahnsinnig stürzte Rudolf gegen das Haus:
     </p>
-    <p xml:id="eco_de_0000141_15220">
+    <p xml:id="eco_de_0000211_15220">
      »Sylvia brennt! Sylvia brennt!«
     </p>
-    <p xml:id="eco_de_0000141_15230">
+    <p xml:id="eco_de_0000211_15230">
      Überall um den Hof öffneten sich Fenster:
     </p>
-    <p xml:id="eco_de_0000141_15240">
+    <p xml:id="eco_de_0000211_15240">
      »Was ist! Um Gotteswillen, ein Kind – ein Kind brennt! Hilfe, Hilfe!«
     </p>
-    <p xml:id="eco_de_0000141_15250">
+    <p xml:id="eco_de_0000211_15250">
      Hans rannte rechts hinüber:
     </p>
-    <p xml:id="eco_de_0000141_15260">
+    <p xml:id="eco_de_0000211_15260">
      »Ulrich! Ulrich!« Vielleicht war Ulrich in der Nähe.
     </p>
-    <p xml:id="eco_de_0000141_15270">
+    <p xml:id="eco_de_0000211_15270">
      Aber hinter Hans gellte das Geschrei Sylvias. So entsetzlich hatte Hans noch nie schreien hören. Plötzlich fuhr es ihm wie ein Blitz durch den Sinn: Nein! so fortrennen und um Hilfe rufen, das ist nichts! ich muss Sylvia selber helfen –
     </p>
-    <p xml:id="eco_de_0000141_15280">
+    <p xml:id="eco_de_0000211_15280">
      Schon hatte er sich umgewendet. Mit ausgestreckten Armen, ganz in Flammen lief Sylvia auf ihn zu. In den Schnee – in den Schnee werfen! Hans wusste nicht, hatte ihm das jemand zugerufen oder kam's ihm von innen: er stürzte sich auf Sylvia, so dass sie hinfiel und Hans mit ihr. Die Flamme schlug ihm entgegen; es war ihm als ob sein ganzes Gesicht zu lodern beginne. Eine Todesangst überkam ihn: Jetzt verbrenne ich auch – beide müssen wir verbrennen –! Aber er liess nicht los. Er warf sich mit seinem ganzen Körper über Sylvia und versuchte mit den Händen die Flammen zu zerdrücken …
     </p>
-    <p xml:id="eco_de_0000141_15290">
+    <p xml:id="eco_de_0000211_15290">
      Jetzt hörte er eine Männerstimme hinter sich. Er fühlte, dass man eine nasse Decke auf ihn und Sylvia warf. Dann half ihm jemand in die Höhe. Herr Zurbuchen vom Goldenen Degen kniete zu der wimmernden Sylvia nieder, um die Funken zu ersticken, die überall in den Kleidern glimmten.
     </p>
-    <p xml:id="eco_de_0000141_15300">
+    <p xml:id="eco_de_0000211_15300">
      Das Dienstmädchen von Herrn Lorez kam herzugestürzt: »Mein Gott! mein Gott!«
     </p>
-    <p xml:id="eco_de_0000141_15310">
+    <p xml:id="eco_de_0000211_15310">
      Der ganze Hof füllte sich mit Menschen; denn das Schreckensgeschrei der Kinder war bis auf den Kornplatz hinausgedrungen. Alles rief und fragte durcheinander:
     </p>
-    <p xml:id="eco_de_0000141_15320">
+    <p xml:id="eco_de_0000211_15320">
      »Was ist geschehen? Was –? Ein Kind verbrannt –?«
     </p>
-    <p xml:id="eco_de_0000141_15330">
+    <p xml:id="eco_de_0000211_15330">
      »Nein, nein! keine Rede davon!« rief Herr Zurbuchen laut; denn jetzt sah er Herrn Lorez herbeieilen.
     </p>
-    <p xml:id="eco_de_0000141_15340">
+    <p xml:id="eco_de_0000211_15340">
      Herr Lorez konnte nicht sprechen. Er schlug die Hände zusammen. Dann streckte er sie nach seiner Sylvia aus.
     </p>
-    <p xml:id="eco_de_0000141_15350">
+    <p xml:id="eco_de_0000211_15350">
      Herr Zurbuchen legte ihm das Kind behutsam auf die Arme. Sylvia hielt stöhnend den Kopf zurückgebeugt, als ob sie immer noch im Entsetzen vor den Flammen wäre.
     </p>
-    <p xml:id="eco_de_0000141_15360">
+    <p xml:id="eco_de_0000211_15360">
      »Fassen sie sich, Herr Lorez«, sagte der alte Herr. »Es ist gnädig abgelaufen! Die langen blonden Haare zwar sind fort, und Brandwunden tun weh –« Er streichelte mitleidig die Achsel des Kindes, von der ein Stück des verbrannten Ärmels herunterhing. »Es hätte schlimm gehen können. Wenn der da nicht gewesen wäre – wir andern wären vielleicht zu spät gekommen –«
     </p>
-    <p xml:id="eco_de_0000141_15370">
+    <p xml:id="eco_de_0000211_15370">
      Die Blicke aller Umstehenden wandten sich zu Hans Turnach, der mit versengtem Haar dastand und die Zähne zusammenbiss vor Schmerzen an Gesicht und Händen.
     </p>
-    <p xml:id="eco_de_0000141_15380">
+    <p xml:id="eco_de_0000211_15380">
      »Hat er das Kind gerettet? Wem gehört er? Turnachs! In den Schnee hat er es gedrückt! Dass ihm das eingefallen ist –! Ja und dass er den Mut hatte! Es will etwas heissen, so grad ins Feuer hineinzugreifen –! Ein wackerer Bursch –« So ging es durcheinander unter den Leuten, die Hans umringten, während man Sylvia ins Haus trug.
     </p>
-    <p xml:id="eco_de_0000141_15390">
+    <p xml:id="eco_de_0000211_15390">
      Herr Turnach, der auch herbeigekommen war, wollte die Kinder heimnehmen. Aber Hans kam fast nicht fort von den Leuten. Er sollte sagen, wie alles zugegangen; man besah seine Hände und seine verbrannte Bluse und klopfte ihm auf die Schulter.
     </p>
-    <p xml:id="eco_de_0000141_15400">
+    <p xml:id="eco_de_0000211_15400">
      Und zu Hause, wo Mama grade durch die Mägde von dem Unglück gehört hatte, ging das Erzählen erst recht an.
     </p>
-    <p xml:id="eco_de_0000141_15410">
+    <p xml:id="eco_de_0000211_15410">
      »Mama, es war entsetzlich«, riefen Marianne und Lotti. »Und Hans hat sich gar nicht gefürchtet! Er ist auf Sylvia losgerannt und hat sie an den Boden geworfen! Und alle haben gesagt, das sei sehr klug gewesen –! Mama, hätte Sylvia sterben müssen, wenn Hans sie nicht gelöscht hätte –?«
     </p>
-    <p xml:id="eco_de_0000141_15420">
+    <p xml:id="eco_de_0000211_15420">
      Mama schauderte bei dem Gedanken, in welcher Gefahr alle sechs Kinder gestanden. Aber Werner lief auf sie zu:
     </p>
-    <p xml:id="eco_de_0000141_15430">
+    <p xml:id="eco_de_0000211_15430">
      »Ich bin auch ein wenig angebrannt, Mama! Riech meine Haare! Aber dann bin ich schnell fortgesprungen! Marianne, ist die Doktorkappe ganz verbrannt –?«
     </p>
-    <p xml:id="eco_de_0000141_15440">
+    <p xml:id="eco_de_0000211_15440">
      Mama gab dem törichten kleinen Buben einen Kuss und holte dann rasch Öl und Watte, um Hansens Hände zu verbinden. Die verbrannten Stellen schmerzten Hans immer stärker; aber im Herzen war ihm sehr wohl zumut. Papa war auch mit heraufgekommen und lobte ihn. Und Papa lobte einen nicht oft. Hans sass auf dem Sofa und trank das Himbeerwasser, das Balbine brachte. Balbine blieb im Zimmer stehen und erzählte eine schreckliche Geschichte aus ihrem Dorfe, wo ein kleiner Bub verbrannt sei, weil die andern Kinder alle weggelaufen waren.
     </p>
-    <p xml:id="eco_de_0000141_15450">
+    <p xml:id="eco_de_0000211_15450">
      Als Hans den andern Morgen mit seinen verbundenen Händen zur Schule ging, rannten ihm schon auf der Brücke Schürmann, Binder, Villeiner und noch ein paar andere aus seiner Klasse nach.
     </p>
-    <p xml:id="eco_de_0000141_15460">
+    <p xml:id="eco_de_0000211_15460">
      »Ist's wahr, Turnach –? Die Schwester von Rudolf Lorez sei fast verbrannt und du habest sie gerettet –? Herrschaft! wie du aussiehst –! Vorn alle Haare weg und gar keine Augenbrauen mehr! Tut dir die Hand arg weh –? Jetzt musst du heut nicht schreiben in der Aufsatzstunde! Ist deine Bluse auch angebrannt?«
     </p>
-    <p xml:id="eco_de_0000141_15470">
+    <p xml:id="eco_de_0000211_15470">
      So stürmten sie auf ihn los, und die Schar von Neugierigen und Bewundernden, die sich um Hans drängten, wurde immer grösser, je näher man dem Schulhause kam.
     </p>
-    <p xml:id="eco_de_0000141_15480">
+    <p xml:id="eco_de_0000211_15480">
      »Ich wollte, ich wäre dabei gewesen, Hans!« sagte Karl Binder. »Ich hätte dir geholfen. Es ist fein, so etwas zu tun!«
     </p>
-    <p xml:id="eco_de_0000141_15490">
+    <p xml:id="eco_de_0000211_15490">
      »Ich bin nur froh, dass es einer aus unserer Klasse gewesen ist und nicht einer aus dem B«, rief Kolb, der Hans die Schulmappe trug. »Die sind sonst schon immer so hochmütig!
     </p>
-    <p xml:id="eco_de_0000141_15500">
+    <p xml:id="eco_de_0000211_15500">
      Dort kommt Herr Altschmid! vielleicht weiss er es noch nicht –« Kolb sprang Herrn Altschmid entgegen.
     </p>
-    <p xml:id="eco_de_0000141_15510">
+    <p xml:id="eco_de_0000211_15510">
      Herr Altschmid vernahm erstaunt und erfreut die Geschichte. Er nickte Hans zu.
     </p>
-    <p xml:id="eco_de_0000141_15520">
+    <p xml:id="eco_de_0000211_15520">
      »Das ist schön, Turnach. Das hast du brav gemacht.«
     </p>
-    <p xml:id="eco_de_0000141_15530">
+    <p xml:id="eco_de_0000211_15530">
      Als Hans in der Pause mit den andern durch den Korridor ging, sah er die Lehrer beisammen stehen und merkte, dass sie von ihm sprachen. Herr Altschmid zeigte auf ihn.
     </p>
-    <p xml:id="eco_de_0000141_15540">
+    <p xml:id="eco_de_0000211_15540">
      Abends kam Herr Lorez ins Turnachhaus herüber. Er erzählte, dass der Arzt Sylvias Zustand nicht schlimm gefunden hatte. Und in seiner Freude und Dankbarkeit überreichte er Hans zur Erinnerung eine schöne silberne Uhr. Hans war ganz betreten vor Überraschung und Glück.
     </p>
-    <p xml:id="eco_de_0000141_15550">
+    <p xml:id="eco_de_0000211_15550">
      Am nächsten Tage aber trat Papa mit der offenen Zeitung in die Stube.
     </p>
-    <p xml:id="eco_de_0000141_15560">
+    <p xml:id="eco_de_0000211_15560">
      »Da –« sagte er halb lachend, halb unmutig. »Das geht nun fast zu weit –«
     </p>
-    <p xml:id="eco_de_0000141_15570">
+    <p xml:id="eco_de_0000211_15570">
      In dem Blatt stand auf der dritten Seite folgendes zu lesen:
     </p>
-    <p xml:id="eco_de_0000141_15580">
+    <p xml:id="eco_de_0000211_15580">
      »Beinahe wäre vorgestern abend ein junges Menschenleben dem Feuer zum Opfer gefallen. Durch die Unvorsichtigkeit spielender Kinder geriet eine Papierlaterne in Brand und entzündete die Kleider eines kleinen Mädchens. Ein elfjähriger Knabe aus der Nachbarschaft aber warf sich beherzt und mit grosser Geistesgegenwart auf die brennende Kleine, und es gelang ihm, die Flammen im Schnee zu ersticken. Diese unerschrockene Tat verdient Anerkennung.«
     </p>
-    <p xml:id="eco_de_0000141_15590">
+    <p xml:id="eco_de_0000211_15590">
      Marianne und Lotti waren fast ebenso stolz wie Hans. Sie zogen sich gegenseitig die Zeitung aus den Händen und lasen die Notiz so lange, bis sie sie auswendig konnten. Sophie, Balbine und Ulrich nahmen auch Anteil. Balbine kaufte sich eigens die Nummer des Blattes und schnitt die Stelle heraus, um sie vorn in ihren Kalender zu kleben.
     </p>
-    <p xml:id="eco_de_0000141_15600">
+    <p xml:id="eco_de_0000211_15600">
      »Werd' mir nur nicht eingebildet, gelt, Hans?« sagte Mama.
     </p>
-    <p xml:id="eco_de_0000141_15610">
+    <p xml:id="eco_de_0000211_15610">
      Hans versprach es. Aber ein wenig des Ruhmes sich freuen durfte man schon.
     </p>
-    <p xml:id="eco_de_0000141_15620">
+    <p xml:id="eco_de_0000211_15620">
      Hans hatte keine Ahnung, dass er bald darauf recht beschämt und gedemütigt vor seiner Mama stehen würde.
     </p>
    </div>
@@ -4848,400 +4848,400 @@
     <head>
      Hansens Heldentum bekommt einen Riss
     </head>
-    <p xml:id="eco_de_0000141_15630">
+    <p xml:id="eco_de_0000211_15630">
      Wenn es keine Schlittbahn und kein Eis gab, waren die Kinder am Sonntagnachmittag sehr oft bei Grossmama, und jedes durfte aus seiner Klasse ein paar Freunde oder Freundinnen mitbringen. Es wurden alle möglichen Spiele gespielt. Jedesmal aber hiess es nach einer Weile:
     </p>
-    <p xml:id="eco_de_0000141_15640">
+    <p xml:id="eco_de_0000211_15640">
      »Jetzt machen wir Scharaden!«
     </p>
-    <p xml:id="eco_de_0000141_15650">
+    <p xml:id="eco_de_0000211_15650">
      In Grossmamas Kammer fand man alles, was man dazu brauchte. Es gab da Schleier und lange Tücher in allen Farben, einen Helm, eine Krone und einen Schlapphut, zwei lange Bärte und einen roten Backenbart. Damit konnte man Könige, Damen, Räuber, Feen, Engländer, Hexen und vieles andere darstellen. Man musste nur Wörter finden, die sich zu einer Scharade eigneten. Ein Teil der Kinder spielte, der andere sah zu und sollte das Wort erraten. Oft aber war der Eifer so gross, dass alle mitmachten, und als Zuschauer blieben bloss Grossmama mit Friederike und auf dem dritten Sessel Aristoteles, der die Scharaden auch liebte.
     </p>
-    <p xml:id="eco_de_0000141_15660">
+    <p xml:id="eco_de_0000211_15660">
      Eine der Scharaden, die heute aufgeführt wurden, war »Dornröschen«. Hans und Marianne hatten sie ausgedacht.
     </p>
-    <p xml:id="eco_de_0000141_15670">
+    <p xml:id="eco_de_0000211_15670">
      »Dorn –« sagte Hans, als die Kinder beratend zusammenstanden, »da ist doch eine Geschichte von einem Löwen, dem ein entsprungener Sklave einen Dorn aus der Tatze zieht –«
     </p>
-    <p xml:id="eco_de_0000141_15680">
+    <p xml:id="eco_de_0000211_15680">
      »Ja«, stimmte Rudolf Lorez bei – die kleine Sylvia, deren Brandwunden zwar gut heilten, hatte heute noch nicht mit dürfen – »ja! Später wurde der Mann wieder gefangen genommen und im Zirkus einem Löwen vorgeworfen. Aber es war der gleiche Löwe; er erkannte den Mann und tat ihm nichts.«
     </p>
-    <p xml:id="eco_de_0000141_15690">
+    <p xml:id="eco_de_0000211_15690">
      »Also, wir brauchen den Anfang mit der Tatze«, sagte Marianne. »Dann »Röschen« das geht leicht: da machen wir einen Blumenladen. Und fürs Ganze nehmen wir ein Stück aus dem Märchen.«»Die Aufführung gelang sehr gut: Hans trat als entsprungener Sklave auf und spähte rechts und links nach einem Weg. Da ertönte plötzlich ein Gebrüll; hinter dem Ofen hervor kroch Walter Schürmann. Über dem Rücken hatte er ein Fell und auf dem Kopfe als Mähne ein gelbes Tuch mit Fransen. Der Löwe hinkte stark und kam auf den Sklaven zu, der erst etwas zurückwich. Da aber der Löwe immer kläglicher brüllte, kniete der Jäger nieder, nahm die Tatze des Tieres und untersuchte sie. Der Löwe stöhnte ein paarmal laut auf; dann aber begann er fröhlich herumzuhüpfen. Da er keinen Schwanz hatte zum Wedeln, leckte er dem guten Manne die Hand; der klopfte ihm auf den Rücken, und beide gingen miteinander davon.
     </p>
-    <p xml:id="eco_de_0000141_15700">
+    <p xml:id="eco_de_0000211_15700">
      Das Publikum hatte sehr gespannt zugesehen. Was für ein Wort das wohl bedeutete?
     </p>
-    <p xml:id="eco_de_0000141_15710">
+    <p xml:id="eco_de_0000211_15710">
      Aus dem zweiten Teile merkte man, dass es sich um eine Blume handelte. Ein paar Buben und Mädchen kauerten als Blumentöpfe am Boden, und Marianne, die Gärtnerin, pries sie dem Käufer Rudolf Lorez an, indem sie einen Topf um den andern herzog. Der Käufer hatte indessen allerlei an den Pflanzen auszusetzen.
     </p>
-    <p xml:id="eco_de_0000141_15720">
+    <p xml:id="eco_de_0000211_15720">
      »Au – das kleine da sticht!« rief er, als er auf einen der Köpfe tupfte.
     </p>
-    <p xml:id="eco_de_0000141_15730">
+    <p xml:id="eco_de_0000211_15730">
      »Ja, aber es riecht herrlich und blüht sehr lang«, sagte die Gärtnerin. »Sehen Sie die vielen Knospen …«
     </p>
-    <p xml:id="eco_de_0000141_15740">
+    <p xml:id="eco_de_0000211_15740">
      »Du, Grossmama«, überlegte Lotti, als der Akt zu Ende war, »gibt es Löwenrosen? Oder hat das erste ›Tatze‹?« Aber Grossmama wusste nichts von Löwenrosen und noch weniger von Tatzenrosen.
     </p>
-    <p xml:id="eco_de_0000141_15750">
+    <p xml:id="eco_de_0000211_15750">
      Dann kam das Ganze: Auf erhöhtem Sitz sassen, umgeben von den Hofleuten, Karl Binder und Lily Rabus als Königspaar. Vor ihnen hatte man aus zwei Sesseln eine Wiege gemacht, in der, mit einem weissen Tuche bedeckt, der kleine Werner lag. Nun huschte in grau gehüllt Berta Strobel als böse Fee herbei und streckte mit finsterem Gesicht den Arm gegen die Wiege aus. Geredet wurde nicht, damit die Zuschauer das Wort nicht zu leicht erraten. Das Königspaar zeigte heftigen Schrecken; dann aber trat von der andern Seite Marianne, die gute Fee, hinzu und breitete ihre Hand über die kleine Prinzessin aus.
     </p>
-    <p xml:id="eco_de_0000141_15760">
+    <p xml:id="eco_de_0000211_15760">
      Es war sehr hübsch. Nur machte Werner, dem es unbehaglich wurde, der Vorstellung einen etwas zu raschen Schluss.
     </p>
-    <p xml:id="eco_de_0000141_15770">
+    <p xml:id="eco_de_0000211_15770">
      »Grossmama; ich bin das Dornröschen; aber ich rutsche hinunter«, rief er und kam, seine weisse Decke hinter sich herziehend, auf Grossmama zugelaufen, so dass alle laut auflachten.
     </p>
-    <p xml:id="eco_de_0000141_15780">
+    <p xml:id="eco_de_0000211_15780">
      »So, mein kleiner Dummerling!« sagte Grossmama. »Nun müssen wir uns doch den Kopf nicht mehr zerbrechen. Du bist wirklich ein niedliches Dornröschen!«
     </p>
-    <p xml:id="eco_de_0000141_15790">
+    <p xml:id="eco_de_0000211_15790">
      Die folgende Scharade wurde dadurch zu einem besonderen Vergnügen, dass Onkel Alfred mitmachte.
     </p>
-    <p xml:id="eco_de_0000141_15800">
+    <p xml:id="eco_de_0000211_15800">
      »Er ist hinten in seinem Zimmer!« rief Hans. »Wir holen ihn! Letztes Jahr hat er auch einmal mitgespielt. Er war Kolumbus und wir waren die unzufriedenen Matrosen und packten ihn an, und dann mussten wir auf einmal alle gegen die Kommode deuten und ›Land! Land!‹ Onkel Alfred sass an seinem Schreibtisch und streckte, als die Schar bei ihm eindrang, zur Abwehr ein langes Lineal vor.«
     </p>
-    <p xml:id="eco_de_0000141_15810">
+    <p xml:id="eco_de_0000211_15810">
      »Nein, Kinder, nein! ich kann euch heute nicht helfen! Wer hilft denn mir beim Studieren! Den Aristoteles habt ihr auch vorn!«
     </p>
-    <p xml:id="eco_de_0000141_15820">
+    <p xml:id="eco_de_0000211_15820">
      »Onkel, wir wissen eine so nette Scharade!« drängte Lotti. »Wir wollen alle zusammen ›Seeweid‹ Weid« »Sehr ehrenvoll, Lotti!«
     </p>
-    <p xml:id="eco_de_0000141_15830">
+    <p xml:id="eco_de_0000211_15830">
      Die Kinder nahmen das als Zusage und zogen den Onkel mit ins Wohnzimmer, wo er sich vorläufig neben Aristoteles setzte; er sagte, er müsse erst wieder lernen, wie so eine Scharade gehe.
     </p>
-    <p xml:id="eco_de_0000141_15840">
+    <p xml:id="eco_de_0000211_15840">
      Der See wurde äusserst lebendig dargestellt. Einige Kinder legten sich auf den Boden und fochten mit Armen und Beinen, als ob sie schwämmen. Zwei andere ruderten auf einem Brett mit Spazierstock und Regenschirm. Hans stellte einen Fisch dar und schnappte nach den Brocken, die man ihm zuwarf. Lotti und Hedwig Zohner sassen auf dem Tisch mit Angelruten.
     </p>
-    <p xml:id="eco_de_0000141_15850">
+    <p xml:id="eco_de_0000211_15850">
      Die zweite Silbe begann schon vor der Türe mit lautem Muh und Mäh. Voran zog der Onkel mit einem alten Strohhut und sang:
     </p>
-    <p xml:id="eco_de_0000141_15860">
+    <p xml:id="eco_de_0000211_15860">
      »Des Morgens in der Frühe, Trallallah, trallallah, Da treiben wir die Kühe, Trallallah, trallallah!«
     </p>
-    <p xml:id="eco_de_0000141_15870">
+    <p xml:id="eco_de_0000211_15870">
      Und hinter ihm kam die Herde, alles auf vier Füssen daherstapfend und nach Gras schnuppernd. Die Kühe taten ungebärdig und stiessen mit den Hörnern; die Ziegen machten wunderliche Sprünge und verstiegen sich auf den Felsen, das heisst auf den Stühlen und der Kommode, wo der Hirte sie herunterholen musste. Aristoteles erhob sich von seinem Sitz und krümmte den Rücken. Zu viel Lärm hatte er ungern; auch war er nicht gewöhnt, dass hier im Hause noch andere Leute als er auf vier Füssen gingen.
     </p>
-    <p xml:id="eco_de_0000141_15880">
+    <p xml:id="eco_de_0000211_15880">
      Es war gut, dass der folgende Akt wieder gesitteter verlief.
     </p>
-    <p xml:id="eco_de_0000141_15890">
+    <p xml:id="eco_de_0000211_15890">
      »Wie machen wir doch das Ganze, Onkel?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_15900">
+    <p xml:id="eco_de_0000211_15900">
      »Ja, das werdet ihr gleich sehen!« sagte der Onkel. »Richtet euch einmal als Fremde her und klopft da an.«
     </p>
-    <p xml:id="eco_de_0000141_15910">
+    <p xml:id="eco_de_0000211_15910">
      Die Kinder stellten sich mit Mützen, Schirmen und Plaids vor die Türe. Der Onkel trat heraus.
     </p>
-    <p xml:id="eco_de_0000141_15920">
+    <p xml:id="eco_de_0000211_15920">
      »Ah, Sie wünschen die Sehenswürdigkeiten dieses Ortes zu betrachten? Sofort – .« Er machte eine tiefe Verbeugung und nahm ein Stöckchen. »Hier, meine Herrschaften«, sagte er mit einem Seitenblick zu Hans hinüber und wies nach einem gewöhnlichen weissen Teller auf den Nebentisch, »hier ein ungemein wertvolles uraltes Götzenbild –«
     </p>
-    <p xml:id="eco_de_0000141_15930">
+    <p xml:id="eco_de_0000211_15930">
      »Ach, Onkel!« rief Hans lachend, der die Neckerei gleich merkte.
     </p>
-    <p xml:id="eco_de_0000141_15940">
+    <p xml:id="eco_de_0000211_15940">
      »Ssst – ein uraltes Götzenbild der Pfahlbauer. Heute ist es noch da zu sehen. Morgen kommt es ins Museum mit den Namen der Entdecker –«
     </p>
-    <p xml:id="eco_de_0000141_15950">
+    <p xml:id="eco_de_0000211_15950">
      Das uralte Götzenbild erregte grosse Heiterkeit.
     </p>
-    <p xml:id="eco_de_0000141_15960">
+    <p xml:id="eco_de_0000211_15960">
      »Weiter betrachten Sie sich, bitte, diesen Molch –«, der Onkel hielt eine schwarze Quaste in die Höhe. »Er sieht ganz harmlos aus, kann aber, wenn er aus der Gefangenschaft entkommt, schreckliche Verheerungen anrichten –«
     </p>
-    <p xml:id="eco_de_0000141_15970">
+    <p xml:id="eco_de_0000211_15970">
      »Ja, Fräulein Fanny hat furchtbar geschrien!« rief Marianne höchlich belustigt.
     </p>
-    <p xml:id="eco_de_0000141_15980">
+    <p xml:id="eco_de_0000211_15980">
      »Da –«, Onkel Alfred sah sich um und packte den Aristoteles, »da haben Sie die Hauswurz – .« Onkel Alfred hob den Kater, der ärgerlich miaute, in die Höhe. »Eine sehr merkwürdige Pflanze; man kann sie nach Belieben vom Dache aufheben, spazierentragen und wieder hinlegen – .« Damit liess er den Kater zum grossen Spass der Kinder auf Friederikes Schoss plumpsen.
     </p>
-    <p xml:id="eco_de_0000141_15990">
+    <p xml:id="eco_de_0000211_15990">
      »Hier aber, meine Herrschaften« – der Onkel streckte ein vollgespicktes Stecknadelkissen hin – »hier zeige ich Ihnen den verhängnisvollen Igel, der sich boshafterweise im Zimmer zweier jungen Damen versteckte –«
     </p>
-    <p xml:id="eco_de_0000141_16000">
+    <p xml:id="eco_de_0000211_16000">
      Alles brach in lauten Jubel aus. Die Geschichte mit dem Igel war jedem bekannt.
     </p>
-    <p xml:id="eco_de_0000141_16010">
+    <p xml:id="eco_de_0000211_16010">
      »Mitten in der Nacht«, so fuhr der Onkel fort, »versuchte der Igel einen Angriff, und ohne den Mut und die Entschlossenheit der beiden jungen Damen weiss man nicht, wie es gegangen wäre –«
     </p>
-    <p xml:id="eco_de_0000141_16020">
+    <p xml:id="eco_de_0000211_16020">
      »Noch mehr, noch mehr, Onkel!« schrie der kleine Werner, wenn er schon nicht alles verstanden hatte.
     </p>
-    <p xml:id="eco_de_0000141_16030">
+    <p xml:id="eco_de_0000211_16030">
      Da packte der Onkel ihn selbst und schwang ihn auf die Schulter.
     </p>
-    <p xml:id="eco_de_0000141_16040">
+    <p xml:id="eco_de_0000211_16040">
      »Zum Schlusse stelle ich Ihnen hier den Frosch Alexius vor. Er kann hübsch quaken und frisst Fliegen, so viel man ihm gibt – .« Damit schob der Onkel dem vor Vergnügen kreischenden Werner ein paar Weinbeeren vom Kuchenteller in den Mund und setzte ihn dann unter allgemeinem Hurra auf den Boden.
     </p>
-    <p xml:id="eco_de_0000141_16050">
+    <p xml:id="eco_de_0000211_16050">
      Grossmama und Friederike erklärten, sie hätten die Scharade erraten. Der Ort, der alle diese Merkwürdigkeiten auszuweisen habe, könne nur die Seeweid sein.
     </p>
-    <p xml:id="eco_de_0000141_16060">
+    <p xml:id="eco_de_0000211_16060">
      »Was für eine Scharade spielen wir jetzt, Hans?« rief Lotti. »Du wirst doch noch eine wissen?«
     </p>
-    <p xml:id="eco_de_0000141_16070">
+    <p xml:id="eco_de_0000211_16070">
      Ja, was für ein Wort konnte man nehmen? Die Buben und Mädchen besannen sich. Nach der lustigen Seeweid dünkte sie nichts mehr gut genug. Die einen liefen hinüber in die Kammer; vor den Sachen zum Verkleiden kam einem vielleicht ein Gedanke. Lotti und ein paar andere versuchten, noch einmal zu Onkel Alfred einzudringen; der aber hatte die Türe abgeschlossen.
     </p>
-    <p xml:id="eco_de_0000141_16080">
+    <p xml:id="eco_de_0000211_16080">
      Da fiel Hans etwas ein. Hinten in der kleinen Stube hatte Grossmama ein Rätsel- und Scharadenbuch. Er lief hinüber; das Buch musste in dem kleinen Schränkchen sein. Er machte auf und suchte eilig in den verschiedenen Fächern. Das Buch fand sich nicht. Vielleicht in der Schublade? Er zog. Sie tat nur einen kleinen Ruck und ging nicht weiter. Ungeduldig zog Hans stärker. Da kam das Schränkchen ins Wanken. Hans hielt es mit beiden Händen; aber über seine Schulter stürzte etwas hinunter. Die Teekanne! dachte er erschrocken.
     </p>
-    <p xml:id="eco_de_0000141_16090">
+    <p xml:id="eco_de_0000211_16090">
      Es war eine besonders feine chinesische Kanne mit Landschaften und goldenen Vögeln bemalt; Grossmama hatte sie vor Jahren als Andenken geschenkt bekommen.
     </p>
-    <p xml:id="eco_de_0000141_16100">
+    <p xml:id="eco_de_0000211_16100">
      Als Hans die Teekanne aufhob, lag der Schnabel zerbrochen daneben. Hans biss sich auf die Lippen. Zu arg, dass ihm das begegnet war! Jetzt musste er gehen und es Grossmama sagen. Nun fiel ihm auch ein, dass er das Schränkchen nicht hätte öffnen sollen, ohne Grossmama zu fragen. Natürlich wurde er gescholten. Wenn man etwas angestellt hatte, zankte Grossmama gehörig. Und alle andern hörten es dann! Für Werner oder Lotti wäre das ja nichts so Schlimmes. Aber er – der Älteste, den man in den letzten Tagen immer gelobt hatte – . Diese Schande! Nein – vor der ganzen Kindergesellschaft mochte er es nicht sagen!
     </p>
-    <p xml:id="eco_de_0000141_16110">
+    <p xml:id="eco_de_0000211_16110">
      Hans stellte die Teekanne hin und legte den Schnabel daneben. Das Buch liess er.
     </p>
-    <p xml:id="eco_de_0000141_16120">
+    <p xml:id="eco_de_0000211_16120">
      Als er ins Wohnzimmer zurückkam, war von Scharaden nicht mehr die Rede. Die Kinder umstanden die Grossmama; sie hatte vom Boden das Schnappspiel heruntergeholt, das alte Schnappspiel mit der lächerlichen hölzernen Fratze, in deren aufgesperrten Rachen man die kleinen Bälle werfen musste.
     </p>
-    <p xml:id="eco_de_0000141_16130">
+    <p xml:id="eco_de_0000211_16130">
      »Hans!« rief Walter Schürmann – Hansens Abwesenheit hatte niemand bemerkt – »du darfst der Aufschreiber sein!«
     </p>
-    <p xml:id="eco_de_0000141_16140">
+    <p xml:id="eco_de_0000211_16140">
      »Du kannst ja diesmal aufschreiben«, sagte Hans und blieb an der Seite stehen.
     </p>
-    <p xml:id="eco_de_0000141_16150">
+    <p xml:id="eco_de_0000211_16150">
      Alle Augenblicke gab es ein fröhliches Gelächter; denn wenn der Ball in den Rachen traf, so rollte die Fratze die Augen und schnappte den Rachen zu. Das war sehr komisch. Hans war der einzige, der nicht mitlachte.
     </p>
-    <p xml:id="eco_de_0000141_16160">
+    <p xml:id="eco_de_0000211_16160">
      »Hans, es ist an dir!« rief Rudolf Lorez und gab Hans einen kleinen Stoss. »Was hast du denn?«
     </p>
-    <p xml:id="eco_de_0000141_16170">
+    <p xml:id="eco_de_0000211_16170">
      Die Kinder wurden immer eifriger und ausgelassener. Aber Grossmama sah auf die Uhr.
     </p>
-    <p xml:id="eco_de_0000141_16180">
+    <p xml:id="eco_de_0000211_16180">
      »Hört, nun müssen wir allmählig ans Aufräumen denken! Das Schnappspiel könnt ihr ja ein anderes Mal wieder spielen.«
     </p>
-    <p xml:id="eco_de_0000141_16190">
+    <p xml:id="eco_de_0000211_16190">
      Mit bedauerndem O! und Ach! klappten die Kinder nach ein paar letzten Würfen zu und suchten dann die im Nebenzimmer verstreuten Scharadensachen zusammen. Schwatzend liefen sie hin und her.
     </p>
-    <p xml:id="eco_de_0000141_16200">
+    <p xml:id="eco_de_0000211_16200">
      Hans überlegte. Jetzt gab es vielleicht einen Augenblick. Eben ging Grossmama hinaus – schnell ihr nach und frisch dran! Hans kam bis zur Türe; dann blieb er wieder stehen. Es war etwas so Unangenehmes. Und natürlich kam es da draussen doch vor die andern. Nein, es war nun eben so gut, zu warten bis morgen oder übermorgen und dann zu Grossmama zu gehen. Vorher sah sie den Schaden jedenfalls nicht; sie war selten in der kleinen Stube. Die dumme Teekanne! Das ganze Schnappspiel hatte sie Hans verdorben –
     </p>
-    <p xml:id="eco_de_0000141_16210">
+    <p xml:id="eco_de_0000211_16210">
      »Kinder, kommt her! ich möchte etwas wissen«, sagte Grossmama, wieder eintretend. Sie hielt in der Hand die Kanne mit den goldenen Vögeln.
     </p>
-    <p xml:id="eco_de_0000141_16220">
+    <p xml:id="eco_de_0000211_16220">
      Hans erschrak.
     </p>
-    <p xml:id="eco_de_0000141_16230">
+    <p xml:id="eco_de_0000211_16230">
      »Wer von euch war in der kleinen Stube? Ich wollte das Fransentuch in die Kommode legen und sehe meine Teekanne zerbrochen.«
     </p>
-    <p xml:id="eco_de_0000141_16240">
+    <p xml:id="eco_de_0000211_16240">
      Die Kinder kamen alle herzu und sahen die Teekanne an und dann einander.
     </p>
-    <p xml:id="eco_de_0000141_16250">
+    <p xml:id="eco_de_0000211_16250">
      »Wer es getan hat, hätte es gleich ehrlich sagen sollen, statt zu warten, bis ich frage!« fuhr Grossmama fort.
     </p>
-    <p xml:id="eco_de_0000141_16260">
+    <p xml:id="eco_de_0000211_16260">
      Hans stand Qualen aus. Etwas in ihm trieb immer: Sag es doch! red' doch! und etwas war, was ihn nicht sprechen liess.
     </p>
-    <p xml:id="eco_de_0000141_16270">
+    <p xml:id="eco_de_0000211_16270">
      »Mir tut die Teekanne leid; aber viel schlimmer fände ich, wenn eins unter euch wäre, das die Wahrheit nicht sagen will.« Grossmama sah im Kreise herum. Ihr Blick ging jedoch rasch über die Grössern weg. Die waren doch schon vernünftig und wussten, was recht ist. Auch dachte sie weniger an die fremden Kinder, denen es wohl kaum eingefallen wäre, in die kleine Stube zu dringen. Grossmama hatte Lotti ein wenig in Verdacht und dann den kleinen Werner.
     </p>
-    <p xml:id="eco_de_0000141_16280">
+    <p xml:id="eco_de_0000211_16280">
      Aber Lotti sagte fest und frisch:
     </p>
-    <p xml:id="eco_de_0000141_16290">
+    <p xml:id="eco_de_0000211_16290">
      »Grossmama, ich hab' es nicht getan!«
     </p>
-    <p xml:id="eco_de_0000141_16300">
+    <p xml:id="eco_de_0000211_16300">
      »Ich auch nicht!« rief Werner, und Marianne und Lily Rabus versicherten, dass er den ganzen Nachmittag nicht von ihnen weggegangen sei.
     </p>
-    <p xml:id="eco_de_0000141_16310">
+    <p xml:id="eco_de_0000211_16310">
      Grossmama schüttelte den Kopf. Jemand musste es doch getan haben.
     </p>
-    <p xml:id="eco_de_0000141_16320">
+    <p xml:id="eco_de_0000211_16320">
      Hans wurde es immer unmöglicher, zu reden. Er, an den man gar nicht dachte! Jetzt so hinten drein! Neben ihm standen Karl Binder, Walter Schürmann und Rudolf Lorez – nein, er konnte nicht, jetzt nicht!
     </p>
-    <p xml:id="eco_de_0000141_16330">
+    <p xml:id="eco_de_0000211_16330">
      Plötzlich fiel Grossmama etwas ein.
     </p>
-    <p xml:id="eco_de_0000141_16340">
+    <p xml:id="eco_de_0000211_16340">
      »Kinder«, sagte sie, »es kann Hulda gewesen sein, Frau Pflachers Hulda – die hat schon allerlei angerichtet –«
     </p>
-    <p xml:id="eco_de_0000141_16350">
+    <p xml:id="eco_de_0000211_16350">
      Frau Pflacher wohnte im Hinterhause; sie half Friederike am Samstag beim Putzen und war auch jetzt gerade in der Küche. Hulda kam oft herüber mit der Mutter.
     </p>
-    <p xml:id="eco_de_0000141_16360">
+    <p xml:id="eco_de_0000211_16360">
      »Ich war gestern nicht zu Hause«, fuhr Grossmama fort. »Aber ich will Frau Pflacher fragen, ob Hulda da war – .« Grossmama ging hinaus und alle gingen mit.
     </p>
-    <p xml:id="eco_de_0000141_16370">
+    <p xml:id="eco_de_0000211_16370">
      Hans blieb am Fenster stehen. Aber es wurde ihm schnell klar, dass er jetzt gestehen müsse. Er und die beiden Schwestern mochten diese Hulda nicht besonders leiden. Sie war ein bisschen frech. Aber deswegen durfte man doch nicht den Verdacht auf sie kommen lassen. Das wäre ja furchtbar schlecht. Nein, jetzt gab es kein Hin und Her mehr. Jetzt war er gezwungen, herauszurücken, und das war gerade recht –
     </p>
-    <p xml:id="eco_de_0000141_16380">
+    <p xml:id="eco_de_0000211_16380">
      Aber schon kamen sie wieder zurück und Lotti sprang auf Hans zu:
     </p>
-    <p xml:id="eco_de_0000141_16390">
+    <p xml:id="eco_de_0000211_16390">
      »Hans, denk', sie hat's nicht getan! Sie hat Zahnweh gehabt und ist gar nicht dagewesen! Jetzt muss man sich von neuem besinnen!«
     </p>
-    <p xml:id="eco_de_0000141_16400">
+    <p xml:id="eco_de_0000211_16400">
      Lotti stellte sich neben den Bruder. Aber Hans schaute weg. Nun kam es wieder anders! War das ein Wink, dass Hans nichts zu sagen brauche –?
     </p>
-    <p xml:id="eco_de_0000141_16410">
+    <p xml:id="eco_de_0000211_16410">
      Bevor er mit dem Gedanken fertig war, trat Friederike ins Zimmer:
     </p>
-    <p xml:id="eco_de_0000141_16420">
+    <p xml:id="eco_de_0000211_16420">
      »Dass ich nicht gleich darauf gekommen bin –! Der Glaser war's natürlich am Freitag. Seither ist niemand in der kleinen Stube gewesen. Ich liess ihn bloss einen Augenblick allein. Da muss ihn, so alt er war, die Neugierde geplagt haben, dass er die Kanne angefasst und zerbrochen hat. Ich hab' ihm, weil er so erfroren aussah, noch einen Teller Suppe gegeben, und keinen Mux hat er getan von der Kanne. Das nächstemal kann er dann warten! Aber der kommt nicht mehr. Der ist längst über alle Berge. Er hat gesagt, er gehe ins Österreichische!«
     </p>
-    <p xml:id="eco_de_0000141_16430">
+    <p xml:id="eco_de_0000211_16430">
      Wie sich das seltsam fügte für Hans! Er hatte ja gestehen wollen. Aber nun war dieser Glaser dazwischen gekommen und nahm gleichsam Hansens Schuld, ohne es im mindesten zu spüren, »über alle Berge, fort ins Österreichische!«
     </p>
-    <p xml:id="eco_de_0000141_16440">
+    <p xml:id="eco_de_0000211_16440">
      Jetzt nur nicht immer dran denken! Es war ja doch, im Grund genommen, eine Kleinigkeit, dieser abgebrochene Schnabel. Friederike hatte gesagt, er liesse sich wieder ankitten …
     </p>
-    <p xml:id="eco_de_0000141_16450">
+    <p xml:id="eco_de_0000211_16450">
      Zu Hause setzte sich Hans gleich hin, und machte seine Geographiezeichnung, obgleich er sie erst für den Mittwoch aufhatte.
     </p>
-    <p xml:id="eco_de_0000141_16460">
+    <p xml:id="eco_de_0000211_16460">
      Als Hans am Montag morgen erwachte, war das erste, was ihn begrüsste, der Gedanke an die Teekanne. Es war, als ob er die ganze Nacht da am Bette auf Hans gewartet hätte: So, guten Morgen! jetzt gehen wir zusammen in die Schule! Hans versuchte den Gedanken zu verscheuchen. Er horchte auf den Lärm draussen. Ein Bäckerbursche pfiff lustig in den Morgen hinaus:
     </p>
-    <p xml:id="eco_de_0000141_16470">
+    <p xml:id="eco_de_0000211_16470">
      »O Tannenbaum, O Tannenbaum, Wie grün sind deine Blätter …«
     </p>
-    <p xml:id="eco_de_0000141_16480">
+    <p xml:id="eco_de_0000211_16480">
      Der hatte jedenfalls nichts Unangenehmes im Kopfe. Es erfasste Hans ein Zorn gegen die Teekanne. Warum war sie so weit aussen gestanden! Hätte er's doch lieber gleich gesagt! Sollte er am Ende doch heute –? Nein, es war zu spät. Er müsste sich zu arg schämen vor Grossmama. Er wollte sich's gewiss merken und nie mehr so handeln. Er nahm sich auch vor, nun ganz besonders fleissig und freundlich zu sein, Marianne den Bilderbogen zu schenken, um den sie gebeten hatte, und mit Werner zu bauen …
     </p>
-    <p xml:id="eco_de_0000141_16490">
+    <p xml:id="eco_de_0000211_16490">
      Tagsüber schien es Hans wirklich, als ob er die Sache vergessen könnte. Oft dachte er lange nicht daran. Aber ganz los wurde er sie nicht. Und es war gerade, als ob man sich verbündet hätte, ihn immer wieder daran zu erinnern:
     </p>
-    <p xml:id="eco_de_0000141_16500">
+    <p xml:id="eco_de_0000211_16500">
      Am Dienstag, als Hans aus der Schule heimkehrte, hörte er den kleinen Werner mit lauter Stimme: »Glasö – r, Glasö – r!« rufen.
     </p>
-    <p xml:id="eco_de_0000141_16510">
+    <p xml:id="eco_de_0000211_16510">
      »Ich bin der Glaser«, erklärte der Kleine dem Bruder, »und Lotte ist Friederike, und dann muss ich die Scheibe machen und die Teekanne zerbrechen, und dann tut mich Lotti mit dem Besen fortjagen!«
     </p>
-    <p xml:id="eco_de_0000141_16520">
+    <p xml:id="eco_de_0000211_16520">
      Als Hans am Mittwoch nach der Zehnuhrpause vom Hofe ins Klassenzimmer zurückkam, fand er den Kolb, neben dem er sass, ganz aufgebracht.
     </p>
-    <p xml:id="eco_de_0000141_16530">
+    <p xml:id="eco_de_0000211_16530">
      »Der Beschel ist ein miserabler Kerl!« sagte er. »Ich komme herein, und auf meinem Heft ist ein grosser Tintenfleck. Ich frage, wer ihn gemacht habe, und der Beschel tut, als ob er nichts wüsste, bis endlich der Villeiner mir sagt, dass es der Beschel gewesen ist. Ich sage nichts wegen dem Flecken; aber dass er nicht gesteht, wenn ich ihn ins Gesicht hinein frage, das ist gemein, nicht wahr, Turnach?«
     </p>
-    <p xml:id="eco_de_0000141_16540">
+    <p xml:id="eco_de_0000211_16540">
      Hans sagte nichts. Er setzte sich an seinen Platz und sah in sein Buch.
     </p>
-    <p xml:id="eco_de_0000141_16550">
+    <p xml:id="eco_de_0000211_16550">
      Ein paar Tage nachher standen die Knaben in der Pause vorn bei Herrn Altschmid. Er brachte oft Zeitschriften mit. Heute zeigte er den Knaben eine mächtige eiserne Brücke, die über einen breiten Meeresarm führte. Als er umblätterte, sah man auf der andern Seite einen grossen seltsamen Frauenkopf.
     </p>
-    <p xml:id="eco_de_0000141_16560">
+    <p xml:id="eco_de_0000211_16560">
      »Ui!« riefen die Buben. »Die hat Schlangen auf dem Kopf statt Haare!«
     </p>
-    <p xml:id="eco_de_0000141_16570">
+    <p xml:id="eco_de_0000211_16570">
      »Das ist eine Erinnye«, sagte Herr Altschmid. »Die alten Griechen glaubten, die Erinnyen verfolgen die Mörder und Missetäter, so dass diese keinen Frieden mehr finden, bis sie ihre Tat eingestanden und gebüsst haben.«
     </p>
-    <p xml:id="eco_de_0000141_16580">
+    <p xml:id="eco_de_0000211_16580">
      »Aber in Wirklichkeit gab es doch keine Erinnyen«, wendete Karl Binder ein. »Also hatten die Mörder und Missetäter nie eine gesehen.«
     </p>
-    <p xml:id="eco_de_0000141_16590">
+    <p xml:id="eco_de_0000211_16590">
      »O«, sagte Herr Altschmid, »wenn sie fest daran glaubten und in der Seele unruhig und gequält waren, so konnten sie wohl etwa nachts auf einsamem Wege meinen, die Erinnyen zu sehen oder hinter sich zu hören –«
     </p>
-    <p xml:id="eco_de_0000141_16600">
+    <p xml:id="eco_de_0000211_16600">
      Es läutete zum Stundenanfang. Herr Altschmid heftete das Bild an die Wandtafel, damit die Klasse etwas darüber schreibe. Hansens Aufsatz wurde nicht gut. Seine Gedanken zogen ihn immer von der Brücke weg auf die Rückseite des Blattes. Er versuchte, sich selber auszulachen: Was hatte er denn mit den Erinnyen zu tun? Er war doch kein Mörder! Um etwas so Geringes wie eine zerbrochene Teekanne würden sich die Erinnyen jedenfalls nicht kümmern, selbst wenn es welche gäbe!
     </p>
-    <p xml:id="eco_de_0000141_16610">
+    <p xml:id="eco_de_0000211_16610">
      Aber das Bild kam ihm immer wieder in den Sinn, auch am Nachmittag und Abend. Er verstand sehr gut, dass mit diesen unheimlichen Göttinnen nichts anderes als das böse Gewissen gemeint war – das ihn seit dem Sonntag bei Grossmama plagte. Ganz wohl war ihm eigentlich seitdem nicht mehr gewesen. Drum wollte es ihm auch nicht recht glücken mit dem Freundlichsein.
     </p>
-    <p xml:id="eco_de_0000141_16620">
+    <p xml:id="eco_de_0000211_16620">
      »Du bist jetzt immer so langweilig!« hatte Lotti ihm gestern zugerufen, als sie mit Marianne das Rutschbrett hinuntersauste, und Hans umsonst aufforderte mitzutun.
     </p>
-    <p xml:id="eco_de_0000141_16630">
+    <p xml:id="eco_de_0000211_16630">
      Und heute abend hatte Papa ihm auf die Schulter geklopft:
     </p>
-    <p xml:id="eco_de_0000141_16640">
+    <p xml:id="eco_de_0000211_16640">
      »Warum so ernsthaft, Hans?«
     </p>
-    <p xml:id="eco_de_0000141_16650">
+    <p xml:id="eco_de_0000211_16650">
      In der Nacht schlief Hans unruhig. Er erwachte und hörte vom Kirchturm vier Uhr schlagen. Noch nie hatte er früh vier Uhr schlagen hören. Er blieb eine Weile wach. Die greuliche Kanne – . Er drehte sich gegen die Wand. Und wirklich schlief er wieder ein. Aber die Kanne schlich sich in seinen Traum hinein: er war ein Glaser; statt dem Kasten mit den Scheiben trug er jedoch auf dem Rücken die Teekanne; sie war sehr schwer. Er musste mit ihr über alle Berge; aber er kam gar nicht vorwärts. Neben ihm ging eine grosse Katze, der Schlangen vom Kopf herunterhingen. Hans wollte laut »Glasö – r!« rufen, damit die Katze verschwinde; aber er brachte keinen Ton heraus. Da erwachte er. Was für ein widerwärtiger Traum –! Bevor er sich recht besinnen konnte, schlief er wieder ein, und gleich war auch die Katze da. Hans sollte hinter ihr über eine eiserne Brücke gehen; die wurde immer länger und schmaler. Die Katze schritt ganz sicher, und eines ihrer Schlangenhaare streckte sich zurück gegen Hans; jetzt war es aber keine Schlange mehr, sondern der abgebrochene Kannenschnabel. Hans wollte ihn wegstossen; da schwindelte ihm und er stürzte in die Tiefe –
     </p>
-    <p xml:id="eco_de_0000141_16660">
+    <p xml:id="eco_de_0000211_16660">
      Hans fuhr auf. Nun wollte er lieber wach bleiben. Er behielt die Augen offen, und in der Morgenstille ging er nun endlich der Sache auf den Grund. Ganz schlecht hatte er sich seit dem Sonntag aufgeführt – gemein, Kolb hatte letzthin das rechte Wort gebraucht! Wie hatte Hans nur all die Zeit Grossmama, Mama und Papa und die andern ansehen können und tun als ob nichts wäre, während doch diese Lüge in ihm steckte; denn nicht gestehen war grade wie lügen. Nein, das war nicht mehr auszuhalten; das musste ein Ende nehmen –
     </p>
-    <p xml:id="eco_de_0000141_16670">
+    <p xml:id="eco_de_0000211_16670">
      Von draussen hörte Hans den Bäckerburschen sein frisches »O, Tannenbaum, o, Tannenbaum!« pfeifen. Hans wollte auch wieder so fröhlich pfeifen können. Er sprang aus dem Bett. Es war noch sehr früh; aber heute, am Samstag, war Mama gewiss schon auf. Rasch wusch sich Hans und kleidete sich an.
     </p>
-    <p xml:id="eco_de_0000141_16680">
+    <p xml:id="eco_de_0000211_16680">
      Mama stand am Tische, um Milch für das Schwesterlein zu wärmen. Es war noch dämmerig im Zimmer; die blaue Flamme des Spiritusbrenners warf bloss einen schwachen Schein.
     </p>
-    <p xml:id="eco_de_0000141_16690">
+    <p xml:id="eco_de_0000211_16690">
      »Mama«, sagte Hans, »ich muss dir etwas sagen – etwas Schlechtes von mir –«
     </p>
-    <p xml:id="eco_de_0000141_16700">
+    <p xml:id="eco_de_0000211_16700">
      Mama erschrak, und als Hans nun die ganze Geschichte erzählte von dem Scharadenbuch und der Teekanne und wie es gekommen war, dass er nicht gestanden hatte, da machte sie ein betrübtes Gesicht.
     </p>
-    <p xml:id="eco_de_0000141_16710">
+    <p xml:id="eco_de_0000211_16710">
      »Hans, Hans, wie ist das möglich –! Bei dem Brande drüben so tapfer und nun in dieser Sache so feig –!«
     </p>
-    <p xml:id="eco_de_0000141_16720">
+    <p xml:id="eco_de_0000211_16720">
      Kein Wort hätte Hans schärfer treffen können.
     </p>
-    <p xml:id="eco_de_0000141_16730">
+    <p xml:id="eco_de_0000211_16730">
      »Vor deinen Freunden und vor den andern Kindern hast du dich geschämt, den Fehler zu bekennen; aber vor dir selber schämtest du dich nicht, unwahr zu sein! Ist denn dein Gewissen, das Gott in dich gelegt hat, nicht auch etwas, vor dem du in Ehren bestehen möchtest?«
     </p>
-    <p xml:id="eco_de_0000141_16740">
+    <p xml:id="eco_de_0000211_16740">
      Hans drückte die Hände ineinander und hielt die Augen niedergeschlagen.
     </p>
-    <p xml:id="eco_de_0000141_16750">
+    <p xml:id="eco_de_0000211_16750">
      »Mama«, begann er dann. »Wenn du wüsstest – immer habe ich es sagen wollen – es war gerade, als ob ich nicht könnte! Das mit der Sylvia und dem Feuer ging viel leichter; da konnte ich mich nicht lang besinnen, sondern ich hab sie gleich gepackt und in den Schnee gedrückt, und dann haben alle gerufen: Brav, brav –!«
     </p>
-    <p xml:id="eco_de_0000141_16760">
+    <p xml:id="eco_de_0000211_16760">
      Nun ging ein kleines Lächeln über Mamas Gesicht.
     </p>
-    <p xml:id="eco_de_0000141_16770">
+    <p xml:id="eco_de_0000211_16770">
      »Es war brav, Hans. Aber es gibt noch eine andere Bravheit und Tapferkeit, so eine inwendige, eine gegen die eigenen Fehler. Da heisst's auch furchtlos dran gehen und fest angreifen! Und lieber einmal von aussen Spott und Schande ertragen, als in sich innen nicht ganz in Ordnung sein.«
     </p>
-    <p xml:id="eco_de_0000141_16780">
+    <p xml:id="eco_de_0000211_16780">
      »Heut abend geh ich zu Grossmama und sag ihr alles.«
     </p>
-    <p xml:id="eco_de_0000141_16790">
+    <p xml:id="eco_de_0000211_16790">
      »Natürlich, Hans –« Mama sah Hans an, als ob sie noch einen Gedanken hätte.
     </p>
-    <p xml:id="eco_de_0000141_16800">
+    <p xml:id="eco_de_0000211_16800">
      »Mama, meinst du –« Hans zögerte, »meinst du, ich müsse es morgen nachmittag bei Grossmama auch den andern sagen?«
     </p>
-    <p xml:id="eco_de_0000141_16810">
+    <p xml:id="eco_de_0000211_16810">
      »Ja, Hans, wenn du das über dich bringst –«
     </p>
-    <p xml:id="eco_de_0000141_16820">
+    <p xml:id="eco_de_0000211_16820">
      Hans seufzte.
     </p>
-    <p xml:id="eco_de_0000141_16830">
+    <p xml:id="eco_de_0000211_16830">
      »Mama, sagst du dann nicht mehr, ich sei feig? Weisst du, das gilt bei uns in der Klasse als das Ärgste!«
     </p>
-    <p xml:id="eco_de_0000141_16840">
+    <p xml:id="eco_de_0000211_16840">
      »Feigheit ist auch etwas Arges. Wie hat sie dir die letzten Tage verdorben! nicht wahr? Wie hast du bereuen müssen, dass du nicht im rechten Augenblick mutig warst!«
     </p>
-    <p xml:id="eco_de_0000141_16850">
+    <p xml:id="eco_de_0000211_16850">
      Das Schwesterlein im Korbwagen fing an zu weinen. Es wollte seine Milch haben.
     </p>
-    <p xml:id="eco_de_0000141_16860">
+    <p xml:id="eco_de_0000211_16860">
      Mama gab Hans die Hand und schaute ihm noch einmal ernst ins Gesicht; aber er fühlte, dass sie ihm verziehen hatte.
     </p>
-    <p xml:id="eco_de_0000141_16870">
+    <p xml:id="eco_de_0000211_16870">
      Der Gang am Abend zu Grossmama wurde Hans nicht leicht, und der Gedanke an das Geständnis am Sonntag in der Kindergesellschaft war ihm noch schwerer. Aber Grossmama erleichterte es ihm, so viel sie nur konnte.
     </p>
-    <p xml:id="eco_de_0000141_16880">
+    <p xml:id="eco_de_0000211_16880">
      »Hört einen Augenblick«, sagte sie, als die Grössern ihr halfen den Tisch zurückstellen und die Stühle ins Wohnzimmer tragen, während die Kleinern mit Werner draussen herumtollten; die brauchten ja nicht dabei zu sein. »Hört, Hans will euch etwas sagen. Es wäre besser gewesen, er hätte es gleich am letzten Sonntag, da wir beisammen waren, gesagt. Die Sache hat ihn die ganze Zeit gedrückt; jetzt aber will er sie los werden.«
     </p>
-    <p xml:id="eco_de_0000141_16890">
+    <p xml:id="eco_de_0000211_16890">
      Einen Moment blieben die Kinder ganz still, als Hans sein Geständnis vorgebracht hatte. Sie konnten sich vorstellen, wie unangenehm das war. Dann aber fiel Karl Binder ein, dass er auch einmal um die Wahrheit hatte herumgehen wollen. Er erzählte es, und Lily Rabus und Walter Schürmann wussten ebenfalls so etwas zu berichten. Ja, es war vielleicht keins unter den Kindern, das nicht schon Ähnliches erlebt hatte.
     </p>
-    <p xml:id="eco_de_0000141_16900">
+    <p xml:id="eco_de_0000211_16900">
      »Grossmama«, sagte dann aber Marianne, »das ist nett für den Glaser, dass er es nicht getan hat. Gelt, nun ruft ihn Friederike doch wieder herauf, wenn er später vielleicht aus dem Österreichischen zurückkommt.«
     </p>
-    <p xml:id="eco_de_0000141_16910">
+    <p xml:id="eco_de_0000211_16910">
      »Ja, Marianne«, antwortete lächelnd die Grossmama. »Und wir müssen sehen, dass dann wieder eine zerbrochene Scheibe und ein Teller Suppe für ihn bereit ist!«
     </p>
-    <p xml:id="eco_de_0000141_16920">
+    <p xml:id="eco_de_0000211_16920">
      Hans fühlte sich sehr froh und erleichtert in seinem Herzen. In den nächsten Tagen aber, als er einmal in die Küche kam, blätterte Balbine in ihrem Kalender, und der Zeitungsausschnitt, den sie sich hineingeklebt hatte, fiel heraus und flog gegen das offene Fenster.
     </p>
-    <p xml:id="eco_de_0000141_16930">
+    <p xml:id="eco_de_0000211_16930">
      »O, o!« rief sie, darnach haschend. »Der darf nicht verloren gehen!«
     </p>
-    <p xml:id="eco_de_0000141_16940">
+    <p xml:id="eco_de_0000211_16940">
      »Ach«, sagte Hans im Hinausgehen. »Das war eigentlich nichts Besonderes. Weisst du, Balbine, es gibt noch ganz andere schwerere Sachen.«
     </p>
    </div>
@@ -5249,514 +5249,514 @@
     <head>
      Marianne lernt das Heimweh kennen
     </head>
-    <p xml:id="eco_de_0000141_16950">
+    <p xml:id="eco_de_0000211_16950">
      Es hatte eben zwölf Uhr geschlagen. Die grosse Türe des Schulhauses tat sich auf, und die Kinderscharen strömten heraus. Lotti und vier oder fünf aus ihrer Klasse waren unter den ersten. Sie eilten auf die schöne Eisschleife zu, die an der Strasse entlang lief, und fuhren mit ausgestreckten Armen hintereinander her. Plötzlich aber schoss Lotti wie ein Pfeil davon mitten durch eine Gruppe sich balgender Buben hindurch und zum Platze vor.
     </p>
-    <p xml:id="eco_de_0000141_16960">
+    <p xml:id="eco_de_0000211_16960">
      »Sophie!« rief sie. »Das ist nett. Marianne kommt auch gleich. Jetzt gehen wir zusammen heim!«
     </p>
-    <p xml:id="eco_de_0000141_16970">
+    <p xml:id="eco_de_0000211_16970">
      »Nein, Lotti, heim geht es eben nicht«, erwiderte Sophie, die an der Ecke des Platzes auf die Kinder gewartet hatte. »Der Herr Doktor sagt, ihr sollt alle aus dem Hause. Mama ist recht krank –«
     </p>
-    <p xml:id="eco_de_0000141_16980">
+    <p xml:id="eco_de_0000211_16980">
      Mama –! Ja, nun fiel es Lotti wieder ein: Mama war gestern schon unwohl gewesen, und heute morgen hatten die Kinder sie nicht gesehen. Aber Lotti hatte sich weiter keine Gedanken gemacht. Beim Mittagessen würde man Mama schon wieder gesund treffen.
     </p>
-    <p xml:id="eco_de_0000141_16990">
+    <p xml:id="eco_de_0000211_16990">
      »Marianne!« rief Lotti der daherkommenden Schwester entgegen. »Wir dürfen nicht heim, hat der Herr Doktor gesagt. Das Schwesterlein und Werner sind schon bei Grossmama. Und Hans sollen wir auch abholen. Du muss zu Tante Oberst, weil du am artigsten seiest. Ich bin froh, dass ich bei Grossmama sein darf –«
     </p>
-    <p xml:id="eco_de_0000141_17000">
+    <p xml:id="eco_de_0000211_17000">
      Marianne sah erschrocken zu Sophie auf.
     </p>
-    <p xml:id="eco_de_0000141_17010">
+    <p xml:id="eco_de_0000211_17010">
      »Ja, Marianne«, sagte diese mit bekümmertem Gesicht. »So schnell ist das gekommen; gestern um diese Zeit hat noch niemand eine Ahnung gehabt!«
     </p>
-    <p xml:id="eco_de_0000141_17020">
+    <p xml:id="eco_de_0000211_17020">
      Marianne hatte schon während der Stunde an Mama gedacht, aber auch daran, dass am Nachmittag keine Schule sei, und dass sie dann vielleicht Mama vorlesen dürfe. Nun kam Sophies Botschaft wie ein Schlag.
     </p>
-    <p xml:id="eco_de_0000141_17030">
+    <p xml:id="eco_de_0000211_17030">
      »Sophie«, sagte Lotti im Weitergehen, »Grossmama macht mir jedenfalls mein Bett auf das rote Sofa. Wenn ich herunterfalle, komme ich grade auf das graue Fell. Glaubst du, Mama werde bald wieder gesund? Der Aristoteles, der wird gucken, wenn wir alle über Nacht bleiben!«
     </p>
-    <p xml:id="eco_de_0000141_17040">
+    <p xml:id="eco_de_0000211_17040">
      »Sophie«, fragte Marianne, »könnte ich nicht auch bei Grossmama wohnen?«
     </p>
-    <p xml:id="eco_de_0000141_17050">
+    <p xml:id="eco_de_0000211_17050">
      »Nein, Marianne, sei vernünftig! Tante Oberst war selbst da und hat es mit Papa ausgemacht. Deine Kleider und was du brauchst, hat Hermine schon geholt.«
     </p>
-    <p xml:id="eco_de_0000141_17060">
+    <p xml:id="eco_de_0000211_17060">
      An der nächsten Strassenecke trennten sich die drei. Sophie und Lotti gingen Hans entgegen. Onkel und Tante wohnten drüben am Stadtgraben.
     </p>
-    <p xml:id="eco_de_0000141_17070">
+    <p xml:id="eco_de_0000211_17070">
      Langsam stieg Marianne die Treppe hinauf. Es lehnte da kein Rutschbrett an der Seite. Die Stufen glänzten von Sauberkeit. Man hörte keinen Ton. Es war, als ob hier nur ernste erwachsene Leute auf- und abgingen.
     </p>
-    <p xml:id="eco_de_0000141_17080">
+    <p xml:id="eco_de_0000211_17080">
      »Ah, da kommt die Marianne!« Die Tante, die eben an der Glastüre vorbeiging, machte auf.
     </p>
-    <p xml:id="eco_de_0000141_17090">
+    <p xml:id="eco_de_0000211_17090">
      »Das ist ja sehr traurig bei euch zu Hause! Die arme Mama! Hast du keine Galoschen an bei dem Schnee, Kind? Häng den Hut hierher – . O, deine Haare –! Ihr seid wohl recht herumgetollt in der Pause –«
     </p>
-    <p xml:id="eco_de_0000141_17100">
+    <p xml:id="eco_de_0000211_17100">
      Tante Oberst, die eigentlich die Tante von Herrn Turnach war, hatte nie Kinder gehabt; darum vielleicht war sie oft erstaunt oder gar entsetzt über das, was Kinder taten. Marianne war nicht besonders unbesonnen oder unordentlich. Aber wie sie nun so bei Tante Oberst wohnte, begegnete ihr doch allerlei. Zu Hause ging es immer ein wenig laut her; da merkte man nicht, wenn eins die Türe zuschlug, oder über einen Schemel stolperte oder an einen Stuhl stiess. Aber die Tante fuhr zusammen, und der Onkel sah von seiner Zeitung auf:
     </p>
-    <p xml:id="eco_de_0000141_17110">
+    <p xml:id="eco_de_0000211_17110">
      »Acht geben, acht geben! Das tut Tantes Nerven nicht gut!«
     </p>
-    <p xml:id="eco_de_0000141_17120">
+    <p xml:id="eco_de_0000211_17120">
      Mama zu Hause hatte keine Nerven. Sie machte auch kein bekümmertes Gesicht, wenn man bei Tisch ein Glas Wasser verschüttete oder den Löffel in die Suppe fallen liess. Ein wenig wurde man wohl getadelt; aber man durfte dann auch wieder lachen über das kleine Missgeschick.
     </p>
-    <p xml:id="eco_de_0000141_17130">
+    <p xml:id="eco_de_0000211_17130">
      Und zu Hause standen auch nicht so viele Dinge auf den Tischen und Kommoden, die man nicht anfassen sollte.
     </p>
-    <p xml:id="eco_de_0000141_17140">
+    <p xml:id="eco_de_0000211_17140">
      »Ansehen, Mariannchen, gewiss!« sagte der Onkel. »Aber mit den Augen, nicht mit den Fingern!« Der Onkel wusste jedenfalls nicht, wie schwer das war.
     </p>
-    <p xml:id="eco_de_0000141_17150">
+    <p xml:id="eco_de_0000211_17150">
      Marianne hielt immer die Hände auf dem Rücken, wenn sie vor dem Gestell in der Ecke stand, dessen Fächer von unten bis oben mit lauter merkwürdigen niedlichen Sachen angefüllt waren. Da hatte es eine kleine Sanduhr; wenn man sie drehte, so rieselte der feine rötliche Sand in das untere Gläschen, und wenn man noch einmal drehte, wieder ins andere. Doch eben das durfte man nicht. Daneben war ein zierliches Totenköpfchen aus Elfenbein und ein silbernes Tellerchen mit erhöhten seltsamen Blumen. Dahinter aber stand der Bürgermeister von Saardam aus Holz geschnitzt mit weissem Kragen und rotem Gürtel. Wenn man unten drückte, wendete er sich langsam hin und her, zog den schwarzen Hut ab und hob den Stock. Hermine hatte es Marianne einmal beim Abstauben gezeigt.
     </p>
-    <p xml:id="eco_de_0000141_17160">
+    <p xml:id="eco_de_0000211_17160">
      Wofür stand der Bürgermeister von Saardam da drin? Onkel und Tante machten nie etwas mit ihm. Auch mit den schönen grossen Muscheln nicht, die hier lagen. Sie waren aussen rauh und stachlig, innen zart rosa. Wenn man sie ans Ohr hielt, hörte man das Meer rauschen. So oft Marianne die rosa Muscheln ansah, hatte sie ein starkes Verlangen, das Meer rauschen zu hören.
     </p>
-    <p xml:id="eco_de_0000141_17170">
+    <p xml:id="eco_de_0000211_17170">
      Und dann die Nuss, die man aufmachen konnte und in der ein ganzes Domino war; achtundzwanzig winzige Steinchen! Einmal hatte Marianne nicht widerstehen können. Aber da musste es grade begegnen, dass ein Steinchen herunterfiel und sich nicht mehr fand, bis der Onkel mit dem Absatz darauf trat. Da war Tante böse geworden und hatte gesagt, Marianne sei unartig, und hatte den ganzen Abend ein sehr ernstes Gesicht gemacht, sogar noch beim Lottospiel. Jeden Abend spielten Onkel und Tante Lotto mit Marianne. Der Onkel hielt das Beutelchen mit den Nummern und las laut und deutlich die Zahlen. Tante und Marianne sassen still vor ihren Blättern.
     </p>
-    <p xml:id="eco_de_0000141_17180">
+    <p xml:id="eco_de_0000211_17180">
      »Siebzehn – dreiundzwanzig – fünfzig – Marianne, deck' das Fünfzig! Wo bist du mit deinen Gedanken –?«
     </p>
-    <p xml:id="eco_de_0000141_17190">
+    <p xml:id="eco_de_0000211_17190">
      Dann deckte Marianne rasch ihr Fünfzig. Um halb neun schüttete man die Nummern und Gläschen zusammen, und Marianne sagte Gutnacht. Fast jedesmal trug sie Gewinne davon: Schokoladebonbons und Zuckermandeln oder Haselnussternchen. Das hob sie alles auf, um es am andern Morgen Lotti zu bringen.
     </p>
-    <p xml:id="eco_de_0000141_17200">
+    <p xml:id="eco_de_0000211_17200">
      In der Pause lief sie immer gleich die Treppe hinunter und wartete vor Lottis Schulzimmer, bis die Schwester herauskam. Dann zog Marianne sie in eine Ecke, und Lotti musste erzählen, wie es bei Grossmama zuging.
     </p>
-    <p xml:id="eco_de_0000141_17210">
+    <p xml:id="eco_de_0000211_17210">
      »Wenn du nur gestern dabei gewesen wärst!« fing Lotti an. »Wir haben Lateinischstunde gehabt bei Onkel Alfred. Es war furchtbar lustig! Wir sassen auf dem Bänklein in der Küche, Hans und Friederike und ich. Aber Friederike hat gesagt, sie mache nicht mehr mit; sie habe die ganze Nacht davon geträumt und schreckliche Angst ausgestanden, weil sie's nimmer konnte. Ich weiss es noch gut: Amo, amas, amat, amamus, am –« Lotti besann sich.
     </p>
-    <p xml:id="eco_de_0000141_17220">
+    <p xml:id="eco_de_0000211_17220">
      »Sag mir etwas vom Werner und vom Schwesterlein!« bat Marianne.
     </p>
-    <p xml:id="eco_de_0000141_17230">
+    <p xml:id="eco_de_0000211_17230">
      »Vom Werner und vom Schwesterlein –?« Lotti sog an einer Zuckermandel; den Anteil von Hans und Werner hatte sie in die Tasche gesteckt. »Wart', ja – etwas Nettes! Eigentlich eher vom Aristoteles. Also der Werner, der hat ihn immer am Schwanz genommen, und da hat ihm der Aristoteles mit den Krallen eins auf die Hand gegeben. Werner hat geweint; aber Grossmama hat gesagt, es sei ihm recht geschehen. Und nachher ist der Aristoteles beim Schwesterlein gesessen, und da hat es ihn auch am Schwanz gezogen, und es hat auch einen Klaps bekommen; aber, weisst du, weil es noch so klein ist, hat der Aristoteles die Krallen eingezogen. Gelt, wie klug!«
     </p>
-    <p xml:id="eco_de_0000141_17240">
+    <p xml:id="eco_de_0000211_17240">
      Marianne nickte. Sie wäre so schrecklich gern wieder beim Werner und beim Schwesterlein, bei Hans und Lotti gewesen. Am Sonntag nachmittag hatte sie zu Grossmama gehen dürfen. Aber das war nicht dasselbe; sie war sich fast fremd vorgekommen unter den Geschwistern, und Hermine hatte sie sehr bald wieder geholt.
     </p>
-    <p xml:id="eco_de_0000141_17250">
+    <p xml:id="eco_de_0000211_17250">
      Und noch viel stärker zog es Marianne nach Hause zu Mama. Mama –! Marianne sagte das Wort manchmal vor sich hin, und dann musste sie sich immer wehren, dass ihr nicht die Tränen in die Augen kamen. Wenn sie nur einmal hätte zu Mama hingehen können, nur einen Augenblick! Doch der Herr Doktor hatte das streng verboten.
     </p>
-    <p xml:id="eco_de_0000141_17260">
+    <p xml:id="eco_de_0000211_17260">
      Am Morgen machte Marianne oft den Umweg über den Kornplatz. Die erste Treppe hinauf durfte man schon.
     </p>
-    <p xml:id="eco_de_0000141_17270">
+    <p xml:id="eco_de_0000211_17270">
      »Ulrich, wie geht es Mama!« fragte sie dann atemlos vom raschen Laufen.
     </p>
-    <p xml:id="eco_de_0000141_17280">
+    <p xml:id="eco_de_0000211_17280">
      »Es geht so, so, Marianne«, sagte Ulrich, indem er sich bückte, um das Seil unter dem Ballen durchzuziehen. »Wir wollen das Beste hoffen!«
     </p>
-    <p xml:id="eco_de_0000141_17290">
+    <p xml:id="eco_de_0000211_17290">
      Heute hatte Marianne auch Papa gesehen. Aber er war ganz anders als sonst.
     </p>
-    <p xml:id="eco_de_0000141_17300">
+    <p xml:id="eco_de_0000211_17300">
      »Kind«, sagte er, »was tust du da? Ihr sollt ja nicht herkommen!«
     </p>
-    <p xml:id="eco_de_0000141_17310">
+    <p xml:id="eco_de_0000211_17310">
      »Papa, gelt, Mama wird doch wieder gesund?«
     </p>
-    <p xml:id="eco_de_0000141_17320">
+    <p xml:id="eco_de_0000211_17320">
      »Ja, Marianne, ja –« sagte Papa, ohne Marianne anzusehen. »Geh jetzt! es ist höchste Zeit! Sei recht brav bei der Tante!«
     </p>
-    <p xml:id="eco_de_0000141_17330">
+    <p xml:id="eco_de_0000211_17330">
      Marianne ging schweren Herzens in die Schule und aus der Schule zu Onkels.
     </p>
-    <p xml:id="eco_de_0000141_17340">
+    <p xml:id="eco_de_0000211_17340">
      Das Mittagessen schmeckte ihr nicht. Sogar den süssen Eierkuchen ass sie nur auf, weil man nichts liegen lassen durfte.
     </p>
-    <p xml:id="eco_de_0000141_17350">
+    <p xml:id="eco_de_0000211_17350">
      Am Abend gingen Tante und Onkel aus.
     </p>
-    <p xml:id="eco_de_0000141_17360">
+    <p xml:id="eco_de_0000211_17360">
      »Marianne bleibt noch ein Weilchen bei Hermine und legt sich dann bald zu Bett«, hatte die Tante gesagt.
     </p>
-    <p xml:id="eco_de_0000141_17370">
+    <p xml:id="eco_de_0000211_17370">
      Hermine war immer freundlich mit Marianne. Aber heute waren Anna und Babette von droben da, und die drei Dienstmädchen plauderten eifrig über ein Stück weiss und blauen Stoff, aus dem sich Anna ein Kleid zuschneiden wollte.
     </p>
-    <p xml:id="eco_de_0000141_17380">
+    <p xml:id="eco_de_0000211_17380">
      Marianne sass dabei mit ihrem Buche. Sie las die Geschichte vom Silberkettchen. Aber es war so schrecklich traurig, wie die kleine elternlose Flora ihren Grossvater suchte, von dem weder die Matrosen im Hafen von Antwerpen, noch die alte Fischfrau, noch der Diener in dem Palaste etwas wussten. Marianne stand auf. Ihre Trübsal und die der armen Flora gaben so viel zusammen, dass sie es nicht aushalten konnte.
     </p>
-    <p xml:id="eco_de_0000141_17390">
+    <p xml:id="eco_de_0000211_17390">
      »Ach, Marianne – gelt, du gehst heute allein«, sagte Hermine. »Ich komme nachher noch zu dir.«
     </p>
-    <p xml:id="eco_de_0000141_17400">
+    <p xml:id="eco_de_0000211_17400">
      Sie zündete Marianne das Licht an, und diese ging in ihr Schlafzimmer.
     </p>
-    <p xml:id="eco_de_0000141_17410">
+    <p xml:id="eco_de_0000211_17410">
      Das Fenster stand offen. Marianne sah hinaus. Das Haus stand am Kanal; dunkel und still floss das Wasser dahin. Drüben waren die Fenster hell. Marianne sah, wie sich drei kleine Mädchen in dem Zimmer um den Tisch jagten. Ja, die konnten wohl lachen; die hatten ihre Mama bei sich –
     </p>
-    <p xml:id="eco_de_0000141_17420">
+    <p xml:id="eco_de_0000211_17420">
      Marianne fiel jetzt wieder ein, was sie heute den ganzen Tag geängstigt hatte. Wie sie vor Lottis Schulzimmer gewartet hatte, waren zwei Lehrerinnen vorbeigegangen und hatten sie angesehen und dann leise gesprochen.
     </p>
-    <p xml:id="eco_de_0000141_17430">
+    <p xml:id="eco_de_0000211_17430">
      »Das wäre schrecklich!« hatte die eine gesagt. »Wie viel Kinder sind es denn?«
     </p>
-    <p xml:id="eco_de_0000141_17440">
+    <p xml:id="eco_de_0000211_17440">
      »Fünf«, hatte die andere geantwortet. »Noch ein Büblein von drei oder vier Jahren und ein ganz Kleines –«
     </p>
-    <p xml:id="eco_de_0000141_17450">
+    <p xml:id="eco_de_0000211_17450">
      Warum hatten sie so hergeschaut? Sprachen sie von Marianne und ihren Geschwistern? Was wäre schrecklich –? Wenn Mama – Nein! so etwas Furchtbares hatten sie doch nicht gemeint –!
     </p>
-    <p xml:id="eco_de_0000141_17460">
+    <p xml:id="eco_de_0000211_17460">
      Aber Marianne musste immer wieder an das denken.
     </p>
-    <p xml:id="eco_de_0000141_17470">
+    <p xml:id="eco_de_0000211_17470">
      Plötzlich ertönte Musik. Sie kam gegen die Brücke her, eine frische, muntere Weise. Marianne horchte – das war ein Stück aus dem Samstagschwanz daheim –
     </p>
-    <p xml:id="eco_de_0000141_17480">
+    <p xml:id="eco_de_0000211_17480">
      »Was gleicht wohl auf Erden dem Jägervergnügen …«
     </p>
-    <p xml:id="eco_de_0000141_17490">
+    <p xml:id="eco_de_0000211_17490">
      Marianne erkannte die Melodie. Der Samstagschwanz, das war immer, wenn Papa eine Stunde früher aus dem Bureau heraufkam. Dann bettelte Werner:
     </p>
-    <p xml:id="eco_de_0000141_17500">
+    <p xml:id="eco_de_0000211_17500">
      »Papa, jetzt tun wir marschieren!« und fasste Papa am Rocke, und dann ging's los: Papa begann, fest im Takte auf und abschreitend, irgendein schönes Marschlied zu singen, und hinterdrein folgten die Kinder; alles suchte Schritt zu halten und mitzusingen, so gut und so laut es ging. Der Samstagschwanz machte seinen Weg durch sämtliche Zimmer, durch den Korridor und in die Küche …
     </p>
-    <p xml:id="eco_de_0000141_17510">
+    <p xml:id="eco_de_0000211_17510">
      Marianne legte den Kopf auf das Fenstergesimse und fing an bitterlich zu weinen. Die Musik verklang in der Ferne.
     </p>
-    <p xml:id="eco_de_0000141_17520">
+    <p xml:id="eco_de_0000211_17520">
      Auf einmal wischte Marianne die Tränen ab, zog die Schürze, die sie weggefegt hatte, wieder an und sah sich um. Dann ging sie rasch auf den Fusspitzen vor bis zur Korridortüre. Aus der Küche drang das Geplauder der Dienstmädchen.
     </p>
-    <p xml:id="eco_de_0000141_17530">
+    <p xml:id="eco_de_0000211_17530">
      Die Korridortüre war noch nicht abgeschlossen. Vorsichtig huschte Marianne hinaus und die Treppe hinunter. Aber die Haustüre konnte sie nicht aufmachen. Sie besann sich: Hinten, der Fensterladen bei der Waschküche liess sich loshaken. Marianne stieg hinaus. Nun war sie erst im Garten. Es war fast ganz dunkel, und der Wind raschelte durch die kahlen Sträucher. Marianne ging vor bis zum Gitter, wo das Gartenhäuschen stand. An den Latten des Häuschens konnte man hinaufklettern und, wenn man sich gut hielt, auf das Gitter hinüberkommen. So – nun musste Marianne bloss noch an der andern Seite des Gitters hinunter. Hans hatte einmal gesagt, hinunter komme man immer, wenn man den Mut habe loszulassen. Marianne kauerte hin, drehte sich, indem sie die Eisenspitzen gefasst hielt, und liess sich hängen. Jetzt –! Sie schlug das Knie auf und mit dem Kopf traf sie an das Gitter. Aber das machte nichts; drunten war sie. Schnell lief sie davon.
     </p>
-    <p xml:id="eco_de_0000141_17540">
+    <p xml:id="eco_de_0000211_17540">
      Es gingen nicht mehr viel Leute auf der Strasse. Hin und wieder wandte sich verwundert einer um nach dem kleinen Mädchen, das da so spät allein durch die Stadt rannte. Ein Polizeidiener, der unter einer Laterne stand, wollte auf sie zutreten. Aber Marianne lief rasch weiter und weiter. Da war schon die Schwalbengasse. Jetzt stand sie auf dem Kornplatz vor dem Hause. Sie schöpfte Atem. Aber wie sollte sie hinaufkommen zu Mama? Wie konnte sie überhaupt nur ins Haus gelangen, das abgeschlossen war? Wenn Ulrich sie sah, wollte er sie natürlich zu Onkels zurückführen. Ratlos stand Marianne vor der Haustüre.
     </p>
-    <p xml:id="eco_de_0000141_17550">
+    <p xml:id="eco_de_0000211_17550">
      Da kam ein grösserer Bub daher.
     </p>
-    <p xml:id="eco_de_0000141_17560">
+    <p xml:id="eco_de_0000211_17560">
      »Willst du hinein?« fragte er Marianne. »Hast du geläutet?«
     </p>
-    <p xml:id="eco_de_0000141_17570">
+    <p xml:id="eco_de_0000211_17570">
      Marianne schüttelte verlegen den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_17580">
+    <p xml:id="eco_de_0000211_17580">
      »Ja, von selbst geht's nicht auf!« Der Bursche zog fest an der Klingel.
     </p>
-    <p xml:id="eco_de_0000141_17590">
+    <p xml:id="eco_de_0000211_17590">
      Marianne erschrak. Wenn nun Ulrich kam – . Richtig, man hörte den Schlüssel sich im Schlosse drehen. Marianne hatte eben noch Zeit, um die Ecke zu flüchten.
     </p>
-    <p xml:id="eco_de_0000141_17600">
+    <p xml:id="eco_de_0000211_17600">
      Ulrich trat heraus. Er sah niemand als den Burschen, der im Weitergehen sich umwendete.
     </p>
-    <p xml:id="eco_de_0000141_17610">
+    <p xml:id="eco_de_0000211_17610">
      »Was hast du zu läuten? Wart, ich will dir –« rief Ulrich und ging ein paar Schritte dem Burschen nach, der aber ohne zu hören im Dunkel verschwand.
     </p>
-    <p xml:id="eco_de_0000141_17620">
+    <p xml:id="eco_de_0000211_17620">
      Marianne war blitzschnell ins Haus geschlüpft und hatte sich hinter einen grossen Ballen versteckt. Als Ulrich die Treppe hinaufgegangen war, schlich sie nach; auf jeder Stufe blieb sie lauschend stehen.
     </p>
-    <p xml:id="eco_de_0000141_17630">
+    <p xml:id="eco_de_0000211_17630">
      Da tappte Schnauzel heran! Mit einem lauten Wau! schoss er auf Marianne zu.
     </p>
-    <p xml:id="eco_de_0000141_17640">
+    <p xml:id="eco_de_0000211_17640">
      »Still!« rief Ulrich mit gedämpfter Stimme von der Garnkammer her.
     </p>
-    <p xml:id="eco_de_0000141_17650">
+    <p xml:id="eco_de_0000211_17650">
      Marianne fasste den Hund und versuchte, ihm die Schnauze zuzuhalten. Wenn er noch einen Laut gab, so war Marianne entdeckt –
     </p>
-    <p xml:id="eco_de_0000141_17660">
+    <p xml:id="eco_de_0000211_17660">
      Schnauzel aber machte sich los und sprang zu Ulrich zurück.
     </p>
-    <p xml:id="eco_de_0000141_17670">
+    <p xml:id="eco_de_0000211_17670">
      »Wau!« bellte er. Marianne ist draussen! Auf der Treppe steht sie! hiess das in seiner Sprache.
     </p>
-    <p xml:id="eco_de_0000141_17680">
+    <p xml:id="eco_de_0000211_17680">
      Aber diesmal verstand ihn Ulrich nicht.
     </p>
-    <p xml:id="eco_de_0000141_17690">
+    <p xml:id="eco_de_0000211_17690">
      »Dass du still bist –!« drohte er, indem er die Garnkammer schloss.
     </p>
-    <p xml:id="eco_de_0000141_17700">
+    <p xml:id="eco_de_0000211_17700">
      »Wau!« machte Schnauzel noch einmal und kratzte an der Türe.
     </p>
-    <p xml:id="eco_de_0000141_17710">
+    <p xml:id="eco_de_0000211_17710">
      »Nein«, sagte Ulrich. »Mäuse werden nicht mehr gefangen heut abend. Leg dich!«
     </p>
-    <p xml:id="eco_de_0000141_17720">
+    <p xml:id="eco_de_0000211_17720">
      Nun wagte Marianne vorbeizuschleichen zur zweiten Treppe. Es wurde jetzt immer schwieriger: von unten waren Ulrich und Schnauzel zu befürchten, von oben die andern. Aber auf dem Korridor, wo's sonst türaus und türein ging unter Lachen und Rufen, war es totenstill. Einen Augenblick glaubte Marianne Papas Stimme zu vernehmen. Sonst, wenn sie Papa hörte, rannte sie auf ihn zu; jetzt duckte sie sich auf die Treppe nieder.
     </p>
-    <p xml:id="eco_de_0000141_17730">
+    <p xml:id="eco_de_0000211_17730">
      Nach einer Weile öffnete sich geräuschlos die Küche. Balbine kam heraus und ging mit behutsamem Schritte in die hintere Stube. Und von da geht sie zu Mama hinein! dachte Marianne. Das Herz klopfte ihr fast zum Zerspringen. Sie wartete einen Augenblick; dann huschte sie hinüber.
     </p>
-    <p xml:id="eco_de_0000141_17740">
+    <p xml:id="eco_de_0000211_17740">
      Nun trennte sie nur noch eine Türe von Mama! Wenn sie da in den grossen Kleiderschrank schlüpfte und wartete, bis Balbine wieder zurückging in die Küche –? Dann konnte Marianne hinein; dann war sie endlich, endlich wieder bei ihrer Mama –!
     </p>
-    <p xml:id="eco_de_0000141_17750">
+    <p xml:id="eco_de_0000211_17750">
      Sie zog die Türe des Schrankes zu und lauschte zwischen den Kleidern hinaus. Vielleicht hörte sie Mama sprechen. Aber kein Laut drang aus dem Nebenzimmer. Wie diese Stille einem bang machte! Marianne war schon oft da drinnen im Schrank gestanden, wenn sie mit Lotti und Werner Versteckens gespielt hatte. Da war es immer sehr schwer gewesen, nicht durch Lachen sich zu verraten. Es schien Marianne eine Ewigkeit, seit sie mit Lotti und Werner gelacht hatte.
     </p>
-    <p xml:id="eco_de_0000141_17760">
+    <p xml:id="eco_de_0000211_17760">
      Marianne besann sich auf ein Gedicht. Das war gut, wenn man Angst oder Schmerzen ausstand in der Nacht, hatte Grossmama einmal gesagt.
     </p>
-    <p xml:id="eco_de_0000141_17770">
+    <p xml:id="eco_de_0000211_17770">
      »Die Sonne, sie machte den weiten Ritt um die Welt …«
     </p>
-    <p xml:id="eco_de_0000141_17780">
+    <p xml:id="eco_de_0000211_17780">
      flüsterte Marianne. Aber der zweite Vers ging nicht; sie konnte sich nicht besinnen. Vielleicht war es besser zu beten.
     </p>
-    <p xml:id="eco_de_0000141_17790">
+    <p xml:id="eco_de_0000211_17790">
      »Lieber Gott – lieber Gott –« wiederholte Marianne ein paarmal. Doch weiter kam sie in ihrer Angst nicht.
     </p>
-    <p xml:id="eco_de_0000141_17800">
+    <p xml:id="eco_de_0000211_17800">
      Plötzlich machte Balbine die Türe auf – Marianne fuhr zusammen. Balbine kam aber nicht heraus, sondern ging leise zurück zum Fenster. Und Marianne sah nun weit ins Zimmer hinein. Da lag Mama auf den weissen Kissen. Durch den Lampenschirm fiel das Licht auf sie. Wie seltsam Mama aussah – blass und schmal; die Augen waren geschlossen, und die Hände lagen still gefaltet auf der Decke. So hatte Marianne Mama noch nie gesehen – . Auf einmal überkam sie ein furchtbarer Schrecken: Das Gespräch der Lehrerinnen fuhr ihr durch den Sinn und zugleich eine andere Erinnerung: So war Tante Agnes dagelegen vor ein paar Jahren – so schneeweiss und schmal, und die Hände hatte sie so gefaltet gehabt, und im Hause war es auch so ganz still gewesen. Und am Sonntag darauf war Grossmama mit den Kindern auf den Friedhof gegangen, wo man Tante Agnes begraben hatte. Und Lotti, die damals noch klein war, hatte gefragt:
     </p>
-    <p xml:id="eco_de_0000141_17810">
+    <p xml:id="eco_de_0000211_17810">
      »Kommt die Tante dann wieder einmal zu uns?«
     </p>
-    <p xml:id="eco_de_0000141_17820">
+    <p xml:id="eco_de_0000211_17820">
      Aber Marianne hatte gewusst, dass die toten Menschen nie mehr zurückkommen können.
     </p>
-    <p xml:id="eco_de_0000141_17830">
+    <p xml:id="eco_de_0000211_17830">
      War Mama nun auch tot –? Kamen nun dann Männer und trugen sie weg ins Grab –?
     </p>
-    <p xml:id="eco_de_0000141_17840">
+    <p xml:id="eco_de_0000211_17840">
      »Mama –!« schrie Marianne und stürzte aus dem Schranke hervor.
     </p>
-    <p xml:id="eco_de_0000141_17850">
+    <p xml:id="eco_de_0000211_17850">
      Balbine fuhr entsetzt vom Stuhle auf.
     </p>
-    <p xml:id="eco_de_0000141_17860">
+    <p xml:id="eco_de_0000211_17860">
      »Mama, Mama –«, Marianne warf sich an das Bett und fasste die gefalteten Hände.
     </p>
-    <p xml:id="eco_de_0000141_17870">
+    <p xml:id="eco_de_0000211_17870">
      Da öffnete Mama langsam die Augen und sah Marianne an, verwundert, freundlich.
     </p>
-    <p xml:id="eco_de_0000141_17880">
+    <p xml:id="eco_de_0000211_17880">
      Jetzt erst begann Marianne laut zu schluchzen.
     </p>
-    <p xml:id="eco_de_0000141_17890">
+    <p xml:id="eco_de_0000211_17890">
      »Mama, Mama – ich hab gemeint – du hast so weiss ausgesehen, und so still – ganz wie –«
     </p>
-    <p xml:id="eco_de_0000141_17900">
+    <p xml:id="eco_de_0000211_17900">
      »Kind, Marianne! ssst –« Balbine suchte Marianne wegzuziehen. »Wie um des Himmels willen kommst du hieher –«
     </p>
-    <p xml:id="eco_de_0000141_17910">
+    <p xml:id="eco_de_0000211_17910">
      Aber Marianne konnte nicht antworten. Sie hielt Mamas Hand.
     </p>
-    <p xml:id="eco_de_0000141_17920">
+    <p xml:id="eco_de_0000211_17920">
      »Mama, ich bin so froh, ich bin so froh – ich hab' solch eine Angst gehabt –« schluchzte sie.
     </p>
-    <p xml:id="eco_de_0000141_17930">
+    <p xml:id="eco_de_0000211_17930">
      Mama streichelte leis des Kindes Kopf. Sie war zu müde, um darüber nachzudenken, wie denn Marianne auf einmal da an ihrem Bett knien konnte. Aber es tat ihr wohl, wieder eins von ihren Kindern bei sich zu haben.
     </p>
-    <p xml:id="eco_de_0000141_17940">
+    <p xml:id="eco_de_0000211_17940">
      Balbine stand da und wusste nicht, was tun. Man war glücklich gewesen, als Frau Turnach endlich in einen festen Schlaf verfallen war. Und nun brach Marianne plötzlich herein –
     </p>
-    <p xml:id="eco_de_0000141_17950">
+    <p xml:id="eco_de_0000211_17950">
      Indessen war unten im Hause auch allerlei vorgegangen.
     </p>
-    <p xml:id="eco_de_0000141_17960">
+    <p xml:id="eco_de_0000211_17960">
      Bald nachdem Marianne ins Haus geschlüpft war, hatte es wieder geläutet.
     </p>
-    <p xml:id="eco_de_0000141_17970">
+    <p xml:id="eco_de_0000211_17970">
      »Wenn das noch einmal der nichtsnutzige Bub ist –« hatte Ulrich gebrummt, als er zur Türe ging.
     </p>
-    <p xml:id="eco_de_0000141_17980">
+    <p xml:id="eco_de_0000211_17980">
      Es war nicht der nichtsnutzige Bub. Es war Hermine in grösster Eile und Aufregung.
     </p>
-    <p xml:id="eco_de_0000141_17990">
+    <p xml:id="eco_de_0000211_17990">
      »Ulrich!« rief sie. »Marianne ist doch da –? Mein Gott, der Schrecken, wie ich ihr Bett leer sehe und sie in der ganzen Wohnung nirgends finde –«
     </p>
-    <p xml:id="eco_de_0000141_18000">
+    <p xml:id="eco_de_0000211_18000">
      »Marianne?« fragte Ulrich bestürzt. »Nein, hier ist sie nicht!«
     </p>
-    <p xml:id="eco_de_0000141_18010">
+    <p xml:id="eco_de_0000211_18010">
      »Nicht –?« Hermine schlug die Hände zusammen. »Ulrich! es wird doch kein Unglück begegnet sein! Sie wird doch um Gotteswillen bei ihrer Grossmama sein! Anna von droben ist hingelaufen. Ich geh ihr entgegen; ich halte es nicht aus, hier zu warten –«
     </p>
-    <p xml:id="eco_de_0000141_18020">
+    <p xml:id="eco_de_0000211_18020">
      »Ja, gehen Sie!«, sagte Ulrich, der ängstlicher war, als er's gestehen wollte.
     </p>
-    <p xml:id="eco_de_0000141_18030">
+    <p xml:id="eco_de_0000211_18030">
      Nach einer kurzen Weile kam Hermine zurück, verstört, in Tränen.
     </p>
-    <p xml:id="eco_de_0000141_18040">
+    <p xml:id="eco_de_0000211_18040">
      »Nein, Ulrich! Auch nicht dort!« Hermine drückte die Hände vors Gesicht. »Ich vergehe vor Angst! Ulrich, das Fenster in Mariannes Zimmer stand offen und unten das Wasser –«
     </p>
-    <p xml:id="eco_de_0000141_18050">
+    <p xml:id="eco_de_0000211_18050">
      »Seien Sie vernünftig, Hermine! Man soll nicht gleich ans Schlimmste denken –« Aber Ulrich konnte selbst fast nicht anders. Was war zu tun? Sollte er zu Herrn Turnach hinaufgehen –
     </p>
-    <p xml:id="eco_de_0000141_18060">
+    <p xml:id="eco_de_0000211_18060">
      Da läutete die Hausglocke wieder. Hermine hob den Kopf. Vielleicht –
     </p>
-    <p xml:id="eco_de_0000141_18070">
+    <p xml:id="eco_de_0000211_18070">
      Aber herein traten Herr und Frau Oberst. Sie hatten bei ihrer Heimkehr von der Köchin Babette gehört, was geschehen war. Und über den Platz herüber kam im selben Augenblick Friederike, von Grossmama geschickt.
     </p>
-    <p xml:id="eco_de_0000141_18080">
+    <p xml:id="eco_de_0000211_18080">
      »Ulrich, das Kind, die Marianne ist doch da –!« riefen alle drei und lasen auf den ersten Blick aus Ulrichs und Hermines Gesichtern die Antwort.
     </p>
-    <p xml:id="eco_de_0000141_18090">
+    <p xml:id="eco_de_0000211_18090">
      Frau Oberst tat einen Schrei des Entsetzens und stürzte sich auf die jammernde Hermine, die sie zu der Bank hinter der Treppe führte.
     </p>
-    <p xml:id="eco_de_0000141_18100">
+    <p xml:id="eco_de_0000211_18100">
      »Ulrich«, sagte der Herr Oberst, »man muss sofort Schritte tun! Einer von uns muss auf die Polizei –«
     </p>
-    <p xml:id="eco_de_0000141_18110">
+    <p xml:id="eco_de_0000211_18110">
      Da läutete es zum vierten Male. Alle hofften einen Augenblick.
     </p>
-    <p xml:id="eco_de_0000141_18120">
+    <p xml:id="eco_de_0000211_18120">
      »Guten Abend, Ulrich!« sagte eilig eine tiefe Männerstimme. Es war der Herr Doktor, der heute so spät seinen zweiten Besuch machte. »Wie geht's oben?«
     </p>
-    <p xml:id="eco_de_0000141_18130">
+    <p xml:id="eco_de_0000211_18130">
      »Frau Turnach schläft; sie schläft seit drei Uhr«, antwortete Ulrich und hielt die Lampe so, dass nach hinten ein Schatten fiel. Es war besser, wenn der Herr Doktor, der jetzt hinaufging, nichts wusste.
     </p>
-    <p xml:id="eco_de_0000141_18140">
+    <p xml:id="eco_de_0000211_18140">
      »Schläft? seit drei Uhr?« wiederholte der Herr Doktor, schon auf der Treppe. »Das ist gut! das ist ja prächtig! Machen Sie doch kein so trübseliges Gesicht, Ulrich!« Rasch ging der Herr Doktor hinauf, ohne dass er sich umgesehen hatte.
     </p>
-    <p xml:id="eco_de_0000141_18150">
+    <p xml:id="eco_de_0000211_18150">
      Der Herr Oberst trat wieder hervor und fasste seinen Stock.
     </p>
-    <p xml:id="eco_de_0000141_18160">
+    <p xml:id="eco_de_0000211_18160">
      »Ich gehe, Ulrich; Sie können hier nicht fort!«
     </p>
-    <p xml:id="eco_de_0000141_18170">
+    <p xml:id="eco_de_0000211_18170">
      Dann aber horchten alle auf. Laut und im Tone höchsten Erstaunens ertönte von droben Herrn Doktors Stimme:
     </p>
-    <p xml:id="eco_de_0000141_18180">
+    <p xml:id="eco_de_0000211_18180">
      »Marianne –!« und noch einmal: »Was tust du denn hier, Marianne –!«
     </p>
-    <p xml:id="eco_de_0000141_18190">
+    <p xml:id="eco_de_0000211_18190">
      »Marianne –!« wiederholten drunten alle wie aus einem Munde, Onkel und Tante, Ulrich, Hermine und Friederike.
     </p>
-    <p xml:id="eco_de_0000141_18200">
+    <p xml:id="eco_de_0000211_18200">
      »Ulrich!« rief Hermine. »Sie sagten doch –«
     </p>
-    <p xml:id="eco_de_0000141_18210">
+    <p xml:id="eco_de_0000211_18210">
      »Ja – ich begreife nicht – das ist nicht mit rechten Dingen zugegangen –« stotterte Ulrich, eilte dann aber froh und erlöst wie die andern zur Treppe.
     </p>
-    <p xml:id="eco_de_0000141_18220">
+    <p xml:id="eco_de_0000211_18220">
      Oben war der Herr Doktor unter der Türe stehen geblieben. Marianne hielt Mamas Hand fest.
     </p>
-    <p xml:id="eco_de_0000141_18230">
+    <p xml:id="eco_de_0000211_18230">
      »Balbine«, rief der Herr Doktor, »was ist das! Wie kommt das Kind daher! Was habe ich gesagt –!«
     </p>
-    <p xml:id="eco_de_0000141_18240">
+    <p xml:id="eco_de_0000211_18240">
      Der gute alte Herr Doktor, der schon seit vielen Jahren Hausarzt in der Turnachfamilie war, konnte manchmal ziemlich streng sein.
     </p>
-    <p xml:id="eco_de_0000141_18250">
+    <p xml:id="eco_de_0000211_18250">
      »Herr Doktor –« wollte Balbine anfangen.
     </p>
-    <p xml:id="eco_de_0000141_18260">
+    <p xml:id="eco_de_0000211_18260">
      »Nein! auch Marianne nicht! Frau Turnach soll unbedingt Ruhe haben –« Der Herr Doktor wendete sich horchend rückwärts. »Aber es scheint, Ruhe gibt's hier nicht – weder drinnen noch draussen! Was kommt denn jetzt wieder die Treppe herauf?«
     </p>
-    <p xml:id="eco_de_0000141_18270">
+    <p xml:id="eco_de_0000211_18270">
      Er ging rasch durch das Vorzimmer hinaus und schloss die Türen hinter sich zu.
     </p>
-    <p xml:id="eco_de_0000141_18280">
+    <p xml:id="eco_de_0000211_18280">
      »Herr Oberst –! Was fällt Ihnen ein! Wir wollen keine Besuche, absolut keine! Und zu dieser Stunde –«
     </p>
-    <p xml:id="eco_de_0000141_18290">
+    <p xml:id="eco_de_0000211_18290">
      Hinter Onkel Oberst wurde die Tante sichtbar.
     </p>
-    <p xml:id="eco_de_0000141_18300">
+    <p xml:id="eco_de_0000211_18300">
      »Der Kuckuck noch einmal –« Der Herr Doktor wurde ganz zornig. »Der Kuckuck noch einmal, was ist denn heute abend los –!«
     </p>
-    <p xml:id="eco_de_0000141_18310">
+    <p xml:id="eco_de_0000211_18310">
      »Marianne, Marianne!« hörte man Hermine hinter Tante Oberst rufen.
     </p>
-    <p xml:id="eco_de_0000141_18320">
+    <p xml:id="eco_de_0000211_18320">
      »Und was kommt da noch für ein Frauenzimmer – und noch eins! Wollen Sie beide die Güte haben, sofort umzukehren! So, Sie auch, Ulrich –! was haben Sie hier oben zu tun! Hüten Sie lieber das Haus, damit nicht alles hereinläuft –«
     </p>
-    <p xml:id="eco_de_0000141_18330">
+    <p xml:id="eco_de_0000211_18330">
      Aber nun trat auch noch Herr Turnach herzu, der droben Briefe geschrieben, und Sophie, die in der Küche etwas eingenickt war, weil sie nachts bei Frau Turnach gewacht hatte. Erstaunt sahen sie auf all die Leute.
     </p>
-    <p xml:id="eco_de_0000141_18340">
+    <p xml:id="eco_de_0000211_18340">
      »Schön!« fuhr der Doktor fort. »Immer mehr! Wollen wir nicht noch einige von der Strasse herauf holen oder vielleicht vom Goldenen Degen drüben –! Jetzt möcht' ich doch endlich erfahren, was das zu bedeuten hat!«
     </p>
-    <p xml:id="eco_de_0000141_18350">
+    <p xml:id="eco_de_0000211_18350">
      Hermine, die sich etwas erholt hatte, fing an zu erzählen; alles wusste sie aber auch nicht.
     </p>
-    <p xml:id="eco_de_0000141_18360">
+    <p xml:id="eco_de_0000211_18360">
      »Wie kann das Kind nur zum Haus hinausgekommen sein –! Marianne, sag doch –« In ihrem Eifer trat Hermine zur Türe.
     </p>
-    <p xml:id="eco_de_0000141_18370">
+    <p xml:id="eco_de_0000211_18370">
      Aber der Herr Doktor wehrte.
     </p>
-    <p xml:id="eco_de_0000141_18380">
+    <p xml:id="eco_de_0000211_18380">
      »Machen Sie nicht noch mehr Lärm als wir schon haben, Jungfer Hermine!«
     </p>
-    <p xml:id="eco_de_0000141_18390">
+    <p xml:id="eco_de_0000211_18390">
      Er ging hinein und zog die Türe hinter sich zu.
     </p>
-    <p xml:id="eco_de_0000141_18400">
+    <p xml:id="eco_de_0000211_18400">
      »Komm her, kleine Missetäterin, Urheberin dieses nächtlichen Auflaufes –«
     </p>
-    <p xml:id="eco_de_0000141_18410">
+    <p xml:id="eco_de_0000211_18410">
      Marianne liess zögernd Mamas Hand.
     </p>
-    <p xml:id="eco_de_0000141_18420">
+    <p xml:id="eco_de_0000211_18420">
      »Wollen Sie mir Marianne wieder nehmen?« fragte Mama mit ihrer schwachen Stimme.
     </p>
-    <p xml:id="eco_de_0000141_18430">
+    <p xml:id="eco_de_0000211_18430">
      »Gleich, Frau Turnach, gleich!« Der Herr Doktor fasste Marianne am Arm.
     </p>
-    <p xml:id="eco_de_0000141_18440">
+    <p xml:id="eco_de_0000211_18440">
      »Also hör mal, Marianne. In dunkler Nacht bist du hergelaufen zu deiner Mama. Es ist hübsch, wenn man seine Mama lieb hat. Nun sei noch recht vernünftig dazu, dann bist du ein Prachtsmädel! Du gehst jetzt ruhig mit Onkel und Tante zurück –«
     </p>
-    <p xml:id="eco_de_0000141_18450">
+    <p xml:id="eco_de_0000211_18450">
      Marianne warf einen flehenden Blick auf Mama.
     </p>
-    <p xml:id="eco_de_0000141_18460">
+    <p xml:id="eco_de_0000211_18460">
      »Wenn dieser Überfall deiner Mama nicht geschadet hat –«
     </p>
-    <p xml:id="eco_de_0000141_18470">
+    <p xml:id="eco_de_0000211_18470">
      »Ich glaube nicht, Herr Doktor«, sagte Frau Turnach. »Ich fühle mich so viel besser.«
     </p>
-    <p xml:id="eco_de_0000141_18480">
+    <p xml:id="eco_de_0000211_18480">
      »Ssst –! nicht sprechen! Was ist heute? Mittwoch – pass auf, Marianne – wenn alles gut geht, so darfst du am – sagen wir am Samstag heimkommen.«
     </p>
-    <p xml:id="eco_de_0000141_18490">
+    <p xml:id="eco_de_0000211_18490">
      »O!« rief Marianne.
     </p>
-    <p xml:id="eco_de_0000141_18500">
+    <p xml:id="eco_de_0000211_18500">
      »Du kommst und hilfst uns, Mama gesund pflegen.«
     </p>
-    <p xml:id="eco_de_0000141_18510">
+    <p xml:id="eco_de_0000211_18510">
      »Ja, ja!«
     </p>
-    <p xml:id="eco_de_0000141_18520">
+    <p xml:id="eco_de_0000211_18520">
      »Du bringst ihr frisches Wasser und holst die Suppe aus der Küche und –«
     </p>
-    <p xml:id="eco_de_0000141_18530">
+    <p xml:id="eco_de_0000211_18530">
      »Und ich lese Mama vor! Das Silberkettchen, gelt, Mama! Es ist furchtbar traurig; aber wenn ich dir's vorlesen darf, ist's schön! Ich bin jetzt da, wo Flora –«
     </p>
-    <p xml:id="eco_de_0000141_18540">
+    <p xml:id="eco_de_0000211_18540">
      »Willst du gleich aufhören mit deiner Flora und die Mama nun endlich wieder schlafen lassen?« unterbrach der Herr Doktor Marianne. »Schnell sag ihr Gutenacht!« Der Herr Doktor schob Marianne hinaus.
     </p>
-    <p xml:id="eco_de_0000141_18550">
+    <p xml:id="eco_de_0000211_18550">
      Aber erschrocken fuhr sie zusammen, als sie vor die Türe trat. Wer stand da alles! Tante, Onkel und Hermine, Papa, Sophie, Ulrich und Friederike! Verlegen sah sie von einem zum andern. Doch niemand schalt sie. Man war zu glücklich, sie wieder zu haben; man umringte sie:
     </p>
-    <p xml:id="eco_de_0000141_18560">
+    <p xml:id="eco_de_0000211_18560">
      »Marianne! Gott Lob und Dank! Was für eine Angst haben wir ausgestanden!«
     </p>
-    <p xml:id="eco_de_0000141_18570">
+    <p xml:id="eco_de_0000211_18570">
      »Fast gestorben wär' ich vor Schrecken!« versicherte Hermine, aufs neue in Tränen ausbrechen.
     </p>
-    <p xml:id="eco_de_0000141_18580">
+    <p xml:id="eco_de_0000211_18580">
      »Kind, Kind, du hast dich doch nicht erkältet!« rief zugleich die Tante. »Du blutest an der Schläfe –«
     </p>
-    <p xml:id="eco_de_0000141_18590">
+    <p xml:id="eco_de_0000211_18590">
      Sie wollte Marianne die Haare von der kleinen Schramme streifen; aber der Onkel zog das Kind zu sich her.
     </p>
-    <p xml:id="eco_de_0000141_18600">
+    <p xml:id="eco_de_0000211_18600">
      »Da haben wir den Deserteur! Ei, ei, ei! Was fangen wir mit ihm an? Was tun wir, dass er wieder zurückkehrt? Hat er am Ende gar etwas Heimweh bekommen bei uns?«
     </p>
-    <p xml:id="eco_de_0000141_18610">
+    <p xml:id="eco_de_0000211_18610">
      Marianne legte ihre Hand in die des Onkels. Es war ihr so froh und leicht zumut nach all dem Jammer. Mama lebte; Mama wurde wieder gesund, und Marianne durfte am Samstag kommen und sie pflegen! Jetzt schien es ihr auf einmal nicht mehr schlimm, noch bei Onkels zu bleiben. Onkel und Tante waren ja so freundlich, und es tat Marianne leid, dass sie ihnen eine solche Angst bereitet. Daran hatte sie in ihrem eigenen Kummer gar nicht gedacht.
     </p>
-    <p xml:id="eco_de_0000141_18620">
+    <p xml:id="eco_de_0000211_18620">
      »Ja, Marianne, du musst Onkel und Tante schon recht um Verzeihung bitten«, sagte Papa, während man unter vielen Reden und Fragen die Treppe hinunterstieg. Die Tante geriet von neuem in Schrecken, als Marianne auf Onkels Verlangen ihren Weg über das Gitter beschrieb.
     </p>
-    <p xml:id="eco_de_0000141_18630">
+    <p xml:id="eco_de_0000211_18630">
      »Marianne«, sagte Ulrich, der den Weggehenden die Haustür öffnete, »später erzählst du mir dann auch einmal genau, wie du hier hereingekommen bist.«
     </p>
-    <p xml:id="eco_de_0000141_18640">
+    <p xml:id="eco_de_0000211_18640">
      »Ja«, rief Marianne fröhlich zurück. »Das war nicht so schwer, Ulrich. Du hast mir selber die Türe aufgemacht!«
     </p>
    </div>
@@ -5764,373 +5764,373 @@
     <head>
      Die gestörte Rechenstunde
     </head>
-    <p xml:id="eco_de_0000141_18650">
+    <p xml:id="eco_de_0000211_18650">
      Die Aufregung hatte Mama nicht geschadet. Die Besserung schritt rasch voran. Am Samstag kam Marianne heim, und bald war die ganze Familie wieder heiter und glücklich beisammen.
     </p>
-    <p xml:id="eco_de_0000141_18660">
+    <p xml:id="eco_de_0000211_18660">
      Fast hatte es zwar den Anschein, als sollte der Frieden noch einmal gestört werden. Am neunten März war Lottis Geburtstag. Zwei Tage zuvor aber klagte Lotti über Kopf- und Halsweh und über Müdigkeit; sie mochte nichts essen und war fiebrig, so dass Mama sie im Bett behielt.
     </p>
-    <p xml:id="eco_de_0000141_18670">
+    <p xml:id="eco_de_0000211_18670">
      »Es wird doch nicht der Scharlach werden«, sagte Mama etwas ängstlich zu Sophie. »Er geht in der Stadt um, und Lotti hat ihn noch nicht gehabt.«
     </p>
-    <p xml:id="eco_de_0000141_18680">
+    <p xml:id="eco_de_0000211_18680">
      Aber vom Achten auf den Neunten schlief Lotti gegen Morgen fest ein, nachdem sie die Nacht vorher sehr unruhig gewesen war. Sie schlief bis in den hellen Vormittag. Endlich erwachte sie.
     </p>
-    <p xml:id="eco_de_0000141_18690">
+    <p xml:id="eco_de_0000211_18690">
      »Mama, ich hab kein Halsweh mehr.«
     </p>
-    <p xml:id="eco_de_0000141_18700">
+    <p xml:id="eco_de_0000211_18700">
      »Gott Lob, Kind!« Mama beugte sich über sie und sah Lotti in die wieder frischeren Augen.
     </p>
-    <p xml:id="eco_de_0000141_18710">
+    <p xml:id="eco_de_0000211_18710">
      Lotti besann sich.
     </p>
-    <p xml:id="eco_de_0000141_18720">
+    <p xml:id="eco_de_0000211_18720">
      »Mama, heut ist mein Geburtstag.«
     </p>
-    <p xml:id="eco_de_0000141_18730">
+    <p xml:id="eco_de_0000211_18730">
      »Ja, mein Lottikind! Ich wünsche dir recht viel Glück. Der liebe Gott möge dir ein gutes neues Lebensjahr schenken.«
     </p>
-    <p xml:id="eco_de_0000141_18740">
+    <p xml:id="eco_de_0000211_18740">
      Lotti lag ein Weilchen; dann fing sie wieder an:
     </p>
-    <p xml:id="eco_de_0000141_18750">
+    <p xml:id="eco_de_0000211_18750">
      »Mama, ich könnte ganz gut ein wenig Geburtstagskuchen essen.«
     </p>
-    <p xml:id="eco_de_0000141_18760">
+    <p xml:id="eco_de_0000211_18760">
      »Aber jetzt hat Balbine keinen gebacken, Lotti! Gedulde dich bis übermorgen. Wir wollen recht dankbar sein, dass du nicht ernstlich krank geworden bist.«
     </p>
-    <p xml:id="eco_de_0000141_18770">
+    <p xml:id="eco_de_0000211_18770">
      Mama holte Milch und Brot für Lotti.
     </p>
-    <p xml:id="eco_de_0000141_18780">
+    <p xml:id="eco_de_0000211_18780">
      »Nun bleib noch schön ruhig liegen!« sagte sie. »Am Nachmittag versuchen wir dann aufzustehen.«
     </p>
-    <p xml:id="eco_de_0000141_18790">
+    <p xml:id="eco_de_0000211_18790">
      »Mama«, seufzte Lotti nach weiteren zehn Minuten. »Das ist ein bisschen ein langweiliger Geburtstag.«
     </p>
-    <p xml:id="eco_de_0000141_18800">
+    <p xml:id="eco_de_0000211_18800">
      Sie drehte sich gegen die Wand und betrachtete die grünlichen Kleebüschel an der weissen Tapete. Sie zählte die Kleeblätter und die Stiele und fand heraus, dass jeder Büschel einen Stiel zu wenig hatte. Aber auf die Dauer war das keine Unterhaltung.
     </p>
-    <p xml:id="eco_de_0000141_18810">
+    <p xml:id="eco_de_0000211_18810">
      Plötzlich wurde es draussen auf dem Vorplatz laut. Man hörte Tritte und Stimmen und ein unterdrücktes Lachen. Mama ging hinaus ins andere Zimmer. Da streckte Hans den Kopf zur Türe herein.
     </p>
-    <p xml:id="eco_de_0000141_18820">
+    <p xml:id="eco_de_0000211_18820">
      »Mama!« rief er leise.
     </p>
-    <p xml:id="eco_de_0000141_18830">
+    <p xml:id="eco_de_0000211_18830">
      »Still, Hans –« winkte Mama; denn sie glaubte, Lotti sei noch einmal eingeschlafen.
     </p>
-    <p xml:id="eco_de_0000141_18840">
+    <p xml:id="eco_de_0000211_18840">
      »Mama«, flüsterte Hans, »es ist etwas Wichtiges und Komisches! Es ist –«
     </p>
-    <p xml:id="eco_de_0000141_18850">
+    <p xml:id="eco_de_0000211_18850">
      »Kräh!« tönte es auf einmal laut durch die offene Türe. »Kräh, kräh –«
     </p>
-    <p xml:id="eco_de_0000141_18860">
+    <p xml:id="eco_de_0000211_18860">
      Lotti hatte sich aufgerichtet und lauschte. Dann lachte sie mit dem ganzen Gesicht:
     </p>
-    <p xml:id="eco_de_0000141_18870">
+    <p xml:id="eco_de_0000211_18870">
      »Mama! Mama!« rief sie. »Horch! ein Vogel – ein Rabe – Mama, das ist der Peter von Larstetten!«
     </p>
-    <p xml:id="eco_de_0000141_18880">
+    <p xml:id="eco_de_0000211_18880">
      Mama sah erstaunt auf Hans.
     </p>
-    <p xml:id="eco_de_0000141_18890">
+    <p xml:id="eco_de_0000211_18890">
      »Ja, Mama, Lotti hat recht!« sagte er. »Darf ich ihn hereinbringen?«
     </p>
-    <p xml:id="eco_de_0000141_18900">
+    <p xml:id="eco_de_0000211_18900">
      Und ehe Mama wusste, ob sie ja oder nein sagen solle, kam Hans mit einem Korbe, aus dem leibhaftig und munter der Peter von Larstetten herausstieg.
     </p>
-    <p xml:id="eco_de_0000141_18910">
+    <p xml:id="eco_de_0000211_18910">
      Nein, das Entzücken von Lotti!
     </p>
-    <p xml:id="eco_de_0000141_18920">
+    <p xml:id="eco_de_0000211_18920">
      In dem Korbe aber, in dem der Peter gereist war, steckte ein Brief von der Tante Doktor. Und in diesem Briefe stand, die Turmsette, die nun wirklich in nächster Zeit nach Amerika zu ihrem Sohne übersiedle, den Peter jedoch nicht mitnehmen könne, habe diesen Trudi und Otto schenken wollen. Die Tante aber finde, es sei schon etwas viel Getier im Hause: Zu den zwei Katzen, dem Hund und dem Kanarienvogel seien in letzter Zeit noch vier Meerschweinchen und eine Schildkröte gekommen. Da schicke die Tante nun den Peter ihrem Patenkind Lotti zum Geburtstag. Es gehe ja nun bald wieder in die Seeweid hinaus, wo der Peter sich gewiss sehr glücklich fühlen werde.
     </p>
-    <p xml:id="eco_de_0000141_18930">
+    <p xml:id="eco_de_0000211_18930">
      »Mama!« rief Lotti in lautem Jubel. »Nun ist's doch noch ein schöner Geburtstag geworden! Sieh, wie er hüpft! Und wenn du wüsstest, wie gescheit er ist –«
     </p>
-    <p xml:id="eco_de_0000141_18940">
+    <p xml:id="eco_de_0000211_18940">
      Hans hatte den Vogel auf das Fussende von Lottis Bett gesetzt. Peter sah sich neugierig in der fremden Stube um. Dann legte er den Kopf auf die Seite und betrachtete Lotti: Kenn ich die oder kenn ich sie nicht? Ein wenig sieht sie aus wie Doktors Trudi! Mit possierlichen Seitensprüngen hopfte er hin und her.
     </p>
-    <p xml:id="eco_de_0000141_18950">
+    <p xml:id="eco_de_0000211_18950">
      Lotti klatschte ein über das andere Mal in die Hände vor Vergnügen und erzählte Mama von den Kartoffeln, die der Peter sich aus der Pfanne hole, und wie er auf Fingerhüte und Scheren und Löffel aus sei. Mama hatte nur zu wehren, dass Lotti nicht zu viel spreche. Sie war sehr froh, als Lotti schliesslich sich zurücklegte, eine Weile noch den Raben vergnügt anblinzelte und dann wieder einschlief.
     </p>
-    <p xml:id="eco_de_0000141_18960">
+    <p xml:id="eco_de_0000211_18960">
      Hans trug den Raben weg und stiess draussen mit Balbine zusammen, die Holz heruntertrug.
     </p>
-    <p xml:id="eco_de_0000141_18970">
+    <p xml:id="eco_de_0000211_18970">
      »Du – du liebe Güte!« rief sie entsetzt. »Woher kommt das Unglückstier –!«
     </p>
-    <p xml:id="eco_de_0000141_18980">
+    <p xml:id="eco_de_0000211_18980">
      »Das ist kein Unglückstier; das ist der Peter von Larstetten.«
     </p>
-    <p xml:id="eco_de_0000141_18990">
+    <p xml:id="eco_de_0000211_18990">
      »Was, Peter von Larstetten«, sagte Balbine, misstrauisch den Kopf schüttelnd. »Ein Rabe ist ein Rabe! Nein, Hans, lass – ich will ihn nicht auf meinem Holzkorb! Es soll mich freuen, wenn ich unrecht habe; aber so viel ich weiss, bringt so ein schwarzer Vogel nichts Gutes ins Haus!«
     </p>
-    <p xml:id="eco_de_0000141_19000">
+    <p xml:id="eco_de_0000211_19000">
      Balbine hatte wirklich vollkommen unrecht. Der Vogel Peter bereitete der ganzen Familie nur Vergnügen. Sogar das Schwesterlein krähte vor Lust, wenn der Rabe seine lustigen Sprünge vor ihm aufführte.
     </p>
-    <p xml:id="eco_de_0000141_19010">
+    <p xml:id="eco_de_0000211_19010">
      Schnauzel war im Anfang sehr aufgeregt über den neuen Hausgenossen. Vögel gab es wohl auch auf dem Kornplatz, Spatzen und Tauben, die Schnauzel mit grosser Freude aufscheuchte. Aber einer, der sich gar nicht fürchtete, wenn man auf ihn losging, sondern die Flügel schlug und Augen machte und gar mit dem Schnabel kam – . Über diesen Schnabel ärgerte sich der sonst so gutmütige Schnauzel sehr.
     </p>
-    <p xml:id="eco_de_0000141_19020">
+    <p xml:id="eco_de_0000211_19020">
      Doch Ulrich nahm die beiden in seine Garnkammer, wo sie unter Bellen und Gekrächz sich vertragen lernten. Ja, er brachte sie bald dazu, aus derselben Schüssel zu fressen. Die Kinder hatten jedesmal ihren grossen Spass dabei. Zuerst ging's sehr eifrig und friedlich. Wenn aber dann nur noch zwei oder drei Brocken da waren, schielte Schnauzel hinüber und knurrte, und Peter schielte auch und streckte den Schnabel. So bewachten sie beide den letzten Brocken. Keiner getraute sich, ihn zu erschnappen, und keiner gönnte ihn dem andern. Schnauzel wäre wohl im Grunde der Stärkere gewesen; aber dafür war Peter der Frechere. Schliesslich machte Ulrich dann der Sache ein Ende, indem er dem einen oder dem andern den letzten Bissen zuschob.
     </p>
-    <p xml:id="eco_de_0000141_19030">
+    <p xml:id="eco_de_0000211_19030">
      »Mama, ich freue mich schrecklich auf die Schule!« sagte
     </p>
-    <p xml:id="eco_de_0000141_19040">
+    <p xml:id="eco_de_0000211_19040">
      Lotti, als sie bald nach ihrem Geburtstag wieder hinausdurfte.
     </p>
-    <p xml:id="eco_de_0000141_19050">
+    <p xml:id="eco_de_0000211_19050">
      »Das ist recht, Lotti.«
     </p>
-    <p xml:id="eco_de_0000141_19060">
+    <p xml:id="eco_de_0000211_19060">
      »Am meisten freu' ich mich darauf, Fräulein Matthias und den Kindern vom Peter zu erzählen, Mama!«
     </p>
-    <p xml:id="eco_de_0000141_19070">
+    <p xml:id="eco_de_0000211_19070">
      Auf dem Schulweg aber besann sich Lotti auf einmal anders. Sie beschloss, das vom Raben Peter als Geheimnis und Überraschung zu behalten. Als die Mädchen sie nach ihren Geburtstagsgeschenken fragten, erzählte sie bloss von dem Kuchen mit den acht Lichtern, von den Stelzen, dem Bilderbuche und der Tasse mit den roten Blümchen. Diese Zurückhaltung war sehr schwer für Lotti.
     </p>
-    <p xml:id="eco_de_0000141_19080">
+    <p xml:id="eco_de_0000211_19080">
      Als sie mit Hedwig Zohner und Karoline Rupprecht heimging, konnte sie denn auch nicht mehr ganz schweigen. Die drei waren Freundinnen; manchmal stritten sie sich zwar ein bisschen.
     </p>
-    <p xml:id="eco_de_0000141_19090">
+    <p xml:id="eco_de_0000211_19090">
      »Hört!« sagte Lotti, »ich bringe wahrscheinlich morgen etwas in die Schule. Etwas furchtbar Lustiges! Könnt ihr erraten was?«
     </p>
-    <p xml:id="eco_de_0000141_19100">
+    <p xml:id="eco_de_0000211_19100">
      Nein, Karoline und Hedwig konnten nicht erraten.
     </p>
-    <p xml:id="eco_de_0000141_19110">
+    <p xml:id="eco_de_0000211_19110">
      »Einen – denkt, einen Raben!«
     </p>
-    <p xml:id="eco_de_0000141_19120">
+    <p xml:id="eco_de_0000211_19120">
      »Das ist gar nicht so etwas Besonderes, ein Rabe«, erwiderte Karoline. »Hinter dem Hause von meiner Tante auf dem grossen Acker am Kreuzberg sind immer eine Menge Raben.«
     </p>
-    <p xml:id="eco_de_0000141_19130">
+    <p xml:id="eco_de_0000211_19130">
      »Ach, das sind ja bloss Krähen, hat Papa gesagt. Meiner gehört zu den Dohlen; das sind die feinsten und nettesten Raben.«
     </p>
-    <p xml:id="eco_de_0000141_19140">
+    <p xml:id="eco_de_0000211_19140">
      »Jedenfalls mag ich Katzen viel lieber als Raben!« entgegnete Karoline.
     </p>
-    <p xml:id="eco_de_0000141_19150">
+    <p xml:id="eco_de_0000211_19150">
      »Katzen –!« machte Lotti geringschätzig.
     </p>
-    <p xml:id="eco_de_0000141_19160">
+    <p xml:id="eco_de_0000211_19160">
      »Ja, du solltest einmal unsere sehen! Zwei herzige, ganz junge! Eine hat gelb und weisse und schwarze Flecken. Das ist eine Glückskatze. Sicher würden meine Kätzchen dem Fräulein Matthias besser gefallen als dein Rabe!«
     </p>
-    <p xml:id="eco_de_0000141_19170">
+    <p xml:id="eco_de_0000211_19170">
      »Das glaube ich gar nicht!« sagte Lotti.
     </p>
-    <p xml:id="eco_de_0000141_19180">
+    <p xml:id="eco_de_0000211_19180">
      »Vielleicht hätte sie am allermeisten Freude an meinen Mäusen«, begann nun auch Hedwig Zohner.
     </p>
-    <p xml:id="eco_de_0000141_19190">
+    <p xml:id="eco_de_0000211_19190">
      »Was sagst du? an Mäusen?« rief Lotti. »Viele Leute mögen Mäuse nicht ausstehen! Balbine tut schrecklich, wenn sie eine sieht!«
     </p>
-    <p xml:id="eco_de_0000141_19200">
+    <p xml:id="eco_de_0000211_19200">
      »Ich meine nicht gewöhnliche Mäuse«, erwiderte Hedwig, »sondern weisse. Wenn ihr wüsstet, wie allerliebst sie sind! Mamas Vetter hat sie uns gebracht. Sie haben rote Augen, und wenn sie fressen, machen sie ein Männchen –«
     </p>
-    <p xml:id="eco_de_0000141_19210">
+    <p xml:id="eco_de_0000211_19210">
      »Ein Männchen machen meine Katzen manchmal auch«, sagte Karoline. »Und sie können mit dem eigenen Schwanz spielen und noch allerlei –«
     </p>
-    <p xml:id="eco_de_0000141_19220">
+    <p xml:id="eco_de_0000211_19220">
      »Aber so gescheit und komisch wie mein Rabe sind sie jedenfalls nicht!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000141_19230">
+    <p xml:id="eco_de_0000211_19230">
      »Das ist noch die Frage!« gab Karoline zurück, worauf die drei Mädchen sich trennten, ohne Adieu zu sagen. Erstens weil sie ärgerlich aufeinander waren und dann, weil ihnen wichtige Dinge durch den Kopf gingen. Auch Karoline und Hedwig fassten, jede für sich, einen Plan.
     </p>
-    <p xml:id="eco_de_0000141_19240">
+    <p xml:id="eco_de_0000211_19240">
      Mama war zuerst nicht einverstanden mit Lottis Vorhaben.
     </p>
-    <p xml:id="eco_de_0000141_19250">
+    <p xml:id="eco_de_0000211_19250">
      »O, Mama, sag ja!« bettelte aber Lotti. »Letztes Jahr nach Weihnacht hat auch die ganze Klasse die neuen Puppen in die Schule mitbringen dürfen!«
     </p>
-    <p xml:id="eco_de_0000141_19260">
+    <p xml:id="eco_de_0000211_19260">
      »Das ist nun wirklich nicht ganz dasselbe, Lotti!«
     </p>
-    <p xml:id="eco_de_0000141_19270">
+    <p xml:id="eco_de_0000211_19270">
      »Aber einmal ist Anna Lenz mit einem Krebs gekommen! Fräulein Matthias mag gewiss gern den Peter sehen. Vielleicht lässt sie uns dann Sätze machen über ihn!«
     </p>
-    <p xml:id="eco_de_0000141_19280">
+    <p xml:id="eco_de_0000211_19280">
      So gab denn Mama die Erlaubnis, und Marianne und Lotti steckten den Peter in einen Korb. Wenn er im Dunkeln sass, blieb er immer ganz lange still. Marianne legte zur Sicherheit noch eine Speckrinde hinein, damit der Peter eine Unterhaltung habe.
     </p>
-    <p xml:id="eco_de_0000141_19290">
+    <p xml:id="eco_de_0000211_19290">
      Aber als Lotti ins Schulzimmer eintrat, stand ein Herr am Tische bei Fräulein Matthias. Es war ein Herr von der Schulpflege. Im Laufe des Jahres und besonders gegen den Frühling kamen öfters solche Herren, um zu sehen, ob die Kinder etwas gelernt hätten und ob sie folgsam und ruhig seien.
     </p>
-    <p xml:id="eco_de_0000141_19300">
+    <p xml:id="eco_de_0000211_19300">
      »An die Plätze, Kinder, schnell!« rief Fräulein Matthias, indem sie mit ernstem Gesicht vor die Klasse trat.
     </p>
-    <p xml:id="eco_de_0000141_19310">
+    <p xml:id="eco_de_0000211_19310">
      Jetzt grade ging es also nicht mit dem Raben. Lotti stellte den Korb in die Ecke, wo sie Hut und Mantel hingehängt hatte, und setzte sich in ihre Bank. Aber sie konnte nicht recht aufpassen; sie dachte an den Peter. Ein Mädchen hinter ihr zupfte sie am Ärmel und frug flüsternd:
     </p>
-    <p xml:id="eco_de_0000141_19320">
+    <p xml:id="eco_de_0000211_19320">
      »Was ist denn in dem Korb?«
     </p>
-    <p xml:id="eco_de_0000141_19330">
+    <p xml:id="eco_de_0000211_19330">
      Lotti antwortete nicht. Sie sah zu dem Herrn Schulpfleger hinüber, der das Rechnungsheft von Marie Glogger durchblätterte. Er hatte einen schwarzen Bart und runzelte eben jetzt die Stirne.
     </p>
-    <p xml:id="eco_de_0000141_19340">
+    <p xml:id="eco_de_0000211_19340">
      Er wird doch bald wieder gehen! dachte Lotti. Aber der Herr Schulpfleger lehnte sich, nachdem er das Heft hingelegt hatte, an das Fenster und hörte aufmerksam zu, wie die Kinder rechneten.
     </p>
-    <p xml:id="eco_de_0000141_19350">
+    <p xml:id="eco_de_0000211_19350">
      Jetzt ging die Türe auf, und herein kam, rot vom eiligen Gehen, Karoline Rupprecht, ebenfalls mit einem Korb.
     </p>
-    <p xml:id="eco_de_0000141_19360">
+    <p xml:id="eco_de_0000211_19360">
      »Karoline, du bist ja viel zu spät!« rief Fräulein Matthias. »Und was soll der Korb!«
     </p>
-    <p xml:id="eco_de_0000141_19370">
+    <p xml:id="eco_de_0000211_19370">
      Karoline guckte seitwärts nach dem Herrn Schulpfleger und machte ein verlegenes Gesicht. Um nicht Zeit zu verlieren, schickte Fräulein Matthias Karoline an ihren Platz. In der Pause wollte sie dann mit ihr reden.
     </p>
-    <p xml:id="eco_de_0000141_19380">
+    <p xml:id="eco_de_0000211_19380">
      Aber die Rechenstunde ging heute gar nicht gut. Mit der einen Abteilung nahm Fräulein Matthias mündlich das Einmaleins durch. Der andern hatte sie Zusammenzählaufgaben an die Wandtafel geschrieben. Lotti und Karoline waren jedoch nicht fleissig. Karoline sah immer zurück nach Lotti und machte ein geheimnisvolles Gesicht. Das ärgerte Lotti; sie zog den Mund schief und rümpfte die Nase, worauf Karoline dasselbe tat. Hedwig Zohner kam ebenfalls nicht vorwärts in ihrem Heft. Alle Augenblicke guckte sie unter den Tisch, wo die Schulsachen lagen, und rückte da an etwas herum.
     </p>
-    <p xml:id="eco_de_0000141_19390">
+    <p xml:id="eco_de_0000211_19390">
      »Karoline! Hedwig! warum schreibt ihr nicht!« rief Fräulein Matthias. »Und Lotti Turnach! du solltest nun doppelt fleissig sein, nachdem du fünf Tage gefehlt hast!«
     </p>
-    <p xml:id="eco_de_0000141_19400">
+    <p xml:id="eco_de_0000211_19400">
      Lotti wollte Fräulein Matthias folgen und weiterschreiben. Aber dann fing Karoline von neuem an sich umzudrehen, und Lotti machte wieder eine kleine Grimasse, welche Karoline zurückgab. Die beiden waren heute wirklich ein wenig unartig.
     </p>
-    <p xml:id="eco_de_0000141_19410">
+    <p xml:id="eco_de_0000211_19410">
      Nun entstand auch hinten in den zwei letzten Bänken Unruhe. Zwei Mädchen kicherten leise, und Selma Leuenstein streckte die Hand auf. Da Fräulein Matthias das nicht gleich beachtete, rief Selma laut über die Klasse:
     </p>
-    <p xml:id="eco_de_0000141_19420">
+    <p xml:id="eco_de_0000211_19420">
      »Fräulein Matthias, da hinten tut eines immer miauen!«
     </p>
-    <p xml:id="eco_de_0000141_19430">
+    <p xml:id="eco_de_0000211_19430">
      Der Herr Schulpfleger sah verwundert auf. Was war denn das heute? Sonst ging es in Fräulein Matthias' Klasse doch immer in Frieden und in schönster Ordnung!
     </p>
-    <p xml:id="eco_de_0000141_19440">
+    <p xml:id="eco_de_0000211_19440">
      Fräulein Matthias aber kam rasch herüber zur zweiten Abteilung.
     </p>
-    <p xml:id="eco_de_0000141_19450">
+    <p xml:id="eco_de_0000211_19450">
      »Wer macht hier Unruhe!« rief sie in sehr strengem Ton.
     </p>
-    <p xml:id="eco_de_0000141_19460">
+    <p xml:id="eco_de_0000211_19460">
      Da – man hörte es ganz deutlich – ertönte wieder ein leises »Miau«.
     </p>
-    <p xml:id="eco_de_0000141_19470">
+    <p xml:id="eco_de_0000211_19470">
      Alle Kinder drehten sich und horchten. Bloss Karoline sass mit hochgezogenen Achseln über ihrem Heft.
     </p>
-    <p xml:id="eco_de_0000141_19480">
+    <p xml:id="eco_de_0000211_19480">
      »Miau – miau –«
     </p>
-    <p xml:id="eco_de_0000141_19490">
+    <p xml:id="eco_de_0000211_19490">
      Wer konnte nur so ungezogen sein!
     </p>
-    <p xml:id="eco_de_0000141_19500">
+    <p xml:id="eco_de_0000211_19500">
      Jetzt streckte Selma Leuenstein wieder die Hand auf:
     </p>
-    <p xml:id="eco_de_0000141_19510">
+    <p xml:id="eco_de_0000211_19510">
      »Fräulein Matthias, es ist kein Kind! Es kommt aus dem Korb von Karoline –«
     </p>
-    <p xml:id="eco_de_0000141_19520">
+    <p xml:id="eco_de_0000211_19520">
      Und nun erhoben sich alle vier Mädchen der letzten Bank und schrien in höchster Aufregung:
     </p>
-    <p xml:id="eco_de_0000141_19530">
+    <p xml:id="eco_de_0000211_19530">
      »Ein Kätzchen, Fräulein Matthias! Ein Kätzchen –!«
     </p>
-    <p xml:id="eco_de_0000141_19540">
+    <p xml:id="eco_de_0000211_19540">
      Auch der Herr Schulpfleger schritt herzu. Von Ordnung in der Klasse war keine Rede mehr. Die Kinder lachten und streckten sich, um das entsprungene Kätzchen zu sehen; einige Mädchen vorn stiegen auf die Bank.
     </p>
-    <p xml:id="eco_de_0000141_19550">
+    <p xml:id="eco_de_0000211_19550">
      »O! noch eins –!« riefen die hinten.
     </p>
-    <p xml:id="eco_de_0000141_19560">
+    <p xml:id="eco_de_0000211_19560">
      »Das ist die Glückskatze!« schrie Lotti, die ihren Ärger über Karoline vergass.
     </p>
-    <p xml:id="eco_de_0000141_19570">
+    <p xml:id="eco_de_0000211_19570">
      »Karoline!« rief Fräulein Matthias. »Was ist das! Was sollen die Katzen hier –!«
     </p>
-    <p xml:id="eco_de_0000141_19580">
+    <p xml:id="eco_de_0000211_19580">
      Das Glückskätzchen aber sprang behend gegen Selma, die zu äusserst sass, und als sie es fasste, entkam es mit einem Satz und lief über den ganzen Tisch weg bis zu Hedwig Zohner.
     </p>
-    <p xml:id="eco_de_0000141_19590">
+    <p xml:id="eco_de_0000211_19590">
      »Halt es! halt es doch!« riefen die Kinder.
     </p>
-    <p xml:id="eco_de_0000141_19600">
+    <p xml:id="eco_de_0000211_19600">
      Hedwig aber hatte eine Schachtel unter ihrem Tisch hervorgezogen und streckte sie ängstlich in die Höhe, wie um sie vor dem Kätzchen zu schützen. Da auf einmal krabbelte es weiss unter dem halb offenen Deckel hervor und an ihren Armen herunter.
     </p>
-    <p xml:id="eco_de_0000141_19610">
+    <p xml:id="eco_de_0000211_19610">
      Fräulein Matthias schlug die Hände zusammen. Sie wusste nicht mehr, was sie denken sollte.
     </p>
-    <p xml:id="eco_de_0000141_19620">
+    <p xml:id="eco_de_0000211_19620">
      »Mäuse –! Mäuse –!« schrien die Kinder, die einen voll Schrecken, die andern entzückt, während die sechs weissen Mäuschen blindlings nach allen Seiten hinausfuhren. Das wuselte nur so am Boden umher, und die Kätzchen hopsten hinter den Mäusen drein, und die Kinder haschten nach den Katzen –
     </p>
-    <p xml:id="eco_de_0000141_19630">
+    <p xml:id="eco_de_0000211_19630">
      »Sie frisst es! sie frisst es!« jammerte Hedwig laut auf, als das graue Kätzchen eine der Mäuse zwischen seinen kleinen Tatzen hielt.
     </p>
-    <p xml:id="eco_de_0000141_19640">
+    <p xml:id="eco_de_0000211_19640">
      Doch das graue Kätzchen liess die Maus wieder fahren und rannte gegen den Herrn Schulpfleger, der es fast zertreten hätte.
     </p>
-    <p xml:id="eco_de_0000141_19650">
+    <p xml:id="eco_de_0000211_19650">
      »Na, ich muss gestehen«, sagte er, indem er zwei Schritte zurückwich und dabei an den Korb stiess, der auf dem Schemel in der Ecke stand, »ich muss gestehen, das geht heute ja merkwürdig zu in Ihrer Klasse, Fräulein Matthias –«
     </p>
-    <p xml:id="eco_de_0000141_19660">
+    <p xml:id="eco_de_0000211_19660">
      »Kräh!« tönte es hinter ihm. Er wendete sich um und erblickte einen grossen schwarzen Vogel, der auf dem Henkel des umgestürzten Korbes stand.
     </p>
-    <p xml:id="eco_de_0000141_19670">
+    <p xml:id="eco_de_0000211_19670">
      »Da hört aber doch alles auf –!« rief der Herr Schulpfleger. »Sind wir eigentlich hier in einer Menagerie oder in einer Schule –«
     </p>
-    <p xml:id="eco_de_0000141_19680">
+    <p xml:id="eco_de_0000211_19680">
      »Ach! O! Nein! Ein Rabe – ein Rabe!« schrie die Klasse, jetzt völlig aus Rand und Band, und die, welche unter den Tischen nach den Katzen und Mäusen gehascht, tauchten wieder hervor.
     </p>
-    <p xml:id="eco_de_0000141_19690">
+    <p xml:id="eco_de_0000211_19690">
      Der Rabe aber tat einen Sprung und packte kriegslustig das Glückskätzchen, das gerade unter dem Tisch hervorrannte, am Bein. Schreiend stürzte Karoline herzu, um ihre Katze zu retten –
     </p>
-    <p xml:id="eco_de_0000141_19700">
+    <p xml:id="eco_de_0000211_19700">
      »Wer hat den Vogel gebracht?« rief Fräulein Matthias. »Wer den Vogel gebracht hat, soll ihn einfangen! Das ist ja zu arg! Wem gehört er?«
     </p>
-    <p xml:id="eco_de_0000141_19710">
+    <p xml:id="eco_de_0000211_19710">
      »Mir!« klang Lottis Stimme durch den Lärm. »Er ist von Larstetten; er ist ganz zahm –«
     </p>
-    <p xml:id="eco_de_0000141_19720">
+    <p xml:id="eco_de_0000211_19720">
      Aber davon merkte man wenig. Der Rabe wollte nichts von Lotti wissen. Der Tumult und die vielen Leute brachten ihn ganz auseinander. Halb flatternd, halb springend jagte er quer über die Klasse weg. Lachend und schreiend duckten die Mädchen ihre Köpfe. Jetzt tappte er mit dem Fuss in die Tinte, besah ihn einen Augenblick und rannte dann weiter, auf allen Heften schwarze Zeichen hinterlassend. Eins der Mäuschen, das vor ihm herflüchtete, fasste er am Schwanz und schlenkerte es über den Tisch hinunter. Eine Tapfere in der vordersten Bank erwischte ihn am Flügel; er riss sich los, erreichte den Stuhl, schwang sich auf die Lehne, auf den Zählrahmen und von da auf die Wandtafel –
     </p>
-    <p xml:id="eco_de_0000141_19730">
+    <p xml:id="eco_de_0000211_19730">
      »Korokikoh!« rief er. Das sagte er nur, wenn er ganz böse war.
     </p>
-    <p xml:id="eco_de_0000141_19740">
+    <p xml:id="eco_de_0000211_19740">
      Und in seinem Zorn da droben sah er so komisch aus, dass sogar der Herr Schulpfleger in ein lautes Lachen ausbrach. Und Fräulein Matthias lachte mit, und alle Kinder lachten nun erst recht nach Herzenslust.
     </p>
-    <p xml:id="eco_de_0000141_19750">
+    <p xml:id="eco_de_0000211_19750">
      »Korokikoh!« schrie der Rabe noch einmal; denn das Auslachen mochte er gar nicht.
     </p>
-    <p xml:id="eco_de_0000141_19760">
+    <p xml:id="eco_de_0000211_19760">
      Als aber der Herr Schulpfleger nach ihm langte, drohte er mit dem Schnabel, und blitzschnell wendete er sich auch auf die andere Seite gegen Fräulein Matthias.
     </p>
-    <p xml:id="eco_de_0000141_19770">
+    <p xml:id="eco_de_0000211_19770">
      Die Kätzchen und die Mäuse waren unter Gekreisch und Gehetz endlich eingefangen worden. Aber der Rabe blieb droben auf der Wandtafel und zankte und spreizte die Flügel, bis der Herr Schulpfleger vorschlug, dass alle mit Ausnahme Lottis das Zimmer verlassen. Die Mädchen drängten hinaus. So eine lustige Stunde, wie das war –!
     </p>
-    <p xml:id="eco_de_0000141_19780">
+    <p xml:id="eco_de_0000211_19780">
      Und wirklich, vor der leeren Stube wurde der Rabe ruhig. Er zwinkerte pfiffig mit seinen glänzenden Augen und sah dann zu Lotti hinunter: Was ist? Hab ich's ihnen gehörig gesagt? Haben sie das Feld geräumt?
     </p>
-    <p xml:id="eco_de_0000141_19790">
+    <p xml:id="eco_de_0000211_19790">
      Als Lotti auf einen Stuhl stieg und den Arm ausstreckte, hüpfte der Rabe darauf und liess sich gutwillig wieder in den Korb zu der Speckrinde stecken.
     </p>
-    <p xml:id="eco_de_0000141_19800">
+    <p xml:id="eco_de_0000211_19800">
      So konnten die Kinder denn ihre Plätze wieder einnehmen. Es war aber gut, dass die Pause bald kam; denn man war mit dem Lachen, Schwatzen und Fragen über die Geschichte noch lange nicht zu Ende.
     </p>
-    <p xml:id="eco_de_0000141_19810">
+    <p xml:id="eco_de_0000211_19810">
      Ein wenig etwas hören mussten Lotti, Karoline und Hedwig schon, dass sie so eigenmächtig das Getier mitgebracht hatten.
     </p>
-    <p xml:id="eco_de_0000141_19820">
+    <p xml:id="eco_de_0000211_19820">
      »Und warum denn nur alles am selben Tag?«
     </p>
-    <p xml:id="eco_de_0000141_19830">
+    <p xml:id="eco_de_0000211_19830">
      Als aber Fräulein Matthias erfuhr, dass das so eine Art Wettstreit zwischen den dreien gewesen war, begann sie aufs neue zu lachen.
     </p>
-    <p xml:id="eco_de_0000141_19840">
+    <p xml:id="eco_de_0000211_19840">
      »Ja, ja, Kinder! ihr törichten Kinder! Euere Tiere sind allerliebst, jedes in seiner Art! Aber als meine Schüler will ich sie doch nicht; ich habe an euch grade genug. Tragt sie jetzt hinunter zur Frau Hausmeister und fragt, ob ihr sie bis elf Uhr einstellen dürft!«
     </p>
-    <p xml:id="eco_de_0000141_19850">
+    <p xml:id="eco_de_0000211_19850">
      In einem hatte Lotti jedoch recht gehabt: Sätze liessen sich in Menge machen über den Raben, und über die Kätzchen und die weissen Mäuse nicht minder. Auch die allerfaulsten und ungeschicktesten Schülerinnen streckten eifrig die Hand, und im Nu war die ganze Wandtafel voll. Und was für nette und spasshafte Sätze das gab!
     </p>
-    <p xml:id="eco_de_0000141_19860">
+    <p xml:id="eco_de_0000211_19860">
      Der Herr Schulpfleger aber hatte sich in der Pause verabschiedet.
     </p>
-    <p xml:id="eco_de_0000141_19870">
+    <p xml:id="eco_de_0000211_19870">
      »Fräulein Matthias«, hatte er lachend gesagt, indem er seinen Hut genommen, »Sie werden erlauben, dass ich nächste Woche noch einmal komme zu einer einfachen Rechenstunde. Das heute kam mir eher vor wie eine Treibjagd oder, wenn Sie wollen, wie eine Zirkusvorstellung; die Dressur der Tiere hat zwar zu wünschen übrig gelassen!«
     </p>
    </div>
@@ -6138,508 +6138,508 @@
     <head>
      Die Strafaufgabe
     </head>
-    <p xml:id="eco_de_0000141_19880">
+    <p xml:id="eco_de_0000211_19880">
      Das Wetter wurde jetzt warm und sonnig. An einem Freitag brachte Balbine vom Markte ein Büschel Schlüsselblumen heim.
     </p>
-    <p xml:id="eco_de_0000141_19890">
+    <p xml:id="eco_de_0000211_19890">
      »Die riechen nach Frühling!« sagten die Turnachkinder und drückten der Reihe nach ihre Nasen hinein.
     </p>
-    <p xml:id="eco_de_0000141_19900">
+    <p xml:id="eco_de_0000211_19900">
      Man merkte auch draussen auf den Gassen und Plätzen, dass es Frühling wurde. Wie es im Januar durch die ganze Stadt von Schlittschuhen geklirrt hatte, so klatschte und klapperte, schnurrte und surrte es jetzt von Kreiseln und Springseilen, von Stelzen und Reifen und Bällen. Die grossen Leute konnten sehen, wie sie durchkamen.
     </p>
-    <p xml:id="eco_de_0000141_19910">
+    <p xml:id="eco_de_0000211_19910">
      »Schlagt uns nicht tot! lasst uns gnädigst vorbei!« wehrte lachend Herr Zurbuchen vom »Goldenen Degen«, der mit Herrn Apotheker Lorez daherspazierte.
     </p>
-    <p xml:id="eco_de_0000141_19920">
+    <p xml:id="eco_de_0000211_19920">
      Von vorn surrten den beiden ein paar Kreisel entgegen, links hüpften die Mädchen in schnellen Sprüngen über ihr Seil, und rechts hopste Lotti Turnach hoch auf den Stelzen daher.
     </p>
-    <p xml:id="eco_de_0000141_19930">
+    <p xml:id="eco_de_0000211_19930">
      »Ich kann jetzt auf einem Bein!« schrie sie den Herren zu und schwang die Stelze auf die Schulter wie ein Soldat. »Es ist aber schwer! …«
     </p>
-    <p xml:id="eco_de_0000141_19940">
+    <p xml:id="eco_de_0000211_19940">
      Und weil man nun abends bis um halb sieben draussen beisammen sein konnte, fiel den Buben und Mädchen alles mögliche ein. Man wusste nicht, hatte Karl Binder zuerst den Gedanken gehabt oder Hans Turnach; kurz, es kam ein wunderschönes Spiel in Gang, ein wilder Krieg zwischen Römern und Helvetiern. Es war ganz schwierig, sich zu entscheiden, welcher Partei man angehören wollte. Die Römer waren ein sehr tapferes, stolzes, mächtiges Volk; sie herrschten über viele Länder, und es hatte grosse Helden unter ihnen gegeben, wie den Decius Mus und den Horatius Cocles –
     </p>
-    <p xml:id="eco_de_0000141_19950">
+    <p xml:id="eco_de_0000211_19950">
      »Das war der, gelt Hans, der vor der Brücke kämpfte und dann zuletzt noch über den Tiber schwamm!« Marianne hatte Hansens Heldenbuch auch gelesen.
     </p>
-    <p xml:id="eco_de_0000141_19960">
+    <p xml:id="eco_de_0000211_19960">
      »Ja, und erst Mucius Scävola!« rief Rudolf Lorez. »Der hat seine rechte Hand im Feuer verbrennen lassen, damit man sehe, wie standhaft die Römer seien –«
     </p>
-    <p xml:id="eco_de_0000141_19970">
+    <p xml:id="eco_de_0000211_19970">
      »Verbrennen –? seine ganze Hand –?« fragte seine kleine Schwester Sylvia mit entsetzten Augen.
     </p>
-    <p xml:id="eco_de_0000141_19980">
+    <p xml:id="eco_de_0000211_19980">
      Die Helvetier waren ebenfalls stolz und tapfer und sehr freiheitsliebend. Nicht so berühmt wie die Römer; aber dafür hatten sie früher hier im Lande gewohnt, rings um den See, und wo jetzt die Stadt stand. Also war es auch sehr schön, Helvetier zu sein.
     </p>
-    <p xml:id="eco_de_0000141_19990">
+    <p xml:id="eco_de_0000211_19990">
      Am besten konnte man Römer und Helvetier spielen vor dem Schulhaus am Graben. Da war ein grosser freier Platz. An der andern Seite aber ging es in eine alte Gasse, wo man sich in den Hinterhalt legte, um dann plötzlich gegen den Feind loszubrechen. Am Eingang der Hühnergasse befand sich auch eine grosse Holzbeige; es sah furchtbar aus, wenn die Helvetier unter ihrem Anführer Orgetorix da oben standen und mit den Scheitern drohten, so dass Cäsar, der römische Feldherr, bei allem Heldenmut nicht heran konnte mit seiner Schar.
     </p>
-    <p xml:id="eco_de_0000141_20000">
+    <p xml:id="eco_de_0000211_20000">
      Nebenan in dem kleinen Hofe, der Hermann Villeiners Vater gehörte, so dass man also hineindurfte, stand ein alter Wagen.
     </p>
-    <p xml:id="eco_de_0000141_20010">
+    <p xml:id="eco_de_0000211_20010">
      »Da könnt ihr hinauf!« sagte Hans zu Marianne, Lotti und den andern Mädchen. »Das ist die Wagenburg. Wenn die Helvetier besiegt wurden, so hatten sie immer noch die Wagenburg, die dann von den Frauen verteidigt wurde!«
     </p>
-    <p xml:id="eco_de_0000141_20020">
+    <p xml:id="eco_de_0000211_20020">
      »Ja, ja!« riefen die Mädchen, indem sie auf den Wagen kletterten, »Sylvias Puppe und Klärchen und Fritzchen Villeiner können unsere Kinder sein!«
     </p>
-    <p xml:id="eco_de_0000141_20030">
+    <p xml:id="eco_de_0000211_20030">
      Das dreijährige Klärchen und das zweijährige Fritzchen wurden, ohne dass man sie lange fragte, auf den Wagen geschleppt, wo sie sich sehr gut in ihre Rolle als Helvetierkinder fanden, indem sie jedesmal, wenn die Römer heranstürmten, jämmerlich zu heulen anfingen.
     </p>
-    <p xml:id="eco_de_0000141_20040">
+    <p xml:id="eco_de_0000211_20040">
      Wenn aber eine Weile weder Römer noch Helvetier sich vor der Wagenburg zeigten, bekamen die Mädchen Lust, sich draussen in den Kampf der Männer zu mischen. Nur Sylvia erklärte dann, sie bleibe bei den Kindern.
     </p>
-    <p xml:id="eco_de_0000141_20050">
+    <p xml:id="eco_de_0000211_20050">
      »Also, bleib du bei den Kindern. Aber wenn der Feind kommt, musst du sie bis zum Äussersten verteidigen!« ermahnte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_20060">
+    <p xml:id="eco_de_0000211_20060">
      »Ja, ja!« versprach Sylvia, obgleich sie durchaus nicht wusste, wie man das machte.
     </p>
-    <p xml:id="eco_de_0000141_20070">
+    <p xml:id="eco_de_0000211_20070">
      Auf der Seite der Helvetier wie auf der römischen legte man es darauf an, recht viele Gefangene zu machen. Sowie man einen Feind erwischt hatte, wurde er durch den Jochgalgen getrieben. Der Jochgalgen bestand aus zwei Stangen, über die man eine dritte quer festgebunden hatte. Es war eine furchtbare Schmach, mit gesenktem Rücken unter dem Hohngeschrei der Feinde durch den Jochgalgen zu gehen. Hans dachte jeden Morgen, da er sich auf das Kriegsspiel freute: Wenn ich nur nicht durch den Jochgalgen muss! Lotti aber und Karoline Rupprecht liessen sich absichtlich einmal fangen, um zu sehen, wie das sei. Sie waren sehr beleidigt, als die Buben sagten, der Jochgalgen sei nur für gefangene Männer, und mit ein paar leichten Lanzenhieben die zwei in ihre Wagenburg zurückjagten.
     </p>
-    <p xml:id="eco_de_0000141_20080">
+    <p xml:id="eco_de_0000211_20080">
      An einem Donnerstagabend entfaltete sich das Spiel besonders schön. Hans als Orgetorix war vor die Römer getreten und hatte mit stolzer Rede Eingang in das Römische Land verlangt:
     </p>
-    <p xml:id="eco_de_0000141_20090">
+    <p xml:id="eco_de_0000211_20090">
      »Wir wollen auch in einer so warmen und fruchtbaren Gegend leben. Unser Land ist uns zu rauh. Und wir können jetzt überhaupt nicht mehr zurück; wir haben unsere Städte und Dörfer verbrannt und unsere Habe und die Frauen mitgebracht!«
     </p>
-    <p xml:id="eco_de_0000141_20100">
+    <p xml:id="eco_de_0000211_20100">
      »Ja, und die Kinder auch!« sagte Lotti vorwitzig, die als Waffenträger neben Hans stand.
     </p>
-    <p xml:id="eco_de_0000141_20110">
+    <p xml:id="eco_de_0000211_20110">
      »Das ist uns ganz gleich«, entgegnete Otto Lauener aus der sechsten Klasse. Er war Julius Cäsar und lehnte vornehm an seiner Stange, die als Lanze diente. »Das ist uns ganz gleich. Ihr werdet doch nicht meinen, dass man euch so mir nichts dir nichts hereinlässt! Wir brauchen unser Land selber!«
     </p>
-    <p xml:id="eco_de_0000141_20120">
+    <p xml:id="eco_de_0000211_20120">
      »Ja, natürlich! wir brauchen es selber!« schrien alle Römer und erhoben feindlich ihre Stangen, während unter den Helvetiern sich ein zorniges Gemurr erhob. Sie zogen zur Beratung nach der Wagenburg zurück; die Römer aber marschierten über den Platz zum Schulhaus, wo sie sich breit auf der Freitreppe aufstellten. Plötzlich machte einer die Türe auf, und die ganze Schar verschwand im Schulhause.
     </p>
-    <p xml:id="eco_de_0000141_20130">
+    <p xml:id="eco_de_0000211_20130">
      »Wie die frech sind!« riefen die Helvetier.
     </p>
-    <p xml:id="eco_de_0000141_20140">
+    <p xml:id="eco_de_0000211_20140">
      »Sie sollen nur warten, bis wir morgen die Schlacht von Bibrakte machen!« sagte Walter Schürmann. »Im Geschichtsbuch steht zwar, die Römer haben gesiegt; aber wir wollen dann schon sehen!«
     </p>
-    <p xml:id="eco_de_0000141_20150">
+    <p xml:id="eco_de_0000211_20150">
      »Kommt«, schrien ein paar andere. »Wir lauern an der Türe auf und überfallen sie, wenn sie herauswollen!«
     </p>
-    <p xml:id="eco_de_0000141_20160">
+    <p xml:id="eco_de_0000211_20160">
      Die Helvetier stürmten durch den Schulhof die Treppe hinauf und drückten sich rechts und links an die Wand, um nicht gesehen zu werden.
     </p>
-    <p xml:id="eco_de_0000141_20170">
+    <p xml:id="eco_de_0000211_20170">
      Die Römer kamen aber nicht; es blieb alles still.
     </p>
-    <p xml:id="eco_de_0000141_20180">
+    <p xml:id="eco_de_0000211_20180">
      »Leis die Türe aufgemacht und in die Gänge!« befahl Orgetorix. »Sie haben sich irgendwo versteckt!«
     </p>
-    <p xml:id="eco_de_0000141_20190">
+    <p xml:id="eco_de_0000211_20190">
      Die Helvetier schlichen in das Schulhaus. In den Korridoren war weit und breit kein Römer zu sehen.
     </p>
-    <p xml:id="eco_de_0000141_20200">
+    <p xml:id="eco_de_0000211_20200">
      »Vielleicht in einem Schulzimmer!« flüsterten die Helvetier und tappten auf den Zehen von einer Türe zur andern, um zu horchen. Nichts.
     </p>
-    <p xml:id="eco_de_0000141_20210">
+    <p xml:id="eco_de_0000211_20210">
      »Dann sind sie oben!« flüsterte Villeiner.
     </p>
-    <p xml:id="eco_de_0000141_20220">
+    <p xml:id="eco_de_0000211_20220">
      »Aber wenn Herr Kronberg kommt?« Herr Kronberg war der Hausmeister, der ziemlich kurzen Prozess machte, wenn etwas gegen die Schulordnung geschah.
     </p>
-    <p xml:id="eco_de_0000141_20230">
+    <p xml:id="eco_de_0000211_20230">
      »Wir sagen, die andern seien zuerst hinauf!«
     </p>
-    <p xml:id="eco_de_0000141_20240">
+    <p xml:id="eco_de_0000211_20240">
      Lautlos ging's ins zweite Stockwerk. Wo steckten sie? Im Va, b oder c? Oder hinten in der sechsten Klasse?
     </p>
-    <p xml:id="eco_de_0000141_20250">
+    <p xml:id="eco_de_0000211_20250">
      Wahrhaftig, von dorther tönte ein Geräusch, als ob man Bänke rücke.
     </p>
-    <p xml:id="eco_de_0000141_20260">
+    <p xml:id="eco_de_0000211_20260">
      »Jetzt haben wir sie! jetzt haben wir sie!« jubelten die Helvetier mit unterdrückter Stimme. »Still, nur still –«
     </p>
-    <p xml:id="eco_de_0000141_20270">
+    <p xml:id="eco_de_0000211_20270">
      Sie stellten sich vor der Türe auf. Der kleine Joseph Puhl aus der vierten Klasse war ganz aufgeregt. Mit gezückter Lanze stand er zuvorderst.
     </p>
-    <p xml:id="eco_de_0000141_20280">
+    <p xml:id="eco_de_0000211_20280">
      »Wenn wir sie alle kriegten –!« flüsterte er. »Und sie alle durch den Jochgalgen müssten, der hochmütige Cäsar auch!«
     </p>
-    <p xml:id="eco_de_0000141_20290">
+    <p xml:id="eco_de_0000211_20290">
      Von drinnen hörte man wieder ein Geräusch.
     </p>
-    <p xml:id="eco_de_0000141_20300">
+    <p xml:id="eco_de_0000211_20300">
      »Aha, sie merken, dass wir da sind; aber sie getrauen sich nicht heraus!« sagte Villeiner. Er öffnete die Türe ein wenig. »So kommt, wenn ihr den Mut habt!«
     </p>
-    <p xml:id="eco_de_0000141_20310">
+    <p xml:id="eco_de_0000211_20310">
      »Ja, kommt!« riefen Hans Turnach und Karl Binder. »Kommt, ihr römischen Feiglinge, ihr Sklavenseelen!«
     </p>
-    <p xml:id="eco_de_0000141_20320">
+    <p xml:id="eco_de_0000211_20320">
      »Ihr Sklavenseelen, ihr römischen Feiglinge!« rief die ganze helvetische Schar in ihrem Freiheitsstolz.
     </p>
-    <p xml:id="eco_de_0000141_20330">
+    <p xml:id="eco_de_0000211_20330">
      Da riss ein fester Griff von innen die Türe weit auf. Joseph Puhl sprang vor und traf mit seinem Lanzenstoss mitten – auf die schwarze Weste von Herrn Professor Taubenmüller, dem Präsidenten der Schulpflege.
     </p>
-    <p xml:id="eco_de_0000141_20340">
+    <p xml:id="eco_de_0000211_20340">
      Denn es waren nicht die Römer, die hier im VIb sich aufgehalten; diese hatten längst das Schulhaus durch die hintere Türe verlassen. Die heraustraten, waren die Herren von der Schulpflege, welche sich über neue Bänke beraten hatten, bis der Ruf: »Ihr Feiglinge, ihr Sklavenseelen!« sie veranlasste, vor die Tür zu treten.
     </p>
-    <p xml:id="eco_de_0000141_20350">
+    <p xml:id="eco_de_0000211_20350">
      Die Buben liessen ihre Stangen sinken und standen starr. Es war grässlich! Was hatten sie hineingerufen –? Man durfte gar nicht daran denken. Und der Joseph Puhl –! Herr Professor Taubenmüller rieb sich mit bösem Gesicht die Weste; der Stoss war unsanft gewesen. Hinten sah Herr Altschmid hervor: Hans Turnach, Karl Binder und Walter Schürmann wären am liebsten in die Erde gesunken vor Verlegenheit.
     </p>
-    <p xml:id="eco_de_0000141_20360">
+    <p xml:id="eco_de_0000211_20360">
      Nun wussten die Herren wohl, dass der Zuruf nicht ihnen gegolten. Ja, Herrn Altschmid zuckte es wie ein Lächeln übers Gesicht, als er die bewaffnete Schar erblickte, hinter der auch einige Mädchenköpfe hervorguckten. Aber nein – das ging denn doch über den Spass –! Es war den Schülern streng verboten, nach den Stunden das Schulhaus zu betreten.
     </p>
-    <p xml:id="eco_de_0000141_20370">
+    <p xml:id="eco_de_0000211_20370">
      »Was soll das bedeuten! Was habt ihr hier zu tun!« rief Herr Altschmid.
     </p>
-    <p xml:id="eco_de_0000141_20380">
+    <p xml:id="eco_de_0000211_20380">
      »Wir sind – wir waren die Helvetier –« stotterte Walter Schürmann. »Wir – wir haben gemeint, die Römer seien da –«
     </p>
-    <p xml:id="eco_de_0000141_20390">
+    <p xml:id="eco_de_0000211_20390">
      »Ja wohl, die Römer!« sagte der Herr Professor Taubenmüller und nahm den Joseph Puhl, der regungslos stehen geblieben war, am Arm. »Man wird euch jetzt zeigen, wer da ist!«
     </p>
-    <p xml:id="eco_de_0000141_20400">
+    <p xml:id="eco_de_0000211_20400">
      Er schüttelte den Buben und sah ihm näher ins Gesicht.
     </p>
-    <p xml:id="eco_de_0000141_20410">
+    <p xml:id="eco_de_0000211_20410">
      »Ah – das ist ja der – wie heissest du? Wohnst du nicht beim Buchbinder Klein im ›Grünen Winkel‹ –? Da wollte ich eben hin! Nun kann ich ihm nebenbei ein wenig von dir erzählen. Gleich mit der Stange dreinschlagen –! Wäre statt mir einer deiner Kameraden dagestanden, du hättest ihm ein Auge ausstossen können! Vorwärts, geh, ich komme nach.«
     </p>
-    <p xml:id="eco_de_0000141_20420">
+    <p xml:id="eco_de_0000211_20420">
      Mit diesen Worten wollte der Herr Professor den Knaben vor sich herschieben. Aber nun war auf einmal Leben in Joseph Puhl gekommen. Er sträubte sich, weiterzugehen. Er drückte den Arm an die Stirn und rief:
     </p>
-    <p xml:id="eco_de_0000141_20430">
+    <p xml:id="eco_de_0000211_20430">
      »Nein – nicht! Nicht dem Vetter sagen – nicht!«
     </p>
-    <p xml:id="eco_de_0000141_20440">
+    <p xml:id="eco_de_0000211_20440">
      »Auch noch widerspenstig! Auch noch unfolgsam!« sagte der Herr Professor, der nun sehr ärgerlich wurde.
     </p>
-    <p xml:id="eco_de_0000141_20450">
+    <p xml:id="eco_de_0000211_20450">
      »Tu nicht so unvernünftig, Bub! Füg dich!« rief Herr Altschmid, da Josephs Lehrer nicht da war. »So machst du ja die Sache viel ärger!«
     </p>
-    <p xml:id="eco_de_0000141_20460">
+    <p xml:id="eco_de_0000211_20460">
      Aber Joseph verlor alle Besinnung. Er hielt sich am Treppengeländer fest, immer schreiend:
     </p>
-    <p xml:id="eco_de_0000141_20470">
+    <p xml:id="eco_de_0000211_20470">
      »Nein, nicht –! Sonst darf ich – sonst lässt –« Aus dem Schreien und Weinen heraus hörte man nur undeutlich etwas wie »Ferien« und »heimreisen«. Als der Herr Professor ihn losmachen wollte, stiess er mit dem Ellbogen nach ihm. Drei- oder viermal mit dem Ellbogen. Er wusste offenbar gar nicht mehr, was er tat und wen er vor sich hatte.
     </p>
-    <p xml:id="eco_de_0000141_20480">
+    <p xml:id="eco_de_0000211_20480">
      Die andern Knaben standen entsetzt. Etwas rasch zornig war ja der Joseph Puhl manchmal beim Spiel. Aber so –!
     </p>
-    <p xml:id="eco_de_0000141_20490">
+    <p xml:id="eco_de_0000211_20490">
      Mit einem Ruck brachte ihn der Herr Professor mitten auf die Treppe. Da plötzlich, als Joseph merkte, dass aller Widerstand umsonst war, liess er nach. Er weinte nur noch vor sich hin und ging neben Herrn Professor Taubenmüller zum Hof hinunter und hinaus auf den Graben …
     </p>
-    <p xml:id="eco_de_0000141_20500">
+    <p xml:id="eco_de_0000211_20500">
      Wortlos vor Bestürzung verliessen die Buben und Mädchen das Schulhaus. An der Ecke trafen sie mit den Römern zusammen; aber die Helvetier wollten nichts mehr von Kampf und Jochgalgen wissen. Das mit dem Joseph Puhl war zu arg gewesen. Gegen einen Herrn Professor so zu tun –!
     </p>
-    <p xml:id="eco_de_0000141_20510">
+    <p xml:id="eco_de_0000211_20510">
      Für die übrigen Helvetier war die Sache natürlich auch nicht angenehm. Sie hatten vorhin einen scharfen Verweis erhalten, und wahrscheinlich gab es am andern Morgen noch Strafaufgaben oder Nachsitzstunden. Aber das war ja ganz unwichtig neben Joseph Puhls Geschichte. Was er wohl für eine Strafe erhielt –?
     </p>
-    <p xml:id="eco_de_0000141_20520">
+    <p xml:id="eco_de_0000211_20520">
      Am folgenden Tag hörte man von Kindern, die in Buchbinder Kleins Haus wohnten, wie es gegangen war. Herr Klein hatte Joseph nicht geschlagen. Er hatte ganz ruhig zugehört.
     </p>
-    <p xml:id="eco_de_0000141_20530">
+    <p xml:id="eco_de_0000211_20530">
      »Ich überlasse Ihnen, wie Sie den Joseph zu Hause strafen wollen für dieses Benehmen, für diese unerhörte Widersetzlichkeit! Jedenfalls werde ich beantragen, dass er in der Schule die schlechteste Betragensnote bekommt!« hatte Herr Professor Taubenmüller seinen Bericht geschlossen.
     </p>
-    <p xml:id="eco_de_0000141_20540">
+    <p xml:id="eco_de_0000211_20540">
      »So, die schlechteste?« hatte der Buchbinder Klein geantwortet. »Dann sind wir ja schnell fertig. Dann geht der Joseph eben in den Ferien nicht heim zu seiner Mutter. Gelt, Bürschchen, so haben wir's ausgemacht: Keine Klage dieses Vierteljahr von irgendwelcher Seite und im Zeugnis die Betragensnote Eins oder wenigstens Zwei. Nun gibt's eine Vier! Da braucht es von mir weiter nichts mehr«, wendete er sich an den Herrn Professor. »Er hat dann seinen Teil!«
     </p>
-    <p xml:id="eco_de_0000141_20550">
+    <p xml:id="eco_de_0000211_20550">
      Joseph Puhl habe darauf von neuem schrecklich zu weinen begonnen und sei von Herrn Klein hinauf in die Wohnung geschickt worden. –
     </p>
-    <p xml:id="eco_de_0000141_20560">
+    <p xml:id="eco_de_0000211_20560">
      In den nächsten Tagen sprach man auf den Spielplätzen und in den Schulpausen fast nur von Joseph Puhl. Sein Lehrer hatte ihn hinten in eine leere Bank gesetzt; denn einen Knaben, der stosse und schlage wie ein unverständiges Tier, könne man vorläufig nicht bei den andern lassen. Als aber Joseph gar so still und betrübt dasass, nahm Herr Hirt ihn wieder vor. Doch merkte man wohl, dass es Joseph gleichgültig war, ob er allein oder unter seinen Kameraden sitze, und dass er immer nur an eine Sache denke. Manchmal, wenn es beim Schreiben ganz still in der Klasse war, hörte man den Joseph Puhl seufzen. Er tat seinem Lehrer leid. Es war eine fatale Geschichte.
     </p>
-    <p xml:id="eco_de_0000141_20570">
+    <p xml:id="eco_de_0000211_20570">
      Eines Tages trafen die Turnachkinder den Joseph Puhl am Kornplatz. Er sass auf der Mauer und sah in das rasch fliessende Wasser hinunter. Die Kinder setzten sich zu ihm.
     </p>
-    <p xml:id="eco_de_0000141_20580">
+    <p xml:id="eco_de_0000211_20580">
      »Du warst aber auch furchtbar unartig, Joseph!« begann Lotti.
     </p>
-    <p xml:id="eco_de_0000141_20590">
+    <p xml:id="eco_de_0000211_20590">
      »Ja«, sagte Hans. »Wenn du doch nur gegen einen von uns so getan hättest! Wir hätten dich einfach ein wenig durchgehauen, und dann wäre es in Ordnung gewesen.«
     </p>
-    <p xml:id="eco_de_0000141_20600">
+    <p xml:id="eco_de_0000211_20600">
      Joseph nickte kummervoll.
     </p>
-    <p xml:id="eco_de_0000141_20610">
+    <p xml:id="eco_de_0000211_20610">
      »Wärst du eben schrecklich gern zu deiner Mutter heim?« fragte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_20620">
+    <p xml:id="eco_de_0000211_20620">
      Joseph nickte wieder und drehte sein nasses Taschentuch in den Händen.
     </p>
-    <p xml:id="eco_de_0000141_20630">
+    <p xml:id="eco_de_0000211_20630">
      »Gelt, sie hat eine Menge Gänse?« drang Lotti weiter in Joseph. Sie wusste allerlei durch Anna Klein. »Sind die jungen Gänse auch so herzig wie die Entchen? So gelb? und watscheln so komisch?«
     </p>
-    <p xml:id="eco_de_0000141_20640">
+    <p xml:id="eco_de_0000211_20640">
      Joseph schluchzte, was jedenfalls ein Ja bedeutete.
     </p>
-    <p xml:id="eco_de_0000141_20650">
+    <p xml:id="eco_de_0000211_20650">
      »Und, gelt, deine Mutter macht allemal Kuchen, wenn du kommst? Ist es Speckkuchen oder Apfelkuchen?«
     </p>
-    <p xml:id="eco_de_0000141_20660">
+    <p xml:id="eco_de_0000211_20660">
      »Speck«, schluchzte Joseph.
     </p>
-    <p xml:id="eco_de_0000141_20670">
+    <p xml:id="eco_de_0000211_20670">
      »Tut sie viel Speck darauf?«
     </p>
-    <p xml:id="eco_de_0000141_20680">
+    <p xml:id="eco_de_0000211_20680">
      »Lotti, du bist grässlich!« wehrte Hans leise. »Das ist doch jetzt nicht wichtig, ob viel oder wenig Speck!«
     </p>
-    <p xml:id="eco_de_0000141_20690">
+    <p xml:id="eco_de_0000211_20690">
      »Ja, Lotti«, sagte Marianne. »Man macht nur, dass er noch mehr weint, wenn man von den Gänsen und von dem Speck redet! Joseph, wenn du deinen Vetter recht, recht, recht bitten würdest –!«
     </p>
-    <p xml:id="eco_de_0000141_20700">
+    <p xml:id="eco_de_0000211_20700">
      Joseph schüttelte den Kopf. Vom Münster herüber schlug es sechs Uhr. Joseph stand auf und trottete trübselig heim, ohne sich weiter um die Turnachkinder zu kümmern. Diese blieben noch eine Weile sitzen.
     </p>
-    <p xml:id="eco_de_0000141_20710">
+    <p xml:id="eco_de_0000211_20710">
      »Wenn ihm Herr Hirt nur eine recht lange Strafaufgabe gegeben hätte und er dann doch noch ein Zwei bekommen könnte!« fing Marianne wieder an.
     </p>
-    <p xml:id="eco_de_0000141_20720">
+    <p xml:id="eco_de_0000211_20720">
      »Für so etwas gibt es gar keine, die lang genug wäre!« erwiderte Hans. »Da müsste Joseph Tag und Nacht schreiben und rechnen und würde doch nicht fertig bis zur Zeugnisausteilung.«
     </p>
-    <p xml:id="eco_de_0000141_20730">
+    <p xml:id="eco_de_0000211_20730">
      »Hans, wenn man –« Marianne sprang auf.
     </p>
-    <p xml:id="eco_de_0000141_20740">
+    <p xml:id="eco_de_0000211_20740">
      »Wenn wir –« Hans sprang auch auf. Die beiden sahen einander an. Im selben Augenblick kam ihnen derselbe Gedanke.
     </p>
-    <p xml:id="eco_de_0000141_20750">
+    <p xml:id="eco_de_0000211_20750">
      »Wenn wir ihm helfen würden! Wenn alle, die dabei gewesen sind, eine Strafaufgabe schrieben! Etwas recht Schweres, Hans!« Marianne war ganz aufgeregt. »Ich weiss – hinten im Lesebuch ist ein langes Gedicht, das ich gar nicht mag. Das lern' ich und schreib' es auswendig –«
     </p>
-    <p xml:id="eco_de_0000141_20760">
+    <p xml:id="eco_de_0000211_20760">
      »Ja, und wir müssen uns alle das Ehrenwort geben, dass wir nicht abgucken und niemand fragen!« rief Hans. »Ich entlehne von einem Sechstklässler das Rechenbuch. Otto Lauener hat gesagt, da habe es schreckliche Sachen, die man fast nicht zustand bringe –«
     </p>
-    <p xml:id="eco_de_0000141_20770">
+    <p xml:id="eco_de_0000211_20770">
      »Und ich«, sagte Lotti, indem sie sich gleichfalls erhob und ihr halbvollendetes Papierschiffchen in die Tasche schob. »Ich könnte vielleicht stricken; das mag ich am wenigsten! Ja, ich stricke noch einmal so ein langweiliges Musterstück, drei Reihen rechts, drei links – oder ich mache dann vier links, Marianne!« sagte sie mutig.
     </p>
-    <p xml:id="eco_de_0000141_20780">
+    <p xml:id="eco_de_0000211_20780">
      Die Kinder konnten kaum warten, den andern ihren Plan mitzuteilen. Auf der Wagenburg in der Hühnergasse fand am folgenden Tage eine grosse Besprechung statt. Alle Helvetier und Römer stimmten ohne Ausnahme ein.
     </p>
-    <p xml:id="eco_de_0000141_20790">
+    <p xml:id="eco_de_0000211_20790">
      »Das ist eine feine Idee! Ja, natürlich! Alle zusammen machen wir eine Riesenstrafaufgabe: Eine, die so lang ist, wie von da zum Grünen Winkel hinunter –!« schrien sie.
     </p>
-    <p xml:id="eco_de_0000141_20800">
+    <p xml:id="eco_de_0000211_20800">
      »Ich zeichne den Rhein mit seinen Zuflüssen!« erklärte Otto Lauener. »Das ist gehörig schwer! Der Main, der schlängelt sich so von rechts her –« Otto Lauener holte mit dem Arme so kräftig aus, dass Hans Turnach beinahe eine Ohrfeige erhalten hätte.
     </p>
-    <p xml:id="eco_de_0000141_20810">
+    <p xml:id="eco_de_0000211_20810">
      »Und ich schreibe Noten!« rief ein anderer. »Das ist, mein ich, widerwärtig genug. Besonders, wenn man die Linien selber zieht!«
     </p>
-    <p xml:id="eco_de_0000141_20820">
+    <p xml:id="eco_de_0000211_20820">
      »Marianne«, flüsterte Sylvia, »ist es, damit Joseph Puhl heim darf zu den Gänsen? Dann will ich eine Tafel voll grosse S schreiben. Die kann ich gut.«
     </p>
-    <p xml:id="eco_de_0000141_20830">
+    <p xml:id="eco_de_0000211_20830">
      »Nein, Sylvia!« verwies Lotti. »Du muss etwas nehmen, was du nicht kannst! Irgendein schweres langes Wort. Schreib du: Konstantinopolitanischerdudelsackpfeifergesell!«
     </p>
-    <p xml:id="eco_de_0000141_20840">
+    <p xml:id="eco_de_0000211_20840">
      Sylvia sah sie entsetzt an.
     </p>
-    <p xml:id="eco_de_0000141_20850">
+    <p xml:id="eco_de_0000211_20850">
      »Natürlich, Lotti! mach du wieder Dummheiten!« sagte Hans. »Wo wir noch gar nicht wissen, ob es gerät –!«
     </p>
-    <p xml:id="eco_de_0000141_20860">
+    <p xml:id="eco_de_0000211_20860">
      »Ja, und dann freut sich Joseph vielleicht umsonst!« meinte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_20870">
+    <p xml:id="eco_de_0000211_20870">
      »Dem sagt man nichts vorher!«
     </p>
-    <p xml:id="eco_de_0000141_20880">
+    <p xml:id="eco_de_0000211_20880">
      »So! er könnte aber wirklich auch eine Aufgabe schreiben!« warf Haubinger aus Hansens Klasse ein.
     </p>
-    <p xml:id="eco_de_0000141_20890">
+    <p xml:id="eco_de_0000211_20890">
      »Nein, nein! wir sagen ihm nichts!« rief die Mehrzahl. »Erst wenn es gerät!«
     </p>
-    <p xml:id="eco_de_0000141_20900">
+    <p xml:id="eco_de_0000211_20900">
      »Der wird dann ein Gesicht machen! Jetzt sieht er so drein –« Villeiner zog seine dicken Backen so viel als möglich in die Länge. »Und nachher auf einmal so –« Villeiners Gesicht ging wieder in die Breite; er hüpfte auf einem Bein und warf mit einem Juchschrei den Hut in die Höhe.
     </p>
-    <p xml:id="eco_de_0000141_20910">
+    <p xml:id="eco_de_0000211_20910">
      »Aber wem bringen wir eigentlich die Strafaufgaben?« fragte plötzlich einer.
     </p>
-    <p xml:id="eco_de_0000141_20920">
+    <p xml:id="eco_de_0000211_20920">
      Darüber konnte man verschiedener Meinung sein.
     </p>
-    <p xml:id="eco_de_0000141_20930">
+    <p xml:id="eco_de_0000211_20930">
      »Dem Herrn Klein, weil er doch dem Joseph erlauben muss, heimzureisen!«
     </p>
-    <p xml:id="eco_de_0000141_20940">
+    <p xml:id="eco_de_0000211_20940">
      »Ach, der Herr Klein macht sich gewiss nichts aus Strafaufgaben!«
     </p>
-    <p xml:id="eco_de_0000141_20950">
+    <p xml:id="eco_de_0000211_20950">
      »Und jedenfalls hat er nicht Zeit, alles durchzusehen!«
     </p>
-    <p xml:id="eco_de_0000141_20960">
+    <p xml:id="eco_de_0000211_20960">
      Nein, also nicht zu Herrn Klein. Eher zu Herrn Hirt. Er gab doch Joseph die Betragensnote.
     </p>
-    <p xml:id="eco_de_0000141_20970">
+    <p xml:id="eco_de_0000211_20970">
      »Oder zu Herrn Professor Taubenmüller selbst?«
     </p>
-    <p xml:id="eco_de_0000141_20980">
+    <p xml:id="eco_de_0000211_20980">
      »Huh! nein!«
     </p>
-    <p xml:id="eco_de_0000141_20990">
+    <p xml:id="eco_de_0000211_20990">
      »Doch, doch!« schrien viele. »Gegen ihn ist Joseph so schrecklich grob gewesen. Er ist böse. Also muss man vor allem machen, dass er wieder gut wird!«
     </p>
-    <p xml:id="eco_de_0000141_21000">
+    <p xml:id="eco_de_0000211_21000">
      Nach lebhaftem Hin und Her vereinigte man sich endlich auf Herrn Professor Taubenmüller.
     </p>
-    <p xml:id="eco_de_0000141_21010">
+    <p xml:id="eco_de_0000211_21010">
      In den nächsten Tagen war das herrlichste Wetter. Die Sonne schien hell auf den Graben. Von den Bäumen schmetterten ein paar Finken in die blaue Luft hinaus. Aber unten auf dem Platze blieb es still. Die Helvetier und die Römer sassen alle zu Hause, jeder an seinem Tisch mit der Feder in der Hand. Mancher stöhnte ein wenig und schaute zum Fenster hinaus. So lustig wär's draussen! Aber dann rückte er wieder zurecht und fuhr tapfer fort. Es war dann auch lustig, wenn der Joseph Puhl wirklich heim durfte.
     </p>
-    <p xml:id="eco_de_0000141_21020">
+    <p xml:id="eco_de_0000211_21020">
      Vierunddreissig Buben und Mädchen versammelten sich am Dienstag um fünf Uhr vor dem Hause, in dem Herr Professor Taubenmüller wohnte. Flüsternd zeigten sie einander ihre Blätter. Lotti war stolz, dass sie zu ihrem Musterstück noch drei Sätze mit »wenn« und drei mit »weil« geschrieben hatte. Zuletzt war ihr zwar ein Unglück begegnet. Es hatte unten hin – Lotti konnte gar nicht begreifen wie – auf einmal einen grossen Tintenfleck gegeben.
     </p>
-    <p xml:id="eco_de_0000141_21030">
+    <p xml:id="eco_de_0000211_21030">
      »So, jetzt kannst du von vorn anfangen!« sagte Hans. »Ausreiben darf man nicht.«
     </p>
-    <p xml:id="eco_de_0000141_21040">
+    <p xml:id="eco_de_0000211_21040">
      Lotti war nah am Weinen. Noch einmal von vorn!
     </p>
-    <p xml:id="eco_de_0000141_21050">
+    <p xml:id="eco_de_0000211_21050">
      Doch Marianne half. Sie malte über den Fleck ein grosses dunkelblaues Veilchen mit einem artigen grünen Stielchen.
     </p>
-    <p xml:id="eco_de_0000141_21060">
+    <p xml:id="eco_de_0000211_21060">
      »Wenn das nur passt auf eine Strafaufgabe!« warf Hans ein.
     </p>
-    <p xml:id="eco_de_0000141_21070">
+    <p xml:id="eco_de_0000211_21070">
      Aber Sophie, die daneben bügelte, meinte, es gehe. Veilchen möge jeder gern, auch ein Herr Professor.
     </p>
-    <p xml:id="eco_de_0000141_21080">
+    <p xml:id="eco_de_0000211_21080">
      Die Magd des Herrn Professor Taubenmüller war hoch erstaunt, als sie die Haustüre aufmachte und die Schar sah.
     </p>
-    <p xml:id="eco_de_0000141_21090">
+    <p xml:id="eco_de_0000211_21090">
      »Ihr seid gewiss nicht am rechten Ort. Hier wohnt der Herr Professor Taubenmüller.«
     </p>
-    <p xml:id="eco_de_0000141_21100">
+    <p xml:id="eco_de_0000211_21100">
      »Ja, wir müssen zu ihm!«
     </p>
-    <p xml:id="eco_de_0000141_21110">
+    <p xml:id="eco_de_0000211_21110">
      »Alle?«
     </p>
-    <p xml:id="eco_de_0000141_21120">
+    <p xml:id="eco_de_0000211_21120">
      »Ja, alle!« Man hatte ausgemacht, dass jedes seine Arbeit selber bringe, weil es feierlicher sei.
     </p>
-    <p xml:id="eco_de_0000141_21130">
+    <p xml:id="eco_de_0000211_21130">
      Die Magd rieb sich das Kinn.
     </p>
-    <p xml:id="eco_de_0000141_21140">
+    <p xml:id="eco_de_0000211_21140">
      »So wird man euch halt hineinlassen müssen. Wartet da. Ich will's dem Herrn Professor sagen.«
     </p>
-    <p xml:id="eco_de_0000141_21150">
+    <p xml:id="eco_de_0000211_21150">
      Die Kinder standen in dem braun getäfelten Korridor und sahen einander an. Keines lachte. Auf einmal kam ihnen die Sache sehr bedenklich vor. Wenn nun der Herr Professor nichts wissen wollte von den Strafaufgaben und wenn er noch böser wurde, weil sie so ungeheissen kamen –? Aber es war nicht mehr Zeit, sich zu besinnen.
     </p>
-    <p xml:id="eco_de_0000141_21160">
+    <p xml:id="eco_de_0000211_21160">
      »Ihr sollt da hereinkommen!« rief die Magd von der hintern Türe.
     </p>
-    <p xml:id="eco_de_0000141_21170">
+    <p xml:id="eco_de_0000211_21170">
      Vor Verlegenheit sich auf die Lippen beissend, rückte die Schar vor. Niemand wollte zuerst ins Zimmer. Da sass der gefürchtete Herr in einem weiten Armsessel vor seinem Schreibtisch.
     </p>
-    <p xml:id="eco_de_0000141_21180">
+    <p xml:id="eco_de_0000211_21180">
      »Was ist das für ein Aufzug? Was wollt ihr?« fragte er kurz.
     </p>
-    <p xml:id="eco_de_0000141_21190">
+    <p xml:id="eco_de_0000211_21190">
      Alle drehten sich nach Hans Turnach um. Es war verabredet, dass er spreche.
     </p>
-    <p xml:id="eco_de_0000141_21200">
+    <p xml:id="eco_de_0000211_21200">
      »Herr Professor«, begann Hans. »Wir bringen unsere Strafaufgaben – wir haben –« er stotterte vor Beklemmung.
     </p>
-    <p xml:id="eco_de_0000141_21210">
+    <p xml:id="eco_de_0000211_21210">
      »Strafaufgaben –? Wer hat sie euch gegeben?«
     </p>
-    <p xml:id="eco_de_0000141_21220">
+    <p xml:id="eco_de_0000211_21220">
      »Wir selber«, antwortete Hans. »Es ist wegen dem Joseph Puhl – wir haben gedacht, er könne keine machen, die gross genug wäre – und da –«
     </p>
-    <p xml:id="eco_de_0000141_21230">
+    <p xml:id="eco_de_0000211_21230">
      »Joseph Puhl«, unterbrach ihn der Herr Professor, die Stirne runzelnd. »Sein Benehmen war unerhört, unverzeihlich! Ganz unverzeihlich! Daran ist nichts zu ändern!« Der Herr Professor sah mit strengem Gesicht auf Hans.
     </p>
-    <p xml:id="eco_de_0000141_21240">
+    <p xml:id="eco_de_0000211_21240">
      »Wir möchten –« hob dieser noch einmal an.
     </p>
-    <p xml:id="eco_de_0000141_21250">
+    <p xml:id="eco_de_0000211_21250">
      »Nichts zu ändern!« wiederholte der Herr Professor und schlug mit der flachen Hand auf seinen Schreibtisch.
     </p>
-    <p xml:id="eco_de_0000141_21260">
+    <p xml:id="eco_de_0000211_21260">
      Hans hielt erschrocken inne. Also ging es nicht –! Die ganze Geschichte war verloren –! Walter Schürmann zog ihn am Ärmel zurück.
     </p>
-    <p xml:id="eco_de_0000141_21270">
+    <p xml:id="eco_de_0000211_21270">
      »Siehst du! ich hab's gedacht!« flüsterte er.
     </p>
-    <p xml:id="eco_de_0000141_21280">
+    <p xml:id="eco_de_0000211_21280">
      »Herr Professor – .« Alle schauten zurück. Marianne Turnach! Dass die sich getraute –!
     </p>
-    <p xml:id="eco_de_0000141_21290">
+    <p xml:id="eco_de_0000211_21290">
      »Herr Professor, Joseph Puhl möchte so furchtbar gern heim. Und das von jenem Donnerstag tut ihm schrecklich leid. Er hat sich nur so gewehrt, weil er gleich Angst hatte, er dürfe nicht heim zu seiner Mutter, wenn –«
     </p>
-    <p xml:id="eco_de_0000141_21300">
+    <p xml:id="eco_de_0000211_21300">
      »Ja«, fiel Lotti ein. Wenn Marianne redete, durfte sie auch etwas sagen. »Ja, sie wohnt in einem kleinen Haus mit blauen Läden, und mitten durch das Dorf läuft ein Bach; es heisst Läumelfingen, und wenn Joseph allemal heim kommt, so –«
     </p>
-    <p xml:id="eco_de_0000141_21310">
+    <p xml:id="eco_de_0000211_21310">
      Hans gab Lotti nach rückwärts einen Puff. Sie war imstande und fing von dem Speckkuchen an.
     </p>
-    <p xml:id="eco_de_0000141_21320">
+    <p xml:id="eco_de_0000211_21320">
      »Läumelfingen?« sagte der Herr Professor.
     </p>
-    <p xml:id="eco_de_0000141_21330">
+    <p xml:id="eco_de_0000211_21330">
      »Ja, Läumelfingen!« riefen alle Kinder, aufs neue Hoffnung schöpfend. Sie rückten etwas näher, und dabei fiel dem Otto Lauener seine Geographiezeichnung gerade dem Herrn Professor zu Füssen.
     </p>
-    <p xml:id="eco_de_0000141_21340">
+    <p xml:id="eco_de_0000211_21340">
      »Was soll das sein?« fragte dieser, als Lauener das Blatt aufhob. »Auswendig gezeichnet? Nun – nicht gerade schlecht.«
     </p>
-    <p xml:id="eco_de_0000141_21350">
+    <p xml:id="eco_de_0000211_21350">
      Jetzt wagte Hermann Villeiner seine Winkel hinzuhalten und Marianne ihr Gedicht und Hans seine Rechnungen aus dem Sechstklässlerbuch … Vierunddreissig Hände mit blauen Heften und weissen Blättern streckten sich nach dem Herrn Professor aus, und ganz vorn stand Lotti mit ihrem Probestück.
     </p>
-    <p xml:id="eco_de_0000141_21360">
+    <p xml:id="eco_de_0000211_21360">
      »Zuletzt ist noch ein Lochgang«, erklärte sie. »Das ist immer einmal abgenommen und eine Luftmasche. Und das Veilchen da hat Marianne gemacht, damit man den Tintenfleck nicht sieht.«
     </p>
-    <p xml:id="eco_de_0000141_21370">
+    <p xml:id="eco_de_0000211_21370">
      »So, so!« sagte der Herr Professor, wandte sich dann aber mit nochmaligem Stirnrunzeln zu den andern.
     </p>
-    <p xml:id="eco_de_0000141_21380">
+    <p xml:id="eco_de_0000211_21380">
      »Das ist nichts! Das geht nicht! Was einer selber tut, muss er auch selber büssen.« Er nahm eines der Hefte und legte es wieder weg. »Sonderbarer Einfall! So eine Art Massenopfer – . Von euerem Standpunkt aus ja nicht übel –! Einer für alle – hier nun alle für einen! Hm – man müsste –«, er ergriff sein Papiermesser und wiegte es hin und her. »Man müsste also einmal Gnade für Recht ergehen lassen! Einmal, ausnahmsweise –! Legt das Zeug daher –«
     </p>
-    <p xml:id="eco_de_0000141_21390">
+    <p xml:id="eco_de_0000211_21390">
      Alle drängten an den Schreibtisch und kniffen einander vor Vergnügen schnell ein wenig in die Arme. Dass der Herr Professor die Aufgaben sehen wollte, war ein gutes Zeichen! Ganz zuletzt kam noch Sylvia halb ängstlich, halb stolz mit ihrer Schreibtafel. Sie hatte sechsmal »Herr Professor Taubenmüller« darauf geschrieben. Die Tante hatte ihr aber dabei geholfen, weil Sylvia doch erst in die erste Klasse ging.
     </p>
-    <p xml:id="eco_de_0000141_21400">
+    <p xml:id="eco_de_0000211_21400">
      »Ei, ei!« sagte der Herr Professor und betrachtete die langen, steifen Buchstaben. »Nun – wir wollen sehen! Wir wollen sehen! Jedenfalls soll er auch noch herkommen, dass ich ein Wörtlein mit ihm rede. Er muss lernen sich zusammenzunehmen, seinen Jähzorn zu bekämpfen. Einer, der sich so gehen lässt, wird nie ein rechter Mensch! Merkt's euch! Nie!«
     </p>
-    <p xml:id="eco_de_0000141_21410">
+    <p xml:id="eco_de_0000211_21410">
      »Ja, Herr Professor, ja! Adieu, Herr Professor! Wir danken vielmal, vielmal!« riefen die Kinder, indem sie dem Herrn Professor die Hand gaben. Sie hatten alle aus seinem Ton gemerkt, dass die Sache gewonnen war, gewonnen! –
     </p>
-    <p xml:id="eco_de_0000141_21420">
+    <p xml:id="eco_de_0000211_21420">
      Sehr manierlich hatten sie den Weg hergemacht. Um so lauter ging es auf der Rückkehr zu. Wie ein wildes Heer rannten sie die Ackerstrasse und den Greifenweg hinunter, bogen zum Graben ein und stürzten auf den »Grünen Winkel« los.
     </p>
-    <p xml:id="eco_de_0000141_21430">
+    <p xml:id="eco_de_0000211_21430">
      »Joseph! Joseph!« schrien sie vor dem Hause. »Joseph! Herunterkommen sollst du –! Wir müssen dir etwas sagen!«
     </p>
-    <p xml:id="eco_de_0000141_21440">
+    <p xml:id="eco_de_0000211_21440">
      Die einen drangen hinauf in die Wohnung, so dass Frau Klein mit eingestemmten Armen unter der Küchentür erschien. Aber schon zogen die Buben den Joseph die Stiege hinunter auf die Strasse und fingen alle miteinander an, auf ihn einzureden, was sie getan und wie es bei Herrn Professor Taubenmüller gegangen.
     </p>
-    <p xml:id="eco_de_0000141_21450">
+    <p xml:id="eco_de_0000211_21450">
      »Zuerst war es sehr unheimlich, und wir haben schon gemeint, es sei alles aus! Aber dann wurde er ganz nett! Und jetzt darfst du, Joseph! Du darfst! Der Herr Professor richtet es dann ein mit Herrn Hirt und mit deinem Vetter. Er weiss schon, wie man das macht! Natürlich! Er ist ja der Präsident –! Du musst dann auch noch ein wenig zu ihm. Aber es ist jedenfalls nicht so schrecklich! Wie die Sylvia ihre Tafel gezeigt hat, hat er fast ein wenig lachen müssen –«, so tönte es durcheinander, und Joseph Puhl stand betäubt in der Mitte und wusste die längste Zeit nicht, was man da an ihn hinschrie.
     </p>
-    <p xml:id="eco_de_0000141_21460">
+    <p xml:id="eco_de_0000211_21460">
      Als er endlich begriff, machte er keinen Luftsprung, wie Villeiner prophezeit hatte; er tat auch keinen Juchschrei. Dunkelrot vor Überraschung stand er da, und in seinem Gesichte, das fast zwei Wochen lang nicht mehr gelacht hatte, zuckte es wunderlich, als ob die grosse Betrübnis sich gar nicht so schnell verscheuchen lasse. Aber dann brach die Freude durch, und glückselig schaute Joseph Puhl seine Kameraden an. Reden konnte er vorläufig noch nicht.
     </p>
-    <p xml:id="eco_de_0000141_21470">
+    <p xml:id="eco_de_0000211_21470">
      Herr Professor Taubenmüller hatte wirklich gewusst, wie man es mache. Als am 6. April um zwölf Uhr in den Klassen des Grabenschulhauses die Zeugnisse ausgeteilt worden waren, schossen die Buben von allen Seiten auf Joseph Puhl los:
     </p>
-    <p xml:id="eco_de_0000141_21480">
+    <p xml:id="eco_de_0000211_21480">
      »Zeig! zeig her –!«
     </p>
-    <p xml:id="eco_de_0000141_21490">
+    <p xml:id="eco_de_0000211_21490">
      Joseph bekam sein Zeugnis eine ganze Weile nicht mehr zu Gesicht.
     </p>
-    <p xml:id="eco_de_0000141_21500">
+    <p xml:id="eco_de_0000211_21500">
      In dem Zeugnisse aber war an Stelle der Betragensnote folgendes zu lesen:
     </p>
-    <p xml:id="eco_de_0000141_21510">
+    <p xml:id="eco_de_0000211_21510">
      »Am 22. März hat Joseph sich sehr ungebührlich aufgeführt. Da er aber bereut und da sein Betragen vor- und nachher gut war, wird ihm verziehen. Wir empfehlen Herrn Klein, Joseph heimreisen zu lassen.
     </p>
-    <p xml:id="eco_de_0000141_21520">
+    <p xml:id="eco_de_0000211_21520">
      G. Hirt. Prof. Taubenmüller.«
     </p>
-    <p xml:id="eco_de_0000141_21530">
+    <p xml:id="eco_de_0000211_21530">
      Und Buchbinder Klein liess Joseph reisen. Da alle dafür waren, konnte er nicht mehr widerstehen. Auch hatte es ihm gefallen, dass die ganze Kameradschaft für seinen kleinen Vetter eingestanden war.
     </p>
-    <p xml:id="eco_de_0000141_21540">
+    <p xml:id="eco_de_0000211_21540">
      Am ersten Ferientage morgens acht Uhr wanderte Joseph Puhl mit seinem bescheidenen Handköfferchen dem Bahnhof zu, begleitet von einer grossen Schar Helvetier und Römer. In der Einsteigehalle konnte man zwar so viel Buben und Mädel nicht brauchen, wie der Schaffner erklärte. Aber da war ja gleich vorn der Bahnsteg. Und als der Zug abfuhr und Joseph Puhl richtig aus dem zweitletzten Wagen hinaufguckte, da schrie und jauchzte, vom weissen Dampf umhüllt, die Schar auf ihn herunter:
     </p>
-    <p xml:id="eco_de_0000141_21550">
+    <p xml:id="eco_de_0000211_21550">
      »Adieu, Joseph! Gute Reise! Grüss die Gänse! und wenn du Speckkuchen issest, so denk an uns! Ja, und bring einen mit! Hurra!«
     </p>
    </div>
@@ -6647,130 +6647,130 @@
     <head>
      Aufs Land hinaus
     </head>
-    <p xml:id="eco_de_0000141_21560">
+    <p xml:id="eco_de_0000211_21560">
      Der Frühling war nun da. Auch in der Stadt spürte man ihn. Die Hecke am Graben trieb rötliche glänzende Sprossen, und in den kleinsten Gärten blühten die weissen und braunen Aurikeln und der blaue Krokus. Die ganze Luft roch nach warmer Erde. Wie musste es erst draussen auf dem Lande sein! Die Turnachkinder hielten es vor Verlangen und Ungeduld fast nicht mehr aus.
     </p>
-    <p xml:id="eco_de_0000141_21570">
+    <p xml:id="eco_de_0000211_21570">
      »Mama, gelt, du findest doch auch, dass es schrecklich schade ist um jeden Tag, den wir nicht in der Seeweid sind!« drängten sie.
     </p>
-    <p xml:id="eco_de_0000141_21580">
+    <p xml:id="eco_de_0000211_21580">
      Ja, ja, Mama sehnte sich selber hinaus und tat, was sie konnte, um mit den Vorbereitungen zum Umzug rasch fertig zu werden. Am Dienstag der ersten Ferienwoche konnte man denn auch bereits jubeln: Morgen! Und schon der Nachmittag brachte die schönste Vorfreude; denn es wurde beschlossen, dass Sophie mit den drei Grossen bei Steppacher ein Ruderschiff nehme und ein paar Körbe Geschirr und anderes in die Seeweid hinausbringe.
     </p>
-    <p xml:id="eco_de_0000141_21590">
+    <p xml:id="eco_de_0000211_21590">
      »Mama, ich helf' auch!« rief Werner. »Ich nehm' meinen Wagen und ich stelle alle Tassen hinein –«
     </p>
-    <p xml:id="eco_de_0000141_21600">
+    <p xml:id="eco_de_0000211_21600">
      »Ja, Werner, dir übergeben wir die zerbrechlichen Sachen!« lachte Mama; aber sie erlaubte, dass Werner mitfahre, worauf er so unbändig anfing herumzuhüpfen, dass das Schwesterlein von seinem Jubel angesteckt wurde.
     </p>
-    <p xml:id="eco_de_0000141_21610">
+    <p xml:id="eco_de_0000211_21610">
      »Löm, löm!« rief es übermütig und warf seinen Wollhasen im Bogen in die Stube hinaus.
     </p>
-    <p xml:id="eco_de_0000141_21620">
+    <p xml:id="eco_de_0000211_21620">
      »Mama, darf es auch mit! Mama, sag' ja!« bettelte Marianne.
     </p>
-    <p xml:id="eco_de_0000141_21630">
+    <p xml:id="eco_de_0000211_21630">
      »Aber, Marianne, es würde Sophie recht im Wege sein. Sie will den Geschirrschrank einräumen und der Putzerin helfen.«
     </p>
-    <p xml:id="eco_de_0000141_21640">
+    <p xml:id="eco_de_0000211_21640">
      »Mama, wenn ich es aber hüte! Frau Völklein freut sich gewiss schon lange auf das Schwesterlein!«
     </p>
-    <p xml:id="eco_de_0000141_21650">
+    <p xml:id="eco_de_0000211_21650">
      »Und wenn es heute mitfährt, so kennt es sich morgen schon besser aus in der Seeweid!« rief Lotti.
     </p>
-    <p xml:id="eco_de_0000141_21660">
+    <p xml:id="eco_de_0000211_21660">
      Mama fand dies nun zwar keinen sehr triftigen Grund. Aber schliesslich war das Schwesterlein bei Marianne und Frau Völklein ja in guter Hut, und zu Hause konnten Mama und Balbine um so ungestörter vorwärts kommen mit der Arbeit.
     </p>
-    <p xml:id="eco_de_0000141_21670">
+    <p xml:id="eco_de_0000211_21670">
      So zog man denn am Nachmittag aus zur Schifflände. Hans und Sophie trugen einen schweren Waschkorb; Lotti und Werner zogen den kleinen Wagen, den man zwar nicht gerade schwer mit Tassen und Gläsern bepackt hatte. Marianne schob den Kinderwagen, aus welchem das Schwesterlein zwischen allerlei Gerät lustig hervorguckte. Auf Lottis Arm aber sass der Rabe Peter. Er sollte die Vorfreude auch geniessen.
     </p>
-    <p xml:id="eco_de_0000141_21680">
+    <p xml:id="eco_de_0000211_21680">
      Mama und Balbine gingen hinauf in die oberen Stuben. Es gab noch sehr viel zu räumen, zu packen, zuzudecken und abzuschliessen. Man wollte morgen schon mittags in der Seeweid sein.
     </p>
-    <p xml:id="eco_de_0000141_21690">
+    <p xml:id="eco_de_0000211_21690">
      Ulrich half und trug Kisten und Bettladen hinunter. Der Schnauzel war immer hinter ihm drein und sah sich erstaunt in den schon halb geleerten Zimmern um.
     </p>
-    <p xml:id="eco_de_0000141_21700">
+    <p xml:id="eco_de_0000211_21700">
      »Ja, Schnauzel, jetzt gehen sie wieder fort!« sagte Ulrich. »Willst auch mit? Willst einmal einen Sommer in der Seeweid sein?«
     </p>
-    <p xml:id="eco_de_0000141_21710">
+    <p xml:id="eco_de_0000211_21710">
      Schnauzel sprang an Ulrich auf mit einem lauten Wau! Nein, nein, ich bleib bei dir!
     </p>
-    <p xml:id="eco_de_0000141_21720">
+    <p xml:id="eco_de_0000211_21720">
      Schnauzel liebte die Kinder sehr. Aber immer lief er nach einer Weile wieder zu seinem Ulrich zurück, und nie liess er sich bewegen, mit jemand anderm als mit ihm einen Ausgang zu machen.
     </p>
-    <p xml:id="eco_de_0000141_21730">
+    <p xml:id="eco_de_0000211_21730">
      Vom Münster herüber läutete es eben sechs Uhr in den hellen warmen Frühlingsabend hinaus. Nun sollten sie bald wieder da sein, dachte Mama. Und richtig, kam es die Treppe heraufgetrabt.
     </p>
-    <p xml:id="eco_de_0000141_21740">
+    <p xml:id="eco_de_0000211_21740">
      »O, Mama! o! nein –!«
     </p>
-    <p xml:id="eco_de_0000141_21750">
+    <p xml:id="eco_de_0000211_21750">
      Vor Entzücken und Freude konnten die Kinder erst gar nicht reden. Dann aber ging es los. Alle vier sprachen auf einmal.
     </p>
-    <p xml:id="eco_de_0000141_21760">
+    <p xml:id="eco_de_0000211_21760">
      »Mama, es ist zu schön draussen! Herrlich! Göttlich! Man kann gar nicht sagen wie –!«
     </p>
-    <p xml:id="eco_de_0000141_21770">
+    <p xml:id="eco_de_0000211_21770">
      »Mama«, rief Lotti, »die Enten sind jetzt ganz gross und machen ganz ernsthafte Gesichter! Und der Peter ist auch mit in den Hühnerhof gekommen. Er war sehr nett und hat nach allen Seiten Kräh! gesagt. Aber die Hühner sind nur so um ihn herumgestanden; da hat ihnen Frau Völklein zugesprochen, sie sollen nicht so steif tun; das sei jetzt ihr neuer Kamerad –«
     </p>
-    <p xml:id="eco_de_0000141_21780">
+    <p xml:id="eco_de_0000211_21780">
      »Mama, sieh!« Marianne streckte Mama ihre Veilchen entgegen. »Unter dem Apfelbaum bei der Scheune war es ganz blau! Wir haben sechs Sträusse gemacht! Einen stellen wir Papa ins Bureau und einen auf das Pult von Herrn Frei und Herrn Oberauer, und Ulrich bekommt auch einen! Riech, wie gut –«
     </p>
-    <p xml:id="eco_de_0000141_21790">
+    <p xml:id="eco_de_0000211_21790">
      »Ich hab dürfen auf dem Dachs reiten!« schrie Werner und zog an Mama, dass sie auf ihn höre. »Und der Bless hat mich angeschnauft; aber ich hab mich nicht gefürchtet! Der Jakob hat gesagt, ich solle dann immer helfen im Stall –«
     </p>
-    <p xml:id="eco_de_0000141_21800">
+    <p xml:id="eco_de_0000211_21800">
      Werner lief zu seinen hölzernen Kühen, um ihnen mitzuteilen, dass er jetzt grosse habe, die er füttern und zum Brunnen führen müsse.
     </p>
-    <p xml:id="eco_de_0000141_21810">
+    <p xml:id="eco_de_0000211_21810">
      »Mama«, rief Hans, »das Schiff hat neue Stehruder! Sie laufen famos! Ich bin schnell mit Fritz Völklein ein wenig gefahren! O, wenn man jetzt wieder so mit aller Kraft hinausrudern kann, Mama, jeden Tag –«
     </p>
-    <p xml:id="eco_de_0000141_21820">
+    <p xml:id="eco_de_0000211_21820">
      »Aber jetzt die Hauptsache – Hans, lass uns doch die Hauptsache erzählen!« unterbrachen Marianne und Lotti den Bruder.
     </p>
-    <p xml:id="eco_de_0000141_21830">
+    <p xml:id="eco_de_0000211_21830">
      »Also, Mama«, fing Lotti an und fasste Mama voll Eifer am Arm, »Frau Völklein hat uns Butterbrot und Äpfel gebracht und hat gefragt, wo wir sie essen wollen, und wir haben natürlich alle gerufen: Auf der Seemauer! Und das Schwesterlein hat immer gebettelt und ist von einem zum andern gekrochen –«
     </p>
-    <p xml:id="eco_de_0000141_21840">
+    <p xml:id="eco_de_0000211_21840">
      »Weisst du, Mama, da wo das Holzgitter noch ein Stück weit geht«, fiel Marianne ein. »Und Sophie und Frau Völklein blieben dabei, dass das Schwesterlein nicht falle. Da ist es an Hans aufgestanden, und auf einmal – auf einmal läuft es zu mir! Sieben oder acht Schritte hat es gemacht, Mama –!«
     </p>
-    <p xml:id="eco_de_0000141_21850">
+    <p xml:id="eco_de_0000211_21850">
      »Ja, sieben oder acht Schritte!« wiederholten Hans und Lotti. »Ist das nicht zu nett, dass das Schwesterlein auf der Seemauer gehen gelernt hat – gerade auf der Seemauer!«
     </p>
-    <p xml:id="eco_de_0000141_21860">
+    <p xml:id="eco_de_0000211_21860">
      »Mama«, fuhr Marianne fort, »man würde denken, das Schwesterlein habe gesehen, wie weit alles ist in der Seeweid und wie man da mit Rutschen nirgends hinkommt!«
     </p>
-    <p xml:id="eco_de_0000141_21870">
+    <p xml:id="eco_de_0000211_21870">
      »Ja, ja, ich habe eine kluge grosse Tochter!« sagte Mama und hob das Schwesterlein lachend auf. Schon immer hatte man erwartet, dass es nun endlich zu gehen beginne, da es schon vierzehn Monate alt war.
     </p>
-    <p xml:id="eco_de_0000141_21880">
+    <p xml:id="eco_de_0000211_21880">
      »Nein, bitte, halt, Mama«, riefen die Kinder, als Mama mit dem Schwesterlein in die hintere Stube gehen wollte. »Es kommt noch etwas! Also das Schwesterlein hat gehen gelernt, und der Peter – denk! der hat zu fliegen angefangen! Es war so lustig! Er ist auf der Seemauer unter der Silberpappel gestanden, und oben hat eine Amsel gesungen. Da hat er gehorcht und hinaufgeschaut und hat mit den Flügeln geschlagen, immer stärker und ist auf einmal geflogen, Mama – ganz hoch geflogen bis zu dem Ast, der gegen den See hinausgeht und dann auf einen noch höheren und weiter bis fast zu der Amsel hin –«
     </p>
-    <p xml:id="eco_de_0000141_21890">
+    <p xml:id="eco_de_0000211_21890">
      »Wie nett!« sagte Mama.
     </p>
-    <p xml:id="eco_de_0000141_21900">
+    <p xml:id="eco_de_0000211_21900">
      »Gelt! und sonst flattert der Peter doch nur auf einen Stuhl und von da auf den Tisch und höchstens auf einen niedrigen Schrank!« fuhr Hans fort. »Niemand hat gewusst, dass er fliegen kann; er selber vielleicht auch nicht –«
     </p>
-    <p xml:id="eco_de_0000141_21910">
+    <p xml:id="eco_de_0000211_21910">
      »Und die Amsel ist ein bisschen auf die Seite gerückt«, nahm Marianne das Wort, »und hat so geguckt. Aber dann hat sie weiter gesungen, weisst du, wie letztes Jahr: Tiu tiu, tirürü. Und der Peter hat Kräh! gerufen. Immer die Amsel und dann wieder der Peter. Vielleicht hat er schon gemerkt, dass die Amsel es schöner könne. Aber er war so vergnügt. Fast wäre er nicht mehr heruntergekommen –«
     </p>
-    <p xml:id="eco_de_0000141_21920">
+    <p xml:id="eco_de_0000211_21920">
      »Mama, wie wir wieder im Schiff gewesen sind, habe ich ihm gesagt, er dürfe morgen ganz in der Seeweid bleiben!« rief Werner und kauerte zu dem Raben: »Du, Peter! nur noch einmal musst du schlafen! Nur noch einmal!«
     </p>
-    <p xml:id="eco_de_0000141_21930">
+    <p xml:id="eco_de_0000211_21930">
      Der Peter spreizte die Flügel.
     </p>
-    <p xml:id="eco_de_0000141_21940">
+    <p xml:id="eco_de_0000211_21940">
      »Ja!« lachten die Kinder. »Dann darfst du wieder auf die Silberpappel zu der Amsel fliegen! Und das Schwesterlein darf auf der Seemauer spazieren! Zeig Mama einmal, wie du's kannst! Zeig!«
     </p>
-    <p xml:id="eco_de_0000141_21950">
+    <p xml:id="eco_de_0000211_21950">
      Aber das Schwesterlein hielt sich an Marianne fest, machte ein schelmisches Gesicht und schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000141_21960">
+    <p xml:id="eco_de_0000211_21960">
      »Es will erst wieder in der Seeweid laufen!« riefen die Geschwister.
     </p>
-    <p xml:id="eco_de_0000141_21970">
+    <p xml:id="eco_de_0000211_21970">
      »Ja«, sagte Mama. »Wir wollen es als gutes Zeichen nehmen, dass das Schwesterlein dort den ersten Schritt getan hat. Es soll diesen Sommer, und wenn Gott will, noch manches Jahr recht viele frohe Schritte machen in der Seeweid und ihr mit ihm!«
     </p>
    </div>

--- a/tei/Boehlau_Helene_Altweimarische_Liebesgeschichten_Das_ehrbussliche_Weiblein.xml
+++ b/tei/Boehlau_Helene_Altweimarische_Liebesgeschichten_Das_ehrbussliche_Weiblein.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000142" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000212" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000142_20">
+   <p xml:id="eco_de_0000212_20">
     Das ehrbußliche Weiblein
    </p>
   </front>
@@ -92,109 +92,109 @@
    <div type="group">
     <head>
     </head>
-    <p xml:id="eco_de_0000142_30">
+    <p xml:id="eco_de_0000212_30">
      Auf dem Horn bei Weimar, einer Anhöhe, von der aus man auf das grüne Ilmthal weit hinabblickt und auf das Städtchen, das von der grauen zweitürmigen Stadtkirche und dem grünkuppeligen Schloßturm und dem spitzen Hofkirchturm überragt wird, da wohnten Herr und Frau Egidi in einem alten Sommerhaus, das am Ende eines ansteigenden Gartens lag.
     </p>
-    <p xml:id="eco_de_0000142_40">
+    <p xml:id="eco_de_0000212_40">
      Das Häuschen stand gerade über Goethes Gartenhaus, und auch in Pogwischs Garten konnte man von dem Wohnzimmer aus blicken. Es hatte, wie Frau Friederikchen Egidi sagte: »wirklich eine recht kommode und amisante Lage. Kommod eigentlich nich gerade, weil mer doch weit von der Stadt wohnt, aber weil mer äben alles hat, was mer braucht, da macht sich's; Gemise un Obst, eine Zwetschgendarre sogar. Hihner un ene Ziege, äben alles – Bier hamm mer eingelegt un die gute Luft fir ›Lein-Oel‹, wegen der sin mer 'nausgezogen, die duht ihn so wohl, un der Spaziergang allemal 'nunter ins Hofamt – äben alles.«
     </p>
-    <p xml:id="eco_de_0000142_50">
+    <p xml:id="eco_de_0000212_50">
      So ähnlich antwortete Frau Egidi stets, wenn die Freunde in der Stadt ihr immer wiederholten: »Na aber, so weit draußen!«
     </p>
-    <p xml:id="eco_de_0000142_60">
+    <p xml:id="eco_de_0000212_60">
      Uebrigens »so weit draußen« war es eben nur für die bequemen Weimaraner.
     </p>
-    <p xml:id="eco_de_0000142_70">
+    <p xml:id="eco_de_0000212_70">
      Frau Egidi war ein ganz kleines, junges, bescheidenes Persönchen mit flachsgelben Haaren. die mit einem hohen Kamm fest und stramm oben auf dem Wirbel zu einem Knötchen zusammengesteckt waren. Ihr Kleid schien ganz besonders eng zu sein, und der schmale Longshawl und der Strickbeutel und die Kreuzbänderschuhe, alles war so bescheiden und hausfraulich, ganz musterhaft – und wie jedes Fältchen lag und die steifen Seitenlöckchen an den Schläfen, und die Schritte, wie sie das Horn hinabtrippelte – das war alles so gut weimarisch – so ein bißchen »ehrbußlich«, wie sie in Weimar sagen, und wie sie's in Weimar ganz gern bei einem jungen Frauchen sehen, denn so ein Frauchen, das kocht und backt und stopft und flickt und handelt und wandelt gut, und der Mann ist bei ihr wohl versorgt, und das ist die Hauptsache.
     </p>
-    <p xml:id="eco_de_0000142_80">
+    <p xml:id="eco_de_0000212_80">
      Und das hatte in diesem Falle auch seine Richtigkeit, Frau Friederikchen Egidis Mann, Lionel Egidi, war sehr gut aufgehoben. Was hatte er immer für gute Dinge gegessen und getrunken, wenn zufällig die Rede darauf kam, und sein Rock war tadellos und seine Wäsche blendend, und das alles bei einem winzigen Gehalte, bei dem man allerlei Unzureichendes leicht hätte entschuldigen können. Er war ein langer Mann mit einer großen, breiten Denkerstirn und großen Händen und Füßen und einer tiefen Stimme, und sah aus, als hätte er es weiter bringen können, als zu einem Sekretär am Hofamte. Dazu war es nur so eine Art Aushilfstelle, die nicht gerade auf festen Beinen stand.
     </p>
-    <p xml:id="eco_de_0000142_90">
+    <p xml:id="eco_de_0000212_90">
      Und zu seiner großen Person und seiner kleinen Stelle hieß er auch noch mit Vornamen Lionel, das war Frau Friederikchens Stolz, daß er so hieß – aber auch ihr Unglück; »Lionel« – das brachte mit aller Mühe und aller Hingebung ihre gut weimarische Zunge nie und nimmer fertig. »Lei-o-nehl, Lein-ehl« – dabei blieb's.
     </p>
-    <p xml:id="eco_de_0000142_100">
+    <p xml:id="eco_de_0000212_100">
      Und alle Mühe, die Lionel sich gab, der Zunge seines kleinen Weibes den stolzen Namen beizubringen, war fruchtlos – »Lein-Oel« oder »Lein-Ehl« höchstens mußte er sich rufen hören und hätte es nicht für möglich gehalten, seinen wunderschönen Namen auf diese Weise verlieren zu müssen. Nie hätte er eine Weimarerin geheiratet, wenn er gewußt hätte, daß die weimarischen Zungen so unbiegsam sind.
     </p>
-    <p xml:id="eco_de_0000142_110">
+    <p xml:id="eco_de_0000212_110">
      Und zu seinem größten Aerger hieß er nun »Lein-Oel«, wo er sich auch blicken ließ. Auch geschicktere Zungen, als die seines Weibchens, blieben bei »Lein-Oel«, weil die guten Weimaraner ihren Spaß daran hatten, daß ein Mensch gewissermaßen »Lein-Oel« getauft war. Da half ihm seine hochstrebende Natur nichts und seine Denkerstirn nichts; das alles vertrug sich mit »Lein-Oel« nicht. Man konnte ihn mit diesem Namen unmöglich ernst nehmen, meinte er. Mit dem Namen Lionel Egidi aber glaubte er, daß ihm die Welt offen gestanden hätte.
     </p>
-    <p xml:id="eco_de_0000142_120">
+    <p xml:id="eco_de_0000212_120">
      Die Umtaufe, die sein Weib mit ihm vorgenommen hatte, war verhängnisvoll geworden – auch für das brave Weibchen. Die ersten Mißstimmungen kamen dadurch, und es flossen Thränen. Sie hatte sich zwar geübt, »Lein-Oel« richtig auszusprechen, und wenn ihr auch hin und wieder ein Anklang geriet, so war das Unglück doch einmal angerichtet. »Lein-Oel« saß einmal den Weimaranern in den Ohren, sie hörten es gar nicht mehr anders, und Lein-Oels oben auf dem Horn mußten sich eben darein finden. – Sie hatten auch den schönen Namen Egidi verloren und hießen in aller Mund nun einfach Lein-Oels. So dumm war es Lionel Egidi mit seinem Namen ergangen. Als er aus Erfurt nach Weimar kam, da hatte er große Ideen im Kopfe, und die kleine Stelle am Hofamt betrachtete er damals nur als eine Art Absteigequartier, bis er Umschau gehalten. Er war auch Poet, und es konnte ihm kaum in Weimar fehlen. Mit einem wunderschönen himmelblauen Frack war er damals angekommen, und der stattliche Mann in diesem blauen Frack und mit dem stolzen Namen wurde auch durchaus nicht unbemerkt gelassen.
     </p>
-    <p xml:id="eco_de_0000142_130">
+    <p xml:id="eco_de_0000212_130">
      In Weimar sind von alters her die Weiber in Ueberzahl gewesen, und ein neuer Mann im Weichbild des Städtchens war jedesmal ein Ereignis, auch von alters her. Die weimarischen Weiber hoben einen reputierlichen männlichen Ankömmling, bildlich gesprochen, alsobald wie auf einem Schild empor, daß er allen Augen sichtbar war. Unbekannt konnte ein Mann im himmelblauen Frack und gar mit einem so schönen Namen gewiß nicht bleiben.
     </p>
-    <p xml:id="eco_de_0000142_140">
+    <p xml:id="eco_de_0000212_140">
      In den ersten Wochen war er auch schon der erhoffte Schwiegersohn von so und so viel Bürgerhäusern, und ehe ein paar Monate in das Land gingen, war er wirklich der Schwiegersohn eines sehr angesehenen und reputierlichen pensionierten Rentamtmanns geworden, der samt seiner Familie Weidgans hieß. So kam es, daß Friederikchen Weidgans die Ehehälfte des vielversprechenden Lionel Egidi wurde.
     </p>
-    <p xml:id="eco_de_0000142_150">
+    <p xml:id="eco_de_0000212_150">
      Zur Zeit unsrer Erzählung aber sind sie schon ein paar Jährchen verheiratet, der himmelblaue Frack ist abgelegt, Lein-Oel ist in einen kaffeebraunen gekrochen und aus dem blauen hat sich Friederikchen einen Spenzer gemacht. Die übergebliebenen Fleckchen verarbeitet sie zu blauen Kreuzbänderschuhen für sich, denn sie versteht alles, sie schustert wie ein gelernter Meister, und auch der Gatte trägt oben auf dem Horn blaue Pantoffel, die ihm sein Weib aus dem blauen Frack gemacht hat, der in Lappen und Läppchen zerschnitten ist, wie seine Hoffnungen und Pläne auch.
     </p>
-    <p xml:id="eco_de_0000142_160">
+    <p xml:id="eco_de_0000212_160">
      Er war sich in den ersten Jahren seiner Ehe vollkommen klar darüber, daß er einen rechten Hemmschuh angelegt hatte, als er die kleine Weidgans heiratete. Die Arme der Weimaranerinnen, die ihn auf dem Schild triumphierend hochgehalten, sanken wie mit einem Schlage gleichgültig herab, als er das Unrecht begangen, eine einzige von allen glücklich zu machen, und er stand in seinem blauen Frack und mit dem stolzen Namen und mit der kleinen Weidgans plötzlich da, als wäre er unsichtbar geworden. Niemand kümmerte sich um ihn.
     </p>
-    <p xml:id="eco_de_0000142_170">
+    <p xml:id="eco_de_0000212_170">
      Und von diesem Augenblicke an wollte ihm nichts mehr glücken. Er war nahe daran gewesen, daß Excellenz Goethe seine schriftstellerischen Erzeugnisse unterthänigst überreicht worden wären, aber die Hände, die sich zu diesem Liebeswerk erboten hatten, waren mit einemmal paralysiert, und die Köpfe, die dieses Anerbieten ihm gemacht hatten, waren schwachsinnig geworden und verstanden nichts mehr und erinnerten sich an nichts mehr.
     </p>
-    <p xml:id="eco_de_0000142_180">
+    <p xml:id="eco_de_0000212_180">
      Ganz natürlich, sie hatten das dem hoffnungsvollen, vielversprechenden Lionel Egidi zugedacht, dem jungen Mann im blauen Frack, dem die Welt offen stand, von dem sie erwarteten, daß er eine ihrer Töchter heimführen würde – aber dem Mann der kleinen Weidgans, dem »Lein-Oel«, brauchten sie nichts von alledem zu halten. Der war durch seine alberne Heirat in eine Sphäre geraten, in der er den Weimaranern nichts mehr nützen konnte, also von ihnen auch nichts mehr zu erwarten hatte.
     </p>
-    <p xml:id="eco_de_0000142_190">
+    <p xml:id="eco_de_0000212_190">
      All diese Erfahrungen hatten Lionel Egidis Wohlgefallen an seiner Weidgans nicht gerade gesteigert, besonders da er sich gar nicht mehr recht erinnern konnte, wie er selbst eigentlich auf die Idee gekommen war, die Kleine zu heiraten.
     </p>
-    <p xml:id="eco_de_0000142_200">
+    <p xml:id="eco_de_0000212_200">
      An eins erinnerte er sich noch ganz wohl. Auf einem Ball im Stadthaus hatte er sie zum erstenmal gesehen und auch mit ihr getanzt, und daß es ihm Spaß gemacht hatte, wie der blonde, frisierte Kopf der kleinen Weidgans sich auf seinem blauen Frack während des Tanzes gut ausgenommen – das wußte er noch ganz gut; auch daß er öfters, als erlaubt, mit ihr getanzt hatte, denn in seinen blauen Frack war er gewissermaßen verliebt gewesen, und wer und was zu diesem gut stand, das oder der oder die war ihm nicht unsympathisch. Von diesem Abend an aber war er wie in einen Wirbel von lauter Verwandten, Basen, Tanten und Onkeln, Großmüttern und Müttern der Weidgansschen Familie geraten. Weidganssche Abendessen, Weidganssche Nachmittagspartieen, Weidganssche Geburtstage mit solenner Feier waren sein Schicksal geworden – und das Ende all dieser Weidgansschen Feste war sein und Friederikchens Verlobungsfest gewesen, und zuallerletzt seine Hochzeit, die von der Weidgansschen Familie splendid ausgerichtet wurde.
     </p>
-    <p xml:id="eco_de_0000142_210">
+    <p xml:id="eco_de_0000212_210">
      So war er zu seinem Friederikchen gekommen, er wußte selbst nicht, wie – und daß er dieser Weidgans nun Opfer über Opfer bringen mußte, diesem kleinen Götzen, der ihm vom Schicksal aufgehalst worden war, das stimmte ihn nicht freundlich und nicht heiter, und er war dabei, ein wenig liebenswürdiger Ehegatte zu werden. Mürrisch ließ er sich alle Hingebung und Fürsorge der Kleinen gefallen, ließ sie springen und laufen, kochen und backen, früh aufstehen und spät zur Ruhe gehen, und ließ sich's schmecken, was sie kochte und buk, und kroch in lauter schön gewaschene und geflickte, blendende und duftende Wäsche und schlüpfte in Schuhe, die immer bereit standen, und hatte abends eine immer hell- und gleichbrennende Kerze, denn das war eine Extrageschicklichkeit der Kleinen, leise aufzustehen, ohne alle Auffälligkeit, so daß niemand es zu bemerken brauchte, und das Licht zu schneuzen, gerade im rechten Augenblicke. Nie brachte es ihre Kerze zu einem qualmigen Räuber, und in der Lichtputzschere brenzelte und roch es deshalb auch nicht, und die Kerze kam nicht zum Träufeln und war nicht zu kurz geschnitten. Vielleicht brannte in ganz Weimar keine Kerze, die es mit der Egidischen hätte aufnehmen können.
     </p>
-    <p xml:id="eco_de_0000142_220">
+    <p xml:id="eco_de_0000212_220">
      Als Lionel Egidi Junggeselle war, da hatte das kleine Einkommen, das ihm sein Absteigequartier von Stelle einbrachte, nicht hinten und nicht vorn gereicht, und jetzt hatte es den Anschein, als wäre er ohne sein Wissen avanciert. Sie hatten immer Geld; die Weidgans that, als wenn sie im Ueberflusse wirtschaftete, und er mußte sich selbst gestehen, sein Lebtag hatte er nicht so vortrefflich gegessen.
     </p>
-    <p xml:id="eco_de_0000142_230">
+    <p xml:id="eco_de_0000212_230">
      Sie hatte sich von ihrem Aussteuergeld, das viel schmäler ausgefallen war, als es erst den Anschein gehabt hatte, eine Ziege angeschafft, trotzdem ihr Gatte gesagt hatte, daß er nie einen Tropfen von der Milch dieses Tieres anrühren würde, da er vor Ziegenmilch einen Ekel habe.
     </p>
-    <p xml:id="eco_de_0000142_240">
+    <p xml:id="eco_de_0000212_240">
      Es war aber mit der Ziege alles so still vor sich gegangen, und er trank Ziegenmilch, ohne es zu ahnen.
     </p>
-    <p xml:id="eco_de_0000142_250">
+    <p xml:id="eco_de_0000212_250">
      Als endlich die Rede darauf kam, sagte das kleine Weibchen: »Siehste, Lein-Oel, das macht, weil se so renklich gehalten is, und es is auch die Art, von der die Milch nich bockelt.«
     </p>
-    <p xml:id="eco_de_0000142_260">
+    <p xml:id="eco_de_0000212_260">
      Ja, hätte sie den Mund nicht aufgethan, die kleine Weidgans!
     </p>
-    <p xml:id="eco_de_0000142_270">
+    <p xml:id="eco_de_0000212_270">
      Da war es wieder, das miserable »Lein-Oel« und der ganze weimarische Schwanz hinterher – reden konnte er sie eben gar nicht hören – es fiel ihm auf die Nerven.
     </p>
-    <p xml:id="eco_de_0000142_280">
+    <p xml:id="eco_de_0000212_280">
      »Na, übst du denn ordentlich, was du üben sollst?« fragte er sie barsch.
     </p>
-    <p xml:id="eco_de_0000142_290">
+    <p xml:id="eco_de_0000212_290">
      »Ja, beim Melken heute un iberhaupt immer, wenn ich dran denke. Das letzte war: ›Hewe, läwe, schwäwe!‹« sagte sie trocken und schulmäßig, wie sie sonst wohl zu ihrem Herrn Lehrer gesprochen haben mochte.
     </p>
-    <p xml:id="eco_de_0000142_300">
+    <p xml:id="eco_de_0000212_300">
      »Wie sagst du?« fragte er und korrigierte sogleich: »›Hebe, lebe, schwebe.‹ – Du sagst ewig, daß du geübt hast; aber es fällt dir gar nicht ein.«
     </p>
-    <p xml:id="eco_de_0000142_310">
+    <p xml:id="eco_de_0000212_310">
      »Jawohl,« antwortete sie schluchzend. »Hewe – läwe – schwäwe!«
     </p>
-    <p xml:id="eco_de_0000142_320">
+    <p xml:id="eco_de_0000212_320">
      Und sie schluchzte so heftig und bitterlich und legte ihren Kopf, wie schutz- und stützesuchend, an einen alten Pflaumenbaum und setzte ihre gefüllte Gießkanne nieder, und das war das erste Mal, daß sie so ganz hilflos vor ihm weinte.
     </p>
-    <p xml:id="eco_de_0000142_330">
+    <p xml:id="eco_de_0000212_330">
      Und bei dem großen Respekt, den sie vor ihm hatte, that sie es in wahrer Todesangst. »Sei nur nich bes,« – schluchzte sie –»ich weine gar nich – ne, wirklich nich – es weint äben so von sälwer.« –
     </p>
-    <p xml:id="eco_de_0000142_340">
+    <p xml:id="eco_de_0000212_340">
      Und wie er sie gebrochen und ganz in Thränen aufgelöst vor sich stehen sah, so unglückselig und bescheiden und so winzig, – da rührte sich etwas in seinem Herzen, er griff nach ihr, sie fuhr zusammen wie ein Hündchen, das geschlagen werden soll – und da schämte er sich, daß sie so etwas von ihm denken könne, und er erkannte, wie unfreundlich er immer gegen sie gewesen war, und sie so gut und unterthänig.
     </p>
-    <p xml:id="eco_de_0000142_350">
+    <p xml:id="eco_de_0000212_350">
      »Mein gutes Weib!« sagte er und zog sie zu sich heran.
     </p>
-    <p xml:id="eco_de_0000142_360">
+    <p xml:id="eco_de_0000212_360">
      »Ach du mein Gott!« schluchzte sie und lag mit dem Kopf nicht mehr am Pflaumenbaum, sondern an der Brust ihres Gatten.
     </p>
-    <p xml:id="eco_de_0000142_370">
+    <p xml:id="eco_de_0000212_370">
      »Ach Lein-Oel!« – Aber kaum war das Wort heraus, da schreckte sie bis ins innerste Herz zusammen, machte sich aus seinen Armen los, griff zu ihrer Gießkanne und trippelte eilig ab.
     </p>
    </div>
@@ -202,70 +202,70 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_380">
+    <p xml:id="eco_de_0000212_380">
      Als sie aber am Abend dieses selben Tages sich zur Ruhe begaben, er, der große Lein-Oel, und das winzige, ängstliche Püppchen, das er für alle ihre Hingebung immer so rauh und gleichgültig behandelt hatte – da kam es ihm in den Sinn, einen Spaß zu machen, und er sagte großmütig: »Na, ›hewe, läwe, schwäwe‹ – gute Nacht!«
     </p>
-    <p xml:id="eco_de_0000142_390">
+    <p xml:id="eco_de_0000212_390">
      »Gute Nacht, ›hebe, läbe, schwäbe!‹ sagte sie so gut sie konnte – und sagte es ganz freundlich und anmutig.
     </p>
-    <p xml:id="eco_de_0000142_400">
+    <p xml:id="eco_de_0000212_400">
      Und Lein-Oel dachte: Sie versteht also einen Scherz, die kleine Weidgans.
     </p>
-    <p xml:id="eco_de_0000142_410">
+    <p xml:id="eco_de_0000212_410">
      Das hätte er gar nicht von ihr geglaubt. Sie war ihm immer wie ein Opferlamm vorgekommen, und das hatte ihn gelangweilt – und mehr als gelangweilt, es war ihm peinlich gewesen.
     </p>
-    <p xml:id="eco_de_0000142_420">
+    <p xml:id="eco_de_0000212_420">
      Von nun an sagten sie sich jeden Abend dasselbe.
     </p>
-    <p xml:id="eco_de_0000142_430">
+    <p xml:id="eco_de_0000212_430">
      »Gute Nacht, ›hewe, läwe, schwäwe!‹ er, und sie: »Gute Nacht, ›hebe, lebe, schwebe!‹« – ganz richtig und wohleingeübt.
     </p>
-    <p xml:id="eco_de_0000142_440">
+    <p xml:id="eco_de_0000212_440">
      Und er ertappte sich einmal bei dem Gefühl, daß er sich auf den Gutenachtgruß der kleinen Weidgans freute.
     </p>
-    <p xml:id="eco_de_0000142_450">
+    <p xml:id="eco_de_0000212_450">
      Sie war wirklich unterthänig wie ein Hündchen und immer unsäglich ehrbußlich und bescheiden und still wie ein Mäuschen. Wenn er abends über seiner Arbeit brütete – er schriftstellerte immer noch in seinen Freistunden – da saß sie ihm gegenüber und wagte kaum zu atmen, und wenn sie einmal aufstehen mußte, schlich sie wie im Zimmer eines Todkranken umher.
     </p>
-    <p xml:id="eco_de_0000142_460">
+    <p xml:id="eco_de_0000212_460">
      »Ist nicht nötig, Friederikchen so leise zu sein. Was ich da treibe, bekommt ja doch nie im Leben eine Menschenseele zu sehen –« sagte er mißmutig und stützte den Kopf auf und schaute vor sich hin, griesgrämig und freudlos.
     </p>
-    <p xml:id="eco_de_0000142_470">
+    <p xml:id="eco_de_0000212_470">
      Da fühlte er das Händchen seiner Frau auf der Schulter, und sie sagte ganz schüchtern: »Ach nee, das mußt de nich denken, so ein Mensch wie du, der wird schon seinen Lohn bekommen. – Bei all denen hier in Weimar is es sicher auch nich so gleich auf einen Schlag gegangen. – Mach nur weiter!«
     </p>
-    <p xml:id="eco_de_0000142_480">
+    <p xml:id="eco_de_0000212_480">
      Wie freundlich sagte es das gute Geschöpf!
     </p>
-    <p xml:id="eco_de_0000142_490">
+    <p xml:id="eco_de_0000212_490">
      Sie hielt also etwas von ihm.
     </p>
-    <p xml:id="eco_de_0000142_500">
+    <p xml:id="eco_de_0000212_500">
      Das that Lein-Oel wohl.
     </p>
-    <p xml:id="eco_de_0000142_510">
+    <p xml:id="eco_de_0000212_510">
      Ja, sie war doch nicht so dumm, wie es den Anschein hatte, und er wollte sich mehr mit ihr abgeben.
     </p>
-    <p xml:id="eco_de_0000142_520">
+    <p xml:id="eco_de_0000212_520">
      Zumeist waren sie ja auch allein miteinander. Hinunter in die Stadt zu ihren Bekannten und Verwandten kamen sie eben nicht oft.
     </p>
-    <p xml:id="eco_de_0000142_530">
+    <p xml:id="eco_de_0000212_530">
      Er nahm sich vor, jeden Abend etwas Domino mit ihr zu spielen.
     </p>
-    <p xml:id="eco_de_0000142_540">
+    <p xml:id="eco_de_0000212_540">
      Das geschah nun bald ganz regelmäßig. Sie machte ihre Sache gut, wie alles, was sie anfaßte, pflichttreu und aufmerksam.
     </p>
-    <p xml:id="eco_de_0000142_550">
+    <p xml:id="eco_de_0000212_550">
      »Weißt du,« sagte sie einmal, »zu Haus ham mer immer gespielt, wie's 'nausgeht!«
     </p>
-    <p xml:id="eco_de_0000142_560">
+    <p xml:id="eco_de_0000212_560">
      »Wie denn?«
     </p>
-    <p xml:id="eco_de_0000142_570">
+    <p xml:id="eco_de_0000212_570">
      »Wenn's zum Beispiel du gewinnst, da kriegt August von Goethe die Schopenhauern oder irgend eine, oder wenn's 'nausgeht, daß ich gewinne, da kriegt er die Pogwischen – und dann wieder geht's darauf 'naus, ob die Frau Rat Tiburtsius ein neues Kleid bekommen hat, oder ob die Muskulus ihre Perücke verlieren wird. – Oder wenn eine heirat't – oder ob eine noch ein Kind kriegt – eben solche Sachen. Siehste, wir kennten fragen, ob's 'nausgeht, daß du dem Geheimrat Goethe deine Schreiberei doch noch eimal vorliest – und ob's ihm gefallen dhut – und was for 'ne Stelle er dir verschafft – und ob du bald auf'n Hofamt kommst. Siehste, so!«
     </p>
-    <p xml:id="eco_de_0000142_580">
+    <p xml:id="eco_de_0000212_580">
      Und ohne viel Worte darüber zu machen, wurde der Vorschlag angenommen, und oben auf dem Horn arbeiteten zwei, wenn sie abends bei einander saßen, an ihrem eigenen Schicksal und an dem Schicksal der übrigen Weimaraner, und bauten Luftschlösser über Luftschlösser und erhitzten sich über alles Mögliche, was keineswegs in ihrer Macht lag, und die Kleine war so eifrig dabei, und Lein-Oel vergaß seine Würde und spielte mit seinem Frauchen, als ging es um Tod und Leben.
     </p>
-    <p xml:id="eco_de_0000142_590">
+    <p xml:id="eco_de_0000212_590">
      Manchmal kam es ihm in den Sinn, daß es eine sehr alberne Sache sei, mit der er sich da abgebe, und er unterbrach das Spiel plötzlich und ging im Zimmer auf und nieder. Er hatte aber die Entschuldigung, daß er es zur Unterhaltung seiner kleinen Weidgans thue, daß es gewissermaßen seine Pflicht sei.
     </p>
    </div>
@@ -273,70 +273,70 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_600">
+    <p xml:id="eco_de_0000212_600">
      Als Weihnachten wieder einmal ins Land kam, waren sie schon fast drei Jahre verheiratet, und als sein Weib sich das Kapuzchen über den Kopf zog, um mit ihm hinunter zu den Eltern zu gehen und dort den Weihnachtsabend zu feiern, und sie die schmale Treppe miteinander hinabstiegen, da lag mit einemmal seine kleine Weidgans schluchzend ihm an der Brust.
     </p>
-    <p xml:id="eco_de_0000142_610">
+    <p xml:id="eco_de_0000212_610">
      »Na, was ist denn, was fehlt dir denn?« fragte er sehr erstaunt. Er konnte lange fragen, und immer heißer wurde das Schluchzen, aber eine Antwort bekam er nicht. –
     </p>
-    <p xml:id="eco_de_0000142_620">
+    <p xml:id="eco_de_0000212_620">
      »Na also, was denn?« fragte er barsch, um der Sache ein Ende zu machen.
     </p>
-    <p xml:id="eco_de_0000142_630">
+    <p xml:id="eco_de_0000212_630">
      »Ein Kindchen!« – sagte sie. – »Ach siehste, ein Kindchen, wenn wir ein Kindchen hätten!«
     </p>
-    <p xml:id="eco_de_0000142_640">
+    <p xml:id="eco_de_0000212_640">
      Das klang zitternd unter den heißen Thränen hervor.
     </p>
-    <p xml:id="eco_de_0000142_650">
+    <p xml:id="eco_de_0000212_650">
      Nun sehnt sie sich wieder nach einem Kinde – mein Gott, diese ewigen Geschichten, dachte Lein-Oel und meinte, daß es besser sei, keins zu haben. Er war so vortrefflich versorgt, konnte sich es gar nicht besser wünschen, hatte, weiß Gott, genug Not mit seiner Frau gehabt, daß er es ohne Kinder nun sehr wohl mit ansehen konnte.
     </p>
-    <p xml:id="eco_de_0000142_660">
+    <p xml:id="eco_de_0000212_660">
      Deshalb war auch seine Entgegnung auf ihre Thränen kühl.
     </p>
-    <p xml:id="eco_de_0000142_670">
+    <p xml:id="eco_de_0000212_670">
      »Du lieber Gott, es gibt genug Kinder auf der Welt,« sagte er ihr. »Du hast für deinen Mann zu sorgen, das ist auch etwas – und schließlich kriegen wir Kinder, mehr als wir wollen. Laß gut sein.«
     </p>
-    <p xml:id="eco_de_0000142_680">
+    <p xml:id="eco_de_0000212_680">
      So ging sie still neben ihm her, und die Thränen liefen ihr über die Wangen, und der Atem zitterte dem kleinen, einsamen Weibe. Als sie aber der Stadt näher kamen, dachte sie: »Herr Jes, sie werden doch nich sehen. daß ich geweint habe!« und nun hauchte sie eifrig auf ihr Taschentuch, übertupfte sich die Augen und machte sich mit ihren Seitenlöckchen zu thun, und hörte aufmerksam, wie ihr Lein-Oel sagte, daß sie Rat Tiburtsiusens auf die Feiertage zu sich bitten müßten, und was man ihnen vorsetzen könnte.
     </p>
-    <p xml:id="eco_de_0000142_690">
+    <p xml:id="eco_de_0000212_690">
      Lein-Oel sah sein kleines Weib nun lange nicht mehr wieder weinen – und er hütete sich wohl, sie an jenen Abend zu erinnern. Er wollte eine ruhige, vernünftige Frau, aber durchaus nicht eine, die ihm Scenen machte, das fehlte noch.
     </p>
-    <p xml:id="eco_de_0000142_700">
+    <p xml:id="eco_de_0000212_700">
      Aber beim Domino entfuhr es ihm einmal, und er sagte, um ihr einen Gefallen zu thun: »Na, und wenn wir ein Kind hätten, wie würden wir denn das nennen?«
     </p>
-    <p xml:id="eco_de_0000142_710">
+    <p xml:id="eco_de_0000212_710">
      Da sagte sie, weil sie es längst und ganz genau wußte: »Lieschen« – und die Thränen traten ihr wieder in die Augen, gerade als wären sie von jenem Abend an noch darin – und das waren sie wohl auch.
     </p>
-    <p xml:id="eco_de_0000142_720">
+    <p xml:id="eco_de_0000212_720">
      »Ei du mein Gott,« sagte er.
     </p>
-    <p xml:id="eco_de_0000142_730">
+    <p xml:id="eco_de_0000212_730">
      »Sei nich bes, Leinel,« bat sie;»siehste –«
     </p>
-    <p xml:id="eco_de_0000142_740">
+    <p xml:id="eco_de_0000212_740">
      Weiter konnte sie nicht sprechen, sondern ging zur Thüre hinaus, wie eine Katze so leise. Und als sie wieder hereinkam, da brachte sie Lein-Oels dampfenden Schlummerpunsch auf einem Teller getragen – und Lein-Oel drohte ihr mit dem Finger, da ging ein Zittern durch den Arm, der den Teller hielt. Diesmal aber bemerkte das Lein-Oel nicht.
     </p>
-    <p xml:id="eco_de_0000142_750">
+    <p xml:id="eco_de_0000212_750">
      Mein Gott, so ein Frauenzimmer bringt eben tausenderlei Aerger und Unannehmlichkeiten mit sich, dachte er oftmals, wenn das Dasein seines Weibchens ihn in irgend einer Weise daran erinnerte, daß eine fremde Persönlichkeit neben ihm ihr eigenes Leben hatte. Sie war eigentlich nur bequem, wenn sie ganz in ihm aufging, nur für ihn da war, sich selbst völlig vergaß, da ging es an; sowie sie aber sich mit der eigenen kleinen Person abgab, erschien es Lein-Oel, als lärmte sie doppelt und dreifach. Frühmorgens, wenn er noch schlief und sie sich an ihrem Spiegelchen mit aller Sorgfalt ihr Haar machte und dabei höchst accurat und ernstlich zu Werke ging, das erschien ihm unerträglich – und gar am Abend, wenn die Frisur aufgemacht wurde und die Kämmerei von neuem losging, verlor er alle Geduld.
     </p>
-    <p xml:id="eco_de_0000142_760">
+    <p xml:id="eco_de_0000212_760">
      »Herrgott noch einmal!« brummte er oftmals, halb verschlafen, »hat denn die abscheuliche Kämmerei kein Ende!« – oder: »Jeses, jetzt halt aber Ruh!« – oder: »Heute wird's wohl ewig dauern!« oder: »Willst du mich denn zur Verzweiflung bringen – du?«
     </p>
-    <p xml:id="eco_de_0000142_770">
+    <p xml:id="eco_de_0000212_770">
      Sie hatte von ihrem hübschen, blonden Haar tausend Aerger und Aengste.
     </p>
-    <p xml:id="eco_de_0000142_780">
+    <p xml:id="eco_de_0000212_780">
      Das Spiegelchen hing nun einmal im Schlafzimmer und gehörte ins Schlafzimmer.
     </p>
-    <p xml:id="eco_de_0000142_790">
+    <p xml:id="eco_de_0000212_790">
      Die Haare im Wohnzimmer zu kämmen oder wohl am Ende in der Küche, das wäre ihr der Inbegriff von Unreinlichkeit und wüster Wirtschaft gewesen.
     </p>
-    <p xml:id="eco_de_0000142_800">
+    <p xml:id="eco_de_0000212_800">
      Eines schönen Morgens hatte ihr Lein-Oel wieder gehörig gebrummt, und sie hatte gesagt: »Weißte, da schneid' ich sie mer äben einfach weck!«
     </p>
-    <p xml:id="eco_de_0000142_810">
+    <p xml:id="eco_de_0000212_810">
      »Meinetwegen, hatte er verschlafen aus dem großen Bett herausgegrunzt.
     </p>
    </div>
@@ -344,94 +344,94 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_820">
+    <p xml:id="eco_de_0000212_820">
      Als an diesem Tage Lein-Oel heimkam, trug ihm ein Kahlköpfchen, ein ganz kurzgeschorenes Geschöpf, die Suppe auf den Tisch.
     </p>
-    <p xml:id="eco_de_0000142_830">
+    <p xml:id="eco_de_0000212_830">
      Das war, als wenn der Blitz eingeschlagen hätte –»Herrgott in deine Hände! – der Kopf! – der Kopf! – der Kopf!« schrie Lionel Egidi auf. »Bist du verrückt!« Und er fuhr sich mit beiden Händen nach dem eigenen Kopf. Er stand wie erstarrt. »Pfui – pfui – pfui!« schrie er wieder außer sich, »was hast du denn gethan?«
     </p>
-    <p xml:id="eco_de_0000142_840">
+    <p xml:id="eco_de_0000212_840">
      »Aber ich hab dich doch gefragt,« antwortete sie ganz verängstigt, »du hast doch ›meinetwegen‹ gesagt.«
     </p>
-    <p xml:id="eco_de_0000142_850">
+    <p xml:id="eco_de_0000212_850">
      »Wahnsinn!«
     </p>
-    <p xml:id="eco_de_0000142_860">
+    <p xml:id="eco_de_0000212_860">
      »Nein, du hast's doch gesagt.«
     </p>
-    <p xml:id="eco_de_0000142_870">
+    <p xml:id="eco_de_0000212_870">
      »Bewahre!« donnerte er sie an.
     </p>
-    <p xml:id="eco_de_0000142_880">
+    <p xml:id="eco_de_0000212_880">
      »Heut morgen doch, als ich dich frug.«
     </p>
-    <p xml:id="eco_de_0000142_890">
+    <p xml:id="eco_de_0000212_890">
      »Ja, wie konnte ich denn denken, daß du so ein Narr wärst, so ein alberner! Geh – geh – mach fort – ich kann dich nicht ansehen! – Auch das noch! Das fehlte noch gerade!«
     </p>
-    <p xml:id="eco_de_0000142_900">
+    <p xml:id="eco_de_0000212_900">
      Er deckte die Augen mit beiden Händen zu, um sie nicht ansehen zu müssen, aß nicht und war ganz außer sich. Sie hingegen löffelte bedrückt und unterthänig ihre Suppe. Sie war so daran gewöhnt, gescholten zu werden, daß es sich bei ihr ganz gut mit einer Nebenbeschäftigung vertrug.
     </p>
-    <p xml:id="eco_de_0000142_910">
+    <p xml:id="eco_de_0000212_910">
      Sie hatte gemeint, er würde es gar nicht bemerken, daß sie geschoren war – vielleicht erst am Abend, wenn die Kämmerei ausfiel.
     </p>
-    <p xml:id="eco_de_0000142_920">
+    <p xml:id="eco_de_0000212_920">
      Ihr hatte es leid gethan, sich das Haar abzuschneiden, aber das Zanken wegen ihres Frisierens und die Angst immer, das hatte sie nicht mehr gewollt – und wenn es ihm so widerwärtig war, weshalb sollte sie denn ihr Haar behalten, für wen denn und weshalb denn? – Es war nun einmal alles, wie es war. Und sie hatte so allerlei dumpf und bang gefühlt, als wenn es mit ihr aus wäre, ganz aus – das bißchen Kochen und Flicken und Säubern, dazu brauchte sie ihr Haar nicht – das ging auch so.
     </p>
-    <p xml:id="eco_de_0000142_930">
+    <p xml:id="eco_de_0000212_930">
      Und er hatte ja doch »meinetwegen« gesagt, als sie fragte, ganz so, wie sie es sich gedacht hatte.
     </p>
-    <p xml:id="eco_de_0000142_940">
+    <p xml:id="eco_de_0000212_940">
      Und nun – was war denn nun? – Jetzt saß er da und aß nicht und behandelte seine Frau wie eine Verbrecherin.
     </p>
-    <p xml:id="eco_de_0000142_950">
+    <p xml:id="eco_de_0000212_950">
      »Glaubst du denn,« donnerte er wieder los, »daß ich dich so geheiratet hätte – so – Doch eine Frau will man wenigstens haben – keinen Hanswurscht. – Kein solches entre-deux – Pfui – pfui – pfui! – geh mir aus den Augen! – Weshalb glaubst du denn, daß ich dich überhaupt geheiratet habe?« fragte er wütend und machte so ein Gesicht, als wollte er auf diese Frage eine Antwort von ihr haben.
     </p>
-    <p xml:id="eco_de_0000142_960">
+    <p xml:id="eco_de_0000212_960">
      »Das weiß ich nicht,« sagte sie ganz verängstigt und sah ihn mit großen Augen an und hielt den gefüllten Löffel zwischen Teller und Lippen.
     </p>
-    <p xml:id="eco_de_0000142_970">
+    <p xml:id="eco_de_0000212_970">
      »Ohne deine Haare ganz gewiß nicht – daß du es weißt, du dumme Gans!«
     </p>
-    <p xml:id="eco_de_0000142_980">
+    <p xml:id="eco_de_0000212_980">
      »Du hast mir aber doch nie gesagt, daß du die Haare gern hattest,« sagte sie kleinlaut.
     </p>
-    <p xml:id="eco_de_0000142_990">
+    <p xml:id="eco_de_0000212_990">
      »Weil das selbstverständlich ist – die Sachen liebt man doch!« rief er ganz desperat.
     </p>
-    <p xml:id="eco_de_0000142_1000">
+    <p xml:id="eco_de_0000212_1000">
      »So,« sagte sie und sah ihn verwundert mit ihren armen Augen an.
     </p>
-    <p xml:id="eco_de_0000142_1010">
+    <p xml:id="eco_de_0000212_1010">
      Er konnte keinen Bissen von allen guten Dingen, die weiter kamen, anrühren, und immer von neuem brach der Aerger bei ihm los.
     </p>
-    <p xml:id="eco_de_0000142_1020">
+    <p xml:id="eco_de_0000212_1020">
      »Dir laufen nun die Gassenjungen nach – du – du –! Und von mir werden die Leute sagen, daß ich vollends verrückt bin, daß ich dir, Gott weiß weshalb, die Haare heruntergeschnitten habe – denn daß ein Weib das selbst gethan, werden sie nun und nimmermehr glauben.«
     </p>
-    <p xml:id="eco_de_0000142_1030">
+    <p xml:id="eco_de_0000212_1030">
      So ging es fort. Er war unermüdlich – und es mochte ihm schon nahegegangen sein.
     </p>
-    <p xml:id="eco_de_0000142_1040">
+    <p xml:id="eco_de_0000212_1040">
      »Siehste du,« sagte er, »wenn du dein Haar so um die Stirn hattest – so lose – wenn du in deinen Kissen lagst, da sahst du wie eine ›Lapine‹, wie eine Karnickelin aus – und da gefielst du mir immer so.« Und wie er das sagte, wurde er ganz weich.
     </p>
-    <p xml:id="eco_de_0000142_1050">
+    <p xml:id="eco_de_0000212_1050">
      Sein kleines Weib wußte gar nicht, was sie von ihm halten sollte, sie war so erstaunt, wie noch nie bevor.
     </p>
-    <p xml:id="eco_de_0000142_1060">
+    <p xml:id="eco_de_0000212_1060">
      »Hättest du mir nur gesagt, daß du die Haare magst, da hätte ich sie aber gewiß nich runter gemacht. Siehste, mir hat's auch leid gethan,« – und nun war die Reihe des Thränenvergießens an ihr; aber sie weinte aus den verschiedensten Gründen. Es kam ihr alles so unverständlich vor – und ihr Mann that ihr so leid. Es war nicht, wie es sein sollte mit ihm, das fühlte sie sehr wohl. Er steckte zu viel oben auf dem Horn, es war ihr ganz, als hätte man ihn unten in Weimar vergessen, und vor seiner Heirat war er doch Hans in allen Gassen gewesen. Mit der Anstellung, die doch schon einmal so gut wie gewiß war, verlautete auch gar nichts. Und seine Schreiberei, damit fleckte es auch nicht – und was er fertig hatte, das brachte er nicht an – that auch nichts damit, schloß die Sachen in sein Schreibpultchen, und damit war's gut.
     </p>
-    <p xml:id="eco_de_0000142_1070">
+    <p xml:id="eco_de_0000212_1070">
      Und das mit dem »Lein-Oel« war ihr auch ganz schrecklich – und gar, daß sie es aufgebracht hatte.
     </p>
-    <p xml:id="eco_de_0000142_1080">
+    <p xml:id="eco_de_0000212_1080">
      Ihr Mann hatte es ihr ja gesagt, von da an, mit dem »Lein-Oel« war sein böser Stern aufgegangen.
     </p>
-    <p xml:id="eco_de_0000142_1090">
+    <p xml:id="eco_de_0000212_1090">
      Sie wußte es, daß sie in Weimar fast vergessen hatten, daß auf dem Horn nicht »Lein-Oels«, sondern Egidis wohnten. Und ihr selbst war es oft so traurig zu Mute – als wäre alles aus, als hätte überhaupt noch nie etwas für sie angefangen.
     </p>
-    <p xml:id="eco_de_0000142_1100">
+    <p xml:id="eco_de_0000212_1100">
      Das und noch manches war wohl Grund genug, um ordentlich ins Weinen zu kommen. So steckten die beiden recht trübselig oben in ihrem Sommerhaus.
     </p>
-    <p xml:id="eco_de_0000142_1110">
+    <p xml:id="eco_de_0000212_1110">
      Es fehlte ihnen an einem frischen Wind, der die Lebensgeister angefacht hätte. Bei ihnen glomm und qualmte es dumpf hin und konnte nicht ins Brennen kommen. Und so ging es weiter, der frische Wind blieb aus. Es kam keine Klarheit, und sie waren dabei, in ihrer Dumpfheit zu ersticken, wie schon tausend und aber tausend Ehepärchen.
     </p>
    </div>
@@ -439,97 +439,97 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_1120">
+    <p xml:id="eco_de_0000212_1120">
      Das Haar der kleinen Weidgans hatte sich wieder ans Wachsen gemacht und wunderlicherweise die Idee gefaßt, sich diesmal zu kräuseln. Es stand ihr wie ein Heiligenschein, wenn sie in die Sonne trat, ums Köpfchen. Und durch dieses merkwürdige Naturspiel kam es Lein-Oels Schwiegermutter ins Gedächtnis, daß Friederikchen als kleines Mädchen auch Ringellöckchen gehabt hatte, die aber ihre Mutter, die einen Zottelkopf nicht liebte, ihr sozusagen totgebürstet, totgekämmt und geklebt hatte. Und jetzt sollte diese Operation auch wieder vorgenommen werden – aber Lein-Oel erklärte rundweg: »Die Löckchen, die bleiben.« Und sie blieben, so wenig sie auch zu seiner ehrbußlichen Hausfrau zu passen schienen.
     </p>
-    <p xml:id="eco_de_0000142_1130">
+    <p xml:id="eco_de_0000212_1130">
      Zu dieser Zeit ungefähr war Lein-Oel mit einem Schauspieler bekannt geworden, mit dem er sich hin und wider unten im Elefanten traf und den er abends auch einmal und dann öfter mit hinauf aufs Horn brachte.
     </p>
-    <p xml:id="eco_de_0000142_1140">
+    <p xml:id="eco_de_0000212_1140">
      Friederikchen war dieser Verkehr sehr recht, denn es schien ihr, als lebte ihr Mann ordentlich auf, wenn er daheim Gesellschaft hatte. Der Schauspieler war ein lebhafter Mensch, kannte alle Welt, wußte tausenderlei zu erzählen, war immer obenauf, und der kleinen Weidgans machte es den größten Spaß, den beiden Männern zuzuhören, wenn sie beim Abendessen miteinander plauderten.
     </p>
-    <p xml:id="eco_de_0000142_1150">
+    <p xml:id="eco_de_0000212_1150">
      So lustig wie an diesen Abenden ist noch nie, solange Egidis oben wohnten, im Sommerhaus gelacht worden.
     </p>
-    <p xml:id="eco_de_0000142_1160">
+    <p xml:id="eco_de_0000212_1160">
      Der Gast war erst sei kurzem in Weimar, aber gut gelitten. Frau von Goethe schreibt von ihm zur Zeit, als sie schon Frau von Goethe und nicht mehr Mamselle Vulpius war: »Der ›Liebing‹ spillt heit awend.«
     </p>
-    <p xml:id="eco_de_0000142_1170">
+    <p xml:id="eco_de_0000212_1170">
      Einen Liebing gab es aber niemals in Weimar, Frau von Goethes »Liebing« hat sich ganz anders geschrieben; aber weil sie ihn so genannt hat, wollen wir bei Liebing bleiben, da man mit Namennennung vorsichtig sein muß und ich mir dies gleich anfangs vorgenommen habe. Liebing war ein beweglicher Mensch mit seinen Gliedern, einem schmalen Kopf, nah aneinander stehenden dunkeln Augen, großem, gescheitem Mund. Er hatte von allem, was einen Schauspieler interessant macht, eine ganz hübsche Portion, war auch, so viel davon nötig sein mag, blasiert, verstand zu prahlen, außerordentlich vornehm und angenehm zu affektieren, war enfant terrible und enfang gâté aller Welt, verstand es auch, sich auf den Stühlen zu räkeln, die Frauen zu ignorieren auf eine Weise, die ihn doppelt interessant erscheinen ließ, und wenn es ihm paßte, dann war er wie ein Narr hinter irgend einem weiblichen Wesen her, rutschte auf den Knieen vor ihm, hörte und sah nichts weiter als eben das eine Frauenzimmer, und that alles, wie die Laune es ihm eingab.
     </p>
-    <p xml:id="eco_de_0000142_1180">
+    <p xml:id="eco_de_0000212_1180">
      Man erzählte sich, daß er eine junge Dame aus den höchsten Kreisen in Weimar, nach einer Gesellschaft bei Excellenz Goethe, vor aller Augen, wie ein Verzückter, die Treppen hinabgetragen habe, und daß er dann die Kniee vor ihr gebeugt und sie angebetet habe mit erhobenen Händen. Es war eben seine Art, sich so anzustellen, und er that, was er that, ohne sich um jemand zu kümmern, immer, als wäre er ganz allein da, und das imponierte den Leuten, und ganz besonders den Weibern.
     </p>
-    <p xml:id="eco_de_0000142_1190">
+    <p xml:id="eco_de_0000212_1190">
      Die Backfische schnitten seinen Namen aus den Theaterzetteln und legten ihn sich aufs Butterbrot, verzehrten ihn so und waren dadurch beseligt und gleichsam mit dem Herrlichen verbunden.
     </p>
-    <p xml:id="eco_de_0000142_1200">
+    <p xml:id="eco_de_0000212_1200">
      Die heutigen weimarischen Backfische haben diese schöne Sitte beibehalten. Es ist gewissermaßen ihr Privilegium geworden, geliebte Namen aus dem Zettel zu schneiden und auf dem Butterbrot zu verspeisen. Aber damals mit Liebing begann es, damals war es originell, der unmittelbare Ausdruck gewaltigen Empfindens.
     </p>
-    <p xml:id="eco_de_0000142_1210">
+    <p xml:id="eco_de_0000212_1210">
      Es ist auch möglich, daß es in Frau von Goethes Brief »Liebling« statt »Liebing« heißen sollte – Gott weiß, was die Weiber in der sentimentalen Zeit, Anfang unsres Jahrhunderts, ihrem Abgott für Liebesbezeichnungen gaben.
     </p>
-    <p xml:id="eco_de_0000142_1220">
+    <p xml:id="eco_de_0000212_1220">
      Also Liebing erging es in Weimar vortrefflich und er war obenauf, wie nur ein Mensch obenauf sein kann.
     </p>
-    <p xml:id="eco_de_0000142_1230">
+    <p xml:id="eco_de_0000212_1230">
      Er war so glücklich, wirklich eine Ausnahmsstellung in der Gesellschaft einzunehmen und thun zu können, was ihm behagte.
     </p>
-    <p xml:id="eco_de_0000142_1240">
+    <p xml:id="eco_de_0000212_1240">
      »Kleinigkeit, Ihre Sachen Excellenz zu übergeben,« versicherte er Lionel einmal übers andre und bat ihn dann, etwas davon vorzulesen – denn die Katze im Sack nehmen, das wollte er nicht.
     </p>
-    <p xml:id="eco_de_0000142_1250">
+    <p xml:id="eco_de_0000212_1250">
      So war Liebing aufs Horn gekommen; und es behagte ihm dort. Wie ein junger Gott kam er sich da oben vor. Er hatte das Gefühl, in das alte Sommerhaus Glück und Segen zu bringen.
     </p>
-    <p xml:id="eco_de_0000142_1260">
+    <p xml:id="eco_de_0000212_1260">
      Lein-Oel las ihm mit der Erregung, die ein unbeachteter Mensch fühlt, der endlich einmal hervortritt, einiges aus seinen Arbeiten vor, und es war ihm, als geschähe damit etwas Entscheidendes.
     </p>
-    <p xml:id="eco_de_0000142_1270">
+    <p xml:id="eco_de_0000212_1270">
      Und Liebing lobte, spielte den Meister und den alles Vermögenden – und ließ sich vortrefflich bewirten – und versprach Lein-Oel goldene Berge, und nebenbei gefiel ihm Lein-Oels Frau, die kleine Weidgans, gar nicht übel.
     </p>
-    <p xml:id="eco_de_0000142_1280">
+    <p xml:id="eco_de_0000212_1280">
      Wenn sie so dasaß und andächtig zuhörte, wie die beiden Männer miteinander sprachen, und wenn Liebing Lein-Oels Sachen lobte, da strahlte ihr Gesicht und ihre Augen ruhten mit einem dankbaren, bewundernden Ausdruck auf Liebing. Jetzt war ihr Lein-Oel doch glücklich! – Jetzt war es besser für ihn – und was alles kommen würde für ihren armen guten Mann. Glück und Ehre in Hülle und Fülle – und all diese über ihnen schwebenden Glücksgüter, die sich nur noch nicht völlig zu ihnen niedergelassen hatten, die waren durch Liebing gekommen, der hatte alles, alles gebracht – der edle; gute Mann.
     </p>
-    <p xml:id="eco_de_0000142_1290">
+    <p xml:id="eco_de_0000212_1290">
      Und Lein-Oel war auch viel freundlicher mit ihr, der kleinen Weidgans, vergaß, sie bei manchen Dingen zu schelten, und sie ging leer aus, wenn sie schon ganz gefaßt war, daß es etwas geben würde.
     </p>
-    <p xml:id="eco_de_0000142_1300">
+    <p xml:id="eco_de_0000212_1300">
      Lein-Oel hatte mancherlei Dinge geschrieben, ganz besonders hatte er an Fabeln und Gleichnissen seine Freude, und es war ihm da allerlei beigefallen.
     </p>
-    <p xml:id="eco_de_0000142_1310">
+    <p xml:id="eco_de_0000212_1310">
      So war er zu einer Fabel gekommen, die hieß: »Der Wortpelzverlust«.
     </p>
-    <p xml:id="eco_de_0000142_1320">
+    <p xml:id="eco_de_0000212_1320">
      Und in dieser Fabel stand unter anderm folgendes: Sie hatten ihre Wortpelze verloren, die schwammigen Wortpelze, mit denen sie ein Gedankennichts so gut aufzubauschen verstanden, mit denen sie einen Gedankenkrüppel hübsch säuberlich auswattieren konnten, und standen nun nackt und kahl in aller Elendigkeit da und wußten nicht, was sie thun sollten, schämten sich und froren, keiner erkannte den andern in seiner Nacktheit, und sie wollten einander auch nicht erkennen, das war ihnen viel zu despektierlich. Und so gingen sie stumm und dumm und sehnten sich nach ihren alten bequemen Pelzen, die ein Teufel, der seinen Spaß daran haben mochte, ihnen weggenommen hatte.
     </p>
-    <p xml:id="eco_de_0000142_1330">
+    <p xml:id="eco_de_0000212_1330">
      Sie waren ganz zu nichts geworden, erbärmliche, elende Kreaturen.
     </p>
-    <p xml:id="eco_de_0000142_1340">
+    <p xml:id="eco_de_0000212_1340">
      Es fiel ihnen auch wirklich sehr schwer, sich selbst und ihre Brüder zu erkennen, und sie sahen sich scheu nach all der Würde und Herrlichkeit um, die sie einst umkleidet hatte, als sie alle ihren herrlichen Wortpelz noch hatten, schauten sich um nach der Würde des Menschentums, nach aller Weisheit und Erhabenheit, und fanden nichts mehr und konnten nicht begreifen, wo alles geblieben sei.
     </p>
-    <p xml:id="eco_de_0000142_1350">
+    <p xml:id="eco_de_0000212_1350">
      Hochweise Herren, die immer sonst das große Wort führten, waren jetzt zu fadendünnen, jammervollen Bürschchen geworden, die ein Lufthauch zu Dutzenden umblasen konnte. Sie hatten doch früher allen gewaltig imponiert.
     </p>
-    <p xml:id="eco_de_0000142_1360">
+    <p xml:id="eco_de_0000212_1360">
      Sie standen umher, so nackt und bloß, und wunderten sich, daß unter ihnen hier und da etliche, sehr wenige Leute, die der Verlust der Wortpelze nicht mitbetroffen hatte, wohl und schön eingewickelt wie sonst gingen, als man noch ihre Einfachheit unter all den wundervollen Pelzröcken nicht geachtet hatte.
     </p>
-    <p xml:id="eco_de_0000142_1370">
+    <p xml:id="eco_de_0000212_1370">
      Jetzt aber waren sie beneidet und angestaunt, und die armseligen Nacktfrösche hätten ihnen die einfachen schönen Röcke am liebsten vom Leibe gerissen, um sich selbst damit zu bedecken, wenn das angegangen wäre.
     </p>
-    <p xml:id="eco_de_0000142_1380">
+    <p xml:id="eco_de_0000212_1380">
      »Wer mögen diese Leute sein? Weshalb sind sie verschont geblieben – Weshalb hat der schimpfliche Verlust sie nicht auch betroffen?« das riefen alle.
     </p>
-    <p xml:id="eco_de_0000142_1390">
+    <p xml:id="eco_de_0000212_1390">
      Das kann und will ich sagen: Es sind die Leute, die nicht mit Worten dachten, die sich nicht von Worten blenden ließen, die sich nicht mit Worten zufrieden gaben.
     </p>
-    <p xml:id="eco_de_0000142_1400">
+    <p xml:id="eco_de_0000212_1400">
      Es sind die Leute, die das Elend, die jämmerliche Verlogenheit an jedem, auch dem herrlichsten Worte kleben sahen, die mit vornehmem Widerstreben diese abgegriffenen, schmutzigen Münzen gebrauchten, um Dinge, die weit über diesen armen Worten liegen, mühselig, herabgewürdigt und ewig ungenügend den Menschen zu offenbaren.
     </p>
-    <p xml:id="eco_de_0000142_1410">
+    <p xml:id="eco_de_0000212_1410">
      Es sind die Leute, die über der stumpfsinnigen Gewohnheit stehen, die den Zauber der ersten Anschauung in die Worte legen und so das Uebersehene, Allzugewöhnte neu vor Augen stellen.
     </p>
-    <p xml:id="eco_de_0000142_1420">
+    <p xml:id="eco_de_0000212_1420">
      Nur solche Leute, die nicht nur an Worten hingen, die sich den hergebrachten Redensarten nicht fügten und weit über diese hinaus fühlten und dachten, standen bei dem großen Wortpelzverlust nicht kahl und nackt und armselig da. Er hatte ihnen gar nichts anhaben können. – Aber ihrer waren wenige.
     </p>
    </div>
@@ -537,13 +537,13 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_1430">
+    <p xml:id="eco_de_0000212_1430">
      Solcherlei Dinge schrieb Lein-Oel, und als er so ein ganzes Päckchen nach und nach Liebing vorgelesen hatte, legte dieser auf dieses Häuflein den Wortpelzverlust, schob alles in seine Tasche, um es Excellenz Goethe wirklich zu überreichen.
     </p>
-    <p xml:id="eco_de_0000142_1440">
+    <p xml:id="eco_de_0000212_1440">
      Es waren schöne Abende oben auf dem Horn im alten Sommerhaus gewesen, als die drei Menschen, Lein-Oel, Liebing und ein junges, liebreizendes Weib, da miteinander saßen. Drei Menschen? Lein-Oel, Liebing und die kleine Weidgans, Lein-Oels Frau doch? – aber kein liebreizendes, junges Weib, denkt der Leser und meint, er wäre unversehens in eine andre Geschichte geraten. Es ist ganz richtig: Lein-Oel, Liebing und die kleine Weidgans saßen da miteinander – aber um die Stirn der kleinen Frau hatten sich die abgeschnittenen Haare in Löckchen gekräuselt – und sie schaute mit so großen, dankbaren, wunderlichen Augen auf Liebing, mit so strahlenden Augen, so glückseligen Augen, daß Lein-Oel die kleine Weidgans selbst nicht mehr erkannte.
     </p>
-    <p xml:id="eco_de_0000142_1450">
+    <p xml:id="eco_de_0000212_1450">
      Ueber ihr braves Gesichtchen hatte das Glück seinen Zauber gebreitet; wenn es auch nur ein Funke wahren Glückes ist, es ist immer göttlich, steht siegreich über jedem andern Ausdruck, wäscht die Gesichter rein von aller kleinbürgerlichen Ehrbarkeit, aller Zimperlichkeit, aller Verzerrung, das Glück spült das alles hinweg.
     </p>
    </div>
@@ -551,61 +551,61 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_1460">
+    <p xml:id="eco_de_0000212_1460">
      An einem Abend, als Liebing spät gegangen war – die Fenster standen offen, das Licht flackerte, die weiche Herbstluft drang ein – ging Lein-Oel im Zimmer auf und nieder und simulierte und baute an neuen Luftschlössern – und das kleine Weib blickte wie gedankenverloren in die bewegte Flamme, – da, mit einemmal flog es Lein-Oel wie ein weicher, großer Vogel an die Brust – und Friederikchen hing mit ausgebreiteten Armen an ihm. »Ach du – er ist so gut!« flüsterte sie und schaute ihren Mann mit großen, strahlenden Augen an.
     </p>
-    <p xml:id="eco_de_0000142_1470">
+    <p xml:id="eco_de_0000212_1470">
      »Bist du verrückt?«
     </p>
-    <p xml:id="eco_de_0000142_1480">
+    <p xml:id="eco_de_0000212_1480">
      Aber sie achtete nicht auf das, was er sagte, und verbarg ihr Gesicht an seinem Herzen. – »Wie wir ihm danken müssen! – Wie gut, daß er gekommen ist!« flüsterte sie unter Thränen.
     </p>
-    <p xml:id="eco_de_0000142_1490">
+    <p xml:id="eco_de_0000212_1490">
      »Ach Leinel, es is so scheen jetzt bei uns – lieber – lieber Leinel, sei nun auch manchmal gut mit mir!« Das sagte sie so demütig süß.
     </p>
-    <p xml:id="eco_de_0000142_1500">
+    <p xml:id="eco_de_0000212_1500">
      Wie ihm das zu Herzen ging! Er schämte sich. Hatte er sie denn bis jetzt ein allereinziges Mal glücklich gesehen?
     </p>
-    <p xml:id="eco_de_0000142_1510">
+    <p xml:id="eco_de_0000212_1510">
      Immer unterwürfig, immer geduckt, immer pflichttreu wie eine kleine Maschine – und nun mit einemmal diese Seligkeit. An seinem Hals hing ein ihm ganz fremdes, süßes Geschöpf – ein Weib in wunderlicher, zärtlicher Verwirrung – das wie im Traum sprach, ganz unschuldig; und dieses wonnige Haar – wie ein goldener Schein – und dieses Anschmiegen! die zärtlichen, jungen Glieder! – Wie es ihn durchschauerte. – War das sein Weib, sein langweiliges, ehrbußliches Weib, die dumme, kleine Weidgans?
     </p>
-    <p xml:id="eco_de_0000142_1520">
+    <p xml:id="eco_de_0000212_1520">
      Und was sie sprach! So voller Vertrauen zu ihm – und voll heißer, sinnverwirrender Liebe zu einem andern.
     </p>
-    <p xml:id="eco_de_0000142_1530">
+    <p xml:id="eco_de_0000212_1530">
      Wie gelähmt war er – ganz starr – rohhart, würden die Weimaraner sagen. War's ihm doch, als müßte er sie von sich schleudern wie eine giftige Schlange; – aber er konnte kein Glied rühren – er konnte nicht sprechen – nicht denken – nicht wollen. Er hielt sie, als wäre nichts geschehen – nichts gesprochen, als wäre er vor Schreck über das Außergewöhnliche versteinert.
     </p>
-    <p xml:id="eco_de_0000142_1540">
+    <p xml:id="eco_de_0000212_1540">
      Und die kleine Weidgans schmiegte sich in seligem Vertrauen weiter an ihn und hing in aller Unschuld ihrer aufstrebenden Liebe nach, wie an der Brust eines guten Vaters.
     </p>
-    <p xml:id="eco_de_0000142_1550">
+    <p xml:id="eco_de_0000212_1550">
      Lein-Oel machte sich endlich schwer atmend von ihr los, stumm und dumm. Vor der Unschuld seines Weibes blieb ihm der Verstand stehen.
     </p>
-    <p xml:id="eco_de_0000142_1560">
+    <p xml:id="eco_de_0000212_1560">
      Alles war wie ein Zauber vor sich gegangen – war es vor sich gegangen oder nicht vor sich gegangen? War er verrückt oder nicht verrückt? – Hatte sie etwas gesagt oder hatte sie nichts gesagt? – Er wußte es nicht, war plötzlich wie mitten in einem Nervenfieber angelangt.
     </p>
-    <p xml:id="eco_de_0000142_1570">
+    <p xml:id="eco_de_0000212_1570">
      Und wie er scheu und wie aus den Wolken gefallen nach ihr hinblickte, lag auf dem jungen Weibe ein Sonnenglanz von traumhaftem Glück, wie er ihn nie in seinem Leben auf irgend einem Menschenantlitz gesehen hatte. Wie ein Engel in seiner unschuldigen Herrlichkeit sah sie aus.
     </p>
-    <p xml:id="eco_de_0000142_1580">
+    <p xml:id="eco_de_0000212_1580">
      Ihm waren die Hände gebunden, er hätte nicht plump in dieses Strahlen etwas werfen können, nicht seine Wut, nicht seine Verachtung, nicht seine Eifersucht, nicht sein Mißtrauen.
     </p>
-    <p xml:id="eco_de_0000142_1590">
+    <p xml:id="eco_de_0000212_1590">
      Stumm wie ein Fisch blieb er.
     </p>
-    <p xml:id="eco_de_0000142_1600">
+    <p xml:id="eco_de_0000212_1600">
      Und in seinem innersten Herzen stieg es ihm auf, daß seine Gleichgültigkeit, seine Lehrhaftigkeit, seine Mißachtung, seine schlechte Behandlung, seine Hoffärtigkeit – wie ein Stein schwer auf der armen, kleinen Weidgans gelegen, daß er sie wirklich wie eine Gans achtlos in einen dunkeln Stall gesperrt und gar nicht bemerkt hatte, was für ein schöner, lustiger Vogel sie war – ein Vogel, der in der Sonne leben wollte.
     </p>
-    <p xml:id="eco_de_0000142_1610">
+    <p xml:id="eco_de_0000212_1610">
      Und das stimmte ihn nachsichtig und bedrückte ihn und ließ seinen ehelichen, richterlichen Zorn nicht zum Ausbruche kommen.
     </p>
-    <p xml:id="eco_de_0000142_1620">
+    <p xml:id="eco_de_0000212_1620">
      Die kleine Weidgans ging ungestört und unschuldig wie ein Engel schlafen.
     </p>
-    <p xml:id="eco_de_0000142_1630">
+    <p xml:id="eco_de_0000212_1630">
      Und als Liebing eines schönen Abends wiederkam, strahlte sie ihn in aller Harmlosigkeit wie ihr Götterbild an, und auch Liebings Gefallen an der schmachtenden, allerliebsten Frau stieg von Abend zu Abend – und er fühlte schon eine Art Raptus über sich kommen, und wußte, daß er wie ein Narr hinter der kleinen Weidgans herlaufen würde.
     </p>
-    <p xml:id="eco_de_0000142_1640">
+    <p xml:id="eco_de_0000212_1640">
      Liebing war wirklich ohne alle Komödie ein sehr verliebter Kater. Alle Nasenlang hatte er eine unsinnige Glückseligkeit oder Verzweiflung durchzumachen – und wäre er nicht enfant terrible und enfant gâté von aller Welt gewesen, so möchte ich wissen, was die Weimaraner über den Lebenswandel ihres Liebing gesagt hätten; so aber drückten sie ein Auge über das andre zu und ließen sich durch nichts in ihrer Vergötterung stören.
     </p>
    </div>
@@ -613,76 +613,76 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_1650">
+    <p xml:id="eco_de_0000212_1650">
      Aber ganz wie Liebing es befürchtet hatte, traf es ein. Er wurde wieder einmal Narr, vernachlässigte alle und jede und lief der kleinen Weidgans nach auf Schritt und Tritt, wo er nur hoffen durfte, ihr zu begegnen. Oben auf dem Horn strich er umher im Dunkeln. – Und da war es auch einmal, daß er über die Mauer in Lein-Oels Garten stieg, aus verrückter Laune – und daß er zufällig das kleine hübsche Weib im Garten traf, das da im Dunkeln schwärmerisch und wie ein schwermütiges Kätzchen promenierte.
     </p>
-    <p xml:id="eco_de_0000142_1660">
+    <p xml:id="eco_de_0000212_1660">
      Und dieses Zusammentreffen mochte wie ein zündender Blitzstrahl gewirkt haben, der auch, wo er niederfährt, alle Vernunft und Ueberlegung verscheucht.
     </p>
-    <p xml:id="eco_de_0000142_1670">
+    <p xml:id="eco_de_0000212_1670">
      Liebing hatte wie ein Wirbelsturm das kleine, thörichte Geschöpf gefaßt und geküßt – geküßt! – Ja, mein Gott, geküßt, daß der Kleinen die Sinne schwanden! – Was war das für eine Liebe! – Da vergaß man alles – alles miteinander dabei, und es war Liebing, der herrliche Liebing! Das hatte gar keine Aehnlichkeit mit Lein-Oels bedächtigen, ehrbaren Küssen, die er ihr hin und wieder in aller Gemütlichkeit gegeben hatte, weil es so sein mußte und sein sollte und in der Ordnung war. Aber das, was jetzt über sie hereinstürmte, das war das leibhaftige Feuer, die leibhaftige Seligkeit!
     </p>
-    <p xml:id="eco_de_0000142_1680">
+    <p xml:id="eco_de_0000212_1680">
      Ihr schien es, als wäre ein Gott zu ihr herniedergestiegen.
     </p>
-    <p xml:id="eco_de_0000142_1690">
+    <p xml:id="eco_de_0000212_1690">
      Sie fühlte keine Reue, sie hatte keine Gedanken, sie war ein Blatt, vom wilden Sturm der Liebe erfaßt und geschüttelt.
     </p>
-    <p xml:id="eco_de_0000142_1700">
+    <p xml:id="eco_de_0000212_1700">
      Daß es so etwas auf Erden gab! – Das Herz jauchzte ihr! Jetzt war sie erst geboren, das war erst Leben, alles andre dumpfer Qualm, erstickender Qualm!
     </p>
-    <p xml:id="eco_de_0000142_1710">
+    <p xml:id="eco_de_0000212_1710">
      Und als Liebing von ihr gestürzt war, stand sie wie eine Bildsäule starr – und lief mit einemmal wie gehetzt dem Hause zu, die Treppe hinauf und stürzte vor ihren Mann hin, der an seinem Arbeitstisch saß und schrieb, und preßte ihr Gesicht an ihn und schluchzte wild und heiß wie ein erschüttertes Kind.
     </p>
-    <p xml:id="eco_de_0000142_1720">
+    <p xml:id="eco_de_0000212_1720">
      Und er fragte – und sie antwortete – so schwül, so bang – so treu und ehrlich – so unschuldig – so sinnlos.
     </p>
-    <p xml:id="eco_de_0000142_1730">
+    <p xml:id="eco_de_0000212_1730">
      Und er konnte sie nicht schlagen und nicht treten, und auch nicht von sich stoßen. Er war überwältigt von etwas Unbegreiflichem.
     </p>
-    <p xml:id="eco_de_0000142_1740">
+    <p xml:id="eco_de_0000212_1740">
      Es lag etwas Unwiderstehliches in dem umgewandelten kleinen Weibe und solch unerhörte Offenheit – Rückhaltlosigkeit und Liebesunschuld.
     </p>
-    <p xml:id="eco_de_0000142_1750">
+    <p xml:id="eco_de_0000212_1750">
      Es war ein Stück Natur, das sprechen konnte – gar nichts weiter.
     </p>
-    <p xml:id="eco_de_0000142_1760">
+    <p xml:id="eco_de_0000212_1760">
      Er starrte darauf hin und hörte, was es sprach, und da war keine Lüge, keine Verstellung. Es war eine Quelle, die er niedergehalten, und die nun wild und unwiderstehlich ihm entgegen und über ihn her sprudelte.
     </p>
-    <p xml:id="eco_de_0000142_1770">
+    <p xml:id="eco_de_0000212_1770">
      Was war da zu wüten und zu zürnen – es war so, wie es war.
     </p>
-    <p xml:id="eco_de_0000142_1780">
+    <p xml:id="eco_de_0000212_1780">
      Er fühlte aber einen unsinnigen Schmerz, als wäre er verwundet.
     </p>
-    <p xml:id="eco_de_0000142_1790">
+    <p xml:id="eco_de_0000212_1790">
      Daß seine Weidgans ihm solche Qual bereiten konnte! Darüber hätte er fast lachen können. Aber das war ja die Weidgans nicht mehr!
     </p>
-    <p xml:id="eco_de_0000142_1800">
+    <p xml:id="eco_de_0000212_1800">
      »Ah siehste, daß ich dir das duh!« schluchzte das kleine Weib und sah ihn so gut und treu und unterwürfig an, so hilflos und um Erbarmen bittend.
     </p>
-    <p xml:id="eco_de_0000142_1810">
+    <p xml:id="eco_de_0000212_1810">
      Und er that ihr so leid – das rief sie ein über das andre Mal.
     </p>
-    <p xml:id="eco_de_0000142_1820">
+    <p xml:id="eco_de_0000212_1820">
      »Ach, du duhft mir so leid!«
     </p>
-    <p xml:id="eco_de_0000142_1830">
+    <p xml:id="eco_de_0000212_1830">
      Und hatte er zuerst nicht gezürnt und gewütet – jetzt ging es nicht mehr – jetzt war er darin im Strom, jetzt war er mit fortgerissen. Er wurde gut, übermenschlich gut, ohne zu wissen, wie es eigentlich gekommen. Nie hatte er früher etwas dergleichen in sich gespürt – und nun mit einemmal.
     </p>
-    <p xml:id="eco_de_0000142_1840">
+    <p xml:id="eco_de_0000212_1840">
      Wie ein Dämon verlangte das Weibchen Uebermenschliches von ihm, und wie verhext, wie geblendet that er alles, was das kleine Ungeheuer von ihm wollte.
     </p>
-    <p xml:id="eco_de_0000142_1850">
+    <p xml:id="eco_de_0000212_1850">
      Eine nützliche Gans hatte er zu sich hereingelassen, ein unbedeutendes mißachtetes Weib, von dem er nichts wollte, als daß es gut kochen sollte, daß es ihm diente und aufging in Arbeit und Sparsamkeit, Demut und Hingebung.
     </p>
-    <p xml:id="eco_de_0000142_1860">
+    <p xml:id="eco_de_0000212_1860">
      Aus diesem gutmütigen Nutztier war aber ein Geschöpf geworden wie eine Sphinx, ein rätselhaftes Tier, das ihn beherrschte, unter dessen Zauber er geraten war, das ihm das Herz zerriß.
     </p>
-    <p xml:id="eco_de_0000142_1870">
+    <p xml:id="eco_de_0000212_1870">
      Die kleine Weidgans ahnte in ihrem Taumel nicht, was für ein unerhörter Zustand zwischen ihr und ihrem Manne bestand. Sie fühlte sich so sicher bei ihm – er war so gut!
     </p>
-    <p xml:id="eco_de_0000142_1880">
+    <p xml:id="eco_de_0000212_1880">
      Und Lein-Oel hatte das sonderbare Schicksal, den Liebesrausch seines Weibes und alle Begegnungen und alles, was zwischen den Liebenden sich zutrug, gewissermaßen mitzuerleben. Ihr Vertrauen und ihre demütige, rückhaltlose Offenheit kannte keine Grenzen.
     </p>
    </div>
@@ -690,187 +690,187 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_1890">
+    <p xml:id="eco_de_0000212_1890">
      Als der November herankam und die langen Abende, da wurde das kleine Weib von tiefer Sehnsucht gepackt. Es lag wie eine Schwermut über ihr – und sie war haltlos wie ein Schilfhalm im Winde. Und was sie wollte und was sie dachte, das lag so offenbar. Sie war wie durchsichtig – den blonden Kopf mit den windigen Löckchen legte sie müde auf die Arme, wenn sie am Tische saß, an dem sie sonst so eifrig gestopft und geflickt hatte – und dabei liefen ihr die Thränen über die Wangen. Und wenn sie gar nicht mehr ein und aus wußte, lehnte sie sich ihrem Mann in die Arme wie ein krankes Kind.
     </p>
-    <p xml:id="eco_de_0000142_1900">
+    <p xml:id="eco_de_0000212_1900">
      Und als wäre es ganz natürlich, und als hätten tausend Ehemänner vor ihm schon so gehandelt, nahm er den Arm seines Weibchens in den seinen, half ihr das Kapuzchen aufsetzen und führte sie hinunter nach Weimar, um Liebing zu begegnen. Er wußte gar nicht mehr, was er machen sollte, that alles, wie von einem dunkeln Geist getrieben.
     </p>
-    <p xml:id="eco_de_0000142_1910">
+    <p xml:id="eco_de_0000212_1910">
      Er hatte den Anfang versäumt, er hätte sie am Anfang schlagen sollen, er hätte sie treten und von sich schleudern sollen, da hätte die Sache ein andres Gesicht bekommen – aber nun – nun mit einemmal – nun war's verspielt.
     </p>
-    <p xml:id="eco_de_0000142_1920">
+    <p xml:id="eco_de_0000212_1920">
      So gingen sie miteinander den dunkeln Weg nach Weimar hinab, sie zitternd an ihn gelehnt, scheu und vertrauensvoll zugleich. Es war der 10. November, der Martinstag. Die Straßen waren hie und da mit einer Oellampe erhellt, die an einer Kette hing, die quer über die Straße lief; aber auf dem Marktplatz, da standen die erleuchteten Buden, da war ein ganz ungewohntes Leben. Ganz Weimar lief zwischen der einen langen Budenreihe hin und her und kaufte Pfefferreiter, weiße und braune, und Pfefferkuchen mit Sprüchen, Pfefferkuchen mit Mandeln, und bei den Hökerweibern, die ihre Ware mit einem Laternchen beleuchtet hatten, Aepfel und Nüsse. Alle Fenster rings um den Markt her waren hell erleuchtet, denn überall wurde heute die Martinsgans gegessen.
     </p>
-    <p xml:id="eco_de_0000142_1930">
+    <p xml:id="eco_de_0000212_1930">
      Die Kinder brieten, sowie sie mit ihren Schätzen daheim angelangt waren, ihre Aepfel in der Ofenröhre. Aus Apothekers Haus kamen ganze Ströme von Duft heraus nach Bratäpfeln und auch nach Martinsgans; da war heute die ganze Gesellschaft versammelt, die Ratsmädchen mit ihrer Sippe und Müllersch, und bei Tiburtsiusens ging's auch hoch her, das sah man an der strahlenden Beleuchtung.
     </p>
-    <p xml:id="eco_de_0000142_1940">
+    <p xml:id="eco_de_0000212_1940">
      Zu denen, die auf dem Markte wohnten, kamen heute eben alle aus allen Ecken und Enden von Weimar angelaufen, um den Martinsmarkt vom Fenster aus zu beobachten.
     </p>
-    <p xml:id="eco_de_0000142_1950">
+    <p xml:id="eco_de_0000212_1950">
      Dort konnte man wirklich auch alles sehen, was nur in Weimar zu sehen war, und man begegnete aller Welt.
     </p>
-    <p xml:id="eco_de_0000142_1960">
+    <p xml:id="eco_de_0000212_1960">
      Auch Goethe sah sich das bunte Treiben zwischen der hellen Budenstraße gern an.
     </p>
-    <p xml:id="eco_de_0000142_1970">
+    <p xml:id="eco_de_0000212_1970">
      Lein-Oel und sein kleines Weib begegneten heute aber Frau von Goethe, die lebhaft umherlief und Einkäufe machte, und mit ihren großen, schwarzen Augen sich alles genau betrachtete und um alles gehörig feilschte, wie es eine gute weimarische Hausfrau zu jeder Zeit redlich gethan hat.
     </p>
-    <p xml:id="eco_de_0000142_1980">
+    <p xml:id="eco_de_0000212_1980">
      Die Goethe sprach mit unsern beiden, war ganz beladen mit Pfefferkuchen und Pfefferreitern, erzählte, daß sie gewaltig eilen müsse, um zur Gans rechtzeitig daheim zu sein, und daß sie dazu Hagebutten mit Rosinen gäbe, alles halb und halb, das Leibkompott ihres Geheimrats.
     </p>
-    <p xml:id="eco_de_0000142_1990">
+    <p xml:id="eco_de_0000212_1990">
      Aber wen Lein-Oels auch begegnet haben mochten, Liebing blieb aus, und sie waren nun schon in der Budenstraße oft genug auf und nieder gegangen.
     </p>
-    <p xml:id="eco_de_0000142_2000">
+    <p xml:id="eco_de_0000212_2000">
      Aber schließlich sahen sie ihn doch – und da war er auch schon neben ihnen und allerbester Laune und kaufte Pfefferreiter, und die kleine Weidgans wachte auf wie aus einem tiefen Schlafe und lebte wieder auf und sah aus wie ein Kind vor dem Weihnachtsbaum – und schließlich ging Liebing mit beiden hinauf zu Tiburtsiusens. Das war ein wundervoller Abend für die kleine Weidgans.
     </p>
-    <p xml:id="eco_de_0000142_2010">
+    <p xml:id="eco_de_0000212_2010">
      Denn Frau Rat Tiburtsius hatte mit allen Gästen, die sich oben bei ihr angesammelt hatten, einen Streifzug hinunter auf den Markt unternommen, und da ging es immer wie im Märchen »Schwan, kleb an«, sie brachten einen ganzen Schwanz mit hinauf.
     </p>
-    <p xml:id="eco_de_0000142_2020">
+    <p xml:id="eco_de_0000212_2020">
      Beim Nachhausegehen hing sie sich glücklich und schläfrig in den Arm ihres Mannes ein, und er hatte an ihr schwer zu schleppen, denn er dachte, daß die Sache ein Ende nehmen müsse und was er eigentlich mit dem unsinnigen Geschöpf beginnen solle, und er wußte wieder nicht ein und nicht aus.
     </p>
-    <p xml:id="eco_de_0000142_2030">
+    <p xml:id="eco_de_0000212_2030">
      So ging es noch eine Weile fort.
     </p>
-    <p xml:id="eco_de_0000142_2040">
+    <p xml:id="eco_de_0000212_2040">
      Eines schönen Abends kam ihm seine Weidgans gar nicht mehr nach Hause. Es war stockfinster, und er wartete wie ein Narr. Sie hatte ihn verlassen.
     </p>
-    <p xml:id="eco_de_0000142_2050">
+    <p xml:id="eco_de_0000212_2050">
      So mußte es kommen.
     </p>
-    <p xml:id="eco_de_0000142_2060">
+    <p xml:id="eco_de_0000212_2060">
      Das dachte er, so weit man es denken nennen kann – denn er saß da und starrte vor sich hin und fuhr sich mit den Händen ins Haar.
     </p>
-    <p xml:id="eco_de_0000142_2070">
+    <p xml:id="eco_de_0000212_2070">
      Was hatte er nun?
     </p>
-    <p xml:id="eco_de_0000142_2080">
+    <p xml:id="eco_de_0000212_2080">
      Ein leeres Haus – Unbehagen in allen Ecken – Spott und Hohn, denn wer den Schaden hat, braucht für den Spott nicht zu sorgen; und was das Schlimmste war, einen ungeheuren Schmerz, eine große Leere, es war ihm, als wäre ein Leben ohne die kleine Weidgans ihm unmöglich. Sie fehlte ihm in allen Ecken. Ihre blonden Locken, ihre flinken Schritte – das ganze Persönchen, ihr Hantieren um ihn her und ihre Stimme – ach, auch ihr weimarisches Sprachschimpfieren, was ihm so qualvoll gewesen, jetzt, in der Erinnerung, klang es ihm wie Musik. Und manchmal war es ihm, als führe ihm das lebendige Feuer durch den Körper, wenn er an Liebing dachte, und wie sie nun miteinander auf und davon gegangen.
     </p>
-    <p xml:id="eco_de_0000142_2090">
+    <p xml:id="eco_de_0000212_2090">
      Was für ein Esel war er gewesen!
     </p>
-    <p xml:id="eco_de_0000142_2100">
+    <p xml:id="eco_de_0000212_2100">
      Aber nein – nein, tausendmal nein, seine kleine Weidgans wie ein Kerkermeister zwingen, das hätte er nie gekonnt – nie. Was hätte er dann gehabt? Ein verzweifeltes, weinendes, übel gelauntes Weibsbild, eine Trauerweide, ein Hauskreuz.
     </p>
-    <p xml:id="eco_de_0000142_2110">
+    <p xml:id="eco_de_0000212_2110">
      »Um Gotteswillen!«
     </p>
-    <p xml:id="eco_de_0000142_2120">
+    <p xml:id="eco_de_0000212_2120">
      Ja, wenn sie angeflogen gekommen wäre, die dumme kleine Gans – aus freiem Willen – mein Gott – das wäre etwas gewesen.
     </p>
-    <p xml:id="eco_de_0000142_2130">
+    <p xml:id="eco_de_0000212_2130">
      Nichts als Kreuz und Aerger hatte er von dem Geschöpf gehabt, dachte er nun wieder wütend weiter. Erst haben sie es ihm aufgehalst – dann hat es nichts als Widerwärtigkeiten gegeben – und die miserable Sprache und die ganze Spießbürgerlichkeit und Langweiligkeit – und auf einmal die Umwandlung – und da, wie sie ihm recht gewesen, läuft sie ihm davon.
     </p>
-    <p xml:id="eco_de_0000142_2140">
+    <p xml:id="eco_de_0000212_2140">
      Lein-Oel ging im Zimmer auf und ab und hatte das Gefühl, als preßte ihm jemand den Hals zu, daß ihm die Thränen in die Augen kamen. Das Leben lag so öde vor ihm. Er kam sich wie ein alter, abgedankter, beschimpfter Mensch vor – und um etwas zu thun, zog er die Fächer von der Kommode seines ungetreuen Weibes auf und wollte ihre Wäsche in ein Bündel packen, um ihr alles nachzuschicken. Wie lag da alles so sauber und wohlgeordnet und duftete nach Lavendel. Das Licht, das ihm zu seiner Arbeit leuchtete, hatte einen großen Räuber, brannte trüb und qualmte.
     </p>
-    <p xml:id="eco_de_0000142_2150">
+    <p xml:id="eco_de_0000212_2150">
      Mit einem Mal hielt er inne. Es war ihm ganz, als wenn er Schritte gehört hätte, leichte, fliegende Schritte; und ehe er nur in seinem schwerfälligen Kummer zur Besinnung kam, stand sein kleines Weib schon auf der Schwelle mit dick verweintem Gesicht – und weder er, noch sie redeten eine Silbe.
     </p>
-    <p xml:id="eco_de_0000142_2160">
+    <p xml:id="eco_de_0000212_2160">
      Das erste, was sie that, war, daß sie die Lichtputzschere nahm und die Flamme schneuzte und den Räuber in der Lichtputze totdrückte.
     </p>
-    <p xml:id="eco_de_0000142_2170">
+    <p xml:id="eco_de_0000212_2170">
      »Was machst du denn da?« fragte sie.
     </p>
-    <p xml:id="eco_de_0000142_2180">
+    <p xml:id="eco_de_0000212_2180">
      »Deine Sachen wollt' ich dir nachschicken!« antwortete er trocken.
     </p>
-    <p xml:id="eco_de_0000142_2190">
+    <p xml:id="eco_de_0000212_2190">
      Da fing sie an zu schluchzen und strich mit der Hand über seinen Aermel.
     </p>
-    <p xml:id="eco_de_0000142_2200">
+    <p xml:id="eco_de_0000212_2200">
      »Ach Leinel, siehste, siehste,« begann sie und kam nicht weiter.
     </p>
-    <p xml:id="eco_de_0000142_2210">
+    <p xml:id="eco_de_0000212_2210">
      »Die Geschichte muß einmal ein Ende nehmen!« sagte er hart. »Weshalb bist du denn noch einmal hergekommen? – Was glaubst du denn? Für was für einen Esel hältst du mich denn eigentlich?«
     </p>
-    <p xml:id="eco_de_0000142_2220">
+    <p xml:id="eco_de_0000212_2220">
      »Ach, für keinen Esel, Leinel – siehste. – Ach, du bist so schrecklich gut – wie kei Mensch auf der Welt sonst. Tausendmal guter als Liebing!« Sie schluchzte herzbrechend.
     </p>
-    <p xml:id="eco_de_0000142_2230">
+    <p xml:id="eco_de_0000212_2230">
      »So, da hat er dich wohl sitzen lassen?« fragte er kurz.
     </p>
-    <p xml:id="eco_de_0000142_2240">
+    <p xml:id="eco_de_0000212_2240">
      »Ach nee – nee – er hat gewollt, daß ich mit ihm fort sollte« –
     </p>
-    <p xml:id="eco_de_0000142_2250">
+    <p xml:id="eco_de_0000212_2250">
      »Na, und du?«
     </p>
-    <p xml:id="eco_de_0000142_2260">
+    <p xml:id="eco_de_0000212_2260">
      Sie strich ihm immer lebhafter und zärtlicher mit der Hand über den Aermel.
     </p>
-    <p xml:id="eco_de_0000142_2270">
+    <p xml:id="eco_de_0000212_2270">
      »Nee, das hätt' ich nich gethan,« das kam alles unter Thränen kaum hörbar hervor.
     </p>
-    <p xml:id="eco_de_0000142_2280">
+    <p xml:id="eco_de_0000212_2280">
      »Weshalb denn nicht – du hast doch sonst – dächt' ich« –
     </p>
-    <p xml:id="eco_de_0000142_2290">
+    <p xml:id="eco_de_0000212_2290">
      »Ach nee – ach laß doch! – ach sag' doch nichts, Leinel!«
     </p>
-    <p xml:id="eco_de_0000142_2300">
+    <p xml:id="eco_de_0000212_2300">
      Sie wollte nicht, daß er weiter sprechen sollte.
     </p>
-    <p xml:id="eco_de_0000142_2310">
+    <p xml:id="eco_de_0000212_2310">
      »Ach du bist so gut – so gut – so gut – so gut« –
     </p>
-    <p xml:id="eco_de_0000142_2320">
+    <p xml:id="eco_de_0000212_2320">
      Die Thränen und das Schluchzen und alles, was sie sagte, überstürzte sich zu einem erbarmungswürdigen Durcheinander.
     </p>
-    <p xml:id="eco_de_0000142_2330">
+    <p xml:id="eco_de_0000212_2330">
      »Was soll denn nun aber werden?« fragte er barsch. – »Nun soll's wohl so fortgehen, die saubere Geschichte?«
     </p>
-    <p xml:id="eco_de_0000142_2340">
+    <p xml:id="eco_de_0000212_2340">
      »Ach nee – nee, nichts, Liebing – Lein-Oel – verbesserte sie sich. «Wirklich nich, Lein-Oel.«
     </p>
-    <p xml:id="eco_de_0000142_2350">
+    <p xml:id="eco_de_0000212_2350">
      »Wirklich nich? – So – und das soll ich dir glauben?«
     </p>
-    <p xml:id="eco_de_0000142_2360">
+    <p xml:id="eco_de_0000212_2360">
      »Ja, so wahr ich läb'!« rief sie. »Glaub mir, Lein-Oel, glaub mir!«
     </p>
-    <p xml:id="eco_de_0000142_2370">
+    <p xml:id="eco_de_0000212_2370">
      Und ganz erbärmlich und demütig küßte sie seine Hand.
     </p>
-    <p xml:id="eco_de_0000142_2380">
+    <p xml:id="eco_de_0000212_2380">
      So in dieser Weise sprachen sie noch eine hübsche Weile miteinander.
     </p>
-    <p xml:id="eco_de_0000142_2390">
+    <p xml:id="eco_de_0000212_2390">
      Sie schien aus ihrem Liebesrausch wach geworden zu sein und wollte, so nahm auch Lein-Oel es an, in die gewohnten Verhältnisse zurückkehren.
     </p>
-    <p xml:id="eco_de_0000142_2400">
+    <p xml:id="eco_de_0000212_2400">
      »So,« sagte er, »du bist also zu Verstand gekommen und hast gemeint, ein guter warmer Ofen ist besser als eine Rakete.«
     </p>
-    <p xml:id="eco_de_0000142_2410">
+    <p xml:id="eco_de_0000212_2410">
      »Ach siehste, ja!« rief sie aufschluchzend und fiel in seine Arme und hing an seinem Hals.
     </p>
-    <p xml:id="eco_de_0000142_2420">
+    <p xml:id="eco_de_0000212_2420">
      »Leinel, von dir fort, das hätt' ich nich gekonnt, da is mir alles erscht klar geworden.« Und jetzt kamen die reinen Abschiedsthränen, weil sie sich die Trennung wieder vorgestellt haben mochte.
     </p>
-    <p xml:id="eco_de_0000142_2430">
+    <p xml:id="eco_de_0000212_2430">
      Und er hielt sie fest in seinen Armen, und was sie nun auch alles miteinander redeten, lief darauf hinaus, daß er seine kleine Weidgans wiedergewonnen hatte.
     </p>
-    <p xml:id="eco_de_0000142_2440">
+    <p xml:id="eco_de_0000212_2440">
      »Aber,« sagte er, »was ist denn das, was macht er denn nun mit meinem Manuskript – mit den Fabeln?« –
     </p>
-    <p xml:id="eco_de_0000142_2450">
+    <p xml:id="eco_de_0000212_2450">
      »Ach, die hat er ja Goethen schon gezeigt, und der hat gesagt: ›artig, sehr artig‹,« schluchzte sie immer noch, »und will sich die Sachen noch weiter ansehen – siehste!«
     </p>
-    <p xml:id="eco_de_0000142_2460">
+    <p xml:id="eco_de_0000212_2460">
      So verging eine gute Weile in Thränen mit Fragen und Antworten.
     </p>
-    <p xml:id="eco_de_0000142_2470">
+    <p xml:id="eco_de_0000212_2470">
      Dann gingen sie miteinander in die Küche und besorgten ihr Abendessen und konnten sich gar nicht trennen, wie zwei Leute, die hätten voneinander gerissen werden sollen.
     </p>
-    <p xml:id="eco_de_0000142_2480">
+    <p xml:id="eco_de_0000212_2480">
      Und wie sie beide so einträchtiglich wirtschafteten, da fiel die Sünderin ihrem Manne mit erneuten, heißen Thränen um den Hals und schluchzte: »Siehste, daß ich mich so sehr in Liebing verliebt hab', war doch im Grund zu allererscht nur, weil er gegen dich so sehr gut war.«
     </p>
-    <p xml:id="eco_de_0000142_2490">
+    <p xml:id="eco_de_0000212_2490">
      »So, also aus Dankbarkeit! – Na, nun hör' mir aber auf, du kleine Kröte.«
     </p>
    </div>
@@ -878,10 +878,10 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000142_2500">
+    <p xml:id="eco_de_0000212_2500">
      Lein-Oel hatte gemeint, es wäre keine Kunst, ein Weib zu nehmen und hatte sich die Sache unverschämt leicht gemacht, wie Ehemänner das thun. – Dafür war er aber gehörig in die Kur genommen worden, hatte auf eine ganz sonderbare Weise für seine Thorheit büßen und lernen müssen, daß ein Weib nicht so ohne weiteres zu erringen sei. Auf dieser kalten Welt einen Menschen zu haben, der ihm mit Leib und Seele angehört, aus freiem Willen für ihn sorgt und für ihn lebt und denkt und schafft und leidet und sich freut, für ihn hofft, ihn gut und klug und brav und Gott weiß was findet, nur für ihn da ist, wenn das solch ein thörichter Mann wie Lein-Oel einstens für nichts ansieht – der muß in Teufels Küche kommen und ausessen, was er sich eingebrockt hat.
     </p>
-    <p xml:id="eco_de_0000142_2510">
+    <p xml:id="eco_de_0000212_2510">
      So soll es immer und allen solchen ergehen.
     </p>
    </div>

--- a/tei/Boehlau_Helene_Altweimarische_Liebesgeschichten_Im_alten_Roedchen.xml
+++ b/tei/Boehlau_Helene_Altweimarische_Liebesgeschichten_Im_alten_Roedchen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000143" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000213" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000143_20">
+   <p xml:id="eco_de_0000213_20">
     Im alten Rödchen zu Weimar
    </p>
   </front>
@@ -92,253 +92,253 @@
    <div type="group">
     <head>
     </head>
-    <p xml:id="eco_de_0000143_30">
+    <p xml:id="eco_de_0000213_30">
      Im Rödchen bei Weimar, da hat vor Zeiten ein Dorf gestanden; jetzt ist es ein einsames niedriges Gehölz von etlichen hohen Eichen und Buchen, Ahorn und Erlen überragt; das zieht sich, sanft ansteigend, bis an den weiten, schönen Buchenwald hin auf dem langgestreckten Rücken des Ettersberges, dem Wahrzeichen der guten Stadt Weimar.
     </p>
-    <p xml:id="eco_de_0000143_40">
+    <p xml:id="eco_de_0000213_40">
      Das Dorf ist längst vergessen und versunken, ein Bruderkrieg hat es vom Heimatboden weggefegt, wie so manches andre Dorf und Städtchen, von dessen Dasein kein Mensch mehr weiß.
     </p>
-    <p xml:id="eco_de_0000143_50">
+    <p xml:id="eco_de_0000213_50">
      Aber einst hat es gestanden und geblüht, das Dörflein Roda bei Weimar, und Doktor Faust, der Wundermann, soll, so erzählt man sich, in Roda geboren sein, also so nahe dem Orte, wo er in großer Verklärung für ewige Dauer auferstehen sollte.
     </p>
-    <p xml:id="eco_de_0000143_60">
+    <p xml:id="eco_de_0000213_60">
      Im Rödchen bei Weimar gehen mancherlei Sagen um, die aus versunkenen, vermoderten Mauerresten aufsteigen, wie es auf verlassenen Stätten vergessener Menschen zu geschehen pflegt. Ueber dem Ganzen liegt ein eigener Zauber – eine wehmütige Stille. Der Duft von frischem und gefallenem feuchten Laub verbindet sich eigentümlich scharf. Das macht das Erlen- und Eichenlaub, das auf nassem Grunde zu dichter Decke sich verbunden hat.
     </p>
-    <p xml:id="eco_de_0000143_70">
+    <p xml:id="eco_de_0000213_70">
      Im Rödchen steht ein Wirtshaus und davor, unter jungen Bäumen, einige grau verwitterte Bänke.
     </p>
-    <p xml:id="eco_de_0000143_80">
+    <p xml:id="eco_de_0000213_80">
      Auch dieses Wirtshaus hat jetzt etwas Melancholisches, Vereinsamtes und Verwahrlostes.
     </p>
-    <p xml:id="eco_de_0000143_90">
+    <p xml:id="eco_de_0000213_90">
      Noch zu Anfang unsres Jahrhunderts zogen die Weimaraner gern hinaus zum Rödchen, da gab es Feste über Feste dort.
     </p>
-    <p xml:id="eco_de_0000143_100">
+    <p xml:id="eco_de_0000213_100">
      Wo jetzt am Sonntag der eine oder andre kleine Bürgersmann mit Weib und Kind gelangweilt sein Seidel saures Bier trinkt und vorsichtig sich dazu auf die alten morschen Bänke setzt, da war früher ein reges, warmes, heiteres Leben.
     </p>
-    <p xml:id="eco_de_0000143_110">
+    <p xml:id="eco_de_0000213_110">
      Und gerade diese heimlichen Nester sind es, über denen so eine weiche Stimmung liegt – ein Mollton, wie es über alten vergessenen Gärten zu klingen scheint, die von der jetzigen Generation nicht mehr heimgesucht werden.
     </p>
-    <p xml:id="eco_de_0000143_120">
+    <p xml:id="eco_de_0000213_120">
      Das waren die Nester der Empiremenschen und deren Vorfahren; da haben sie sich harmlos wohlgefühlt, dahin sind sie gezogen, um glücklich und lustig zu sein.
     </p>
-    <p xml:id="eco_de_0000143_130">
+    <p xml:id="eco_de_0000213_130">
      Und wenn jetzt unter den Weimaranern noch so ein verspäteter Kumpan stecken sollte, der die Blutwellen der Leute Anfang dieses Jahrhunderts und Ende des vorigen unvermischt ererbt hat, so ein Abkömmling, der sich in seiner Zeit nicht heimisch fühlt, so ein Träumer, der sich nach etwas sehnt, was er nie kannte, der wird einsam alte, vergessene Wege gehen, die einst seine lustigen Vorfahren so gern wanderten, nach Tröbsdorf, nach Süßenborn zum Aepfelwein, nach Nora, Taubach und auch zum Rödchen.
     </p>
-    <p xml:id="eco_de_0000143_140">
+    <p xml:id="eco_de_0000213_140">
      Und überall wird er alte mürbe Bänke finden.
     </p>
-    <p xml:id="eco_de_0000143_150">
+    <p xml:id="eco_de_0000213_150">
      Unter dem Hausrat der vergessenen Wirtschaften werden hie und da noch steife uralte Täßchen sein, die die Empireleute zurückließen. Und er wird aus so einem Täßchen mit Wehmut trinken und sich nach Menschen, die er nie kannte, wie nach guten Kameraden sehnen. Er wird hie und da in diesen Nestern noch auf ein altes Gartenhaus stoßen, auf einen morschen, gemütsgrün gestrichenen Fensterladen, und alles wird ihm zu Herzen sprechen. Aber es ist wenig, was zurückgeblieben ist – und wir verstehen es nicht mehr.
     </p>
-    <p xml:id="eco_de_0000143_160">
+    <p xml:id="eco_de_0000213_160">
      Und wohl uns, daß wir es nicht verstehen – denn verstünden wir's, würde es uns fehlen auf Schritt und Tritt, das heimliche, seelenruhige Behagen der Alten, ihr harmloser Lebensgenuß.
     </p>
-    <p xml:id="eco_de_0000143_170">
+    <p xml:id="eco_de_0000213_170">
      Eine andre Zeit geht über die Erde hin – eine ganz andre Zeit; allmählich zerfallen und verschwinden die Nester mit den gemütsgrün gestrichenen Fensterläden, den rosa Mauern, den alten Gärten, wo sich unsre Vorfahren einst des Lebens gefreut.
     </p>
-    <p xml:id="eco_de_0000143_180">
+    <p xml:id="eco_de_0000213_180">
      Oben im Rödchen war einst das Haus schmuck und sauber – ganz wie es sein mußte, und ein bemoostes Dach deckte die rosa Mauern – und wo jetzt rings ums Haus klitschiger feuchter Rasen ist und Huflattich wächst und ein paar Hühner trübselig gackern, war ein Garten, ein ganz wunderschöner; Reseda und Flox und Centifolien und Pfingstrosen, Rittersporn und Nachtviolen, Verbenen und Kapuzinerkresse, Obstbäume, von denen noch ein paar wenige uralte Krüppel vor etlichen Jahren standen, Beerensträucher und Himbeerhecken und alles lustig durcheinander und lauschige ländliche Lauben.
     </p>
-    <p xml:id="eco_de_0000143_190">
+    <p xml:id="eco_de_0000213_190">
      Auf dem einsamen Hause lag von alters her ein Schankrecht, das der damalige Förster zu seinem und der Weimaraner Nutzen vortrefflich auszuüben verstand.
     </p>
-    <p xml:id="eco_de_0000143_200">
+    <p xml:id="eco_de_0000213_200">
      Eigentlich war es die Frau Försterin, der diese Ehre gebührte, Haus und Hof so wohl in stand zu halten und es den Gästen behaglich zu machen, vorzüglich zu braten und zu backen, der Försterin und den Töchtern; der Alte kümmerte sich nicht groß darum, der hatte im Ettersberg sein Revier, das ihm Arbeit genug brachte, so daß er den ganzen Tag auf den Beinen war.
     </p>
-    <p xml:id="eco_de_0000143_210">
+    <p xml:id="eco_de_0000213_210">
      Wenn er spät von draußen heimkehrte, sah er es gern, wenn er noch ein paar Leute in dem Gastzimmer vorfand, zu denen er sich dann setzte, um noch ein Partiechen zu machen und zu paffen. Es war ein großer riesenstarker Mann, ein wahrer Wetterbär, der nichts im Kopfe hatte, als seine Pflicht zu thun und von jedem, der mit ihm in Verbindung stand, zu verlangen, daß er die seine thäte. Zu Hause hielt er strenges Regiment. Es war ihm nicht ganz recht, daß die Frau ganz Wirtsfrau geworden war. Da es aber einmal so gekommen, sollte auch das in Ordnung vor sich gehen.
     </p>
-    <p xml:id="eco_de_0000143_220">
+    <p xml:id="eco_de_0000213_220">
      »Daß du mir nicht knappst und geizt, wie das die Frauenzimmer an der Art haben,« sagte er. »Einem jeden sein voll gerüttelt Maß, wie's ihm gebührt, nicht mehr und nicht weniger.«
     </p>
-    <p xml:id="eco_de_0000143_230">
+    <p xml:id="eco_de_0000213_230">
      Er wollte nicht, daß es drunten in Weimar hieße, der alte Walter machte sich mit seiner Wirtschaft Geld.
     </p>
-    <p xml:id="eco_de_0000143_240">
+    <p xml:id="eco_de_0000213_240">
      »Wie sich's gehört, nicht mehr und nicht weniger!«
     </p>
-    <p xml:id="eco_de_0000143_250">
+    <p xml:id="eco_de_0000213_250">
      Was aber mehr als die Redlichkeit des Alten zog, und ebenso wie die guten Werke der Försterin, wie der Kaffee und die Kräpfel und das selbst eingelegte und zu Zeiten auch selbst gebraute Bier und die saftigen Schinkenbrote und was es sonst noch gab, das waren die Kinder des Försters, die drei Mädchen.
     </p>
-    <p xml:id="eco_de_0000143_260">
+    <p xml:id="eco_de_0000213_260">
      Der Förster, der an seinen Mädchen mit einer Liebe hing, wie nur große, bärenhafte Menschen etwas Junges, Hübsches, Zierliches zu lieben verstehen, hatte seine Jüngste, die Ludovikchen hieß, mit dem Kosenamen Schlimpimperlein umgetauft und die zweite, ein dunkeläugiges hübsches Mädchen, das nach der Mutter geartet war und tapfer mitwirtschaftete, rief er Ludschevadel und die Aelteste, die schon verheiratet war, hatte er ihr Lebtag nicht anders als Schmirankel genannt.
     </p>
-    <p xml:id="eco_de_0000143_270">
+    <p xml:id="eco_de_0000213_270">
      Und niemals rief er seine Töchter anders, als mit den Namen, die er ihnen selbst gegeben. Von ihrer Kindheit an hatte er nicht leiden können, wenn irgend etwas an ihnen nicht sauber war. Sie hätten sich dem Vater nicht in einem befleckten Kleide, einer schmutzigen Schürze oder mit wirrem Haar zeigen dürfen, da konnte er ganz außer sich geraten, wenn er dergleichen an ihnen bemerkte.
     </p>
-    <p xml:id="eco_de_0000143_280">
+    <p xml:id="eco_de_0000213_280">
      Die allerliebste war ihm, wie das fast immer der Fall ist, die Jüngste, das Schlimpimperlein.
     </p>
-    <p xml:id="eco_de_0000143_290">
+    <p xml:id="eco_de_0000213_290">
      Das war ein dunkelblondes Mädchen, mit weißer Haut, einem weichen Gesichtchen, hellbraunen Augen und wie aus dem Ei geschält.
     </p>
-    <p xml:id="eco_de_0000143_300">
+    <p xml:id="eco_de_0000213_300">
      Sie war ein stilles feines Kind und wie mit einemmal ein blütenjunges vollkommenes Weibchen geworden, mit aller Klugheit und dem Selbstbewußtsein solch eines schönen Geschöpfchens. Der große bärenhafte Vater hing an diesem Mädchen mit einer fast demütigen Zärtlichkeit.
     </p>
-    <p xml:id="eco_de_0000143_310">
+    <p xml:id="eco_de_0000213_310">
      »Die hat mir keine trübe Stunde gemacht und ihrer Mutter auch nicht. Die ist so ruhig und wohlgesittet schon auf die Welt gekommen, nicht wahr, Alte?« sagte er wohl zu seiner Frau –»die war da, man wußte nicht wie.«
     </p>
-    <p xml:id="eco_de_0000143_320">
+    <p xml:id="eco_de_0000213_320">
      Die Försterin mochte es wohl schon wissen, aber sie nickte immer dazu, wenn ihr Mann das Schlimpimperlein so lobte.
     </p>
-    <p xml:id="eco_de_0000143_330">
+    <p xml:id="eco_de_0000213_330">
      Es war zur Welt gekommen, als der Förster im Ettersberge beim Holzschlag war – und als er abends heimkam, lagen Mutter und Kind und schliefen ganz wohlgemut. Das hat er dem Schlimpimperlein nie vergessen können.
     </p>
-    <p xml:id="eco_de_0000143_340">
+    <p xml:id="eco_de_0000213_340">
      Als seine beiden Aeltesten geboren wurden, das war ihm jedesmal »verflucht nahe gegangen«, wie er sagte.
     </p>
-    <p xml:id="eco_de_0000143_350">
+    <p xml:id="eco_de_0000213_350">
      Schlimpimperlein aber hatte ihm diese, wie er sie nannte, »gottverdammten Stunden« erspart.
     </p>
-    <p xml:id="eco_de_0000143_360">
+    <p xml:id="eco_de_0000213_360">
      Aber eine »gottverdammte Stunde« hatte ihm die Aelteste auch noch eingebracht, das war – als die Mutter zu ihrem Alten eintrat, der gerade sein Nachmittagsschläfchen gehalten hatte, und sagte: »Du, bei uns drüben ist der junge Adjunkt; mit mir hat er schon gesprochen – er will nun zu dir.«
     </p>
-    <p xml:id="eco_de_0000143_370">
+    <p xml:id="eco_de_0000213_370">
      »Was will er denn?« brummte er verschlafen in den Bart.
     </p>
-    <p xml:id="eco_de_0000143_380">
+    <p xml:id="eco_de_0000213_380">
      »Na, Alter – was wird er denn wollen, du?« Die Försterin legte ihm die Hand auf die Schulter und wollte ihn ein bißchen, halb in Verlegenheit, halb scherzend rütteln. Er stand aber wie ein Eichbaum.
     </p>
-    <p xml:id="eco_de_0000143_390">
+    <p xml:id="eco_de_0000213_390">
      »Du weißt's ja, Alter – der Adjunkt – thu doch nicht so!«
     </p>
-    <p xml:id="eco_de_0000143_400">
+    <p xml:id="eco_de_0000213_400">
      Aber der Alte rührte sich nicht.
     </p>
-    <p xml:id="eco_de_0000143_410">
+    <p xml:id="eco_de_0000213_410">
      »Ich weiß gar nichts,« brnmmte er.
     </p>
-    <p xml:id="eco_de_0000143_420">
+    <p xml:id="eco_de_0000213_420">
      »Du mein Gott – das mußt du ja doch längst wissen – das weißt du ja – die Schmirankel will er und hat eben sehr, sehr artig bei mir angefragt – und möchte nun zu dir herein.«
     </p>
-    <p xml:id="eco_de_0000143_430">
+    <p xml:id="eco_de_0000213_430">
      »Laß mich,« kam es hart zwischen den Zähnen, die die Pfeife hielten, heraus.
     </p>
-    <p xml:id="eco_de_0000143_440">
+    <p xml:id="eco_de_0000213_440">
      »Na, Alter, geh – thu doch nicht so. – Er steht schon draußen. Soll ich ihn denn nicht rufen – Alter?« sagte die Försterin ängstlich.
     </p>
-    <p xml:id="eco_de_0000143_450">
+    <p xml:id="eco_de_0000213_450">
      »Nein,« sagte er und hielt sich steif und steifer.
     </p>
-    <p xml:id="eco_de_0000143_460">
+    <p xml:id="eco_de_0000213_460">
      »Na, du wirst doch nicht – der Schmirankel ihrem Glück im Weg stehen wollen – da hast du ja gar keine Veranlassung – denk doch, so eine Partie!«
     </p>
-    <p xml:id="eco_de_0000143_470">
+    <p xml:id="eco_de_0000213_470">
      »Geh mir weg!« brummte er. »Macht, was ihr wollt – das ist den Weibsleuten ihre Angelegenheit – Mich laßt's aus!«
     </p>
-    <p xml:id="eco_de_0000143_480">
+    <p xml:id="eco_de_0000213_480">
      Der Försterin war's, als wäre er dabei bleich geworden; – das mußte aber wohl eine Täuschung gewesen sein, bei so einer Gelegenheit. Aber er hatte den Hut genommen und war, ohne rechts oder links zu sehen, aus dem Hause gegangen, so daß die Försterin ihn noch aufhalten mußte, um zu fragen: »Na, was soll ich ihm denn aber sagen – du?«
     </p>
-    <p xml:id="eco_de_0000143_490">
+    <p xml:id="eco_de_0000213_490">
      »Was du willst! Mich sollst du in Frieden lassen!«
     </p>
-    <p xml:id="eco_de_0000143_500">
+    <p xml:id="eco_de_0000213_500">
      Und fort war er – und kam abends, als alle längst zu Ruhe gegangen waren, erst wieder heim – hat sich aber später mit dem Adjunkten ganz gut befreundet, trotzdem in der ersten Zeit eine stehende Redensart bei ihm war: »Für fremde Leute seine Kinder erziehen, das fehlte mir.« –
     </p>
-    <p xml:id="eco_de_0000143_510">
+    <p xml:id="eco_de_0000213_510">
      Schmirankels Hochzeit war noch ein böser Tag für den Riesen, ein Tag, den er in allen Ausdrücken, die ihm zu Gebote standen, verfluchte. Dann ging es aber besser, als er dachte.
     </p>
-    <p xml:id="eco_de_0000143_520">
+    <p xml:id="eco_de_0000213_520">
      Schmirankel kam oft von Weimar herauf, allein und mit dem Manne, und das waren allemal Festtage. Schmirankel, die manchmal übellaunig gewesen war, benahm sich, wenn sie zu Besuch war, wie die gute Stunde selbst und der Adjunkt war wie ein Sohn. »So ein großer fix und fertiger Sohn ist mir mit einemmal ins Haus gekommen,« sagte der Vater einmal schlau zur Mutter – als hätte er etwas ganz besonders Ueberraschendes ausfindig gemacht.
     </p>
-    <p xml:id="eco_de_0000143_530">
+    <p xml:id="eco_de_0000213_530">
      Försters waren glückliche Leute und galten auch dafür.
     </p>
-    <p xml:id="eco_de_0000143_540">
+    <p xml:id="eco_de_0000213_540">
      Möchte wissen, wenn da oben im Rödchen ruppiges Volk gesteckt hätte, oder eine einsame alte Wirtsfrau mit einer schmutzigen Kellnerin, ob da das Rödchen so einen Zulauf gehabt hätte, wie zur Zeit, als das Glück und das Behagen selbst dort wohnte; als da oben nicht geknappst und gespart wurde, als sie da oben noch Blumen zogen und der Garten in einem Flor stand, daß man seinesgleichen hätte suchen können. In dem Garten, in den stillen ländlichen Lauben, da saßen des Nachmittags die alten Damen beim Kaffee und die unverbesserlichsten unter ihnen machten ihr Partiechen miteinander. – Wie der Flox im Rödchen duftete und die zarten Verbenen und die Büschel Reseda, die am Wege hin wuchsen, das findet man nirgends mehr so, und die alten Damen wurden von Anna, die im Hause Ludschevadel hieß, so verständig und brav bedient, daß sie alles Lobes voll waren. Frau von Goethe, als Frau Geheimrätin von Goethe und auch als Mamselle Vulpius ging gar zu gern hinauf ins Rödchen, und die Schopenhauern und Adele. Auch dem Arthur Schopenhauer hatte es das Rödchen angethan, der spazierte mit Vorliebe, wie mir das Ratsmädchen, die Röse, in ihren alten Tagen erzählt hat, auf der großen aufsteigenden Wiese umher, die sich neben dem Rödchen, von Tannen umsäumt, bis zu den vollzweigigen Buchen des Ettersberges hinaufzieht und von der aus man einen wunderhübschen Blick auf Weimar hat; aber der Arthur Schopenhauer kehrte auch mit Vorliebe bei Försters ein und man neckte ihn ein wenig mit Walters Ludschevadel, von der er gesagt haben soll, daß sie das einzige vernünftige Frauenzimmer in ganz Weimar sei.
     </p>
-    <p xml:id="eco_de_0000143_550">
+    <p xml:id="eco_de_0000213_550">
      Für das junge Volk und die lebhafteren Gemüter standen Bänke und Tische außerhalb des Blumengartens unter einer hohen Linde, die mächtig aufgewachsen und die uralte Dorflinde des vergessenen Dörfleins Roda war, wie man erzählte.
     </p>
-    <p xml:id="eco_de_0000143_560">
+    <p xml:id="eco_de_0000213_560">
      Wenn diese Linde im Rödchen blühte, dann gab's ein Fest für Jung und Alt.
     </p>
-    <p xml:id="eco_de_0000143_570">
+    <p xml:id="eco_de_0000213_570">
      Unter der Linde war seit undenklichen Zeiten schon der Boden gedielt und manches Tänzchen hat der alte Baum, der nun längst gefallen ist, mit angesehen. Zur Lindenblütenzeit tanzten unter den Blüten die Menschen und oben zwischen den Blüten die Bienen, und die Vögel flogen ein und aus und die Fideln klangen, daß es eine Lust war.
     </p>
-    <p xml:id="eco_de_0000143_580">
+    <p xml:id="eco_de_0000213_580">
      Die Lauben, zu denen die schmalen Wege durch die Blumen und die überhängenden Beerensträucher führten, waren eben nur für die alten, vorsichtigen Damen, wenn die aber abends nach Hause gegangen waren, da nisteten sich allerlei lose Vögel dort ein, die die Abendkühle nicht scheuten, wie es die alten Damen thaten.
     </p>
-    <p xml:id="eco_de_0000143_590">
+    <p xml:id="eco_de_0000213_590">
      Manchmal hatten die Försterin und die Töchter wirklich alle Hände voll zu thun, da war kein Fleckchen unbesetzt.
     </p>
-    <p xml:id="eco_de_0000143_600">
+    <p xml:id="eco_de_0000213_600">
      Und wenn abends der Förster heimkam, rief es ihm von allen Bänken entgegen: »Prost, Herr Förster!« und hie und da machte man ihm Platz und er setzte sich mit dem vergnügtesten Gesicht von der Welt.
     </p>
-    <p xml:id="eco_de_0000143_610">
+    <p xml:id="eco_de_0000213_610">
      Das hatte er gern, so einen Empfang, und die Gäste hatten alle den Riesenmenschen gern. Niemand hatte etwas gegen ihn, und das wußte er, das war sein Stolz.
     </p>
-    <p xml:id="eco_de_0000143_620">
+    <p xml:id="eco_de_0000213_620">
      Es war ein prächtiger Riese, der Förster, und sah, wie er schon ein gut Stück über die Fünfzig hinaus war, so frisch und mächtig aus wie ein Stück Hochwald; er war so ein rechter Forstteufel und unangekränkelt.
     </p>
-    <p xml:id="eco_de_0000143_630">
+    <p xml:id="eco_de_0000213_630">
      Wenn er etwas sagen wollte, riß er zuvor den Mund hoch auf, daß seine großen Zähne glänzten, und schaute sich die Leute vergnügt an und dann schnappte er erst wieder zu und fing zu sprechen an.
     </p>
-    <p xml:id="eco_de_0000143_640">
+    <p xml:id="eco_de_0000213_640">
      Wer ihn sah, der wurde guter Laune.
     </p>
-    <p xml:id="eco_de_0000143_650">
+    <p xml:id="eco_de_0000213_650">
      Nur nachmittags, nach dem Schläfchen, war ihm eine Weile nicht zu trauen.
     </p>
-    <p xml:id="eco_de_0000143_660">
+    <p xml:id="eco_de_0000213_660">
      Die alte Madame Kummerfelden, die ihrer Zeit in Weimar, Leipzig und Hamburg eine recht angesehene Schauspielerin gewesen war und jetzt auf ihre alten Tage unten in Weimar eine Nähschule gegründet hatte, die sehr in Flor und Achtung stand und die sie in ihrem eigenen kleinen Hause abhielt, das »am Entenfang« hieß, weil es an einer Schleuse des Lottenbaches lag, bis zu der die Enten von der Lottenmühle ihre Reisen ausdehnen konnten, – diese alte Madame Kummerfelden, die oft, wenn sie Ferien in ihrer Nähschule gegeben hatte, bei Försters oben tagelang steckte, sagte, wenn sie ihrem großen Freund, dem Förster, nach seinem Schläfchen in den Weg lief: »Da geht er umher wie ein brüllender Löwe und suchet, welchen er verschlinge.«
     </p>
-    <p xml:id="eco_de_0000143_670">
+    <p xml:id="eco_de_0000213_670">
      So war es auch, er band dann gern mit aller Welt an und suchte Streit, und wer im Hause irgend konnte, der ging ihm dann aus dem Wege.
     </p>
-    <p xml:id="eco_de_0000143_680">
+    <p xml:id="eco_de_0000213_680">
      In dem Manne steckte eine Riesenhaftigkeit, die er sonst ganz gut zu beherrschen wußte, aber in der schwachen Stunde nach dem Schläfchen, in der er noch nicht alles wieder recht beisammen hatte, brach sie ihm wie unter den Händen hervor.
     </p>
-    <p xml:id="eco_de_0000143_690">
+    <p xml:id="eco_de_0000213_690">
      Und bei noch einer Gelegenheit war er ganz armselig. Er litt etwas an der Gicht, oder am Podagra, am »Bock« sagte er, denn er war jahrelang in Tirol bei einem vornehmen Herrn Förster gewesen, und in Tirol nennt man das Podagra: »den Bock«.
     </p>
-    <p xml:id="eco_de_0000143_700">
+    <p xml:id="eco_de_0000213_700">
      Wenn er den Bock hatte, war er hilflos wie ein Kind und kroch mit seinem Bock ins Bett und machte einen Spektakel, so daß alle im Haus Respekt vor des Vaters Bock hatten.
     </p>
-    <p xml:id="eco_de_0000143_710">
+    <p xml:id="eco_de_0000213_710">
      »Vatter,« sagte Ludschevadel, wenn er nicht so ganz bei Laune war, »Vatter, was ist Ihnen denn?«
     </p>
-    <p xml:id="eco_de_0000143_720">
+    <p xml:id="eco_de_0000213_720">
      »Der Bock noch lange nicht!« brummte er dann.
     </p>
-    <p xml:id="eco_de_0000143_730">
+    <p xml:id="eco_de_0000213_730">
      Da war dieser aber gewöhnlich schon im Anmarsch, denn sonst hatte der Förster keine schlechte Laune, und dann begann ein großes Treiben im Haus, dann mußten Betten gewärmt werden und Habersäcke ließ er sich heiß machen, alle zehn Minuten einen, und allerhand Thee wollte er trinken, um nur um Gottes willen seinen Bock los zu werden.
     </p>
-    <p xml:id="eco_de_0000143_740">
+    <p xml:id="eco_de_0000213_740">
      Da mußte jeder Gast zurückstehen und alles zurückstehen. Das wußten die Leute auch; wenn sie an dem Tag kamen, an dem der Förster den Bock hatte, durften keinerlei Ansprüche gemacht werden.
     </p>
-    <p xml:id="eco_de_0000143_750">
+    <p xml:id="eco_de_0000213_750">
      Der Bock gehörte nun einmal mit in die Familie und man mußte seit Jahren schon mit ihm rechnen.
     </p>
-    <p xml:id="eco_de_0000143_760">
+    <p xml:id="eco_de_0000213_760">
      Dem Förster war es gar nicht recht, daß sie seinen Bock als so etwas ganz Gewöhnliches ansahen.
     </p>
-    <p xml:id="eco_de_0000143_770">
+    <p xml:id="eco_de_0000213_770">
      Der Förster hätte gewünscht, daß die Leute jedesmal in neues Entsetzen darüber mit ihm zusammen ausgebrochen wären. – Und wehe dem, der des Vaters Bock für einen Augenblick vergaß und im Uebermaß seiner Gesundheit einmal auflachte, dem machte der Förster die Hölle heiß.
     </p>
-    <p xml:id="eco_de_0000143_780">
+    <p xml:id="eco_de_0000213_780">
      Das war so eine eigene Sache mit dem Bock.
     </p>
-    <p xml:id="eco_de_0000143_790">
+    <p xml:id="eco_de_0000213_790">
      Eine ordentliche Verwundung hätte er als Ehrensache ohne Augenzwinkern ertragen. Das war etwas für Männer, dagegen hatte er nichts einzuwenden und hatte es auch durchgemacht.
     </p>
-    <p xml:id="eco_de_0000143_800">
+    <p xml:id="eco_de_0000213_800">
      Er hatte einst einen Hieb über seinen Dickkopf bekommen, daß die Schwarte eine Handbreit auseinandergeklafft hatte; das war in der Ordnung gewesen, – aber der Bock war keineswegs in der Ordnung, da war nichts Ehrenhaftes dabei.
     </p>
-    <p xml:id="eco_de_0000143_810">
+    <p xml:id="eco_de_0000213_810">
      »Eine Schweinerei,« wie der Förster sich ausdrückte.
     </p>
-    <p xml:id="eco_de_0000143_820">
+    <p xml:id="eco_de_0000213_820">
      Und noch heute hätte er sich das Fleisch von den Knochen hauen lassen, wenn es darauf angekommen wäre, wenn es wahrhaft heiliger Ernst einmal werden sollte: »Alte,« sagte er, wenn sie miteinander am späten Abend noch allein in der Wohnstube saßen, »wenn einmal der deutsche Teufel wachgeblasen wird, da bin ich auch dabei – so lang bleib' ich ein junger Mann. – He – umsonst bin ich kein solcher Bär. Ich fahr' einmal nicht in die Grube, ohne ein paar Dutzend Lumpenhunde vorausgeschickt zu haben.«
     </p>
-    <p xml:id="eco_de_0000143_830">
+    <p xml:id="eco_de_0000213_830">
      Und wenn die Försterin über solche Rede zu jammern begann, schlug er mit der Faust auf den Tisch: »So ein Weib hat kein Herz im Leib!«
     </p>
-    <p xml:id="eco_de_0000143_840">
+    <p xml:id="eco_de_0000213_840">
      Und wenn die Försterin dann das Ihre darauf sagte, meinte er: »Geh, du bist eine Memme.« Und dann saß er und brütete vor sich hin und schlug wieder mit der Faust auf den Tisch.
     </p>
-    <p xml:id="eco_de_0000143_850">
+    <p xml:id="eco_de_0000213_850">
      Das harte Los des Vaterlandes ging dem Wackeren nah – und bei jeder neuen Schmach, die ihm zu Ohren kam, war er ein schwer getroffener Mann.
     </p>
    </div>
@@ -346,1276 +346,1276 @@
     <head>
      \*
     </head>
-    <p xml:id="eco_de_0000143_860">
+    <p xml:id="eco_de_0000213_860">
      Der Kanonendonner der Schlacht am 14. Oktober 1806 dröhnte und rollte bis über Weimar hin, bis hinauf ins Rödchen, der Himmel war bleiern, der Oktobernebel lag schwer auf der Erde. Und in diesem Nebel wüteten die Völker gegeneinander, brüllte der Tod und waltete das Schicksal. In Weimar zitterten aller Herzen.
     </p>
-    <p xml:id="eco_de_0000143_870">
+    <p xml:id="eco_de_0000213_870">
      Der Förster war in tiefer Erregung. Er war gerade unten in Weimar gewesen, als die Truppen vom Erfurter Thor her in die Stadt gezogen kamen, und er war einer der Ersten gewesen, die von der Affaire bei Saalfeld zu hören bekommen. Kurfürstlich sächsische Soldaten hatten zu ihm von Saalfeld gesprochen, vom 10. Oktober, und der Förster hatte geflucht und gewettert und hatte so mehr und mehr Leute um sich und die Kurfürstlich-sächsischen angezogen.
     </p>
-    <p xml:id="eco_de_0000143_880">
+    <p xml:id="eco_de_0000213_880">
      Ein preußischer Offizier war spottend hinzugetreten und den Förster hatte sein böser Jähzorn überkommen: »Maulheld, verdammter!« hatte er geschrieen – und wäre dem Preußen an die Kehle gesprungen, hätten ihn die Umstehenden nicht ebenso erregt zurückgehalten.
     </p>
-    <p xml:id="eco_de_0000143_890">
+    <p xml:id="eco_de_0000213_890">
      Es war vom Förster eine böse Stimmung ausgegangen.
     </p>
-    <p xml:id="eco_de_0000143_900">
+    <p xml:id="eco_de_0000213_900">
      Und als der Riese seine äußere Ruhe wiedergewonnen hatte, da stand er und sah Regiment auf Regiment an sich vorüberziehen, Infanterie, Kavallerie und Artillerie, und auch die fünftausend Silbermänner, die auserlesene Mannschaft.
     </p>
-    <p xml:id="eco_de_0000143_910">
+    <p xml:id="eco_de_0000213_910">
      Aber sie hatten ihm alle nicht gefallen.
     </p>
-    <p xml:id="eco_de_0000143_920">
+    <p xml:id="eco_de_0000213_920">
      »Das sind die Rechten nicht,« hatte er immer wieder, wenn neue Scharen an ihm vorüberkamen, in seinen blonden langen Bart gemurmelt und den Kopf dazu geschüttelt.
     </p>
-    <p xml:id="eco_de_0000143_930">
+    <p xml:id="eco_de_0000213_930">
      In das Lager auf dem Horn war er gar nicht gegangen, sondern wieder hinauf in das Rödchen und war oben im Ettersberg seiner Pflicht nachgekommen.
     </p>
-    <p xml:id="eco_de_0000143_940">
+    <p xml:id="eco_de_0000213_940">
      Als am 14. Oktober die ersten dumpfen Kanonenschüsse dröhnten und die Frauensleute oben im Rödchen sich nicht zu lassen wußten vor Aufregung und Angst, ging der Förster über die Felder unter die drei großen einsamen Kiefern, die zwischen der Ettersburger Chaussee und dem Rödchen noch stehen, drei düstere Bäume, und schaute auf Weimar hinab und auf die Höhenzüge hin, hinter denen eine große Schlacht geschlagen wurde.
     </p>
-    <p xml:id="eco_de_0000143_950">
+    <p xml:id="eco_de_0000213_950">
      Er hat den ganzen Tag nichts gegessen und nichts getrunken und kaum mit jemand gesprochen, wie ein Verzweifelter.
     </p>
-    <p xml:id="eco_de_0000143_960">
+    <p xml:id="eco_de_0000213_960">
      Einmal sagte er und strich Schlimpimperlein über das Haar: »Das wird ein böser Tag für alle Deutschen,« und dann zur Frau: »Geh, Alte, und nehmt mit, was ihr meint, das ihr nehmen müßt. Geht bis zur vierten Wildraufe, da richtet euch in der Hütte ein, du und die Mädchens und die Magd. – Und daß sich keines hier sehen läßt, bis ich euch hole.«
     </p>
-    <p xml:id="eco_de_0000143_970">
+    <p xml:id="eco_de_0000213_970">
      Die Försterin wollte nicht, redete drein, da reckte er sich auf und stand wie aus Erz gegossen vor ihr.
     </p>
-    <p xml:id="eco_de_0000143_980">
+    <p xml:id="eco_de_0000213_980">
      Und als das Haus leer war, schloß er's ab und ging hinunter nach Weimar.
     </p>
-    <p xml:id="eco_de_0000143_990">
+    <p xml:id="eco_de_0000213_990">
      Das war um die dritte Stunde am Nachmittag gewesen. Er kam mitten hinein in den Durchzug der geschlagenen Truppen, die in grenzenloser Unordnung durch die Straßen sich wieder zurück zum Erfurter Thor wälzten, und die Franzosen mit ihren Geschützen schossen von der Altenburg aus ihnen nach.
     </p>
-    <p xml:id="eco_de_0000143_1000">
+    <p xml:id="eco_de_0000213_1000">
      Da zog das Elend hin und das Pflaster dröhnte davon. Sie waren alle vom Schicksal Gezeichnete, die schwer Blessierten, von denen welche quer über den Pferden hingen, und die abgequälten, todesmatten, blutbefleckten Davongekommenen und die Kanoniere mit den schwarzen Gesichtern, die ihnen der Atem der Schlacht gefärbt hatte, als wäre ihnen Trauerflor darüber gebunden, und die zertrümmerten Geschütze ohne Räder und die Gäule mit dem wilden, blutdürstigen Blick, die die wütenden Schrecken, die entfesselte Riesenwut der menschlichen Bestie mitgesehen und mitgerast hatten. – All das quoll gehetzt und verfolgt grausenerregend durch die engen Gassen, als sollten die auseinandergesprengt werden.
     </p>
-    <p xml:id="eco_de_0000143_1010">
+    <p xml:id="eco_de_0000213_1010">
      Die Luft dröhnte von den Kanonenschlägen, die Häuser zitterten, die Fenster klirrten – und jedes Herz lebte in Angst und Grauen. Dann auf eine Weile Stille, schwüle Stille, ein sanfter Abendhimmel, todesruhige Straßen, das herbstliche Abendzwitschern der Spatzen, die ganze Gleichgültigkeit der Natur über dem Städtchen ausgebreitet. In den Häusern herzensbange Geschäftigkeit. – Dämmerung. –
     </p>
-    <p xml:id="eco_de_0000143_1020">
+    <p xml:id="eco_de_0000213_1020">
      Und mit der Dunkelheit das Hereinbrechen des Schicksals, das alles Ahnen der bebenden Herzen überstieg.
     </p>
-    <p xml:id="eco_de_0000143_1030">
+    <p xml:id="eco_de_0000213_1030">
      Der Feind in der Stadt! Der Feind mit allen Rechten des Siegers – des Stärkeren!
     </p>
-    <p xml:id="eco_de_0000143_1040">
+    <p xml:id="eco_de_0000213_1040">
      Furchtbar klar muß es zu Tage treten, wenn die dicken Köpfe etwas begreifen sollen.
     </p>
-    <p xml:id="eco_de_0000143_1050">
+    <p xml:id="eco_de_0000213_1050">
      Und es trat zu Tage, das unantastbare Recht des Stärkeren – so klar zu Tage, daß auf den dicken, dumpfen Köpfen die Haare zu Berge standen, die Flammen aus den friedlichen Häusern schlugen, wilde Schreie aus den stillen Bürgerstuben hinaus in die Nacht gellten – Schreie, die ausgestoßen wurden, weil alles bedroht war, das Leben, das Gut, Ehre, das Obdach – alles.
     </p>
-    <p xml:id="eco_de_0000143_1060">
+    <p xml:id="eco_de_0000213_1060">
      Angstschreie vor dem Recht des Stärkeren heulten von Haus zu Haus, drangen durch alle Ritzen und Fenster, durch Rauch und Qualm, durch die düstere wilde Nacht.
     </p>
-    <p xml:id="eco_de_0000143_1070">
+    <p xml:id="eco_de_0000213_1070">
      So erfuhren sie das Recht des Stärkeren!
     </p>
-    <p xml:id="eco_de_0000143_1080">
+    <p xml:id="eco_de_0000213_1080">
      Jetzt zweifelten sie nicht mehr. Daß sie so etwas erleben mußten – die dumpfen braven Leute im Schloß und im Städtchen! – Die Zähne klapperten ihnen vor dieser großen Lehre, die von Zeit zu Zeit über die verschlafene Menschheit hindonnert, die große Lehre, daß unter dem bürgerlichen Ehrenrock, dem Zopf, dem Bausch, dem Schleppkleid, der Halsbinde, den engen Stiefeln, der ehrbaren Zimperlichkeit, der würdevollen Vortrefflichkeit, dem ganzen gedrehten, geschwänzelten Behaben die Bestie wohnt – die wilde, blutdürstige Bestie, an die niemand recht glauben will – und die, wenn ihre Zeit wieder einmal gekommen ist – hohnlachend die Maske abwirft und sie in Schmutz und Blut stampft und nackt und unverstellt hervorspringt zu Mord und Wut und Raserei, zu jeder Scheußlichkeit und Schändlichkeit bereit, die Bestie aller Bestien, der es keine nachthut. – Da ist's ihr wohl, dem sonst geschnürten, eingeengten Vieh.
     </p>
-    <p xml:id="eco_de_0000143_1090">
+    <p xml:id="eco_de_0000213_1090">
      Die Schreie der Mißhandelten das ist Musik, die hat es lange nicht gehört! Heut' ist's sein Recht! Offen und unversteckt! Alles ist erlaubt! Es ist Wonne, es ist Raserei, der Schaum steht vor wilder Lust, das sein zu dürfen, was sie ist, der Bestie vor dem Maul und es heißt ehrlicher Krieg und Mannesmut und alles ist in schönster Ordnung.
     </p>
-    <p xml:id="eco_de_0000143_1100">
+    <p xml:id="eco_de_0000213_1100">
      Solches haben die Leute in Weimar bei finsterer Nacht und bei hellem freundlichen Sonnenschein kennen gelernt. Bei hellem freundlichen Sonnenschein, der der Menschen Elend naiv und göttlich gleichgültig beleuchtete. Die helle Sonne, die hat den Weimaranern damals weh gethan; wie war das häßlich, diese helle Sonne über all dem Greuel – taktlos!
     </p>
-    <p xml:id="eco_de_0000143_1110">
+    <p xml:id="eco_de_0000213_1110">
      Und sie hatten doch gemeint, daß der Himmel mit ihnen weinen müßte. Das hätten sie sich nicht vorgestellt, das machte sie betroffen. Er lachte und das war auch in der Ordnung so – vielleicht hielt er's mit den Franzosen.
     </p>
-    <p xml:id="eco_de_0000143_1120">
+    <p xml:id="eco_de_0000213_1120">
      In dunkler Nacht, die von brennenden Häusern zuckend erhellt wurde, und im hellen bösartigen Sonnenschein, da war ein alter blonder großer Bursche auf seinen starken Beinen Tag und Nacht unterwegs. Er hatte keine Sorge für das eigene Haus und hielt es mit allen, die bedrängt waren. Wie ein Teufel fuhr er durch die Straßen, durch das wilde, schleppende, brüllende Pack, stürzte da in ein Haus und dort in eins, und wo er eintrat, war eine ruhige, gesunde Kraft eingetreten, die geängstigten Leute sahen auf. »Da ist der Förster,« sagten sie – und da gab es immer zu thun für ihn. Er trat den Plünderern, die sich, von der unsinnigen Todesangst der Bürgersleute angestachelt, aufgeregt fühlten und sich ihrer Gewalt freuten, ruhig, gut gelaunt entgegen, riß den Mund auf und lachte das eindringende Diebsgesindel an und packte den ersten besten am Kragen und hielt ihn in die Höhe und ließ ihn zappeln und zeigte ihn gutmütig lachend wie einen Hasen den geängstigten Leuten und dem Gesindel, das nicht wußte, was es davon halten sollte – der alte Riesenbursche mit der Riesenkraft und dem guten Humor verblüffte sie und sie zogen ab – für einmal wenigstens.
     </p>
-    <p xml:id="eco_de_0000143_1130">
+    <p xml:id="eco_de_0000213_1130">
      »Da ist eine Kraft von Zwanzig drin!« sagte der Förster und schlug sich auf die Brust – und nickte den Leuten zu: »Ruhig Blut – ruhig Blut! – Verblüfft sie doch, die Hunde!« rief er den Zitternden, Hohläugigen, Bangwangigen zu.
     </p>
-    <p xml:id="eco_de_0000143_1140">
+    <p xml:id="eco_de_0000213_1140">
      »Wenn in jedem Haus so ein blonder Kerl säß, da würden sie so artig kommen und so vorsichtig nehmen, aus Angst, daß sie was auf die Tatzen bekämen.« – Das sagte er immer wieder und immer wieder und begriff nicht, daß die Leute es nicht verstanden und nicht thaten, was er wollte, daß er keinen einzigen solchen blonden Kerl irgendwo fand, sondern lauter Leute, die drei Tage lang in der Gänsehaut steckten mit blauen Lippen, blauen Nägeln und klappernden Zähnen.
     </p>
-    <p xml:id="eco_de_0000143_1150">
+    <p xml:id="eco_de_0000213_1150">
      Der Förster vom Rödchen und Goethes kleines Weib, seine kleine tapfere Freundin, von der ihr später einmal hören sollt, wie ihr die wilden Tage hingegangen sind, das waren die einzigen frischen Leute in Weimar, die nicht nur an sich und ihr Hab und Gut dachten, sonder für andre zu sorgen Zeit und Kraft fanden.
     </p>
-    <p xml:id="eco_de_0000143_1160">
+    <p xml:id="eco_de_0000213_1160">
      Mit den Großen, den berühmten Leuten befassen meine Geschichten sich nun einmal nicht, wie ich schon oft gesagt habe, sonst könnte ich an dieser Stelle auch von der edlen Herzogin sprechen. – Für einen Fürsten ist es eine dankbare Aufgabe, die Kräfte einmal ein wenig zusammenzunehmen und zu handeln, wie es sich für einen gesunden Menschen, dem das Herz auf dem rechten Flecke sitzt, schickt, denn es wird als Riesenthat, als Ausnahmethat in alle Winde und alle künftigen Jahrhunderte geblasen, als Ruhmeszeugnis und menschliches Armutszeugnis zugleich. Ich bleibe bei den Unbekannten, den Vergessenen und erzähle, wie der Förster vom Rödchen durch die Straßen läuft und schaut, wo etwas zu retten, zu helfen ist, wie er mit den Hausvätern in der Vorwerksgasse, denen sie die Häuser angezündet haben, das Feuer löscht. Sie haben eine Spritze herbeigezogen und arbeiten im Schweiße ihres Angesichts. Niemand denkt daran, ihnen beizuspringen. – Es brennt und brennt rettungslos. Sie müssen ihre Spritze und ihre saure Arbeit gegen die Plünderer verteidigen.
     </p>
-    <p xml:id="eco_de_0000143_1170">
+    <p xml:id="eco_de_0000213_1170">
      »Saukerl!« ruft der Förster, als ihm ein Franzose mit der flachen Klinge eine überhaut; – aber läßt den Schlauch nicht los, der den Wasserstrahl in die wilde Glut schickt.
     </p>
-    <p xml:id="eco_de_0000143_1180">
+    <p xml:id="eco_de_0000213_1180">
      Um die Spritze drängt und tollt und schwadroniert es jetzt. Sie schimpfen und wüten. Sie wollen nicht, daß gespritzt wird. Es soll brennen. Aber am Förster vom Rödchen zerschellt alles Schwadronieren und Wüten wie Wellen an einem Felsen.
     </p>
-    <p xml:id="eco_de_0000143_1190">
+    <p xml:id="eco_de_0000213_1190">
      Er reißt den Mund weit auf und lacht und lenkt seinen Schlauch und lenkt ihn auf die Franzosen, da zischt es unter sie hinein – Teufel auch! – Das hätte der Förster mit dem Leben büßen können! Aber er lacht dazu – und es hätten nicht Franzosen sein müssen.
     </p>
-    <p xml:id="eco_de_0000143_1200">
+    <p xml:id="eco_de_0000213_1200">
      »Bravo!« rufen sie. So leicht beweglich sind sie wie bei uns nur die Gassenbuben.
     </p>
-    <p xml:id="eco_de_0000143_1210">
+    <p xml:id="eco_de_0000213_1210">
      Der Förster spritzt weiter, jetzt wieder in die Glut hinein und zwei armselige Hausväter pumpen zähneklappernd; da reißen die Franzosen dem Förster aus dem Rödchen den Schlauch aus den Händen. Zu Zwanzig fielen sie über ihn her; – an der Schulter trägt er eine hübsche Wunde davon. – Dann zertreten und zerschlagen sie den Schlauch. »Da kann ich nichts machen,« sagte der Förster. »Hunde, verdammte!«
     </p>
-    <p xml:id="eco_de_0000143_1220">
+    <p xml:id="eco_de_0000213_1220">
      Er ließ sich seine Wunde von einem alten Weib verbinden, das den Kopf noch so weit bei einander hatte, um zwischen den Trümmern ihrer Habseligkeiten dem Förster einigermaßen zu helfen. –
     </p>
-    <p xml:id="eco_de_0000143_1230">
+    <p xml:id="eco_de_0000213_1230">
      Darauf versucht er sein Glück weiter. An dem Morgen, als die Weimaraner auf Befehl vor dem Schlosse, in welchem der Franzosenkaiser zur Zeit residiert, ein Hoch ausbringen sollen, weil er die Stadt so gnädig verschont habe, da ist's ihm, dem Förster, als hätten hundert Teufel ihn in der Mache.
     </p>
-    <p xml:id="eco_de_0000143_1240">
+    <p xml:id="eco_de_0000213_1240">
      »Sie werden's thun, die Memmen! die Kriecher, die Schlangenbäuche!« sagte er sich. Und wieder fährt er wie ein Teufel in der Stadt herum und geht ein und aus ungehindert in den Häusern ohne Thüren, denn die Thüren waren alle zerschlagen, und er tritt in die wüsten Stuben, in denen kein Stück mehr an seinem Platz steht, nichts als Trümmer und Lumpen und elende verängstigte und verhungerte Gestalten. –
     </p>
-    <p xml:id="eco_de_0000143_1250">
+    <p xml:id="eco_de_0000213_1250">
      »Na,« ruft er, so mitten im Elende stehend: »Heut' früh sollt ihr für die Schweinerei hier, und daß er euch die Haut auf den Knochen ließ, ›Vivat‹ rufen vor dem Schloß. Das laßt euch gesagt sein, wer wirklich so eine gottverdammte Nachteule ist und ihm vorm Fenster krächzt, den zieh' ich bei Gelegenheit übers Leder, daß es dampft – daß ihr's wißt – ich bin am Platz.«
     </p>
-    <p xml:id="eco_de_0000143_1260">
+    <p xml:id="eco_de_0000213_1260">
      So läuft er von Hausvater zu Hausvater und macht überall ein Donnerwetter.
     </p>
-    <p xml:id="eco_de_0000143_1270">
+    <p xml:id="eco_de_0000213_1270">
      In einem Hause hatte er eine Alte durch das Gewühl in Sicherheit gebracht, dort die Kinder, – in einem andern hatte er einen Kranken vor den Diebsgesichtern beschützt – überall hatte er irgend etwas ausgerichtet und sich Dank verdient, da konnte er schon etwas wagen. Wenn auch wenige von den braven Bürgersleuten begriffen, weshalb er sich so darüber ereiferte, daß sie dem Kaiser Napoleon ein Hoch bringen sollten – dafür war er ja Kaiser. Mein Gott, und wenn es sich um einen Kaiser handelt, muß einmal Hoch gerufen werden unter allen Umständen, sei es wie es sei – und Napoleon war den Weimaranern auch ganz recht. Es gab viele, die hätten es gar nicht ungern gesehen, wenn – – na, es ist eins wie's andre schließlich, meinten sie. Jetzt waren es Kriegszeiten – aber in Friedenszeiten da mochte der Napoleon so übel auch nicht sein. Es ist alles Wurst, – das waren so die Gedanken der braven Weimaraner und des guten deutschen Volkes damals.
     </p>
-    <p xml:id="eco_de_0000143_1280">
+    <p xml:id="eco_de_0000213_1280">
      Solche blonde alte Burschen wie der Förster vom Rödchen, solche verrannte Genies der Vaterlandsliebe, so blinde tolle Teufel voller Haß und Schmerz, die waren selten, selten, wenn jetzt auch die Geschichte der damaligen Tage davon zu wimmeln scheint, – so selten wie die Verrückten, die Tobsüchtigen oder seltener.
     </p>
-    <p xml:id="eco_de_0000143_1290">
+    <p xml:id="eco_de_0000213_1290">
      Und an jenem Morgen, da war der Förster an seinem Platz, da sah er jeden, der gehorsam angeschlichen kam, um unter Napoleons Fenstern mitjubeln zu helfen. Wie waren sie alle verhungert, wie sahen sie alle aus; elende Jammerlappen!
     </p>
-    <p xml:id="eco_de_0000143_1300">
+    <p xml:id="eco_de_0000213_1300">
      Der Förster stand wie ein General und musterte seine Rekruten. Es waren ihrer nicht gar zu viele gekommen und die Versammelten waren greulich in der Klemme. – So unter Napoleons Fenstern stehen zu müssen zum Hochrufen, nach glücklich überstandener Plünderung und ausgehungert, erfroren, klappernd, übernächtig, nüchtern, das war ihnen schließlich auch zu dumm, und der stramme Förster vom Rödchen, dem aller Teufel nichts anhaben konnte und der sie sich so listig betrachtete, als dächte er: »Wer's Maul zuerst aufsperrt, der kriegt auch die Plätzerte zuerst!« – der bedrückte sie stärker als Napoleon, der hinter niedergelassenen Gardinen für die Weimaraner gewissermaßen nur ein Begriff war – und von einem bloßen Begriff haben sich die Weimaraner wie alle braven Deutschen ihr Lebtag keinen Begriff machen können. Es muß etwas Thatsächliches, Sichtbares, Hörbares, Fühlbares sein und darf hinter keiner Gardine stecken – dann –!
     </p>
-    <p xml:id="eco_de_0000143_1310">
+    <p xml:id="eco_de_0000213_1310">
      Der Förster riß das Maul hoch auf und lachte sie an und schlug in die Hände und gab so mit einemmal selbst das Zeichen zum Hochrufen – und das hätte eigentlich der Bäckermeister Schilling thun sollen. Jetzt waren sie ganz außer Fassung. Ein paar fingen wirklich ganz heiser und erbärmlich an zu rufen; aber das klang, als wenn ihnen der Magen knurrte und sie machten auch solche Gesichter dazu, als wären sie's gar nicht gewesen, und dann riefen noch ein paar wehleidig und jammervoll, als hätten sie Leibschmerzen und so heulten sie da unten in ihrer seelischen und leiblichen Not – und kein Mensch hätte es mit dem besten Willen für Hochrufen halten können, was man auch in einer solchen Stunde und in so erbärmlichem Zustand keinem Hund und selbst einem verschüchterten Deutschen nicht zumuten konnte.
     </p>
-    <p xml:id="eco_de_0000143_1320">
+    <p xml:id="eco_de_0000213_1320">
      »Herr mein Gott, daß der Kerl da oben von dem Gewinsel nichts gehört hat! Das verdienen die Lumpen wahrhaftig nicht,« denkt der Förster. »Solch ein Volk! wenn ich Er wäre, mit der Hundspeitsche wollt' ich sie zusammenhauen!«
     </p>
-    <p xml:id="eco_de_0000143_1330">
+    <p xml:id="eco_de_0000213_1330">
      Und als der Förster der geplünderten Stadt den Rücken kehrt, fährt er in einem Karren einen armen Blessierten, der auf den bloßen kalten Fliesen der Stadtkirche mit hundert andern gelegen hatte, hinauf ins Rödchen. Und er hat ihn wohl ins Stroh gebettet und ist so vorsichtig mit ihm wie mit einem Wiegenkinde, weicht jedem Stein aus und zieht den Karren sorgsam und ängstlich, achtet auf die Wunde in der Schulter nicht, die ihm das Ziehen beschwerlich genug macht.
     </p>
-    <p xml:id="eco_de_0000143_1340">
+    <p xml:id="eco_de_0000213_1340">
      Und zu Hause angelangt, bettet er den armen Burschen, es ist ein Sachse, in sein eigenes Bett und holt die Frauensleute aus dem Versteck herbei und treibt sie an, zu thun, was sie thun können.
     </p>
-    <p xml:id="eco_de_0000143_1350">
+    <p xml:id="eco_de_0000213_1350">
      Er ist ungeplündert geblieben, der Förster; zu dem versteckten einsamen Haus ist niemand hingekommen.
     </p>
-    <p xml:id="eco_de_0000143_1360">
+    <p xml:id="eco_de_0000213_1360">
      Aber leer will er nicht ausgehen – es sollen noch Blessierte herauf. In jedes Bett einen. Die Gesunden mögen schlafen, wo sie wollen. Die Försterin jammert darüber.
     </p>
-    <p xml:id="eco_de_0000143_1370">
+    <p xml:id="eco_de_0000213_1370">
      »Wenn Gott uns so augenscheinlich vor dem Kriegselend behütet hat, weshalb schleppst du's herauf?«
     </p>
-    <p xml:id="eco_de_0000143_1380">
+    <p xml:id="eco_de_0000213_1380">
      »Daß die Weiber keine Ehre im Leibe haben – auch mein's nicht!« sagt der Förster düster und geht seiner Wege und fährt mit dem Karren wieder zur Stadt hinab. –
     </p>
-    <p xml:id="eco_de_0000143_1390">
+    <p xml:id="eco_de_0000213_1390">
      »Und deine Wunde!« jammert die Försterin ihm nach.
     </p>
-    <p xml:id="eco_de_0000143_1400">
+    <p xml:id="eco_de_0000213_1400">
      »Die ist der Bock noch lange nicht!« ruft er ihr gut gelaunt zu.
     </p>
-    <p xml:id="eco_de_0000143_1410">
+    <p xml:id="eco_de_0000213_1410">
      Und es geschah, wie der Förster gesagt hatte, in jedes Bett im Hause kam ein Blessierter, und die Weiber mußten die armen Burschen pflegen wie ihre Brüder, und das Försterhaus im Rödchen ist den armen Gesellen nach aller Not und allem Elend in der Erinnerung geblieben wie ein Paradies.
     </p>
-    <p xml:id="eco_de_0000143_1420">
+    <p xml:id="eco_de_0000213_1420">
      Das ungefähr waren zu jener Zeit die Leute im Rödchen.
     </p>
-    <p xml:id="eco_de_0000143_1430">
+    <p xml:id="eco_de_0000213_1430">
      Und wieder einmal müssen wir uns mit einem harten Winter abgeben, mit solch einem großen Schneewinter, der die Liebschaften weich einhüllt, so zart, so frisch, so glückselig, so weltverloren, der die Träume mit offenen Augen so ungestört, das Wandeln zwischen den hohen Schneewällen so köstlich macht.
     </p>
-    <p xml:id="eco_de_0000143_1440">
+    <p xml:id="eco_de_0000213_1440">
      Gott weiß, was alles da geschah. Es war im Winter 1808, zwei Jahre nach der großen Plünderung. Oben im Rödchen steckten sie in der Schneewildnis, Weg und Steg verschneit. Die Post, die auf der Ettersburger Straße seit lange schon auf Schlittenkufen ging, war alle nasenlang festgefahren und konnte nicht eher weiterkommen, bis der Schneepflug aus Ettersburg oder aus Weimar, oder wenn das Malheur hinter dem Ettersberg geschah, aus Buttelstädt ihr zu Hilfe kam.
     </p>
-    <p xml:id="eco_de_0000143_1450">
+    <p xml:id="eco_de_0000213_1450">
      Im Rödchen hörte man ganz entfernt und leise über die Schneefelder hin das Posthorn klingen.
     </p>
-    <p xml:id="eco_de_0000143_1460">
+    <p xml:id="eco_de_0000213_1460">
      Der Postillon blies allemal, wenn er in der Nähe des Rödchens vorüberfuhr, denn die Förstersmagd war sein Schatz.
     </p>
-    <p xml:id="eco_de_0000143_1470">
+    <p xml:id="eco_de_0000213_1470">
      Das Posthorn aber war der einzige Ton, der die große Schneestille rings umher belebte, und wenn es erklang, da steckte nicht nur die Magd den Kopf zum Fenster hinaus, auch Schlimpimperlein und Ludschevadel machten das Winterguckloch im Wohnstubenfenster auf und lauschten ganz andächtig, bis der letzte Ton verklungen war, dann gingen sie wieder an ihre Arbeit.
     </p>
-    <p xml:id="eco_de_0000143_1480">
+    <p xml:id="eco_de_0000213_1480">
      Draußen der Wald sah sonderbar aus. Die jungen Bäume hatte der Schnee zur Erde niedergedrückt und sich über sie gelegt, dichter und dichter, daß es die wunderlichsten Gestaltungen gab. Wie gebückte verschneite Männlein sahen die jungen Fichten aus, »getauchte Männer« wie das Volk sagt, und die jungen Erlen hatten sich wie Bogen über die Erde gelegt und trugen ihre gewaltige Last, und die alten, kahlen Bäume hielten mit ihren geduldigen Armen ganze Schneedächer fest. Die großen Tannen hatten schneeweiße Kuppeln auf den breiten grünen Zweigen, die sie eng an sich gedrückt hielten, und die Spitze hing ihnen von der Schneelast tief herab und jeder Graben und jede Unebenheit war verschneit.
     </p>
-    <p xml:id="eco_de_0000143_1490">
+    <p xml:id="eco_de_0000213_1490">
      Im Garten lag eine Schneewehe gerade am Hause an, daß oben aus dem ersten Stock des Försters Dackel ganz bequem zum Fenster hinausspazieren konnte.
     </p>
-    <p xml:id="eco_de_0000143_1500">
+    <p xml:id="eco_de_0000213_1500">
      Beim Rauhfrost war eine unbeschreibliche Herrlichkeit, da hingen an jedem schneefreien Zweiglein dicke Eiskrystalle wie Schuppen und Zapfen, und feine Krystallschleier waren darüber gewebt, und der ferne Wald lag wie in einer weißen, glitzernden, blitzenden Wolke. Wenn der Förster heimkam in seinen riesenhaften Schneestiefeln, hatte er über seinem alten Schafspelz einen köstlichen Spitzenüberzug, und sein Bart glitzerte, und an den Augenbrauen waren zarte Krystalle aufgeschossen und die Pelzkappe flimmerte und tropfte. Der Dackel war ebenso weiß bereift.
     </p>
-    <p xml:id="eco_de_0000143_1510">
+    <p xml:id="eco_de_0000213_1510">
      Aber die Mädchen hatten ein gehörig einsames Leben oben im Rödchen, sahen nichts als Rabenzüge und vor dem Fenster auf dem Futterbrettchen die dicken, aufgeplusterten Amseln, die blauen, flinken Meisen und vor dem Kuhstall die Spatzen und die haubigen Goldammern.
     </p>
-    <p xml:id="eco_de_0000143_1520">
+    <p xml:id="eco_de_0000213_1520">
      Gegen Abend, wenn die Sonne eisig niedergegangen und an manchem Tag die Wölkchen über der verschneiten Erde rosig färbte, kamen die Rehe zum Futterplatz.
     </p>
-    <p xml:id="eco_de_0000143_1530">
+    <p xml:id="eco_de_0000213_1530">
      Vom Fenster aus konnte man sie durch die jungen Stämme sehen. Vorsichtig, in langer Reihe, eins nach dem andern, wie eine Prozession, und verschwanden hinter der großen Futterraufe, eins nach dem andern, immer spähend – immer in Sorge.
     </p>
-    <p xml:id="eco_de_0000143_1540">
+    <p xml:id="eco_de_0000213_1540">
      Wenn die Schneebahn auf der Ettersburger Straße in stand war, kamen wohl ein paar verwegene Spaziergänger bis hinauf ins Rödchen gestiegen und ließen sich einen Glühwein brauen und hingen die Pelzröcke an dem Ofen im Wohnzimmer auf. Der Glühwein, den sie bekamen, das war zwar nur ein echter Jenenser Roter, aber der Förster hatte so seine Kniffe damit, die er niemand recht verriet – aber man wußte schon; er hatte eine solide Quelle in Jena, er bekam seinen Wein gut ausgelesen, und in Erfurt hatte er wieder einen guten Freund, der schickte ihm jedes Jahr mit dem Boten ein leeres Madeirafaß, und in das Madeirafaß wurde der brave Jenenser einlogiert – und suchte dann seinesgleichen. – Die Schneeläufer wußten deshalb sehr wohl, weshalb es sie zum Glühwein bis in das Rödchen hinaufzog.
     </p>
-    <p xml:id="eco_de_0000143_1550">
+    <p xml:id="eco_de_0000213_1550">
      Unter diesen Bürgersleuten, die hin und wider das Wagnis ausführten, Försters in ihrer winterlichen Einsamkeit aufzusuchen, war oft ein junger Maler zu finden, der in Gesellschaft oder einsam zum Rödchen hinaufkam, doch wie es schien, nicht nur des Glühweins halber. Die Ludschevadel hatte es ihm angethan. Daraus machte er kein Hehl, Wohn- und Gaststube war im Winter bei Försters eins geworden und so saß denn die Familie mit ihren Gästen traulich zusammen.
     </p>
-    <p xml:id="eco_de_0000143_1560">
+    <p xml:id="eco_de_0000213_1560">
      Ludschevadel brachte hausfraulich und bescheiden ihrem Anbeter den Glühwein und setzte sich dann neben ihn nieder, in aller Gemütsruh, der junge Heinrich Strobel gefiel auch ihr – und da sie in der Hauptsache miteinander im Reinen waren, nahmen sie es einfach und ruhig.
     </p>
-    <p xml:id="eco_de_0000143_1570">
+    <p xml:id="eco_de_0000213_1570">
      Der Förster aber sah wieder mit Aerger vor seinen Augen, ganz offen und unverhohlen, eine neue Liebesgeschichte entstehen, die ihm wieder eine Tochter kosten sollte – und er konnte nichts dagegen thun, die Sache nahm ihren Lauf.
     </p>
-    <p xml:id="eco_de_0000143_1580">
+    <p xml:id="eco_de_0000213_1580">
      Aber von Ludschevadel hatte der Förster es sich doch nicht gedacht, deren war er so sicher gewesen. Sie hatte schon einige zu seinem größten Wohlbehagen und Triumph ohne weiteres ablaufen lassen, war mit Leib und Seele der elterlichen Wirtschaft ergeben und war ein rechtes Hauskind. – Wie oft hatte sie gesagt, daß sie nun und nimmermehr aus dem Rödchen gehen würde, – aber trau einer den Frauenzimmern.
     </p>
-    <p xml:id="eco_de_0000143_1590">
+    <p xml:id="eco_de_0000213_1590">
      Da ließ sich nichts machen, das wußte er aus Erfahrung – und so saßen sie alle miteinander beisammen, Schlimpimperlein kühl und gleichgültig über ihre Näherei gebückt; die Sache ging sie nichts an.
     </p>
-    <p xml:id="eco_de_0000143_1600">
+    <p xml:id="eco_de_0000213_1600">
      Niemand gab sich mit ihr ab – und daß Ludschevadels Anbeter hin und wider auf seine trockene Art ein paar Worte an sie richtete, das war für sie nicht der Rede wert. Sie war an solche Brosamen, die von einer andern Tisch fielen, nicht gewöhnt; das paßte ihr nicht.
     </p>
-    <p xml:id="eco_de_0000143_1610">
+    <p xml:id="eco_de_0000213_1610">
      Unten in Weimar hatten sie eine Tante, die Schlimpimperlein gerne auf ein paar Wochen im Winter bei sich gehabt hätte, um ihr etwas zu gute zu thun. Aber der Förster wollte das nicht, besonders nicht seit Schmirankel mit ihrem Mann nicht mehr in Weimar lebte, sondern nach Eisenach versetzt war. So saß Schlimpimperlein oben und langweilte sich.
     </p>
-    <p xml:id="eco_de_0000143_1620">
+    <p xml:id="eco_de_0000213_1620">
      Der junge Heinrich Strobel fühlte sich wohl im Haus, er war so ein Biedermann, der die geordneten ruhigen Verhältnisse liebte, ein langer hagerer Bursche mit unglaublich emporstehendem Haar, das keiner Mode der Welt sich bequemt hätte, mit einem grauen unregelmäßigen Gesicht und guten gescheiten grauen Augen. Er hatte auch schon des Vaters Bock oben mit erlebt und sich dabei wie ein guter Sohn bewährt.
     </p>
-    <p xml:id="eco_de_0000143_1630">
+    <p xml:id="eco_de_0000213_1630">
      Der Förster war heimgekommen mit einem Gesicht, einem so starren entsetzten Gesicht, hatte kein Wort gesprochen, seinen Pelz ächzend abgeworfen und sich starr und steif an den Ofen gesetzt.
     </p>
-    <p xml:id="eco_de_0000143_1640">
+    <p xml:id="eco_de_0000213_1640">
      Die Försterin, die bedenklich auf ihn geschaut hatte, sagte ganz erschreckt: »Ach Herr Jes, der Bock – da bringt dem Vatter nur alles, die Betten wärmt und die Habersäcke.« Die Mädchen sprangen und thaten, was ihnen geheißen war. Der Förster aber regte sich nicht, hielt seine, mit einem wollenen Lappen eingewickelte Hand, wie ein Wickelkind vorsichtig auf dem Knie und stöhnte.
     </p>
-    <p xml:id="eco_de_0000143_1650">
+    <p xml:id="eco_de_0000213_1650">
      »Diesmal ist der Bock im Daumen,« sagte er trostlos.
     </p>
-    <p xml:id="eco_de_0000143_1660">
+    <p xml:id="eco_de_0000213_1660">
      Heinrich Strobel, der vom Bock schon alles Nähere wußte, sagte: »Förster, alles was recht ist; – aber den Bock haben Sie nicht im Daumen, wenn nämlich der Bock wirklich Podagra bedeutet, dann kann der Bock nur im Fuß stecken.«
     </p>
-    <p xml:id="eco_de_0000143_1670">
+    <p xml:id="eco_de_0000213_1670">
      »Wieso?« sagte der Förster.
     </p>
-    <p xml:id="eco_de_0000143_1680">
+    <p xml:id="eco_de_0000213_1680">
      »Im Daumen hat eben kein Mensch noch das Podagra gehabt,« antwortete der Maler trocken.
     </p>
-    <p xml:id="eco_de_0000143_1690">
+    <p xml:id="eco_de_0000213_1690">
      »Woll – woll – sel woll,« sagte der Förster mißtrauisch. Das war eine tirolische Erinnerung das »Woll – woll – sel woll« und auch der Bock war eine tirolische Erinnerung.
     </p>
-    <p xml:id="eco_de_0000143_1700">
+    <p xml:id="eco_de_0000213_1700">
      Jetzt fingen die beiden an über den Bock zu streiten, und der Förster vergaß ganz die Schmerzen und stritt aus Leibeskräften, zum Erstaunen der Försterin.
     </p>
-    <p xml:id="eco_de_0000143_1710">
+    <p xml:id="eco_de_0000213_1710">
      »Jetzt geben Sie mal den Daumen her, Förster, daß ich seh, was eigentlich los ist. Geben Sie nur,« sagte der Maler, als der Förster zögerte, und schälte den kranken Daumen aus dem alten wollenen Tuch, das der Förster im Umfang von einer alten Elle sich um die Hand gewickelt hatte, schaute und befühlte ihn, während der Riesenmensch mit geschlossenen Augen und zusammengebissenen Zähnen wie bei einer schweren Operation im Stuhl saß.
     </p>
-    <p xml:id="eco_de_0000143_1720">
+    <p xml:id="eco_de_0000213_1720">
      »Förster,« sagte der Maler, »da ist ein Splitterchen im Gelenk. Gott weiß, – ich seh's – 's is ein bissel tief drin, 's wird rausschwären.«
     </p>
-    <p xml:id="eco_de_0000143_1730">
+    <p xml:id="eco_de_0000213_1730">
      »O – woh',« meinte der Förster stöhnend und verächtlich, stand auf und ging ohne rechts und links zu sehen in sein Schlafzimmer und kroch in die gewärmten Betten und ließ sich auf den Daumen und zur Fürsorge auch gleich auf die Füße die heißen Habersäcke legen. Und in der Wohnstube hörte man ihn bald gewaltig schnarchen. Der Bock war also wirklich nicht gekommen. Und sie hielten sich im Wohnzimmer alle mäuschenstille, damit der »Vatter« seinen Schreck ungestört verschlafen könnte.
     </p>
-    <p xml:id="eco_de_0000143_1740">
+    <p xml:id="eco_de_0000213_1740">
      Als der junge Strobel nach einigen Tagen wieder durch den Schnee heraufgestapft kam, hatte der Förster seinen Daumen immer noch, trotzdem das Splitterchen richtig herausgeschwärt war, der Vorsicht halber mit einem großen weißen Schnupftuch umwickelt – und darüber lachte der Maler und meinte, daß sie mit dem dekorativen Daumen einen Tarock miteinander spielen wollen.
     </p>
-    <p xml:id="eco_de_0000143_1750">
+    <p xml:id="eco_de_0000213_1750">
      »Er hat Recht gehabt,« sagte der Förster, »der Bock war's nicht.« –
     </p>
-    <p xml:id="eco_de_0000143_1760">
+    <p xml:id="eco_de_0000213_1760">
      »Na also,« meinte der Maler und schob seine langen Beine unter den Tisch und steckte dem Förster die Karten zwischen den umwickelten Daumen und die Finger und hatte bei allem, was er that und sagte, so einen trockenen Humor, der bei ihm nicht in den Worten lag. Ludschevadel saß, während ihr guter Freund mit dem Vater spielte, neben ihm mit ihrer Arbeit und man sah ihr an, wie glücklich und ruhig sie sein mochte und wie lieb ihr der lange Mensch war.
     </p>
-    <p xml:id="eco_de_0000143_1770">
+    <p xml:id="eco_de_0000213_1770">
      In einer Pause, die sie im Spiel machten, sagte der Maler: »Bei euch, wenn man von der Chaussee abbiegt – wissen Sie, Förster, gerade wo der Ettersburger Forst den Zwickel macht, – da stehen drei ungeheuer traurige Bäume, – kennen Sie die?«
     </p>
-    <p xml:id="eco_de_0000143_1780">
+    <p xml:id="eco_de_0000213_1780">
      Schlimpimperlein lachte, der kam das komisch vor.
     </p>
-    <p xml:id="eco_de_0000143_1790">
+    <p xml:id="eco_de_0000213_1790">
      »Ja, ja, mag sein,« meinte der Förster, »Bäume haben oft so etwas – – so etwas – –.« Der Förster kam nicht weiter und schaute nachdenklich vor sich hin.
     </p>
-    <p xml:id="eco_de_0000143_1800">
+    <p xml:id="eco_de_0000213_1800">
      »Riesig traurig,« wiederholte der Maler. »Ich weiß nicht, ich bin doch sonst so weit hasenrein in der Beziehung, aber mir legt sich's immer sonderbar auf den Buckel, ordentlich naß, wenn ich an den Bäumen vorüberkomme. Sie stehen da, als wenn sie über etwas Entsetzliches nachgrübelten.«
     </p>
-    <p xml:id="eco_de_0000143_1810">
+    <p xml:id="eco_de_0000213_1810">
      Schlimpimperlein hatte ihre Arbeit sinken lassen, und auf ihr süßes Gesicht trat ein ganz weiches, verächtliches Lächeln und sie sagte: »Ja, und da hängt an jedem von den traurigen Bäumen ein Schnupftuch herab, Herr Strobel, zum Thränen abwischen.«
     </p>
-    <p xml:id="eco_de_0000143_1820">
+    <p xml:id="eco_de_0000213_1820">
      »Sehr gut,« meinte Heinrich Strobel und lachte, Ludschevadel aber blickte ärgerlich auf ihre Schwester. Sie kannte die drei traurigen Bäume auch und erinnerte sich, wie damals bei der Schlacht von Jena, als der Kanonendonner herüberdröhnte, der Vater unter den Bäumen gestanden hatte und sie wollte nicht, daß jemand ihren guten Freund lächerlich fand. Er war es ihr ganz und gar nicht. – Sie liebte ihn mit einem Gefühl der Hochachtung. Es war so eine ernste Liebe – so eine Liebe wie zwischen Ehegatten, denn Ludschevadel war nicht spielerisch, sie war ein pflichtgetreues ruhiges Mädchen mit einem Herzen wie Gold, und Heinrich Strobel war ein Biedermann vom Scheitel bis zur Sohle. Er hatte sich bittersauer bisher durchs Leben schlagen müssen.
     </p>
-    <p xml:id="eco_de_0000143_1830">
+    <p xml:id="eco_de_0000213_1830">
      Sein Vater war ein kleiner Beamter in Kapellendorf bei Weimar gewesen und hatte seinem Sohn während der Lehrzeit nichts mehr als zwei bis drei Korb Kartoffeln jährlich in die Stadt zukommen lassen können und was über die Kartoffeln ging, das hatte er sich dazu verdienen müssen. Und wie weit er mit Kartoffeln reichte, das läßt sich nachrechnen, wenn man bedenkt, daß der Korb zu damaliger Zeit vierzig bis fünfzig Pfennig im Preise stand. Aber er war über die böse lange Zeit mit Hangen und Bangen und durch die Hilfe gutmütiger Leute und durch Fleiß und Anstelligkeit für alle möglichen Dinge gekommen, durch Nachhilfestunden und Bilderkolorieren im Landes- und Industriecomptoir bei Bertuch und durch Handlangerdienste aller Art, und war ein ganz reputierlicher Porträtmaler und Kupferstecher geworden, der seinen eigentlichen Wohnsitz in Leipzig hatte, aber nach Weimar, Jena und Eisenach seine Porträtreisen machte. Es hatte sich da bei jedesmaliger Wiederkehr etwas für ihn zusammengefunden. Diesmal hatte er sich für längere Zeit in Weimar niedergelassen, weil es auch in Rudolstadt und Schwarzburg und Umgegend mancherlei zu thun gab und besonders durch Bertuch hatte er einen großen Auftrag bekommen. Ludschevadel hatte also allen Grund, ihren guten Freund hochzuachten. – Sie war stolz auf ihn, und das ärgerte Schlimpimperlein. Sie gönnte der Schwester den Heinrich Strobel. Er war nicht der Mann, den sie sich gewünscht hätte. Er war ihr langweilig. Aber weil sie im Winter so gar nichts hatte, was sie freute, ärgerte sie sich über die beiden, die miteinander sich bethaten, als gäbe es nichts Besseres und Schöneres und Vortrefflicheres als Ludschevadel und Heinrich Strobel – und darüber war Schlimpimperlein vollständig andrer Meinung, sehr ungerechter Weise, denn es ist zu bezweifeln, ob sie ein besseres und vernünftigeres Mädchen wie ihre ältere Schwester und einen größeren Biedermann wie ihren künftigen Schwager jemals gesehen hatte.
     </p>
-    <p xml:id="eco_de_0000143_1840">
+    <p xml:id="eco_de_0000213_1840">
      Aber was fragt so ein schönes Ding wie Schlimpimperlein danach, wenn es Langeweile hat.
     </p>
-    <p xml:id="eco_de_0000143_1850">
+    <p xml:id="eco_de_0000213_1850">
      Wenn Heinrich Strobel aber von den Weimarschen unten erzählte, da spitzte Schlimpimperlein die Ohren. Herr Gott, was hätte sie darum gegeben, unten in Weimar bei der Tante sein zu dürfen, die sie so gern bei sich gehabt hätte.
     </p>
-    <p xml:id="eco_de_0000143_1860">
+    <p xml:id="eco_de_0000213_1860">
      Es war in Weimar immerhin noch etwas los; wenn es auch nicht mehr so zuging, wie ums Jahr 1777 etwa, von welcher Zeit die Försterin zu erzählen wußte, so war doch auch um 1808 noch für ein junges lebenslustiges Mamsellchen mancherlei zu hören und zu sehen. Da war gerade jetzt die Zeit der Redouten im Stadthaus und Komödie aller nasenlang und Schlittenfahrten und abends auch in den Bürgerhäusern Thees und Gesellschaftsspiele.
     </p>
-    <p xml:id="eco_de_0000143_1870">
+    <p xml:id="eco_de_0000213_1870">
      Und das schöne Geschöpf, das seine Schönheit in der Einsamkeit und Langenweile wie eine bange Last umhertrug, litt und quälte sich. Sie waren alle versorgt im Haus, nur sie nicht. Ludschevadel und Heinrich Strobel und die ganze Zufriedenheit in den vier Wänden erregten das heißblütige Ding. Es war die große Herzenseinsamkeit, in der sie lebte, von der die Zufriedenen und Befriedigten nichts wissen, und die sie nicht verstehen – und verlachen und nicht beachten.
     </p>
-    <p xml:id="eco_de_0000143_1880">
+    <p xml:id="eco_de_0000213_1880">
      Um diese Zeit gerade war es dem alten blonden Riesen, dem Förster, wohl in seiner Haut und in seinem Haus.
     </p>
-    <p xml:id="eco_de_0000143_1890">
+    <p xml:id="eco_de_0000213_1890">
      Der umgangene Bock, der hohe Schnee und der weiße Schneehimmel, der Flockenfall, die Einsamkeit und Weltabgelegenheit besänftigten die heftigen Gefühle und machten dem Behagen und der Zufriedenheit Platz.
     </p>
-    <p xml:id="eco_de_0000143_1900">
+    <p xml:id="eco_de_0000213_1900">
      Es war ihm so wohl unter seinen Leuten und mit einer großen Zärtlichkeit hing er an seinem jüngsten Kinde, dem Schlimpimperlein, dem einzigen, das noch sein eigen war. Wenn sie etwas mürrisch und gelangweilt durch das Zimmer ging, zog er sie zu sich heran und hielt sie mit seinen unbezwinglichen Armen ein wenig an sich gedrückt.
     </p>
-    <p xml:id="eco_de_0000143_1910">
+    <p xml:id="eco_de_0000213_1910">
      Wie er ihr nachsah, wenn er sie wieder frei ließ! Sie war sein Stolz, sein Glück, das lag so deutlich in seinen offenen Zügen ausgeprägt, – und sie, das kühle Schlimpimperlein, fand diese Zärtlichkeit mindestens sehr unnötig, es kam ihr komisch vor und war ihr peinlich.
     </p>
-    <p xml:id="eco_de_0000143_1920">
+    <p xml:id="eco_de_0000213_1920">
      Sie verstand ihn nicht.
     </p>
-    <p xml:id="eco_de_0000143_1930">
+    <p xml:id="eco_de_0000213_1930">
      »Lassen Sie mich, Vatter – lassen Sie mich!« sagte sie halb schmollend, halb verlegen, wenn er sie so im Zimmer auffing und sie festhielt, und sie machte sich los und sträubte sich.
     </p>
-    <p xml:id="eco_de_0000143_1940">
+    <p xml:id="eco_de_0000213_1940">
      Sie war ärgerlich darüber.
     </p>
-    <p xml:id="eco_de_0000143_1950">
+    <p xml:id="eco_de_0000213_1950">
      Ludschevadel aber that der Vater dann leid, sie wußte selbst nicht weshalb.
     </p>
-    <p xml:id="eco_de_0000143_1960">
+    <p xml:id="eco_de_0000213_1960">
      Er kam ihr wie gekränkt und zurückgestoßen vor und sie hatte einen Aerger über ihre Schwester. – Weshalb that sie das dem guten Manne an? Ludschevadel sprach darüber mit ihrem Verlobten, als sie miteinander bei Sonnenuntergang zur Wildraufe gingen, um die Rehe kommen zu sehen. Da schlang er den Arm um sein Mädchen und sagte:
     </p>
-    <p xml:id="eco_de_0000143_1970">
+    <p xml:id="eco_de_0000213_1970">
      »Ludovika,« er nannte die Schwestern bei ihrem Taufnamen, nie anders, »die ist ein rechtes Weibchen.«
     </p>
-    <p xml:id="eco_de_0000143_1980">
+    <p xml:id="eco_de_0000213_1980">
      »Du, wie denn,« frug Ludschevadel – »ich bin doch ein Weibchen?«
     </p>
-    <p xml:id="eco_de_0000143_1990">
+    <p xml:id="eco_de_0000213_1990">
      »Freilich, aber ein gutes dazu, ein ganzer Mensch, ein guter Kamerad und mein lieber Freund.«
     </p>
-    <p xml:id="eco_de_0000143_2000">
+    <p xml:id="eco_de_0000213_2000">
      »Die Weibchen, die nur Weibchen sind,« sagte Heinrich Strobel und wußte sich nicht recht auszudrücken – »die – die – vor denen graust's mich. Schöne Katzen und so hexenhaft wie Katzen – seelenlos. Wenn man nicht in sie verliebt ist, ist man so einsam mit ihnen wie mit einer Katze.«
     </p>
-    <p xml:id="eco_de_0000143_2010">
+    <p xml:id="eco_de_0000213_2010">
      »Wie weißt du denn das?« frug Ludschevadel – und legte ihren Kopf an seine Schulter. »Ludovika kennst du ja kaum. Sie kann auch anders sein. Sie kann manchmal gut sein, so mit einemmal, man weiß nicht wie, da fängt sie an zu weinen und es thun ihr längst vergangene Dinge leid.«
     </p>
-    <p xml:id="eco_de_0000143_2020">
+    <p xml:id="eco_de_0000213_2020">
      »Ja wohl,« sagte Heinrich Strobel trocken. »Meine erste Liebe war auch so. Verfluchte Katzen!«
     </p>
-    <p xml:id="eco_de_0000143_2030">
+    <p xml:id="eco_de_0000213_2030">
      »Aber sie ist doch deine Schwägerin,« sagte Ludschevadel ruhig.
     </p>
-    <p xml:id="eco_de_0000143_2040">
+    <p xml:id="eco_de_0000213_2040">
      »Ah was – Schwägerin, die schert sich den Teufel darum – Schwägerin!« Heinrich Strobel lachte.
     </p>
-    <p xml:id="eco_de_0000143_2050">
+    <p xml:id="eco_de_0000213_2050">
      »Ach geh', du sollst sie eben gern haben – so ein Kind wie sie ist, wir haben uns alle miteinander gern im Haus.
     </p>
-    <p xml:id="eco_de_0000143_2060">
+    <p xml:id="eco_de_0000213_2060">
      »In der Familie muß man einen wie den andern lieben, Heinrich, sonst ist der ganze Frieden nicht mehr im Haus.
     </p>
-    <p xml:id="eco_de_0000143_2070">
+    <p xml:id="eco_de_0000213_2070">
      »Findest du es bei uns nicht mehr hübsch?«
     </p>
-    <p xml:id="eco_de_0000143_2080">
+    <p xml:id="eco_de_0000213_2080">
      Das alles frug und sagte Ludschevadel durcheinander.
     </p>
-    <p xml:id="eco_de_0000143_2090">
+    <p xml:id="eco_de_0000213_2090">
      Und er schloß sie in die Arme und küßte sie.
     </p>
-    <p xml:id="eco_de_0000143_2100">
+    <p xml:id="eco_de_0000213_2100">
      »Du bist mein Weibchen und mein Kamerad, dabei bleibt's,« sagte er. – »Mir ist so wohl!«
     </p>
-    <p xml:id="eco_de_0000143_2110">
+    <p xml:id="eco_de_0000213_2110">
      Es war der ganze Frieden oben im Rödchen, wie Ludschevadel gesagt hatte, so wie Frieden auf Erden aussieht. Die Mutter und Ludschevadel und der Verlobte, die waren wirklich friedlich. In dem treuen unbiegsamen Herzen des Försters aber saß jetzt ein Wurm. Es graute ihm vor der Vereinsamung, wenn die Töchter einmal alle aus dem Hause sein würden. Da konnte er sich in Ruhe nicht hineinfinden.
     </p>
-    <p xml:id="eco_de_0000143_2120">
+    <p xml:id="eco_de_0000213_2120">
      Die verheiratete Tochter war ihm wie gestorben und die Ludschevadel stand nur mit einem Schritt mehr im Haus – und nur Schlimpimperlein lebte ihm noch ganz, war noch ganz sein Kind. Die wollte er nicht hergeben.
     </p>
-    <p xml:id="eco_de_0000143_2130">
+    <p xml:id="eco_de_0000213_2130">
      »Mein Gott, was haben die Mädchen vom Heiraten – was haben sie denn, die armen Narren?« dachte er bei sich.
     </p>
-    <p xml:id="eco_de_0000143_2140">
+    <p xml:id="eco_de_0000213_2140">
      »Für Schlimpimperlein müßte mir schon einer vom Himmel fallen.« Dem ersten besten wollte er sie nicht geben.
     </p>
-    <p xml:id="eco_de_0000143_2150">
+    <p xml:id="eco_de_0000213_2150">
      So saßen sie einmal alle bei einander und Schlimpimperlein neben ihrem Vater.
     </p>
-    <p xml:id="eco_de_0000143_2160">
+    <p xml:id="eco_de_0000213_2160">
      Der war den ganzen Abend auffallend still gewesen. Ludschevadel hatte schon gemeint, daß der Bock im Anzuge sei, aber da legte der Förster den Arm um Schlimpimperleins Nacken und zog sie zu sich heran und bückte sich zu ihr nieder und begann langsam und schwerfällig und bog sich immer tiefer zu Schlimpimperleins Ohr. Er sprach nur für sie allein: »Da war einmal ein Vatter,« sagte er – »dem ging es auf Erden sehr wohl. Er hatte ein schönes Haus, ein gutes Weib und drei Kinder, das waren lauter Mädchen, und er hatte sie alle drei sehr lieb, die älteste hieß Schmirankel, die mittelste Ludschevadel und die jüngste war die Schlimpimperlein.«
     </p>
-    <p xml:id="eco_de_0000143_2170">
+    <p xml:id="eco_de_0000213_2170">
      Jetzt paßten sie alle auf, denn der Vater erzählte etwas von ihnen selbst, aus dem eigenen Hause, aber weil er so ganz seinen großen blonden Kopf zu Schlimpimperlein hingebogen hatte, als wollte er es sie bloß hören lassen, da arbeiteten alle unverdrossen und thaten, als ginge es sie nichts an. Heinrich Strobel zeichnete für Ludschevadels Wäsche die Namenszüge auf. Es lag ein ganzer Berg gezeichnete Wäsche und ungezeichnete vor ihnen, und er war dahinter fast versteckt.
     </p>
-    <p xml:id="eco_de_0000143_2180">
+    <p xml:id="eco_de_0000213_2180">
      »Als die drei, Schmirankel, Ludschevadel und Schlimpimperlein klein waren,« sagte der Förster leise, »da stritten sie miteinander und Schlimpimperlein sagte: ›Ich hätte den Vater geheiratet, wenn er die Mutter nicht genommen hätte;‹ ›nein,‹ sagte Ludschevadel, ›nein, ich hätte ihn geheiratet.‹ Darüber stritten sie alle drei miteinander. Schlimpimperlein aber meinte, sie hätte es zuerst gesagt.
     </p>
-    <p xml:id="eco_de_0000143_2190">
+    <p xml:id="eco_de_0000213_2190">
      »Der Vater nahm sie, eins nach dem andern auf seine Kniee, schaukelte sie und hatte seine Freude an ihnen und war stolz auf sie.
     </p>
-    <p xml:id="eco_de_0000143_2200">
+    <p xml:id="eco_de_0000213_2200">
      »Als sie aber groß wurden, da dachten sie nicht mehr daran, den Vater zu heiraten – sondern ein reicher vornehmer Mann kam und holte die Schmirankel zum Weib – und sie verließ das Vaterhaus und ging ihrem Glücke nach.
     </p>
-    <p xml:id="eco_de_0000143_2210">
+    <p xml:id="eco_de_0000213_2210">
      »Sie hatte ihn lieb und er hatte sie lieb und sie bekamen Kinder, aber ein Krieg brach herein und die Armut kam und der Meister Tod und Schmirankel war traurig und betrübt – kein Mensch kann solchem Leid entgehen.
     </p>
-    <p xml:id="eco_de_0000143_2220">
+    <p xml:id="eco_de_0000213_2220">
      »Aber auch Ludschevadel folgte einem Manne, einem reichen Fürsten, und auch sie ging ihrem Glücke nach und war glücklich; aber kein Glück besteht auf Erden. Der Mann wurde ihrer überdrüssig und verließ sie und nahm eine andre und ließ sie mutterseelenallein in Kummer und Schmerz.
     </p>
-    <p xml:id="eco_de_0000143_2230">
+    <p xml:id="eco_de_0000213_2230">
      »Kein Mensch kann solchem Leid entgehen, wenn es über ihn hereinbricht.
     </p>
-    <p xml:id="eco_de_0000143_2240">
+    <p xml:id="eco_de_0000213_2240">
      »Und als sie an ihren Schwestern sah, wie das Schicksal mit den Menschen umspringt und wie auf Erden kein Glück ist, dem man vertrauen kann, da sagte sie unter heißen Thränen: ›Da ist ja mir das allerbeste Teil geworden.‹ – Und sie blieben bei einander, der alte Vater und das Schlimpimperlein und sie pflegte ihn, bis der Tod sie schied. – Aber sie leben heute noch.«
     </p>
-    <p xml:id="eco_de_0000143_2250">
+    <p xml:id="eco_de_0000213_2250">
      Da hörte der Förster mit seinem Märchen, wie abgebrochen auf. Sein Töchterchen hatte sich von seinem Arme losgemacht und stand mit heißem Gesicht und mit Thränen der Ungeduld von ihrem Stuhle auf.
     </p>
-    <p xml:id="eco_de_0000143_2260">
+    <p xml:id="eco_de_0000213_2260">
      »Nein, Vater, das wäre nichts für mich – das nicht – nein!« Und da brachen die Thränen aus ihren schönen Augen mit voller Gewalt hervor. – »Weshalb denn ich gerade!« schluchzte sie.
     </p>
-    <p xml:id="eco_de_0000143_2270">
+    <p xml:id="eco_de_0000213_2270">
      Der Förster stand auch auf und ging im Zimmer auf und nieder, hielt die Hände auf den Rücken und brummte in den Bart hinein: »Große Kinder – fremde Kinder.« Er ging ganz gebückt, der starke Mann.
     </p>
-    <p xml:id="eco_de_0000143_2280">
+    <p xml:id="eco_de_0000213_2280">
      Sie rissen sich von seinem Herzen los, die Kinder, die einen sanft und kaum merklich, die andern schmerzhaft und grausam.
     </p>
-    <p xml:id="eco_de_0000143_2290">
+    <p xml:id="eco_de_0000213_2290">
      Er verstand den Lauf der Welt nicht und sträubte sich.
     </p>
-    <p xml:id="eco_de_0000143_2300">
+    <p xml:id="eco_de_0000213_2300">
      Die andern wagten nicht aufzublicken, als der Vater so auf und nieder ging, und Schlimpimperlein saß mit schnell getrockneten Thränen, aber trotzig da.
     </p>
-    <p xml:id="eco_de_0000143_2310">
+    <p xml:id="eco_de_0000213_2310">
      Heinrich Strobel reckte seinen Kopf über den Wäschewall, der vor ihm lag, auf und sagte wohlgelaunt, um die schwüle Stille zu unterbrechen: »Aber Förster, daß Ihr den Strobel in einen reichen Taugenichts verwandelt habt, der noch dazu sein Weib sitzen läßt, darüber müssen wir noch miteinander ein Hühnchen rupfen.« –
     </p>
-    <p xml:id="eco_de_0000143_2320">
+    <p xml:id="eco_de_0000213_2320">
      »Das weiß kein Mensch, was er thut oder nicht thut« – sagte der Förster feierlich. »Heut liebt man einander, morgen läßt man einander!«
     </p>
-    <p xml:id="eco_de_0000143_2330">
+    <p xml:id="eco_de_0000213_2330">
      »Aber Fürst ist der Strobel drum doch noch nicht, so wenig als er die Anne jemals läßt!« Dabei gab er seiner Braut einen herzhaften Kuß.
     </p>
-    <p xml:id="eco_de_0000143_2340">
+    <p xml:id="eco_de_0000213_2340">
      »Auch was Rechtes, Fürst! – Fürst oder Lump – Wurm oder Wurm. Es kommt auf eines heraus. Man soll an keinem Menschen hängen, das ist das Sicherste und Beste. Da schlägt man dem Schicksal ein Schnippchen. Merkt's euch – – –
     </p>
-    <p xml:id="eco_de_0000143_2350">
+    <p xml:id="eco_de_0000213_2350">
      »Die Schlimpimperlein ist klug, die hängt hier an niemand. – Wohl ihr.«
     </p>
-    <p xml:id="eco_de_0000143_2360">
+    <p xml:id="eco_de_0000213_2360">
      Das sagte der Förster bitter, während er auf das Mädchen blickte, das scheinbar gleichmütig über die Näherei gebückt saß.
     </p>
-    <p xml:id="eco_de_0000143_2370">
+    <p xml:id="eco_de_0000213_2370">
      »Wie eine Gans wird der Mensch gerupft, Strobel, bis er zuletzt so nackt und bloß dasteht wie zu Anfang. Zu Anfang weiß er nichts und zuletzt will er nichts mehr wissen, das ist der ganze Unterschied. Das bißchen Ehre, das sie einem lassen müssen, wohl oder übel – das ist zuletzt das Einzige, was bleibt. Man könnte sich die Mühe sparen.«
     </p>
-    <p xml:id="eco_de_0000143_2380">
+    <p xml:id="eco_de_0000213_2380">
      Mit diesen Worten ging der Förster hinaus.
     </p>
-    <p xml:id="eco_de_0000143_2390">
+    <p xml:id="eco_de_0000213_2390">
      »Ludovika, warum hast du denn das gethan,« frug Anne vorwurfsvoll, auf ihre ruhige milde Art.
     </p>
-    <p xml:id="eco_de_0000143_2400">
+    <p xml:id="eco_de_0000213_2400">
      Da weinte Schlimpimperlein und sagte: »Du hast gut reden. Was hat man denn vom Leben? Dir hätte er sagen sollen, du sollst bleiben – da hätte ich sehen wollen!«
     </p>
-    <p xml:id="eco_de_0000143_2410">
+    <p xml:id="eco_de_0000213_2410">
      »Wenn du einmal einen Bräutigam hast, wird er's dir auch nicht sagen – Er läßt dich gehen, wie er mich gehen läßt,« sagte die Braut ruhig.
     </p>
-    <p xml:id="eco_de_0000143_2420">
+    <p xml:id="eco_de_0000213_2420">
      »Er wollte dir ja nur zeigen, wie lieb er dich hat und da bist du – so.«
     </p>
-    <p xml:id="eco_de_0000143_2430">
+    <p xml:id="eco_de_0000213_2430">
      »Da hätte er sagen sollen, was er wollte,« antwortete das Mädchen. »Wie soll ich das verstehen.«
     </p>
-    <p xml:id="eco_de_0000143_2440">
+    <p xml:id="eco_de_0000213_2440">
      Alles nimmt einmal ein Ende – auch die Langeweile und Einsamkeit eines schönen Kindes, das seiner Schönheit froh werden möchte. Endlich kommt etwas, lang erwartet oder unvorhergesehen, aber es kommt.
     </p>
-    <p xml:id="eco_de_0000143_2450">
+    <p xml:id="eco_de_0000213_2450">
      Und so sahen sie tags darauf, nachdem Schlimpimperleins Lebensdrang so ungeduldig geworden war, wie ein Füllen, dem ein Zaum angelegt ist, und das nach allen Seiten ausschlägt, eine lange Schlittenreihe die Ettersburger Chaussee heraufkommen.
     </p>
-    <p xml:id="eco_de_0000143_2460">
+    <p xml:id="eco_de_0000213_2460">
      »Ja,« sagte Ludschevadel, »was ist denn das!« als die Schlitten alle zum Feldweg, der zum Rödchen führte, einlenkten. Sie rief im Eifer Schlimpimperlein herbei, die aber der Sache außerordentlich kühl entgegensah.
     </p>
-    <p xml:id="eco_de_0000143_2470">
+    <p xml:id="eco_de_0000213_2470">
      »Ein paar unten aus Weimar,« meinte sie gleichgültig.
     </p>
-    <p xml:id="eco_de_0000143_2480">
+    <p xml:id="eco_de_0000213_2480">
      »Du bist eine Feine,« sagte Anne-Ludschevadel lachend. »Du läßt dir freilich nicht in die Karten sehen. Na! verstell dich nur nicht!« Ludschevadel packte sie an den Schultern und zog sie im Kreise herum.
     </p>
-    <p xml:id="eco_de_0000143_2490">
+    <p xml:id="eco_de_0000213_2490">
      »Geh, laß mich, was ist denn da weiter!«
     </p>
-    <p xml:id="eco_de_0000143_2500">
+    <p xml:id="eco_de_0000213_2500">
      Ludschevadel aber freute sich ganz offen und ehrlich für sie. »Aber was haben wir ihnen vorzusetzen, das möchte ich wissen! Wer denkt denn an so viele Gäste auf einmal!« rief sie.
     </p>
-    <p xml:id="eco_de_0000143_2510">
+    <p xml:id="eco_de_0000213_2510">
      Da ging aber schon die Thür auf und Heinrich Strobel sprang herein und hatte eine rote spitze Kappe auf. »Sie bringen alles mit, ihr Mädchens, seid ohne Sorgen.«
     </p>
-    <p xml:id="eco_de_0000143_2520">
+    <p xml:id="eco_de_0000213_2520">
      »Desto besser!« rief Ludschevadel, »aber wie siehst du denn aus?«
     </p>
-    <p xml:id="eco_de_0000143_2530">
+    <p xml:id="eco_de_0000213_2530">
      »Masken,« sagte Schlimpimperlein träumerisch.
     </p>
-    <p xml:id="eco_de_0000143_2540">
+    <p xml:id="eco_de_0000213_2540">
      Und da kam es auch schon ins Zimmer gequollen. Draußen hörte man die Schlittenpferde mit ihren Glöckchen läuten.
     </p>
-    <p xml:id="eco_de_0000143_2550">
+    <p xml:id="eco_de_0000213_2550">
      Die Försterin kam aus der Küche gestürzt.
     </p>
-    <p xml:id="eco_de_0000143_2560">
+    <p xml:id="eco_de_0000213_2560">
      »Ja du meine Güte! Die ganze Redoute aus dem Stadthaus kommt ja da auf den Schlitten!«
     </p>
-    <p xml:id="eco_de_0000143_2570">
+    <p xml:id="eco_de_0000213_2570">
      Sie standen ganz betreten alle drei über den tollen Menschenschwarm, der mit einemmal in ihre winterliche Einsamkeit übergeflossen kam.
     </p>
-    <p xml:id="eco_de_0000143_2580">
+    <p xml:id="eco_de_0000213_2580">
      Aus Tüchern und Pelzen sprangen die sonderbarsten Figuren: Harlekine und Ritterfrauen, weiße Bäcker und Mönche, Teufel und Bäuerinnen. Manche trugen Masken und manche schauten aus ihren Kapuzen und Kappen mit den rotgefrorenen Gesichtern unternehmend in die Welt hinaus.
     </p>
-    <p xml:id="eco_de_0000143_2590">
+    <p xml:id="eco_de_0000213_2590">
      Aber ob Masken oder keine, die Förstersleute hatten noch lange nicht ihre fünf Sinne bei einander, um irgend jemand erkennen zu können. Draußen warf es jetzt mit Schneeballen an die Fenster und die Schlittenglöckchen läuteten so hell und lustig in die Schneeeinsamkeit hinaus. Und jetzt klang gar vor der Thür eine Fiedel.
     </p>
-    <p xml:id="eco_de_0000143_2600">
+    <p xml:id="eco_de_0000213_2600">
      Sie hätten nicht verwunderter sein können.
     </p>
-    <p xml:id="eco_de_0000143_2610">
+    <p xml:id="eco_de_0000213_2610">
      Schlimpimperlein war ganz verstummt und schaute nur träumerisch in das Gewimmel hinein.
     </p>
-    <p xml:id="eco_de_0000143_2620">
+    <p xml:id="eco_de_0000213_2620">
      Die Förstersmagd war sogleich gesprungen und hatte im sogenannten Saal, in dem bei sommerlichem Regenwetter schon gar manches Tänzchen abgehalten war, ein gehöriges Feuer angezündet.
     </p>
-    <p xml:id="eco_de_0000143_2630">
+    <p xml:id="eco_de_0000213_2630">
      Inzwischen steckten sie alle miteinander noch in der großen Wohnstube.
     </p>
-    <p xml:id="eco_de_0000143_2640">
+    <p xml:id="eco_de_0000213_2640">
      Große Körbe wurden jetzt hereingeschleppt und eine kleine Frau kommandierte.
     </p>
-    <p xml:id="eco_de_0000143_2650">
+    <p xml:id="eco_de_0000213_2650">
      »Das ist ja die Rätin Tiburtsius,« sagte die Försterin zu Ludschevadel.
     </p>
-    <p xml:id="eco_de_0000143_2660">
+    <p xml:id="eco_de_0000213_2660">
      Die Frau Rätin war aber als Königin der Nacht aus ihrem Pelz gekrochen, steckte in einem engen schwarzen Kleid, das mit goldenen Papiersternen besät war, band sich in aller Eile, um vollständig zu sein, einen großen Stern, den sie im Strickbeutel gehabt hatte, auf dem Kopf fest und fing an in den Körben zu wirtschaften, wobei ihr die vortreffliche Magd Kathrine, die sie mitgebracht hatte, half.
     </p>
-    <p xml:id="eco_de_0000143_2670">
+    <p xml:id="eco_de_0000213_2670">
      Das Ganze war also die sogenannte Lawine der Frau Rätin Tiburtsius, die sich in Schlitten zum Rödchen herausgewälzt hatte.
     </p>
-    <p xml:id="eco_de_0000143_2680">
+    <p xml:id="eco_de_0000213_2680">
      Bald durchzog das ganze Haus ein gewürziger Kaffeeduft. Tiburtsiusens Kathrine und die Försterin brauten ihn miteinander. Das Feuer im Saale brannte in voller Eile und mit Geprassel, daß das eiserne Oefchen pustete, fauchte und glühte und die schwarzen Rohre, die durch den halben Saal liefen, knisterten und vor Hitze dröhnten.
     </p>
-    <p xml:id="eco_de_0000143_2690">
+    <p xml:id="eco_de_0000213_2690">
      Wie im Handumdrehen war es warm, wenn auch in den Ecken und an den Fenstern sich noch ein eisiges Lüftchen aufhielt, das wurde bald von den lustigen Masken verscheucht, die jetzt in den Saal einströmten und Tische und Bänke rückten und lachten und lärmten. Ludschevadel und die Försterin brachten die Tassen und die kleine, dicke Tiburtsius kramte in Kuchen und er, Tiburtsius, der als Maske seinen langen weißen Flausrock trug, auf den ihm sein kleines Weib einen großen goldenen Stern auf dem Rücken genäht hatte, mußte die Berge von Kuchen, die die Königin der Nacht auf Schüsseln lud, auf die verschiedenen Tische verteilen. Er trug eine weiße Zipfelmütze auf dem Kopf, die als Troddel einen Stern hatte, und so war der Herr Rat ein billig hergestellter Abend- oder Morgenstern.
     </p>
-    <p xml:id="eco_de_0000143_2700">
+    <p xml:id="eco_de_0000213_2700">
      Und bald saßen sie alle und schwatzten und wärmten sich und tauchten ihren Kuchen in den Kaffee.
     </p>
-    <p xml:id="eco_de_0000143_2710">
+    <p xml:id="eco_de_0000213_2710">
      Die Försters saßen auch alle mit am Tisch.
     </p>
-    <p xml:id="eco_de_0000143_2720">
+    <p xml:id="eco_de_0000213_2720">
      »Teufel auch,« rief der Apotheker, »wenn das nicht gemütlich ist!« Und er stieß mit seiner Kaffeetasse links und rechts an und dienerte dabei.
     </p>
-    <p xml:id="eco_de_0000143_2730">
+    <p xml:id="eco_de_0000213_2730">
      Heinrich Strobel hatte einen jungen Menschen neben sich sitzen, der allen, wie es schien, fremd war, und den er den Förstersleuten als Herrn Friedrich Herzlieb vorstellte; »ein Verwandter von der kleinen Mienchen Herzlieb in Jena, die ich vergangenes Jahr gemalt hab',« sagte er. »Ich hab' ja von ihm erzählt.
     </p>
-    <p xml:id="eco_de_0000143_2740">
+    <p xml:id="eco_de_0000213_2740">
      »Er ist mein Gegenstück in allen Dingen,« dabei faßte Heinrich Strobel das Gegenstück am Kragen. »Seht her, auch in Hinsicht des Mammons. Weiter: arbeite ich wie ein Pferd, er spielt nur und bringt mehr fertig wie ich. Ich bin borstig,« damit streckte Heinrich Strobel seinen unglaublich starr aufstrebenden Haarschopf vor, »er ist ein Karnickel an Zartheit der Behaarung.
     </p>
-    <p xml:id="eco_de_0000143_2750">
+    <p xml:id="eco_de_0000213_2750">
      »Aus mir machen sich die wenigsten was, die Frauenzimmer gar nichts – bei ihm ist das anders.
     </p>
-    <p xml:id="eco_de_0000143_2760">
+    <p xml:id="eco_de_0000213_2760">
      »Ich habe ihn mir zur Ausgleichung nach Weimar kommen lassen.
     </p>
-    <p xml:id="eco_de_0000143_2770">
+    <p xml:id="eco_de_0000213_2770">
      »Er geht unten bei Excellenz Goethe ein und aus, so ein Grünschnabel und ich könnte darüber verrecken, wenn ich mir in den Kopf gesetzt hätte, auch einmal so einer Ehre teilhaftig zu werden.
     </p>
-    <p xml:id="eco_de_0000143_2780">
+    <p xml:id="eco_de_0000213_2780">
      »Na, ich gönne dir's! Und hiermit überliefere ich euch diesen Herzbruder und Seidenhasen. – Ich denke, daß ich selten mehr ohne diese Menschenspecies heraufkommen werde, weil wir eben Ergänzungsstücke sind.«
     </p>
-    <p xml:id="eco_de_0000143_2790">
+    <p xml:id="eco_de_0000213_2790">
      »Die Sache sieht anders aus, wie Strobelmeier sagt,« unterbrach ihn der junge Mensch mit einer leichten Liebenswürdigkeit, »er ist nämlich mein Herr und Meister.«
     </p>
-    <p xml:id="eco_de_0000143_2800">
+    <p xml:id="eco_de_0000213_2800">
      »Welche von beiden ist nun deine Braut, Strobelmeier?« frug er unvermittelt und blickte auf Schlimpimperlein und Ludschevadel, die eben mit einer Ladung Tassen an den Tisch traten.
     </p>
-    <p xml:id="eco_de_0000143_2810">
+    <p xml:id="eco_de_0000213_2810">
      »Rate,« sagte Heinrich Strobel.
     </p>
-    <p xml:id="eco_de_0000143_2820">
+    <p xml:id="eco_de_0000213_2820">
      Der Kamerad legte die Arme auf den Tisch und schaute auf beide Mädchen. Er gehörte zu den Menschen, bei denen der Hals richtig auf dem Rumpf sitzt und der Kopf wieder sein und künstlerisch, nicht grob zugehauen am Hals ansetzt, wie sich's eigentlich gehört. Es ist alles vortrefflich an ihm gebildet, in schönster Ordnung. – Etwas Weiches, Lässiges ist über die ganze Gestalt ausgegossen. Seine Lippen sind auch weich, sybaritisch, in seinen Augen liegt etwas Lebendiges. Er ist blond.
     </p>
-    <p xml:id="eco_de_0000143_2830">
+    <p xml:id="eco_de_0000213_2830">
      »Strobelmeier,« so nannte er seinen Freund, »ist es die Kleine?«
     </p>
-    <p xml:id="eco_de_0000143_2840">
+    <p xml:id="eco_de_0000213_2840">
      »Reingefallen,« lachte Strobel. »Wann lernst du mich kennen!«
     </p>
-    <p xml:id="eco_de_0000143_2850">
+    <p xml:id="eco_de_0000213_2850">
      »Ich denke die Gegensätze.«
     </p>
-    <p xml:id="eco_de_0000143_2860">
+    <p xml:id="eco_de_0000213_2860">
      »Aber heiliger Strohsack, den Gegensatz doch nicht heiraten, Junge, den muß man jeden Augenblick wieder los werden können, wie wir beide einander, zum Beispiel.«
     </p>
-    <p xml:id="eco_de_0000143_2870">
+    <p xml:id="eco_de_0000213_2870">
      »Also Sie, Demoiselle,« wandte er sich an Anna, »Sie werden diesem Lebenskünstler angehören?«
     </p>
-    <p xml:id="eco_de_0000143_2880">
+    <p xml:id="eco_de_0000213_2880">
      »Wie denn, Lebenskünstler?« frug Ludschevadel – wie nicht angenehm berührt von der Art des jungen Menschen.
     </p>
-    <p xml:id="eco_de_0000143_2890">
+    <p xml:id="eco_de_0000213_2890">
      »Lebenskünstler, freilich Lebenskünstler, wissen Sie vielleicht, wie er sein Geld aufbewahrte, als wir miteinander in Dresden studierten, Demoiselle.«
     </p>
-    <p xml:id="eco_de_0000143_2900">
+    <p xml:id="eco_de_0000213_2900">
      »Wenn er nämlich eins hatte,« warf Heinrich Strobel dazwischen.
     </p>
-    <p xml:id="eco_de_0000143_2910">
+    <p xml:id="eco_de_0000213_2910">
      »Das vorausgesetzt. – Da hat er's in der ganzen Stube verstreut zwischen die Betten geschmissen, unter das Bett, auf den Ofen, in den Ofen, in die Asche, zwischen die Möbel, überall hin, und wenn er ein Geld brauchte, hat er gesucht und gewirtschaftet und ist auf allen vieren herumgekrochen – aber so kam nie die Zeit, daß er mit gutem Gewissen hätte sagen können: Ich hab' wirklich nichts mehr, denn irgendwo konnte immer etwas noch stecken. – Und wissen Sie, wie er damals seine Abendsuppe sich kochte? Er hatte so etwas, das er seinen Apparat nannte, einen Henkeltopf an einem Bindfaden, den hing er an einen Nagel, und der Nagel steckte in einer Kiste, die auf seinem Tisch stand, und unter den Topf stellte er sein Licht und bei dem Licht, das kochen und leuchten mußte, hat er gearbeitet – und wie gearbeitet. – Wissen Sie denn das auch noch nicht?« frug er eindringlich.
     </p>
-    <p xml:id="eco_de_0000143_2920">
+    <p xml:id="eco_de_0000213_2920">
      »Nein,« sagte Ludschevadel und hatte sich auf einen Stuhl niedergelassen und sah mit eigentümlich bewegtem Ausdruck auf ihren Bräutigam, der gleichgültig dasaß, als wenn's ihn nichts anging. »Das ist kein Mensch, der Strobelmeier,« fuhr der Kamerad fort – »das ist kein Mensch! Da hat er gar nichts erzählt. Auch nicht, wie er geheizt hat?«
     </p>
-    <p xml:id="eco_de_0000143_2930">
+    <p xml:id="eco_de_0000213_2930">
      Ludschevadel schüttelte den Kopf.
     </p>
-    <p xml:id="eco_de_0000143_2940">
+    <p xml:id="eco_de_0000213_2940">
      »Es war gehörig kalt, Demoiselle, die Fenster waren hinaufgefroren und wir sitzen bei ihm, in seiner Bude, vier Stock hoch unter dem Dach. Er ist ganz wohlgemut; daß es ein Ding wie Heizen gibt, fällt ihm gar nicht ein.
     </p>
-    <p xml:id="eco_de_0000143_2950">
+    <p xml:id="eco_de_0000213_2950">
      »Da schaut er uns mit einmal an: ›Ihr habt wohl kalt – wie?‹ ›Ich glaub' schon,‹ sagt einer und schüttelt sich.
     </p>
-    <p xml:id="eco_de_0000143_2960">
+    <p xml:id="eco_de_0000213_2960">
      »›Wart, das werden wir gleich haben,‹ meint der Strobelmeier, kriecht unter den Tisch und holt einen uralten Pappdeckel vor. – Jetzt schlägt der Strobelmeier Feuer und zündet seinen Pappdeckel im Ofen an. – ›So, nun haben wir's gemütlich!‹ meint er. Und ich sag' Ihnen, Demoiselle, wir hatten es gemütlich, da war keiner, der die Herzlosigkeit gehabt hätte, noch weiter zu frieren.
     </p>
-    <p xml:id="eco_de_0000143_2970">
+    <p xml:id="eco_de_0000213_2970">
      »Und wieder einmal war ein armer Teufel bei ihm auf der Bude krank geworden, da hat er nachts um Zwölf, weil es auch bitter kalt war, ein altes zerfallenes Faß aus dem Hof vier Stock hoch heraufstibitzt und wollte damit heizen, macht aber so einen greulichen Spektakel, weil die Faßdauben nicht ohne weiteres auseinander wollten, daß er das ganze Haus aufweckte.
     </p>
-    <p xml:id="eco_de_0000143_2980">
+    <p xml:id="eco_de_0000213_2980">
      »So geht's, wenn man Luxus treibt,« sagt er da.
     </p>
-    <p xml:id="eco_de_0000143_2990">
+    <p xml:id="eco_de_0000213_2990">
      »Er war eben kein Mensch. Es konnte ihm nichts etwas anhaben.«
     </p>
-    <p xml:id="eco_de_0000143_3000">
+    <p xml:id="eco_de_0000213_3000">
      Da reichten sich die beiden Verlobten die Hände – und schauten sich beide an, als wollten sie sagen: »Wir, wir verstehen einander,« und in den Augen der Braut lag so ein unendliches Vertrauen so offen und ehrlich ausgesprochen – und Heinrich Strobel versank in diesen vertrauensvollen Blick. Er schien ihm gut zu thun.
     </p>
-    <p xml:id="eco_de_0000143_3010">
+    <p xml:id="eco_de_0000213_3010">
      »Mir ist wohl,« sagte er zu seinem Kameraden trocken und ruhig.
     </p>
-    <p xml:id="eco_de_0000143_3020">
+    <p xml:id="eco_de_0000213_3020">
      »Das mag eine feine – feine Geschichte sein, die du da eingefädelt hast,« meinte der Kamerad.
     </p>
-    <p xml:id="eco_de_0000143_3030">
+    <p xml:id="eco_de_0000213_3030">
      »Eine feine, haltbare Geschichte,« antwortete Heinrich Strobel.
     </p>
-    <p xml:id="eco_de_0000143_3040">
+    <p xml:id="eco_de_0000213_3040">
      Schlimpimperlein war, während die drei miteinander sprachen, aufgestanden und hinausgegangen.
     </p>
-    <p xml:id="eco_de_0000143_3050">
+    <p xml:id="eco_de_0000213_3050">
      »Wo ist denn das kleine Wunder hin?« sagte Friedrich Herzlieb, als er nicht mehr sprach, und schaute sich um.
     </p>
-    <p xml:id="eco_de_0000143_3060">
+    <p xml:id="eco_de_0000213_3060">
      »Kleines Wunder ist gut,« meinte Strobel, für sich – halblaut.
     </p>
-    <p xml:id="eco_de_0000143_3070">
+    <p xml:id="eco_de_0000213_3070">
      Es währte nicht lange, da trat sie wieder ein. Sie hatte ihr Hauskleid abgelegt und war in das weiße Sommersonntagskleid geschlüpft, sah liebreizend in ihrer taufrischen Jugendlichkeit aus. An der Brust trug sie eine frische Rosenknospe und einen Resedazweig und einen Heliotropstengel. Die Blumen hatte sie von dem Winterblumenfenster der Försterin sich abgeknickt.
     </p>
-    <p xml:id="eco_de_0000143_3080">
+    <p xml:id="eco_de_0000213_3080">
      »O weh, dein Freund hat ihr gefallen,« sagte Ludschevadel leise zu ihrem Bräutigam, »der arme Vatter! Sie ist noch so jung, die hätte gut noch warten können. Mir thut er selber leid, wenn er so bald allein ist.«
     </p>
-    <p xml:id="eco_de_0000143_3090">
+    <p xml:id="eco_de_0000213_3090">
      »Da kennst du aber den Vater schlecht, der läßt sich zweimal so eine Lehre wie gestern abend nicht geben, der wird froh sein, wenn sie geht,« sagte Heinrich Strobel.
     </p>
-    <p xml:id="eco_de_0000143_3100">
+    <p xml:id="eco_de_0000213_3100">
      »Da kennst du ihn nicht, Heinrich. Es ist etwas Eigenes. Wie sie ein ganz kleines Kind war, ist es schon so gewesen.«
     </p>
-    <p xml:id="eco_de_0000143_3110">
+    <p xml:id="eco_de_0000213_3110">
      »Gestern hat sie ihm einen Tritt versetzt, dünkt mich, an dem ich wenigstens genug hätte.«
     </p>
-    <p xml:id="eco_de_0000143_3120">
+    <p xml:id="eco_de_0000213_3120">
      »Aber Eltern, was ertragen die nicht mit ihren Kindern und bleiben ihnen doch gut.«
     </p>
-    <p xml:id="eco_de_0000143_3130">
+    <p xml:id="eco_de_0000213_3130">
      »Mütterchen,« sagte Heinrich Strobel freundlich, und dann: »Es ist aber doch kaum zu glauben, daß so ein Engelskind, wie sie jetzt so da steht, so ein hartes, rohes Herz haben kann.«
     </p>
-    <p xml:id="eco_de_0000143_3140">
+    <p xml:id="eco_de_0000213_3140">
      »Nimm du einmal so ein Jüngelchen oder ein kleines Mädchen, um es zu küssen, wenn es nicht will, da wirst du sehen, wie es schreit und zappelt und hat dann noch lang kein rohes Herz. So ist's bei ihr auch,« sagte Ludschevadel.
     </p>
-    <p xml:id="eco_de_0000143_3150">
+    <p xml:id="eco_de_0000213_3150">
      »Sie hat eine gute Schwester, das scheint mir das Beste an ihr zu sein,« sagte Heinrich Strobel.
     </p>
-    <p xml:id="eco_de_0000143_3160">
+    <p xml:id="eco_de_0000213_3160">
      Als Schlimpimperlein eintrat, hatten sich aller Augen auf sie gerichtet. Sie war ein kleines Wunder, das blütenjunge Weibchen, in seiner zierlichen Jungfräulichkeit mit dem runden weißen Gesicht, den braunen kühl blickenden Samtaugen.
     </p>
-    <p xml:id="eco_de_0000143_3170">
+    <p xml:id="eco_de_0000213_3170">
      »Von den Waltersmädchen ist doch eins schöner und braver, als das andre, von oben angefangen, der jüngste Käfer ist wirklich ein exquisites Frauenzimmerchen,« meinte der Apotheker. Es währte nicht lange, da wurden die Bänke und Tische an die Wände gerückt, der Fiedler stellte sich in Positur und die Masken schwirrten im Tanz untereinander. Alles tanzte, jung und alt.
     </p>
-    <p xml:id="eco_de_0000143_3180">
+    <p xml:id="eco_de_0000213_3180">
      Dazwischen wurde dem Jenenser, der in seinem Madeirafaß logierte, gehörig zugesprochen. Manche tranken ihn als Bowle, manche als Punsch und wieder manche verehrten ihn am meisten in Form eines derben Glühweins.
     </p>
-    <p xml:id="eco_de_0000143_3190">
+    <p xml:id="eco_de_0000213_3190">
      Die Försterin verstand ihn auf alle Art genießbar zu machen – und er that auch auf alle Art seine Wirkung. Es war unsäglich gemütlich oben in dem einsamen verschneiten Rödchen.
     </p>
-    <p xml:id="eco_de_0000143_3200">
+    <p xml:id="eco_de_0000213_3200">
      Und mitten in dieser bürgerlich behäbigen Heiterkeit genoß ein junges schönes Paar die Glückseligkeiten der Jugend, schwenkte sich im Tanz und fühlte und sah nur sich allein.
     </p>
-    <p xml:id="eco_de_0000143_3210">
+    <p xml:id="eco_de_0000213_3210">
      Das alles geschah im Rödchen, in welchem vor dunklen Zeiten Doktor Faustus geboren war, im Rödchen, das über den Trümmern eines vergessenen Dorfes, über Gräbern vergessener Menschen aufgebaut und aufgewachsen war.
     </p>
-    <p xml:id="eco_de_0000143_3220">
+    <p xml:id="eco_de_0000213_3220">
      Zu Schlimpimperlein ist endlich das Glück und die Jugendlust heraufgekommen, sie brauchte sich deshalb nicht mehr nach Weimar hinabzubemühen – ihre unbeachtete Schönheit ist keine Last mehr, die Langweile ist weggewischt und sie selbst liebenswürdig wie ein glückliches Kind.
     </p>
-    <p xml:id="eco_de_0000143_3230">
+    <p xml:id="eco_de_0000213_3230">
      Sie ist es jetzt, die den Vater aufsucht und sich an ihn schmiegt.
     </p>
-    <p xml:id="eco_de_0000143_3240">
+    <p xml:id="eco_de_0000213_3240">
      »Das sollte man vordem wissen,« sagte der Förster zu Heinrich Strobel – »ehe man die Kinder auf die Welt setzt, glücklich kann man sie selbst nicht machen, das thun andre. Lieben thun sie uns auch nicht, Gott bewahre, das ist ganz etwas andres. Wenn es ihnen die Fremden wohlgemacht haben, fällt ein Brosamen für uns ab, und geht es ihnen nicht, wie sie wollen, kommt unsre Liebe ihnen erst recht armselig vor.
     </p>
-    <p xml:id="eco_de_0000143_3250">
+    <p xml:id="eco_de_0000213_3250">
      »So ein alter Mensch lernt nicht aus.«
     </p>
-    <p xml:id="eco_de_0000143_3260">
+    <p xml:id="eco_de_0000213_3260">
      Das Leben ging über den Förster hinweg, und er begann sich als Alter zu fühlen.
     </p>
-    <p xml:id="eco_de_0000143_3270">
+    <p xml:id="eco_de_0000213_3270">
      Die Jungen eroberten die Welt um ihn her.
     </p>
-    <p xml:id="eco_de_0000143_3280">
+    <p xml:id="eco_de_0000213_3280">
      Er verlegte sich, wenn er daheim saß, aufs Grübeln und wurde schweigsamer und teilnahmloser als sonst.
     </p>
-    <p xml:id="eco_de_0000143_3290">
+    <p xml:id="eco_de_0000213_3290">
      Er hatte da nichts mehr zu thun, wo er sich in seinem Eigentum, im unbestrittenen Besitz, geglaubt hatte. Wie Seifenblasen zerplatzte vor seinen Augen, was er für fest wie Felsenstein gehalten. Ganz anders sah alles aus, wie er geglaubt. Auf festem wohlgegründeten Boden hatte er zu stehen gemeint und wie es hell wurde, sah er, daß er auf einer treibenden Scholle stand, an der die Wasser von allen Seiten gierig fraßen, um sie bald ganz aufzulösen.
     </p>
-    <p xml:id="eco_de_0000143_3300">
+    <p xml:id="eco_de_0000213_3300">
      Er war nachdenklich geworden.
     </p>
-    <p xml:id="eco_de_0000143_3310">
+    <p xml:id="eco_de_0000213_3310">
      An Kraft hätte er es mit all dem jungen Volke aufnehmen können. Er fühlte sich stark und gesund und mußte zurücktreten, andre machten sich breit.
     </p>
-    <p xml:id="eco_de_0000143_3320">
+    <p xml:id="eco_de_0000213_3320">
      Nicht nur im engen Hause war's ihm nicht wohl. Das weite Vaterland bedrückte ihn noch tiefer und schwerer und versank vor seinen Augen in Schmach und Knechtschaft.
     </p>
-    <p xml:id="eco_de_0000143_3330">
+    <p xml:id="eco_de_0000213_3330">
      Durch die Einflüsse des Lebens wurde aus dem mächtigen alten Burschen einer von den einsamen Menschen, den die andern nicht verstehen.
     </p>
-    <p xml:id="eco_de_0000143_3340">
+    <p xml:id="eco_de_0000213_3340">
      Die Försterin und die beiden jungen Paare aber freuten sich des Lebens.
     </p>
-    <p xml:id="eco_de_0000143_3350">
+    <p xml:id="eco_de_0000213_3350">
      Der Försterin ging es wohl auch nah, daß sie in absehbarer Zeit die Töchter hergeben mußte; aber es war auch ein gutes, zufriedenstellendes Gefühl, daß sie dieselben so sicher angebracht hatte. Sie war stolz darauf.
     </p>
-    <p xml:id="eco_de_0000143_3360">
+    <p xml:id="eco_de_0000213_3360">
      Alternde unversorgte Töchter im Hause zu haben, wäre ihr wie eine Schmach erschienen.
     </p>
-    <p xml:id="eco_de_0000143_3370">
+    <p xml:id="eco_de_0000213_3370">
      Lächeln mußte sie aber gar oft über die große Verschiedenartigkeit ihrer beiden Paare. – Das war unruhiges Blut, die beiden Jüngsten! Sie, die Kleine, wohl zwar nicht, die blieb die Kühle, aber der junge Herzlieb machte so viel Wesens von ihr und von seiner Liebe zu ihr, wie der Försterin noch nichts vorgekommen war. Und daß Schlimpimperlein sich alle Ueberschwenglichkeiten gefallen ließ, nahm sie doch wunder. Sie hatte ihre Mädchen so einfach und bescheiden erzogen, daß sie gemeint hätte, die Haare müßten sich der Kleinen sträuben bei dem Gethue. – Aber im Gegenteil, wie ein Götzenbild, das mit Behagen den Opferduft schnuppert, so ließ sie sich jede Vergötterung gefallen.
     </p>
-    <p xml:id="eco_de_0000143_3380">
+    <p xml:id="eco_de_0000213_3380">
      Er war von ihrer Schönheit, ihrem Liebreiz berauscht, so daß sein Freund Heinrich Strobel es liebte, ihn manchmal mit einer Bemerkung abzukühlen.
     </p>
-    <p xml:id="eco_de_0000143_3390">
+    <p xml:id="eco_de_0000213_3390">
      »Mein Gott, Junge,« sagte er ihm, als sie einmal miteinander vom Rödchen abends Weimar wieder zugingen, »so faß doch die Sache einfach auf, sie ist ein nettes Mädel, sie wird dein Weib, sie wird Kinder gebären, deinen Haushalt führen und ein altes Weib werden. Du siehst, die Sache wird im Sande verlaufen.«
     </p>
-    <p xml:id="eco_de_0000143_3400">
+    <p xml:id="eco_de_0000213_3400">
      »Strobelmeier!« rief der junge schöne Mensch. »Jetzt zum Teufel bleib mir mit deiner altbacknen Weisheit zu Haus. Verschände mir das Götterkind da oben nicht,« er zeigte zum Rödchen zurück.
     </p>
-    <p xml:id="eco_de_0000143_3410">
+    <p xml:id="eco_de_0000213_3410">
      »Bleib mir mit deiner Ehe, deinen Kindern und Windeln vom Hals, deinen Hebammen und Pfarrern und Kindergeschrei – pfui Teufel.«
     </p>
-    <p xml:id="eco_de_0000143_3420">
+    <p xml:id="eco_de_0000213_3420">
      »Na, pfui Teufel – was denn pfui Teufel?« sagte Heinrich Strobel trocken. – »Du willst Familienvater werden, da kommen dir und deinem kleinen Balg da oben diese Sachen alle über den Hals!«
     </p>
-    <p xml:id="eco_de_0000143_3430">
+    <p xml:id="eco_de_0000213_3430">
      »Strobelmeier!« rief der junge Herzlieb, »ich erkenne dich ja gar nicht, ein Philister warst du doch weiß Gott nie!«
     </p>
-    <p xml:id="eco_de_0000143_3440">
+    <p xml:id="eco_de_0000213_3440">
      »Bin auch keiner.«
     </p>
-    <p xml:id="eco_de_0000143_3450">
+    <p xml:id="eco_de_0000213_3450">
      »Die Ludschevadel da oben macht dich dazu.«
     </p>
-    <p xml:id="eco_de_0000143_3460">
+    <p xml:id="eco_de_0000213_3460">
      »Lieber Junge,« sagte Heinrich Strobel ernst, »das bitte ich mir aus, – an die rühr' mir nicht – das verstehst du nicht. Es braucht auch kein Mensch zu wissen, was sie mir ist. Mit ihr spielen und es mit ihr treiben, wie mit einer Dirne – nein – das eben nicht. Sie soll mein Weib werden – der Freund fürs Leben. – –
     </p>
-    <p xml:id="eco_de_0000143_3470">
+    <p xml:id="eco_de_0000213_3470">
      »Ich habe dir's gesagt, wie's mit mir steht. Ich hab' mich durchs Leben würgen müssen; da oben,« auch er zeigte, wie vorhin sein Kamerad, zum Rödchen zurück, »da oben habe ich mein Lebensglück gefunden.«
     </p>
-    <p xml:id="eco_de_0000143_3480">
+    <p xml:id="eco_de_0000213_3480">
      Sie schwiegen beide.
     </p>
-    <p xml:id="eco_de_0000143_3490">
+    <p xml:id="eco_de_0000213_3490">
      »Aber verurteilen, dächte ich, solltest du's auch nicht, wenn ich mich an dem wundervollen Geschöpf freue, Strobelmeier.«
     </p>
-    <p xml:id="eco_de_0000143_3500">
+    <p xml:id="eco_de_0000213_3500">
      »Gewiß nicht. Aber es schadet auch nichts, denke nur manchmal daran, daß sie dein eheliches Weib werden wird, daß sie Mutter deiner Kinder wird.«
     </p>
-    <p xml:id="eco_de_0000143_3510">
+    <p xml:id="eco_de_0000213_3510">
      »Na natürlich wird sie das, der arme Narr,« sagte Friedrich Herzlieb; »aber weshalb soll ich ihr und mir das beste Glück damit verderben. – Oder meinst du vielleicht, mir ist's nicht ernst mit ihr, – Strobelmeier?«
     </p>
-    <p xml:id="eco_de_0000143_3520">
+    <p xml:id="eco_de_0000213_3520">
      »Nein,« sagte der, »das mein' ich nicht; – meint' ich's aber – ehe ich den Leuten, dem Förster oben, durch meine Schuld, weil ich dich brachte, so etwas anthun ließ, fiel einer von uns beiden, mein lieber Junge.«
     </p>
-    <p xml:id="eco_de_0000143_3530">
+    <p xml:id="eco_de_0000213_3530">
      »Wer denkt denn daran, du struppiger Kerl. Was stellst denn du dir vor? Totschlagen lass' ich mich lieber, und jetzt halt dein Maul, Pfaff, und laß mich mein schönes Kind feiern, wie's mir beliebt.«
     </p>
-    <p xml:id="eco_de_0000143_3540">
+    <p xml:id="eco_de_0000213_3540">
      »Jawohl,« sagte Heinrich Strobel und summte vor sich hin:
     </p>
-    <p xml:id="eco_de_0000143_3550">
+    <p xml:id="eco_de_0000213_3550">
      »Und schrieb mit Tinte
     </p>
-    <p xml:id="eco_de_0000143_3560">
+    <p xml:id="eco_de_0000213_3560">
      dem Kinde
     </p>
-    <p xml:id="eco_de_0000143_3570">
+    <p xml:id="eco_de_0000213_3570">
      'nen Liebesbrief,
     </p>
-    <p xml:id="eco_de_0000143_3580">
+    <p xml:id="eco_de_0000213_3580">
      drei Ellen lang
     </p>
-    <p xml:id="eco_de_0000143_3590">
+    <p xml:id="eco_de_0000213_3590">
      mit Tinte.
     </p>
-    <p xml:id="eco_de_0000143_3600">
+    <p xml:id="eco_de_0000213_3600">
      Dem Kinde
     </p>
-    <p xml:id="eco_de_0000143_3610">
+    <p xml:id="eco_de_0000213_3610">
      Juchhe!«
     </p>
-    <p xml:id="eco_de_0000143_3620">
+    <p xml:id="eco_de_0000213_3620">
      So gingen sie miteinander.
     </p>
-    <p xml:id="eco_de_0000143_3630">
+    <p xml:id="eco_de_0000213_3630">
      Friedrich Herzlieb aber feierte sein schönes Kind weiter wie's ihm beliebte. Da er der Sohn wohlhabender Eltern war, fehlte es ihm nicht an Mitteln, seine Liebste zu schmücken und zu erfreuen. Ein Bote lief jeden Tag von Weimar zum Rödchen hinauf mit Blumen und Briefchen, Bändern und allerhand Sächelchen.
     </p>
-    <p xml:id="eco_de_0000143_3640">
+    <p xml:id="eco_de_0000213_3640">
      Einmal kam er selbst und brachte ein wunderschönes Halsband mit, zog es aus dem Futteral und wollte es seiner Braut um das schlanke Hälschen legen.
     </p>
-    <p xml:id="eco_de_0000143_3650">
+    <p xml:id="eco_de_0000213_3650">
      Der Förster aber, der zugegen war, legte dem jungen Mann die Hand auf die Schulter.
     </p>
-    <p xml:id="eco_de_0000143_3660">
+    <p xml:id="eco_de_0000213_3660">
      »Nein, mein Bester, das steck' Er wieder ein, ist sie einmal Euer Weib, dann hab' ich nichts dagegen.
     </p>
-    <p xml:id="eco_de_0000143_3670">
+    <p xml:id="eco_de_0000213_3670">
      »Mein Mädchen darf das nicht. Mir behagt's nicht, wenn eine Braut sich so beschenken läßt. Punktum.«
     </p>
-    <p xml:id="eco_de_0000143_3680">
+    <p xml:id="eco_de_0000213_3680">
      Es war Mai geworden, ging auf den Juni zu. – Das Rödchen war in voller Pracht, die Leute zogen hinaus, um sich am jungen Grün zu freuen, an dem Duft der Birken, am Garten der Förstersleute, der im Blütenschmucke prangte. Es war jetzt alles aufgebrochen, die Pfingstrosen, rote und rosa, Nachtviolen, Iris in allen Farben, Stiefmütterchen und Vergißmeinnicht, Primeln und Narzissen, die Beerensträucher trugen ihre goldgelben Träubchen, die Apfelbäume blühten noch und hatten die rosigen Blumenschälchen weit geöffnet, und die dichten dunklen Gaisblattlauben dufteten mit hundert Wohlgerüchen. Das hohe Lied des Frühlings in tausend frohen, neu erwachten Tönen und von jungen Düften begleitet, stieg von der Erde gen Himmel auf.
     </p>
-    <p xml:id="eco_de_0000143_3690">
+    <p xml:id="eco_de_0000213_3690">
      Da war's im Rödchen schön und da hatte die Försterin alle Hände voll zu thun, um ihre Gäste zu befriedigen, und auch die Mädchen hatten zu helfen von früh bis abends. Am Vormittag Kuchen backen, Kaffee brennen und alles für etwaige Gäste herrichten und nachmittags die Gäste bedienen und mit ihnen plaudern.
     </p>
-    <p xml:id="eco_de_0000143_3700">
+    <p xml:id="eco_de_0000213_3700">
      Die Zeit der Lindenblüte war jetzt gekommen und die Zeit der Rosen, der Centifolien.
     </p>
-    <p xml:id="eco_de_0000143_3710">
+    <p xml:id="eco_de_0000213_3710">
      Die Lindenblüte wurde, wie wir wissen, seit Menschengedenken mit Tanz und Fiedel unter dem alten Baum, dem Stolz des Rödchens, der uralten Dorflinde, gefeiert. Auch dieses Jahr.
     </p>
-    <p xml:id="eco_de_0000143_3720">
+    <p xml:id="eco_de_0000213_3720">
      Das ließen sie sich nicht nehmen, die Leute, so traurig es im deutschen Lande aussah.
     </p>
-    <p xml:id="eco_de_0000143_3730">
+    <p xml:id="eco_de_0000213_3730">
      Seit zwei Oktobern war die Kirchweih um Weimar ausgefallen, aber jetzt zur Lindenblüte, da sollte etwas nachgeholt werden.
     </p>
-    <p xml:id="eco_de_0000143_3740">
+    <p xml:id="eco_de_0000213_3740">
      Das einsame Haus im Rödchen hatte seine Gerechtsame, die gleichsam wie an ihrem letzten Halt dort hängen geblieben waren, und die dem verschwundenen Dorfe, das im Bruderkriege zerstört wurde, einst eigentümlich gewesen waren. Der »Heimrich« oder das Hegemahl, das wurde da oben gefeiert, seit Menschengedenken und weit über Menschengedenken hinaus. Das war ein Fest, das noch von alter Gerichtsbarkeit herrührte, die auf eingehegter Wiese einst stattfand, einer Feldgerichtsbarkeit – und die mit einem Mahle, dem Hegemahle, schloß und dieses wieder gegen Morgen, wo noch einmal frisch ausgeschenkt und kalt aufgeschnitten werden mußte, dem »Hahnewackel«, dem Ende des Heimrich. »Heimer« aber hießen die Bauern, die, die ein Heim haben.
     </p>
-    <p xml:id="eco_de_0000143_3750">
+    <p xml:id="eco_de_0000213_3750">
      Um Weimar, unter alten Linden, da findet man noch hie und da uralte Steintische, die das Volk jetzt »Heinrichstische« nennt, Heimrichstische, aus alten Irrblöcken gehauen, an denen einst Gericht gehalten wurde.
     </p>
-    <p xml:id="eco_de_0000143_3760">
+    <p xml:id="eco_de_0000213_3760">
      Ein Heimrich, ein Hegemahl sollte nach altem Brauch im Rödchen wieder gefeiert werden, das ließ sich jung und altes Volk in Weimar nicht nehmen. Unter der blühenden Linde mußte getanzt und an den langen Tischen vor dem Försterhaus mußte getafelt werden bis zum Hahnewackel und wenn es im deutschen Lande noch trauriger, schmachvoller und hoffnungsloser ausgesehen hätte. Die weimarischen Bürger waren behagliche Leute, konnten sich nicht fortwährend ereifern und beklagen. Man muß die Dinge nehmen, wie sie sind, und damit gut.
     </p>
-    <p xml:id="eco_de_0000143_3770">
+    <p xml:id="eco_de_0000213_3770">
      Der Förster fand, es wäre wahrlich nicht an der Zeit, Freudenfeste zu feiern und unnütz Geld auszugeben, wo Kriegskontribution das Land schwer drückte, Fremde sich breit machten und deutsche Fürsten und Bürger Knechtsgestalt angenommen und keiner so hoch im deutschen Lande stand, der nicht demütig den Rücken vor dem großen Tyrannen und seinen Schergen gebeugt hätte.
     </p>
-    <p xml:id="eco_de_0000143_3780">
+    <p xml:id="eco_de_0000213_3780">
      Aber so ein geplagter Bürgersmann will auch einmal aufatmen, und was geht ihn schließlich die Demütigung der Großen an. Er muß hart genug an Gut und Leben darunter leiden.
     </p>
-    <p xml:id="eco_de_0000143_3790">
+    <p xml:id="eco_de_0000213_3790">
      Hol's der Teufel! Er will aus dem Elend heraus. Er will ein freier Mensch sein, der sich um nichts schert, als um sein eigen Haus und Hof und Haut. – Er will heraus und wär's auf ein paar Stunden. So kam es, daß mitten im Juni, wo die Erde voller Rosen strahlt und duftet und die Linden blühen, die Bienen schwärmen und die ganze Natur im Festkleid prangt, das sie auch angelegt, ohne nach Krieg und Frieden der Großen zu fragen, die Ackerbürgersleute aus Weimar ein Frühlings- und Freudenfest oben im Rödchen feierten, auf dem es lustig, so ausgelassen und reichlich zuging, als lebte man im tiefsten Frieden und nicht in Not und Gefahr.
     </p>
-    <p xml:id="eco_de_0000143_3800">
+    <p xml:id="eco_de_0000213_3800">
      Am Nachmittag begann die Herrlichkeit, da saßen sie an den Kaffeetafeln. Am Ehrenplatz der alte Kaufmann Zunkel, mit dem hohen Rohrstab, der einen gewaltigen Silberknauf hatte. Den Stab mußte er als Ehrenältester beim Hegemahl tragen, mußte so den ersten Tanz anführen, den Stab hochheben, wenn ein Trinkspruch gehalten wurde. Er war es auch, der Streitigkeiten zu schlichten hatte. So hatte sich auf ihn die sagenhafte Macht des hohen Richters der Feldgerichte, durch Jahrhunderte abgeschwächt, übertragen.
     </p>
-    <p xml:id="eco_de_0000143_3810">
+    <p xml:id="eco_de_0000213_3810">
      Ihm stand auch das schöne Recht zu, zwischen Braten und Nachtisch, die jungen Mädchen, die am Hegemahl teilnahmen, zu küssen, wozu er einen Umgang um die Tafel halten mußte.
     </p>
-    <p xml:id="eco_de_0000143_3820">
+    <p xml:id="eco_de_0000213_3820">
      Mit feierlichem Kaffeetrinken begannen sie und tanzten dann bei hellem Sonnenschein unter der blühenden Linde; Vogelsang und Bienengesumme in der golddurchwirkten Krone über ihnen.
     </p>
-    <p xml:id="eco_de_0000143_3830">
+    <p xml:id="eco_de_0000213_3830">
      Die Waltersmädchen waren heute von allen Verpflichtungen freigesprochen. An ihrer Stelle waren Mägde aus der Stadt mit herausgebracht, die die Bedienung besorgten. – Beide Bräute trugen weiße Kleider und Schlimpimperlein hatte auf dem schönen Kopf einen Kranz von Centifolien, der ihr die Augen beschattete, Ludschevadel trug nur ein bescheidenes Rosensträußchen am Busen.
     </p>
-    <p xml:id="eco_de_0000143_3840">
+    <p xml:id="eco_de_0000213_3840">
      Schlimpimperlein, am Arme ihres Verlobten, war ein liebreizender Anblick. Die zarte volle Gestalt von dem engen dünnen Kleid umgeben, die zärtlichen runden Arme, das feine Hälschen, die zarten Schatten des jungen Busens.
     </p>
-    <p xml:id="eco_de_0000143_3850">
+    <p xml:id="eco_de_0000213_3850">
      Sie war ein Anblick, der grünem und dürrem Mannsvolk zu Kopf stieg – und sie hätte keinen Augenblick zu Atem kommen können, wenn ihr Verlobter sie einem einzigen zum Tanze gegönnt hätte; aber er hielt sie am Arm und im Arm den ganzen Abend.
     </p>
-    <p xml:id="eco_de_0000143_3860">
+    <p xml:id="eco_de_0000213_3860">
      Das war der Försterin recht und sie lobte ihn, denn ihr schien die Schönheit ihres Mädchens für ein Bürgerskind nicht recht am Platz.
     </p>
-    <p xml:id="eco_de_0000143_3870">
+    <p xml:id="eco_de_0000213_3870">
      Sie hätte ihr gern etwas angelegt oder abgenommen, – und doch schlug ihr das Herz vor Freude zwischen Braten und Kochen und Schelten und Fragen und Antreiben der fremden Mägde, daß sie ein so schönes Kind besaß. – Ludschevadel war eine liebe Seele, die niemandem besonders auffiel und mit allen gut auskam. Sie tanzte mit jedermann, mit alt und jung und sprach mit allen anmutig und bescheiden. Wenn sie zu ihrem Heinrich zurückkehrte, schaute er sie glücklich und zufrieden an und sie ihn strahlend, und sie saßen miteinander und atmeten den Lindenduft ein und hielten sich an der Hand und schauten auf das Getriebe, das zuerst im Sonnenschein sich tummelte und auf das der Mond später sein mildes Licht warf und über das Fackeln- und Windlichterschein zuckte.
     </p>
-    <p xml:id="eco_de_0000143_3880">
+    <p xml:id="eco_de_0000213_3880">
      Am Abend ging das rechte Leben erst an, da kam das eigentliche Hegemahl an die Reihe, und nach dem Trinken und Essen erwachten die Lebensgeister. Die herrliche Sommernacht hüllte alle ein und drängte sie zusammen auf den erleuchteten Platz unter der Linde. – Und in diesem hellen Kreis wimmelte es wie ein Mückenschwarm, der ums Licht schwärmte. – Nur hie und da fiel ein heißgetanztes Pärchen aus dem glänzenden Zauberkreise ab und wandelte im Dunkeln.
     </p>
-    <p xml:id="eco_de_0000143_3890">
+    <p xml:id="eco_de_0000213_3890">
      Und wie sie sich schwangen und wie sie lachten und flüsterten und wie die Herzen schlugen, und der Wein die Sinne belebte und trübte! Entfernt im dichten Gebüsch sangen die Nachtigallen, denen Liebessehnsucht die kleinen Herzen sprengen wollte.
     </p>
-    <p xml:id="eco_de_0000143_3900">
+    <p xml:id="eco_de_0000213_3900">
      Dem Förster war's nicht wohl zu Mute. Sie kamen ihm so erbärmlich vor, die gedankenlosen Leute – wo Tod und Krieg und Schmach und Not über die Erde hinzog und alles mit sich riß, vernichtete, zerstampfte, wo keiner seines Lebens und seines Gutes sicher war, wo Könige in den Staub getreten wurden und jeder Mutter junger Sohn sein Blut einem frechen Eroberer ohne Gnade und ohne Ehre hinopfern mußte.
     </p>
-    <p xml:id="eco_de_0000143_3910">
+    <p xml:id="eco_de_0000213_3910">
      Er fühlte sich einsam, verlassen in seinen heiligsten Gefühlen auch von den Seinen. Seine beiden jüngsten Liebesleute tanzten mit unversieglichen Kräften.
     </p>
-    <p xml:id="eco_de_0000143_3920">
+    <p xml:id="eco_de_0000213_3920">
      So aneinander geschmiegt, in geheimnisvoll dämmriger Nachtluft, einsam unter Menschengedränge dahinzufliegen, den nahen Atem zu fühlen zwischen Blütendüften und die jungen warmen Körper, und jede Regung, Liebesluft und Liebesglut und jede Bewegung Zärtlichkeit und Schönheit und Jugend – das steckt die Sinne an allen Enden zugleich an, wie eine feindliche Stadt, das flackert und loht, das möchte in Flammenglut die ganze Welt begraben. – Und dieses Mückenpärchen fiel auch vom Lichtkreis ab.
     </p>
-    <p xml:id="eco_de_0000143_3930">
+    <p xml:id="eco_de_0000213_3930">
      Die Kleine hing so matt wie ein gehetztes Wild am Arme ihres Liebsten, der Rosenkranz auf ihrem Haar duftete, – die Rosen hatten sich warm und welk ihr tief in die Stirn gesenkt. Dem jungen Bräutigam vergingen die Sinne. Ihr kühles Herzchen hatte ihn oft irregeführt; er hatte sich erschöpfen müssen in Zärtlichkeit, Aufmerksamkeit, um ein gnädiges Lächeln seines schönen kleinen Götzen zu erhaschen. – Und jetzt, welches Wunder! – jetzt war er Herr und Meister, zitternd, mit klopfendem Herzen lag sie in seinen Armen.
     </p>
-    <p xml:id="eco_de_0000143_3940">
+    <p xml:id="eco_de_0000213_3940">
      Jetzt fuhr sie zusammen. Das waren Schritte! – Gleichgültig kühl legte sie ihren Arm in den seinen und ging mit ihm, und sie begegneten Heinrich Strobel, mit dem sprach sie harmlos und liebenswürdig, als hätte kein Windhauch ihr die Seele bewegt. Ihrem Begleiter aber war, als würde ihm der Hals zugeschnürt, er hätte kein Wort hervorbringen können.
     </p>
-    <p xml:id="eco_de_0000143_3950">
+    <p xml:id="eco_de_0000213_3950">
      »Was für eine kleine süße Hexe war sie doch!«
     </p>
-    <p xml:id="eco_de_0000143_3960">
+    <p xml:id="eco_de_0000213_3960">
      Friedrich Herzlieb wollte heute nicht mit seinem Strobelmeier vom Rödchen hinabgehen, wartete nicht bis zum Morgengrauen bis beim Hahnewackel das Fest sich neu auflebte, sondern ging früher, als die Sommernacht dunkel, nachdem der Mond untergegangen war, über der Erde lag. Als er von seiner Braut Abschied nahm, flüsterte er mit ihr und frug sie bang und erregt und sie erwiderte ihm flüsternd und berührte leicht seine Lippen mit einem Küßchen.
     </p>
-    <p xml:id="eco_de_0000143_3970">
+    <p xml:id="eco_de_0000213_3970">
      »Aber du, tanz mir nicht – tanz mir nicht mehr,« sagte er, da lachte sie und er stürzte davon in die dunkle Nacht hinaus.
     </p>
-    <p xml:id="eco_de_0000143_3980">
+    <p xml:id="eco_de_0000213_3980">
      »Wo ist er denn?« frug Heinrich Strobel, als er Schlimpimperlein allein auf dem Tanzplatz stehen sah.
     </p>
-    <p xml:id="eco_de_0000143_3990">
+    <p xml:id="eco_de_0000213_3990">
      »Fort ist er gelaufen.«
     </p>
-    <p xml:id="eco_de_0000143_4000">
+    <p xml:id="eco_de_0000213_4000">
      Da lächelte Heinrich Strobel.
     </p>
-    <p xml:id="eco_de_0000143_4010">
+    <p xml:id="eco_de_0000213_4010">
      »Wie wär's denn mit 'nem Schwagertanz?« meinte er, »den wird er doch erlauben? Wir sind einander ungefährlich, wir beide, denke ich.«
     </p>
-    <p xml:id="eco_de_0000143_4020">
+    <p xml:id="eco_de_0000213_4020">
      »Ich denke es auch,« sagte sie kühl, »der Herr Schwager mag mich nicht besonders.«
     </p>
-    <p xml:id="eco_de_0000143_4030">
+    <p xml:id="eco_de_0000213_4030">
      »Wenn Sie brav sind, Schlimpimperlein, mag ich Sie schon, weshalb nicht – schon um Ihrer Schwester willen.«
     </p>
-    <p xml:id="eco_de_0000143_4040">
+    <p xml:id="eco_de_0000213_4040">
      »Sehr schmeichelhaft,« sagte Schlimpimperlein.
     </p>
-    <p xml:id="eco_de_0000143_4050">
+    <p xml:id="eco_de_0000213_4050">
      »Und wenn Sie an Ihrem Vater gut machen, was Sie Böses gethan haben!«
     </p>
-    <p xml:id="eco_de_0000143_4060">
+    <p xml:id="eco_de_0000213_4060">
      »Na, was denn?« frug Schlimpimperlein ungeduldig.
     </p>
-    <p xml:id="eco_de_0000143_4070">
+    <p xml:id="eco_de_0000213_4070">
      »Damals, im Winter, den Abend eh' ich den Herzlieb brachte.«
     </p>
-    <p xml:id="eco_de_0000143_4080">
+    <p xml:id="eco_de_0000213_4080">
      »Daß ich nicht wüßte.«
     </p>
-    <p xml:id="eco_de_0000143_4090">
+    <p xml:id="eco_de_0000213_4090">
      »Als der Vater Ihnen das Märchen erzählte.«
     </p>
-    <p xml:id="eco_de_0000143_4100">
+    <p xml:id="eco_de_0000213_4100">
      »Ach gehen Sie, Herr Schwager, das ist nett nachträglich, da kann sich meine Schwester freuen, wenn Sie so sind. Der Vater hat das längst vergessen, mein Gott!« Sie war sehr ungeduldig.
     </p>
-    <p xml:id="eco_de_0000143_4110">
+    <p xml:id="eco_de_0000213_4110">
      »Das hat er nicht vergessen, Schwägerin, vielleicht vergißt er's sein Lebtag nicht. – Sie müssen das gut machen, Ludovika, mir hat's schon längst auf dem Herzen gelegen. Heut sag' ich's Ihnen.
     </p>
-    <p xml:id="eco_de_0000143_4120">
+    <p xml:id="eco_de_0000213_4120">
      »Diesen Vater, daß Sie den kränken konnten!
     </p>
-    <p xml:id="eco_de_0000143_4130">
+    <p xml:id="eco_de_0000213_4130">
      »Machen Sie's gut. Und nun den ›Schwagertanz‹.«
     </p>
-    <p xml:id="eco_de_0000143_4140">
+    <p xml:id="eco_de_0000213_4140">
      »Er möchte nicht, daß ich tanze.«
     </p>
-    <p xml:id="eco_de_0000143_4150">
+    <p xml:id="eco_de_0000213_4150">
      »So,« sagte Heinrich Strobel lächelnd, »Sie böses Kind, vorhin wollten Sie doch, und nun weil ich Sie gescholten habe, möchten Sie mich strafen.«
     </p>
-    <p xml:id="eco_de_0000143_4160">
+    <p xml:id="eco_de_0000213_4160">
      »Nein, er will es wirklich nicht.«
     </p>
-    <p xml:id="eco_de_0000143_4170">
+    <p xml:id="eco_de_0000213_4170">
      »Ich bin da ausgeschlossen, meine Beste, bei dem Verbot. Sagen Sie ihm, Sie hätten mit dem Schulmeister getanzt, das ist ungefährlich.«
     </p>
-    <p xml:id="eco_de_0000143_4180">
+    <p xml:id="eco_de_0000213_4180">
      Sie tanzten den Schwagertanz miteinander.
     </p>
-    <p xml:id="eco_de_0000143_4190">
+    <p xml:id="eco_de_0000213_4190">
      »Hast du mich mit dem kleinen Affen gesehen?« frug Heinrich Strobel seine Braut. »Wie nahmen wir uns aus?«
     </p>
-    <p xml:id="eco_de_0000143_4200">
+    <p xml:id="eco_de_0000213_4200">
      »Nicht besonders, mein Herr Liebster; wir sehen schon besser miteinander aus, glaub' ich.«
     </p>
-    <p xml:id="eco_de_0000143_4210">
+    <p xml:id="eco_de_0000213_4210">
      »Das wollt' ich meinen. Sie ist ein Weibchen, wie ich dir sagte, geradeso ein Weibchen, wie ich damals meinte, eine Katze. – Was weiß ich! Prost Mahlzeit, wenn bei Herzliebs einmal die Herzliebe verraucht und die Tasse Schokolade ausgetrunken sein wird, möcht' ich um die Welt nicht in Friedrichen seiner Haut stecken.
     </p>
-    <p xml:id="eco_de_0000143_4220">
+    <p xml:id="eco_de_0000213_4220">
      »Jetzt ist der arme Teufel so verliebt, daß er davongelaufen ist. Vor so einer fressenden Liebe bewahre einen der Himmel!«
     </p>
-    <p xml:id="eco_de_0000143_4230">
+    <p xml:id="eco_de_0000213_4230">
      Heinrich Strobel und Ludschevadel hielten den Hahnewackel aus bis zuguterletzt.
     </p>
-    <p xml:id="eco_de_0000143_4240">
+    <p xml:id="eco_de_0000213_4240">
      »Auch des Lebens Hahnewackel miteinander, so Gott will, bis ans Ende,« sagte Heinrich Strobel, und Anne Ludschevadel gab ihm die Hand darauf.
     </p>
-    <p xml:id="eco_de_0000143_4250">
+    <p xml:id="eco_de_0000213_4250">
      »Wenn die Kinder,« fuhr er etwas weitsichtig fort, »einmal alle verheiratet und untergebracht sind, da haben wir beiden Alten dann unsern Hahnewackel, dann leben wir noch einmal auf, gerade wie das Hegemahl.« Das Bild gefiel ihm und er spann es aus und variierte es noch weiter, und seine Braut hörte ihm friedlich und glücklich zu.
     </p>
-    <p xml:id="eco_de_0000143_4260">
+    <p xml:id="eco_de_0000213_4260">
      Die Nacht, die auf diese festlich durchlebte folgte, erwachte Ludschevadel, sie schlief mit Schlimpimperlein in der Dachkammer zusammen. Der Mond schien durch das Kappfenster in einem breiten Strahl in das Zimmer hinein. Die alte Schwarzwälder Uhr tickte, und Ludschevadel konnte nicht wieder zum Einschlafen kommen. Sie dachte an Heinrich Strobel, an das schöne Fest, an ihr tiefes stilles Glück, an die Zukunft, die so schön und sicher vor ihr lag, an ihr künftiges Heim, an ihre Aussteuer, an alles, was sie an der Seite des geliebten Mannes erwartete. Wie wollte sie es ihm hübsch und behaglich machen! Sie lächelte dabei, als sie sich's vorstellte, wie gut er's haben würde; die schwere Jugend sollte ihm vergessen gemacht werden.
     </p>
-    <p xml:id="eco_de_0000143_4270">
+    <p xml:id="eco_de_0000213_4270">
      Mit einemmal aber hatte sie das unbestimmte Gefühl, als wäre sie allein im Zimmer, als wäre Schlimpimperlein nicht da. »Ludovikchen,« rief sie vorsichtig, um sie nicht zu wecken, und doch so laut, daß die Schwester es hören konnte, im Fall sie auch wach läge.
     </p>
-    <p xml:id="eco_de_0000143_4280">
+    <p xml:id="eco_de_0000213_4280">
      Sie erhielt keine Antwort – da lauschte Ludschevadel noch ein Weilchen, erhob sich dann und schaute nach dem Bette der Schwester, da war es wirklich leer, und wie von ungefähr berührte sie die Kissen, die waren kalt. Schlimpimperlein mußte schon lange aufgestanden sein. Daß sie nichts gehört hatte, sie waren doch miteinander schlafen gegangen!
     </p>
-    <p xml:id="eco_de_0000143_4290">
+    <p xml:id="eco_de_0000213_4290">
      Einen so sonderbaren Schreck empfand sie.
     </p>
-    <p xml:id="eco_de_0000143_4300">
+    <p xml:id="eco_de_0000213_4300">
      Es war ihr, als müßte Schlimpimperlein etwas geschehen sein. Sie schlüpfte in Rock und Schuhe, horchte zur Thüre hinaus, da war alles dunkel und still im Haus. An der Schlafstube der Eltern horchte sie, weil sie meinte, Schlimpimperlein könnte zur Mutter gegangen sein, wenn ihr vielleicht nicht wohl war, auch da war alles still. – Im Wohnzimmer war sie auch nicht, – im ganzen Hause nicht. Wo war sie denn? In die Nacht hinausgegangen?
     </p>
-    <p xml:id="eco_de_0000143_4310">
+    <p xml:id="eco_de_0000213_4310">
      Ludschevadel verstand es nicht, weshalb sollte sie denn das gethan haben?
     </p>
-    <p xml:id="eco_de_0000143_4320">
+    <p xml:id="eco_de_0000213_4320">
      Sie öffnete die Hausthür und trat in die milde Juninacht hinaus. Der Jelängerjelieber und die Lindenblüten dufteten im Mondenschein. Es war eine köstliche Nacht.
     </p>
-    <p xml:id="eco_de_0000143_4330">
+    <p xml:id="eco_de_0000213_4330">
      »Ludovikchen!« rief Ludschevadel leise. »Ludovikchen!« Es war ihr so bang ums Herz.
     </p>
-    <p xml:id="eco_de_0000143_4340">
+    <p xml:id="eco_de_0000213_4340">
      War's ihr nicht, als wenn sie Schritte jetzt hörte, eilige Schritte? Nein, jetzt war's still.
     </p>
-    <p xml:id="eco_de_0000143_4350">
+    <p xml:id="eco_de_0000213_4350">
      Eine Nachtigall hub an zu schlagen: Tü – tü – tü – »Ludovikchen!« rief sie jetzt lauter. Wo war die denn um Gottes willen?
     </p>
-    <p xml:id="eco_de_0000143_4360">
+    <p xml:id="eco_de_0000213_4360">
      Anne Ludschevadel ging weiter bis an den Garten.
     </p>
-    <p xml:id="eco_de_0000143_4370">
+    <p xml:id="eco_de_0000213_4370">
      Wie der Mond so unbeschreiblich über allen Sträuchern und Blüten lag! Wie alles undeutlich schimmerte und eine Nachtigall sang fort und fort: Tü – tü – tüüü.
     </p>
-    <p xml:id="eco_de_0000143_4380">
+    <p xml:id="eco_de_0000213_4380">
      Wie heilig schön war alles. Schöner noch als am Tage. – Aber die Nacht ist nicht für die Menschen gemacht, die sind da beiseite geschafft. Tags über gehört ihnen die Erde, nachts nicht mehr, nachts gehört sie sich selbst an. So etwas empfand Ludschevadel, als sie scheu den nächtlichen Garten betrat.
     </p>
-    <p xml:id="eco_de_0000143_4390">
+    <p xml:id="eco_de_0000213_4390">
      »Ludovikchen! Ludovikchen!« rief sie zaghaft.
     </p>
-    <p xml:id="eco_de_0000143_4400">
+    <p xml:id="eco_de_0000213_4400">
      Und wie erschrak sie, als die Schwester aus einer Laube trat und ihr entgegenkam.
     </p>
-    <p xml:id="eco_de_0000143_4410">
+    <p xml:id="eco_de_0000213_4410">
      Sie wußte gar nicht, was sie sagen sollte.
     </p>
-    <p xml:id="eco_de_0000143_4420">
+    <p xml:id="eco_de_0000213_4420">
      »Nun, weshalb kommst du denn?« frug Schlimpimperlein.
     </p>
-    <p xml:id="eco_de_0000143_4430">
+    <p xml:id="eco_de_0000213_4430">
      »Was thust du denn hier?« frug Ludschevadel endlich. »Ich fand oben das Bett leer und hab' dich überall gesucht.«
     </p>
-    <p xml:id="eco_de_0000143_4440">
+    <p xml:id="eco_de_0000213_4440">
      »Das war nicht nötig, ich geh' nicht verloren.«
     </p>
-    <p xml:id="eco_de_0000143_4450">
+    <p xml:id="eco_de_0000213_4450">
      »So allein in der Nacht – da draußen, das hast du nie gethan. War dir denn nicht wohl?«
     </p>
-    <p xml:id="eco_de_0000143_4460">
+    <p xml:id="eco_de_0000213_4460">
      »Mir war wohl.«
     </p>
-    <p xml:id="eco_de_0000143_4470">
+    <p xml:id="eco_de_0000213_4470">
      »Na, komm.« Anne Ludschevadel wollte sie an der Hand fassen.
     </p>
-    <p xml:id="eco_de_0000143_4480">
+    <p xml:id="eco_de_0000213_4480">
      »I, laß mich!« sagte Schlimpimperlein ärgerlich.
     </p>
-    <p xml:id="eco_de_0000143_4490">
+    <p xml:id="eco_de_0000213_4490">
      So gingen die beiden Schwestern, ohne wieder miteinander zu reden, und legten sich zum zweitenmal diese Nacht schlafen.
     </p>
-    <p xml:id="eco_de_0000143_4500">
+    <p xml:id="eco_de_0000213_4500">
      Ludschevadel aber war es bang zu Mute.
     </p>
-    <p xml:id="eco_de_0000143_4510">
+    <p xml:id="eco_de_0000213_4510">
      »Hast du denn die Schritte nicht gehört, die ich hörte, als ich rief?« frug Ludschevadel nach einer langen Weile, bekam aber keine Antwort, denn Schlimpimperlein schlief fest und ruhig.
     </p>
-    <p xml:id="eco_de_0000143_4520">
+    <p xml:id="eco_de_0000213_4520">
      Der Sommer verging leise abnehmend, wie er leise ansteigend gekommen war, die Blätter färbten sich, der scharfe Herbstduft stieg aus dem feuchten gefallenen Laub auf.
     </p>
-    <p xml:id="eco_de_0000143_4530">
+    <p xml:id="eco_de_0000213_4530">
      Oben auf dem Rödchen wurde eifrig genäht und zugerichtet, denn zu Mitte Oktober war die Hochzeit der Jüngsten. Friedrich Herzlieb hatte auf nichts zu warten, es waren wohlgeordnete und glückliche Verhältnisse, in denen er lebte.
     </p>
-    <p xml:id="eco_de_0000143_4540">
+    <p xml:id="eco_de_0000213_4540">
      »Gönnen wir's ihnen,« sagte Heinrich Strobel zu seiner Braut, »bei uns geht's ein bißchen langsamer, aber was lange währt, wird gut. Und so zwei Mädchens auf einmal verlieren, das würde dem Alten jetzt hart ankommen.«
     </p>
-    <p xml:id="eco_de_0000143_4550">
+    <p xml:id="eco_de_0000213_4550">
      »Jawohl, gönnen's wir ihnen, du goldenes Herz,« sagte Ludschevadel.
     </p>
-    <p xml:id="eco_de_0000143_4560">
+    <p xml:id="eco_de_0000213_4560">
      »Der Alte gefällt mir jetzt gar nicht mehr,« meinte Heinrich Strobel darauf. »Daß er sich so ganz in die Politik hineinvergräbt, ist nicht gut. Das sollte keiner thun, der nichts dabei mitzusagen hat. Befriedigung kann's doch nimmer geben – und es frißt ihm am Herzen, dem braven Menschen. Wenn man ihn doch davon abbringen könnte, du.«
     </p>
-    <p xml:id="eco_de_0000143_4570">
+    <p xml:id="eco_de_0000213_4570">
      »Das ist eins mit ihm, Heinrich.«
     </p>
-    <p xml:id="eco_de_0000143_4580">
+    <p xml:id="eco_de_0000213_4580">
      »Wenn wir viele solcher Förster Walter hätten, sollte es dem in Erfurt doch verdammt schwer werden, das solltest du sehen, Anna, das würde anders werden.«
     </p>
-    <p xml:id="eco_de_0000143_4590">
+    <p xml:id="eco_de_0000213_4590">
      »Freilich,« sagte Anna.
     </p>
-    <p xml:id="eco_de_0000143_4600">
+    <p xml:id="eco_de_0000213_4600">
      »Solche Schmachtlappen! Ich kann's mir vorstellen, wie das so einem Kraftmenschen wie unserm Alten in die Galle fährt. Es ist ein elendes Schauspiel; das wird man in hundert Jahren erst überschauen. Jetzt ist zu viel darum und daran, weißt du, zu viel zu sehen und zu hören. Es ist so eine angenehme Aufregung dabei – und sie schwärmen im Grunde für den Riesenteufel. Er strömt Leben aus, wie ein Gewitter. Sie grausen sich auch wie bei einem Gewitter, aber es prickelt ihnen doch in den Nerven – und das französische Theater! Ich glaube, in Weimar gibt's schöngeistige alte Weiber beiderlei Geschlechts, die das ganze deutsche Reich um ein Freibillet zu einer Vorstellung geben, in der sie Talma hören können, und es segnen, daß Napoleon gekommen ist und bei uns festsitzt, weil er Talma mitgebracht hat. – Das ist schon ein Opfer von tausend und aber tausend Leben wert. So klar denken sie's natürlich nicht, aber sie fühlen etwas Angenehmes, – als wäre Paris zu uns gekommen. Und Paris ist Paris! Weißt du, Vaterlandsliebe ist etwas – wie soll ich sagen – sie ist doch eine Art Treibhauspflanze, in Gottes freier Natur wächst sie nicht. – Es ist eine gezüchtete Pflanze. Weiter als ihr die Wurzeln reichen, geht auch einer natürlichen Menschenpflanze der Erdboden nichts an.«
     </p>
-    <p xml:id="eco_de_0000143_4610">
+    <p xml:id="eco_de_0000213_4610">
      Heinrich Strobel hatte hiermit eine seiner längsten Reden, die er je von sich gegeben, gehalten.
     </p>
-    <p xml:id="eco_de_0000143_4620">
+    <p xml:id="eco_de_0000213_4620">
      »Du solltest doch einmal mit dem Vater so sprechen,« sagte Anna.
     </p>
-    <p xml:id="eco_de_0000143_4630">
+    <p xml:id="eco_de_0000213_4630">
      »Thu' ich auch, hab' ich auch gethan – oft; aber der Alte donnert mich jedesmal so nieder, vor dem bin ich wie eine Pfütze im Vergleich zu einem Strom. Dem Alten kommt's gar nicht vor, als ob ich gerade in so ein Horn tute, wie er eins hat. Es ist ihm viel zu nüchtern. Ich glaube, er meint, ich rede das Gegenteil von dem, was ich rede, so wild wird er jedesmal.
     </p>
-    <p xml:id="eco_de_0000143_4640">
+    <p xml:id="eco_de_0000213_4640">
      »›Ihr verdammten Lumpenhunde‹ heißt's da, so in dem Stil: ›Ja, das glaub' ich, das wär' euch recht!
     </p>
-    <p xml:id="eco_de_0000143_4650">
+    <p xml:id="eco_de_0000213_4650">
      »›So eine Saugesinnung, und das nennt ihr Schöngeisterei? Dafür wollt ihr euer Vaterland verraten. – Ein Künstler hat doch nie und nimmer ein Herz im Leib. Da sieh dir diese Kumpane unten in Weimar an. Ist da ein warmer Tropfen Blut zu finden? Was kauf' ich mir denn für euer bißchen Faselei! Geht mir, ihr eiskaltes Volk!‹ und so weiter – aber es schafft ihm Erleichterung. Und manchmal muß man die Schleusen bei ihm öffnen.«
     </p>
-    <p xml:id="eco_de_0000143_4660">
+    <p xml:id="eco_de_0000213_4660">
      Es hieß zu dieser Zeit, daß Karl August dem Kaiser Napoleon ein großes Fest in Weimar geben würde, und alle Köpfe und Mäuler waren voll davon – ein Fest – das war etwas!
     </p>
-    <p xml:id="eco_de_0000143_4670">
+    <p xml:id="eco_de_0000213_4670">
      Die Fürstlichkeiten würden alle von Erfurt nach Weimar kommen. Zwei Kaiser, vier Könige, acht regierende und nicht regierende Herzöge, deutsche, französische, russische Matadore und Magnaten.
     </p>
-    <p xml:id="eco_de_0000143_4680">
+    <p xml:id="eco_de_0000213_4680">
      All diese Majestäten, Hoheiten, Durchlauchten, Excellenzen, alles drunter und drüber nach Weimar!
     </p>
-    <p xml:id="eco_de_0000143_4690">
+    <p xml:id="eco_de_0000213_4690">
      Was würde es da zu sehen geben! Großer Allmächtiger! Das war ja, um sich neue Augen und Ohren und einen neuen Anzug zu bestellen! Das war etwas für die Weimaraner!
     </p>
-    <p xml:id="eco_de_0000143_4700">
+    <p xml:id="eco_de_0000213_4700">
      Talma und das ganze französische Theater sollte auch kommen. Herrlichkeit über Herrlichkeit!
     </p>
-    <p xml:id="eco_de_0000143_4710">
+    <p xml:id="eco_de_0000213_4710">
      Es war eine großartige Aufregung überall zu spüren. Man sprach von Dingen, die alles Dagewesene überstiegen. Es gab Bürger, die ihre Häuser abputzen ließen. – Man wollte Unerhörtes aushecken; aber über Illumination, Stadtbekränzung, Bälle für alle Gilden, Aufzüge, Einholungen, weiße Jungfrauen kamen sie doch nicht hinaus. Die Phantasie gab nichts weiter her. Aber sie fühlten's, das war gar nichts. – Na, der Hof wird schon etwas ausfindig machen! Aber was? Es gab Leute, die den ganzen Tag auf den Straßen herumliefen, um irgend etwas zu erfahren, was sie weiter tragen könnten. Es war in Weimar eine Stimmung, als fielen alle Feste auf Gottes Erdboden mit einemmal auf einen einzigen Tag zusammen und man stände am Vorabende dieses Monstrefesttages.
     </p>
-    <p xml:id="eco_de_0000143_4720">
+    <p xml:id="eco_de_0000213_4720">
      Die, die gebrannt hatten, einmal nach Erfurt zu kommen und nicht gekommen waren, konnten sich nun die ganze Herrlichkeit in der Nähe nach Herzenslust begucken. Es fiel ihnen nur so in den Schoß. Aber noch wußte immer noch niemand etwas Näheres, womit die Ueberschwemmung höchster und allerhöchster Herrschaften eigentlich gefeiert werden sollte. Hoftafel und französische Komödie, das war abgemachte Sache.
     </p>
-    <p xml:id="eco_de_0000143_4730">
+    <p xml:id="eco_de_0000213_4730">
      Hofball natürlich auch – aber das Allgemeine – das Allgemeine! – das, wobei es etwas zu sehen und zu hören gab, das war es, was alle Gemüter bewegte. – Und schließlich erfuhren sie's. Eine Treibjagd auf dem Ettersberg – und den andern Tag die Besichtigung des Schlachtfelds bei Jena. Napoleon wollte es dem Kaiser Alexander von Rußland zeigen und dort eine Hasenjagd abhalten. Und es wurde an einem Triumphtempel mit Säulen, Altären, Guirlanden gebaut, von dem aus er bequem alles seinem hohen Vetter zeigen konnte. Die Säulen sollten mit Blumen reich geschmückt sein, und die Besiegten, Niedergetretenen bauten höflich und unterthänig, wie es zu jener Zeit gut geschulten Deutschen zukam, diesen hübschen Pavillon, von dem aus er ihr Feld der Schmach behaglich übersehen konnte. Sie schmückten ihn liebevoll mit Blumen, Sprüchen und Guirlanden, wie einen Weihnachtsbaum, waren so voller Festerregung, daß sie nichts hörten und nichts sahen, und es gab gar manche, die sich durchaus nicht recht klar wurden, an was sie eigentlich bauten.
     </p>
-    <p xml:id="eco_de_0000143_4740">
+    <p xml:id="eco_de_0000213_4740">
      Der Förster oben im Rödchen war über die allgemeine Feststimmung und über die sinnige Hasenjagd wie ein Rasender. Die Leute trugen ihm diese Feststimmung hinauf, tranken nachmittags in der Oktobersonne unter den bunten blätterregnenden Bäumen ihren Kaffee und schwadronierten. Der größte Kummer, den sie bei der ganzen Angelegenheit laut werden ließen, war schließlich, nicht alles zu sehen zu bekommen.
     </p>
-    <p xml:id="eco_de_0000143_4750">
+    <p xml:id="eco_de_0000213_4750">
      Die Leute, die am Erfurter Thor herumwohnten, wurden glücklich gepriesen und fühlten sich auch als etwas ganz Besonderes. Eine unbezwingliche Heiterkeit und Schaulust durchströmte alle Herzen.
     </p>
-    <p xml:id="eco_de_0000143_4760">
+    <p xml:id="eco_de_0000213_4760">
      Vom Förster wollten sie Näheres über die Ettersburger Jagd erfahren, kamen aber übel bei ihm an. »Jagd?« sagte er. »Wenn ihr das Jagd nennt, mir ist's recht. Ihr werdet ja hindrängen, – das zieht von allein – da braucht ihr mich nicht.«
     </p>
-    <p xml:id="eco_de_0000143_4770">
+    <p xml:id="eco_de_0000213_4770">
      Auf dem Ettersberg, auf einer freundlichen Waldwiese wurde aber ebenso ein Pavillon gebaut, wie auf dem Schlachtfelde bei Jena, an dem das zusammengetriebene Wild vorübergehetzt werden sollte, um in aller Bequemlichkeit niedergeschossen zu werden.
     </p>
-    <p xml:id="eco_de_0000143_4780">
+    <p xml:id="eco_de_0000213_4780">
      Als der Förster vor siebenundzwanzig Jahren hinauf ins Rödchen gezogen war, da hatte er erbärmliche Wildverhältnisse oben im Berg angetroffen. Und ihm und dem Oberförster in Ettersberg war es gelungen, einen gesunden reichlichen Wildstand zu erhalten – und jetzt in Zeit von ein paar Stunden sollte alles in Grund und Boden vernichtet werden.
     </p>
-    <p xml:id="eco_de_0000143_4790">
+    <p xml:id="eco_de_0000213_4790">
      Der Förster war wie ein geschlagener Mann, wortkarg und finster, besorgte alles, was ihm vom Hofamt aus befohlen wurde, mit peinlichster Gewissenhaftigkeit; aber tagelang hörten die Seinigen kein Wort von ihm.
     </p>
-    <p xml:id="eco_de_0000143_4800">
+    <p xml:id="eco_de_0000213_4800">
      »Das geht mir ans Leben,« sagte er eines Abends, als die Mädchen schon schlafen gegangen waren, zu seiner Alten.
     </p>
-    <p xml:id="eco_de_0000143_4810">
+    <p xml:id="eco_de_0000213_4810">
      Die war froh, daß er endlich wieder sprechen konnte – das hatte ihr Angst gemacht, das Schweigen.
     </p>
-    <p xml:id="eco_de_0000143_4820">
+    <p xml:id="eco_de_0000213_4820">
      »Siehst du, es wird ja so schlimm nicht werden, so heiß wie gekocht wird, ißt man nicht. Sie werden dir ja doch nicht das ganze Wild zusammenschießen.«
     </p>
-    <p xml:id="eco_de_0000143_4830">
+    <p xml:id="eco_de_0000213_4830">
      »Mögen sie's in Gottes Namen! Es ist ihnen immer noch nicht Blut genug geflossen – den Narren! Ein ganz neues Schauspiel, eine Metzelei!
     </p>
-    <p xml:id="eco_de_0000143_4840">
+    <p xml:id="eco_de_0000213_4840">
      »Ich glaube, sie wollen ihn damit kitzeln. Sie wollen ihn an Blut riechen lassen. Ich glaube, sie wollen ihm einen Rippenstoß geben, doch endlich wieder an sein Handwerk zu gehen.«
     </p>
-    <p xml:id="eco_de_0000143_4850">
+    <p xml:id="eco_de_0000213_4850">
      »Ach du,« sagte die Försterin, »ereifere dich doch nicht so, nach meiner dummen Meinung da denken sie sich gar nichts dabei. Sie wissen nur nicht, was sie mit ihm anfangen sollen!«
     </p>
-    <p xml:id="eco_de_0000143_4860">
+    <p xml:id="eco_de_0000213_4860">
      »Stimmt,« sagte der Förster.
     </p>
-    <p xml:id="eco_de_0000143_4870">
+    <p xml:id="eco_de_0000213_4870">
      »Eine Kugel sollten sie ihm zwischen die Rippen jagen, statt sie an einem elenden Rehbocke zu verpuffen, das sollten sie mit ihm anfangen,« brummte er in den Bart hinein.
     </p>
-    <p xml:id="eco_de_0000143_4880">
+    <p xml:id="eco_de_0000213_4880">
      Die Försterin drückte ihm die Hand auf den Mund.
     </p>
-    <p xml:id="eco_de_0000143_4890">
+    <p xml:id="eco_de_0000213_4890">
      »So red' doch nich' sohin, Alter – du willst uns wohl alle unglücklich machen.«
     </p>
-    <p xml:id="eco_de_0000143_4900">
+    <p xml:id="eco_de_0000213_4900">
      »Seid ihr denn glücklich?« donnerte er sie an.
     </p>
-    <p xml:id="eco_de_0000143_4910">
+    <p xml:id="eco_de_0000213_4910">
      »Die Kinder doch, Alter, so junges Volk ist immer glücklich und gar wenn's auf die Hochzeit zugeht, da schert sie nichts.«
     </p>
-    <p xml:id="eco_de_0000143_4920">
+    <p xml:id="eco_de_0000213_4920">
      »Das ist ein sauberes Leben.« Der Förster schlug mit der Hand auf den Tisch. »Ich wollte, daß mich der Teufel holte. – Ist denn irgendwo eine Freude zu sehen!«
     </p>
-    <p xml:id="eco_de_0000143_4930">
+    <p xml:id="eco_de_0000213_4930">
      »Die Kinder sind brav, Alter.« Und sie fügte hinzu: »Du undankbarer Mensch, du!«
     </p>
-    <p xml:id="eco_de_0000143_4940">
+    <p xml:id="eco_de_0000213_4940">
      »Nicht wahr, du weißt noch was,« rief er und lachte laut auf.
     </p>
-    <p xml:id="eco_de_0000143_4950">
+    <p xml:id="eco_de_0000213_4950">
      »Ich weiß gar nicht, wie du mir vorkommst. Da sind doch andre wahrlich schlimmer daran als wir.«
     </p>
-    <p xml:id="eco_de_0000143_4960">
+    <p xml:id="eco_de_0000213_4960">
      »Oho, ich merke schon, jetzt geht's ans Fressen und Saufen. Ich soll mich übers Fressen freuen?«
     </p>
-    <p xml:id="eco_de_0000143_4970">
+    <p xml:id="eco_de_0000213_4970">
      »Wie du das nennst!«
     </p>
-    <p xml:id="eco_de_0000143_4980">
+    <p xml:id="eco_de_0000213_4980">
      »Die Gabe Gottes soll ich sagen!«
     </p>
-    <p xml:id="eco_de_0000143_4990">
+    <p xml:id="eco_de_0000213_4990">
      »Ja, wir sollen dafür danken.«
     </p>
-    <p xml:id="eco_de_0000143_5000">
+    <p xml:id="eco_de_0000213_5000">
      »Gut – auch gut! Hat mir Gott ein Maul gegeben, mag er's auch stopfen!«
     </p>
-    <p xml:id="eco_de_0000143_5010">
+    <p xml:id="eco_de_0000213_5010">
      »Aber er stopft's so manchen nicht.«
     </p>
-    <p xml:id="eco_de_0000143_5020">
+    <p xml:id="eco_de_0000213_5020">
      »Dann wird er eben ein ganz andres Gesicht haben, als du es dir vorstellst. Was weiß ich! Große Herren haben das so an sich, daß man nicht weiß, wie und wo.«
     </p>
-    <p xml:id="eco_de_0000143_5030">
+    <p xml:id="eco_de_0000213_5030">
      »Du lästre nicht, das straft sich.«
     </p>
-    <p xml:id="eco_de_0000143_5040">
+    <p xml:id="eco_de_0000213_5040">
      »Jawohl,« da lachte er wieder. »Da hätte er viel zu thun, wenn er alle, die er tritt und die deshalb schimpfen, strafen wollte.«
     </p>
-    <p xml:id="eco_de_0000143_5050">
+    <p xml:id="eco_de_0000213_5050">
      »Denk doch, wie glücklich wir immer waren, wie treu und gut ich's mit dir gemeint hab'!« sagte die alte Frau weinend.
     </p>
-    <p xml:id="eco_de_0000143_5060">
+    <p xml:id="eco_de_0000213_5060">
      »Du willst auch eine Extra-Belobigung für deine Treue haben, nicht wahr? Ich soll mich auch hinsetzen und mich auch darüber freuen, daß du mich wahrscheinlich nicht hintergangen hast.«
     </p>
-    <p xml:id="eco_de_0000143_5070">
+    <p xml:id="eco_de_0000213_5070">
      »Das nicht. – Ich wollte dir nur sagen, daß ich doch immer meine Pflicht gethan habe und das Haus wohl gehalten habe, die Kinder geboren und erzogen, und daß wir immer ehrliche und von allen geachtete Leute waren. Ist denn das nichts, Alter?«
     </p>
-    <p xml:id="eco_de_0000143_5080">
+    <p xml:id="eco_de_0000213_5080">
      »Es muß wohl was sein.« Seine Stimme klang weicher. »Ehrliche, geachtete Leute, das sind wir weiß Gott immer gewesen. – Das bleiben wir auch, Alte.« Er gab ihr die Hand und schüttelte sie ihr.
     </p>
-    <p xml:id="eco_de_0000143_5090">
+    <p xml:id="eco_de_0000213_5090">
      »Mich packt's manchmal, als ob es mich zerreißen wollte. – Siehst du, bei mir wird's nicht eher gut, als bis einmal ernstlich zum Aufmarsch geblasen wird, bis alle Schlafmützen mitsammen erwachen – dann soll's einer mit uns aufnehmen! Dann bin ich auch dabei, Alte.«
     </p>
    </div>
@@ -1623,862 +1623,862 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000143_5100">
+    <p xml:id="eco_de_0000213_5100">
      Es war abends vor der großen Hofjagd. Im Försterhaus im Rödchen ging es drunter und drüber. Da waren die Oberförster aus Ilmenau und Stützerbach einquartiert, die beide zur Jagd befohlen waren. Forstgehilfen liefen aus und ein. Aus den umliegenden Ortschaften kamen die Landleute, die nachts über den Treiberdienst im Ettersberg versehen sollten. Es war ein gewaltiges Hin und Her, und wie ein Feldherr der Förster Walter mitten darunter. Jeder wendete sich an ihn, er mußte herhalten für zehn. Die Forstgehilfen zogen mit ihren Treibern ab, um sie zu postieren.
     </p>
-    <p xml:id="eco_de_0000143_5110">
+    <p xml:id="eco_de_0000213_5110">
      Wagen voll Jagdnetze fuhren vor und nahmen den Förster mit, der beim Aufstellen derselben zugegen sein mußte. Den Forstgehilfen wurde Abendbrot gereicht, Bauersleute gingen aus und ein und holten sich Fackeln. Vom Walde her tönte das Schreien und Lärmen der Treiber die ganze Nacht durch, und auf dem sonst so stillen Berge war eine Hölle losgelassen. Feuer brannten am Waldessaum, da tranken und lagerten die Bauern und brüllten und johlten.
     </p>
-    <p xml:id="eco_de_0000143_5120">
+    <p xml:id="eco_de_0000213_5120">
      Die Försterin mußte ein gutes Abendessen für die Kameraden ihres Mannes herrichten und wollte sich nicht lumpen lassen. Sie sollten einen Begriff bekommen, wie man bei Förster Walter lebt, und so arbeitete sie mit zwei Mägden und den Töchtern im Schweiße ihres Angesichts.
     </p>
-    <p xml:id="eco_de_0000143_5130">
+    <p xml:id="eco_de_0000213_5130">
      Es mußte auch mancherlei zu einem opulenten Frühstück hergerichtet werden, und im Hause ging und kam es wie im Taubenschlag.
     </p>
-    <p xml:id="eco_de_0000143_5140">
+    <p xml:id="eco_de_0000213_5140">
      So geht's: dem Förster drückte alles, was in dieser Zeit geschah, das Herz ab, und der Försterin war's zu Mut, wie an ihrem Ehrentag. Sie wollte Familie und Haus glänzen lassen und ließ sich deshalb keine Müh' verdrießen. Die alte Kummerfelden, die die Nählehrerin der Waltersmädchen gewesen, war auch mit oben, um mit ihrer zierlichen Altweibergeschäftigkeit die Försterin zu unterstützen. Sie war allerbester Laune, das war so etwas für sie. Bei der Aussteuer für Schlimpimperlein mußte sie auch raten, und das Hochzeitskleid wurde ohne die Kummerfelden auch nicht beschafft. Wer einmal bei der Kummerfelden in die Nähschule gegangen war, wendete sich in allen Lebenslagen, in Freud und Leid, an die prächtige Frau, und sie versagte Rat und Hilfe nirgends, solange ihr die Kräfte aushielten.
     </p>
-    <p xml:id="eco_de_0000143_5150">
+    <p xml:id="eco_de_0000213_5150">
      In das Rödchen hinauf ging sie übrigens gar zu gern, die Förstersleute waren ihr sehr lieb und das muntere Leben im Hause behagte ihr.
     </p>
-    <p xml:id="eco_de_0000143_5160">
+    <p xml:id="eco_de_0000213_5160">
      Mitten in ihrer eifrigen Geschäftigkeit, sie rührte einen gewaltigen Heringssalat zusammen, schnitt Salzgurken und Schinken und hantierte mit allerlei Feinheiten, die sie zu ihrem Salat brauchte, und war dabei so flink und behende und sauber in ihrem geblümten Kleide und der großen Haube, da rief sie nach Schlimpimperlein.
     </p>
-    <p xml:id="eco_de_0000143_5170">
+    <p xml:id="eco_de_0000213_5170">
      »Ludovikchen, mein Kind,« sagte sie, »ist das eine Art, wie ein glückliches Bräutchen sich beträgt, das in ein paar Tagen Hochzeit halten soll. Ich schau' dir die ganze Zeit jetzt zu – ist dir nicht wohl?«
     </p>
-    <p xml:id="eco_de_0000143_5180">
+    <p xml:id="eco_de_0000213_5180">
      »Mir ist wohl,« sagte Schlimpimperlein gleichmütig.
     </p>
-    <p xml:id="eco_de_0000143_5190">
+    <p xml:id="eco_de_0000213_5190">
      »Ueberanstrengen thust du dich aber nicht, dächte ich. – Ich hab's ja gesehen, die ganze Zeit hast du da am Fenster gelehnt, und wo sind denn die roten Backen hin? Na? Du Mädel, verdirb dir die schöne Zeit jetzt nicht mit weiß Gott was. – Schmacht' nicht so, – ich rat's dir. Die Ehe kommt dir bald genug über den Hals, – geh, sei frisch, wer wird denn bei allem Glück wie eine Wehmutsspritze dastehen. Wenn man in etwas frisch gehen muß, ist's in die Ehe. Glaub mir, da darf man gar manches Mal den Humor mit allen Leibeskräften halten, damit er einem nicht auskommt. – Und was sind denn das für Geschichten, wenn er mit dir herumscharmutziert, da bist du ja ganz obenauf?
     </p>
-    <p xml:id="eco_de_0000143_5200">
+    <p xml:id="eco_de_0000213_5200">
      »Kaum ist der fort, läßt du die Flügel hängen.
     </p>
-    <p xml:id="eco_de_0000143_5210">
+    <p xml:id="eco_de_0000213_5210">
      »Na, das sag' ich dir, da wirst du schön hereinfallen, – da kennst du die Männer schlecht.
     </p>
-    <p xml:id="eco_de_0000143_5220">
+    <p xml:id="eco_de_0000213_5220">
      »Glaubst du denn, das geht so fort, wenn du Frau bist? Du weißt nicht, was Ehemänner für miserable Müffe sind. Wenn da die Frau nicht für beide den Humor hat, ging' es ja weiß Gott in jedem Haus wie bei den Trappisten zu.
     </p>
-    <p xml:id="eco_de_0000143_5230">
+    <p xml:id="eco_de_0000213_5230">
      »Geh nur um Gottes willen frisch in die Ehe, sonst bist du verloren. Verloren, sag' ich; wenn's in einem Haus brummig zugeht und trübselig, dann wollt' ich lieber beim Teufel sein, sag' ich.
     </p>
-    <p xml:id="eco_de_0000143_5240">
+    <p xml:id="eco_de_0000213_5240">
      »Also Kopf oben und merk dir's, vom Mann mußt du nie etwas verlangen, das wie Aufmunterung aussieht. Jeder Ehemann, jeder deutsche wenigstens, ist im Handumdrehen ein Muff, ein muffiger Muff. Na, erschrick nur nicht, wenn's kommt, dann kommt's, denn kommen thut's sicher. – Thu das Deine! – und daß ich dich nicht wieder stehen sehe, als wär' dein Brot auf die Butterseite gefallen. – Geh, mach was, Faulpelz.«
     </p>
-    <p xml:id="eco_de_0000143_5250">
+    <p xml:id="eco_de_0000213_5250">
      Schlimpimperlein blieb bei der herzhaften Rede der Kummerfelden ziemlich indolent stehen und drehte an einem Brotkügelchen.
     </p>
-    <p xml:id="eco_de_0000143_5260">
+    <p xml:id="eco_de_0000213_5260">
      »Na,« sagte die Kummerfelden.
     </p>
-    <p xml:id="eco_de_0000143_5270">
+    <p xml:id="eco_de_0000213_5270">
      Da schaute Schlimpimperlein auf – und der Kummerfelden war's gerade, als wenn die Augen der kleinen Braut voll Thränen ständen.
     </p>
-    <p xml:id="eco_de_0000143_5280">
+    <p xml:id="eco_de_0000213_5280">
      »Na,« sagte sie noch einmal mit merkwürdiger Betonung. »Hast du was? Oder riecht dir der Hering und Zwiebel zu stark?«
     </p>
-    <p xml:id="eco_de_0000143_5290">
+    <p xml:id="eco_de_0000213_5290">
      »Was soll ich denn haben?« sagte Schlimpimperlein, »gar nix.«
     </p>
-    <p xml:id="eco_de_0000143_5300">
+    <p xml:id="eco_de_0000213_5300">
      »Also, dann zeig's auch.«
     </p>
-    <p xml:id="eco_de_0000143_5310">
+    <p xml:id="eco_de_0000213_5310">
      Jetzt hatte die Kummerfelden gesagt, was sie zu sagen hatte, und wendete sich wieder zu ihrem Salat und schnitt und hackte so emsig darauf los, als wäre dieser Salat von wahrhaft unermeßlicher Bedeutung für das ganze menschliche Geschlecht.
     </p>
-    <p xml:id="eco_de_0000143_5320">
+    <p xml:id="eco_de_0000213_5320">
      Abends spät, als die Förster abgetafelt hatten und ihre Pfeife bei einem Gläschen Jenenser, der noch immer im Madeirafaß logierte, schmauchten, die Kummerfelden und die Försterin, Ludschevadel und Heinrich Strobel gemütlich in der Küche saßen, in der die Mägde noch den letzten gespülten Napf an Ort und Stelle brachten, stand Schlimpimperlein unten vor der Thür und sah zu, wie den Bauersleuten von einem Forstgehilfen Fackeln verteilt wurden; da legte sich ein Arm um ihren Nacken.
     </p>
-    <p xml:id="eco_de_0000143_5330">
+    <p xml:id="eco_de_0000213_5330">
      »Wo treibst du dich denn herum, Katz'?« frug eine frische, muntere Stimme.
     </p>
-    <p xml:id="eco_de_0000143_5340">
+    <p xml:id="eco_de_0000213_5340">
      Schlimpimperlein war zusammengefahren.
     </p>
-    <p xml:id="eco_de_0000143_5350">
+    <p xml:id="eco_de_0000213_5350">
      »Nur nicht schreckhaft! – Komm, Weibchen – kleines.« Willenlos ging sie mit ihm und sie schlüpften heimlich in den dunkeln Garten. Auf den Wegen lag das bunte, feuchte Laub und die Herbstblumen dufteten so wehmütig. Das war der Duft der sommerlichen Reseda nicht mehr, der sonnendurchwärmte Duft – der war so herbstlich geworden, so schwer und mit der Ausdünstung der gefallenen Blätter vermischt. Der Mondenschein lag über den herbstlichen Bäumen, dem herbstlichen Nebel.
     </p>
-    <p xml:id="eco_de_0000143_5360">
+    <p xml:id="eco_de_0000213_5360">
      Sie gingen stumm miteinander, das Mädchen fest und wie angstvoll an ihren Bräutigam geschmiegt.
     </p>
-    <p xml:id="eco_de_0000143_5370">
+    <p xml:id="eco_de_0000213_5370">
      »Nun sind wir bald am Ziel, mein armes, kleines Närrchen,« sagte er. – »Wart' nur noch ein paar Tage, dann ist die dumme Komödie aus.«
     </p>
-    <p xml:id="eco_de_0000143_5380">
+    <p xml:id="eco_de_0000213_5380">
      »Ja, aber es ist Zeit, Friedel; Friedel, denk doch! Wenn's doch früher gegangen wäre mit der Hochzeit.«
     </p>
-    <p xml:id="eco_de_0000143_5390">
+    <p xml:id="eco_de_0000213_5390">
      »'s ist ja alles gut, Engelskind, – der Alte wollt' es nicht – so ein Narr. Aber sei nur ruhig, die paar Tage thun nun nichts mehr, die halten wir aus. Morgen um die Zeit sind wir wieder einen Tag weiter; was meinst du, die Zeit wird schon vergehen. – Nur Mut.«
     </p>
-    <p xml:id="eco_de_0000143_5400">
+    <p xml:id="eco_de_0000213_5400">
      »Der Vater thut mir leid,« sagte sie, »daß es ihm mit den Rehböcken so zu Herzen geht,« meinte Schlimpimperlein und weinte.
     </p>
-    <p xml:id="eco_de_0000143_5410">
+    <p xml:id="eco_de_0000213_5410">
      »Deswegen thut er dir leid?«
     </p>
-    <p xml:id="eco_de_0000143_5420">
+    <p xml:id="eco_de_0000213_5420">
      »Deswegen,« antwortete sie leise, »und noch – außerdem auch.«
     </p>
-    <p xml:id="eco_de_0000143_5430">
+    <p xml:id="eco_de_0000213_5430">
      »Ach, laß das! – Mein Gott, wenn du dächtest, wie ich denke, da ist nichts, gar nichts, um sich zu kümmern.«
     </p>
-    <p xml:id="eco_de_0000143_5440">
+    <p xml:id="eco_de_0000213_5440">
      Da hielt er sie innig an sich gepreßt – und sie schwiegen beide.
     </p>
-    <p xml:id="eco_de_0000143_5450">
+    <p xml:id="eco_de_0000213_5450">
      Wie er sie so hielt, empfand er, wie das Angstvolle in ihr nachließ, und wie sie sich dem Wohlgefühl, ihm nahe zu sein, hingab.
     </p>
-    <p xml:id="eco_de_0000143_5460">
+    <p xml:id="eco_de_0000213_5460">
      »Gottlob,« sagte er. Und nun plauderten sie miteinander und lachten und zählten die Tage, die noch vergehen mußten.
     </p>
-    <p xml:id="eco_de_0000143_5470">
+    <p xml:id="eco_de_0000213_5470">
      Und damit sagten sie sich gute Nacht.
     </p>
-    <p xml:id="eco_de_0000143_5480">
+    <p xml:id="eco_de_0000213_5480">
      Schlimpimperlein ging hinauf in ihre Dachkammer, um sich schlafen zu legen, und Friedrich Herzlieb gesellte sich zu den Förstern und zu Heinrich Strobel, mit denen er morgen früh in den Wald ausrücken sollte.
     </p>
-    <p xml:id="eco_de_0000143_5490">
+    <p xml:id="eco_de_0000213_5490">
      Der große Tag der Ettersburger Jagd und des Einzugs der Kaiser, Könige, Herzöge und Fürsten in Weimar brach sonnig an. Es war ein Tag wie in goldenes Licht getaucht, frisch wie Champagner, ein Herbsttag ohnegleichen. Die Straße von Erfurt nach dem Ettersberg war von unzähligen Wagen, Reitern und Fußgängern bedeckt.
     </p>
-    <p xml:id="eco_de_0000143_5500">
+    <p xml:id="eco_de_0000213_5500">
      Die Monarchen, an der Landesgrenze von dem Herzog und der ganzen Jägerei zu Pferde empfangen, langten mit ihrem Gefolge unter dem Schalle der Jagdfanfaren gegen ein Uhr mittags an. – In der Mitte des freien Rasenplatzes im Ettersburger Wald, in dem riesigen Jagdpavillon, der vierhundertfünfzig Schritte in der Länge und fünfzig Schritte in der Breite maß, und in den großen Seitenbalkons und -pavillons verteilten sich die gekrönten Häupter mit ihrem Gefolge. Die mittlere Abteilung des großen, reichgeschmückten Baues war für die beiden Kaiser und für die Könige bestimmt.
     </p>
-    <p xml:id="eco_de_0000143_5510">
+    <p xml:id="eco_de_0000213_5510">
      Wie mochte sich der alte simple Ettersberg verwundern, was für ein Wesen mit einemmale auf ihm getrieben wurde! – Er, der, solang er nun langgestreckt dalag, immer nur in Einsamkeit gelegen hatte. Auf seinem Rücken sproßte ihm der tiefe grüne Buchenwald, der die stillen, flinken Rehe barg und die lustigen Vögel. Auf seinen kahlen Seiten wehten die langen Gräser im Wind und leuchteten die weißen Distelsterne – und Regen und Schneewasser legten geheimnisvolle Schätze bloß, die er in seinem Innern barg, Versteinerungen von Pflanzen und Tieren, die von dunkeln versunkenen Jahrtausenden erzählten, als Meereswogen über die langgestreckten Seiten des uralten Berges hinrollten, jahrtausendelang und wieder jahrtausendelang, längst versunkene Pflanzen und Tiere da oben ihr Wesen trieben – jahrtausende- und abermals jahrtausendelang.
     </p>
-    <p xml:id="eco_de_0000143_5520">
+    <p xml:id="eco_de_0000213_5520">
      Jetzt nach ungezählten Zeitläuften machte das Menschenvolk sich hier oben einmal wichtig, auf ein paar kurze Stunden. – Ob das den alten Berg in Erstaunen setzte? Schwerlich. Er war an Eintagskreaturen aller Art gewöhnt, an welche mit Flossen und Schuppen, an welche mit Klauen, an andre mit Federn und Schnäbeln, an kriechende, schwimmende, fliegende, hüpfende, ringelnde; er hatte Kampf und Liebe zwischen aller Art Bestien jahrtausendelang mit angesehen – und jetzt diese bunten, wunderlichen Geschöpfe, die er auf seinem Rücken zu tragen hatte, die sich so merkwürdig wichtig benahmen, voreinander tänzelten und schwänzelten, Männchen machten wie die Hasen, vor dem einen krochen, den andern fast über den Haufen rannten, die sich mit bunten Lappen und Flicken behangen hatten und Gesichter schnitten, als wären sie die Herren der Welt – und andre schnitten Gesichter, als wären sie geringer als das geringste Tier, ja es gab gar kein Tier, das je so ein armseliges Gesicht gemacht hätte, wie diese bunten Kreaturen. – Das war dem alten Berge neu. So etwas hatte er noch nicht in der Nähe gesehen – noch nie. Alle Geschöpfe waren bisher ihres Weges harmlos hingeschwommen, gelaufen, gehüpft und geringelt. Und die Arten untereinander hatten miteinander verkehrt, wie es sich eben gehört, wenn einer vor dem andern nichts voraus hat.
     </p>
-    <p xml:id="eco_de_0000143_5530">
+    <p xml:id="eco_de_0000213_5530">
      Er hatte sich auch schon manchmal in den ungezählten Jahrtausenden, die er so still dalag und von Geschöpfen aller Art umtummelt und belaufen war, seine Gedanken gemacht über die ungeheure Mordlust, die in jeder Bestie steckt. Was hatte er nicht schon für Erhaschen, Erbeuten, Zerfleischen, Verzehren mit angesehen. Der Schwache hatte immer sein Grab im Leibe des Starken gefunden. – Es war dem alten Berg noch nie ein Geschöpf begegnet, das nicht Mordlust und Todesangst gekannt hätte. Was hatten sie in der kurzen Zeit ihres Daseins nicht alles angerichtet und ausgestanden, diese unseligen Kreaturen. Aber die sich so sonderbar auf seinem Rücken drehen und wenden, was thaten denn die? Die mordeten, wie er noch nie etwas gesehen! Sie standen da, wie aus dem Ei geschält, so appetitlich, und machten unausgesetzt Männchen und sahen so harmlos aus, harmloser wie die Hasen. Und satt und wohlgefüttert verstanden diese furchtbaren Tiere mit der freundlichsten Miene zu morden, schnipp-schnapp, da stürzten des alten Berges schöne Rehe blutend zusammen und andre tobten in Angst und Qual vorüber, um sich zu retten – Todesangst in jedem Glied, Verzweiflung in den Augen – da war kein Entkommen!
     </p>
-    <p xml:id="eco_de_0000143_5540">
+    <p xml:id="eco_de_0000213_5540">
      Die bunten, possierlichen Geschöpfe waren gräßlicher als alles, was der Berg vordem gesehen hatte! Wie das arme Wild zitterte und bebte! Die schönen, stillen Augen, wie die um Erbarmen flehten! Und die Bunten mordeten lustig darauf los – mordeten – mordeten ohne Hunger. Der alte Berg fühlte aus Herzenswunden Blut in sich einsickern. Er fühlte Todeszuckungen.
     </p>
-    <p xml:id="eco_de_0000143_5550">
+    <p xml:id="eco_de_0000213_5550">
      Hätte er aber gewußt, daß einer, den er die Ehre hatte, auf seinem Rücken zu tragen, der Mächtigste unter allen andern war, der, der sich unter ihnen hervorgethan hatte und sich anmaßte, mit seinem ganzen Thun und Treiben auf Erden Weltgeschichte zu machen –»Weltgeschichte«, diese bunte, giftige Eintagsfliege, da hätte der alte Berg aus voller Brust gelacht, gedonnert, das wäre ihm nach allem, was er mit angesehen, seit ungezählten Jahrtausenden komisch vorgekommen.
     </p>
-    <p xml:id="eco_de_0000143_5560">
+    <p xml:id="eco_de_0000213_5560">
      Er hatte doch wahrlich Bestien aller Art gekannt und hatte sie ihr ganzes Leben bös herumwirtschaften sehen – ganz gewaltig – aber Weltgeschichte zu machen, das war noch keiner in den Sinn gekommen – ganz gewiß nicht. Aber der verdammt freisinnige Berg blieb still, jedenfalls aus tief angeborener Devotion.
     </p>
-    <p xml:id="eco_de_0000143_5570">
+    <p xml:id="eco_de_0000213_5570">
      Die Treiber hetzten das unglückselige Wild stundenlang und ganze Rudel stürzten in Todesangst an dem blumengeschmückten Pavillon vorüber, in dessen Mitte Napoleon unter den Fürsten stand und heiter mit großem Eifer und wenig Glück auf die vor Angst sinnverwirrten schlanken Flüchtlinge schoß.
     </p>
-    <p xml:id="eco_de_0000143_5580">
+    <p xml:id="eco_de_0000213_5580">
      Um den eingehegten Rasenplatz, der zu der großen Metzelei ausersehen war, hatte man Buden mit Eßwaren aufgeschlagen, für die Bevölkerung, die so nah als thunlich dem köstlichen Schauspiel sein wollte, daß zwei Kaiser, vier Könige, acht regierende und nicht regierende Herzöge, Majestäten, Königliche Hoheiten, Hoheiten sich vergnügten.
     </p>
-    <p xml:id="eco_de_0000143_5590">
+    <p xml:id="eco_de_0000213_5590">
      Wohin man sah, Jubel, Essen und Trinken, lodernde Feuer, Spannung, Erregung und wie ein Blutdunst über der erlauchten Gesellschaft. Unter den gestickten Uniformen saß ihnen Jagdlust, ließ die Augen blitzen, die Herzen schneller schlagen, jagte die Blutwellen rascher durch die Adern. Vornehm oder gemein, sie lag in der Luft, sie war da, sie fuhr auch den Treibern in die Glieder, die sich an den Feuern wälzten nach der durchwachten Nacht im Walde, während der sie das Wild zum großen Tag zusammengehetzt hatten. Wie horchten sie auf die Fanfaren! Wie jubelten sie, wenn es verlautet, wieviel sie drüben wieder zur Strecke gebracht hatten, wie soffen sie, wie fluchten sie, was hätten sie darum gegeben, wenn sie die vornehme Arbeit hätten mitthun dürfen. – Das wäre etwas für sie gewesen, so gut wie für Kaiser, Könige und Herzöge.
     </p>
-    <p xml:id="eco_de_0000143_5600">
+    <p xml:id="eco_de_0000213_5600">
      So in die verdammten Viecher hineinzuschießen, blind und toll.
     </p>
-    <p xml:id="eco_de_0000143_5610">
+    <p xml:id="eco_de_0000213_5610">
      Bei den Feuern da kramten sie statt dessen Schauergeschichten aus, schwatzten von Jagdglück, von Mord und Totschlag, von Weibern und Liebesgeschichten. Einer überbot den andern. Es war eine Stimmung wie um Mitternacht, so überreizt, so überlustig, so wild, und doch schien die krystallklare Oktobersonne über das laute Treiben. Förster Walter mußte an allen Ecken und Enden zugleich sein. In ihm kochten und brauten die heftigsten Gefühle. Zwischen Befehlen und tausend Hetzereien empfand auch er gar wohl den Blutdunst, der sich allen auf die Sinne legte. So eine Kreuzschwerenotjagd hatte es da oben wahrlich noch nicht gegeben, und daß sie keine je wieder so halten konnten, dafür sorgten sie selbst. »Da zum Teufel sollte doch« – träumte der Förster –»zwischen allen Hetzern einer sein, der den Mut hätte – weiß Gott – wo so viel unschuldig Blut vergossen wird – schuldiges zu vergießen. Hier wäre der Platz für den Rächer. – Wo nimmt so ein Teufel den Mut nur her – so voller Schuld, wie der, den ich meine, mitten unter Waffen, mitten unter Feinden, unter Kugeln, von denen eine einzige den Weg zu verfehlen brauchte, zu stehen und sich zu vergnügen, so als könnte Rache und Verrat nie und nimmermehr ihn erreichen. – Das ist's eben! – Das ist's! – Da wag' es einer! – Und es wagt es keiner – trotz allem Haß – nicht einer!«
     </p>
-    <p xml:id="eco_de_0000143_5620">
+    <p xml:id="eco_de_0000213_5620">
      Den Riesen, den Förster, trieb es immer wieder wie gebannt, einen Blick auf den kleinen Mann zu werfen, vor dem Könige zitterten. Wie der so dastand, wie aus Elfenbein so fest, so gelblich, so breitschultrig und mit dem verdammt zusammengeknufften Nacken – und mit den Adleraugen um sich blickte und so gottserbärmlich schoß – – so verteufelt schlecht schoß –
     </p>
-    <p xml:id="eco_de_0000143_5630">
+    <p xml:id="eco_de_0000213_5630">
      Da war's dem Förster, als drehten sich seine Sinne im Kreis – der Mann machte ihn schwindeln – da stand er unbezwinglich und in Feindesland so sicher wie ein Heiligenbild. – Und nicht lange konnte es dauern, da würde er wieder die Kriegsfurie und Tod über die Erde schicken, den Tod tausendfach, wie Gott ihn schickt, ruhigen Herzens. – Was war dem Leben! Was waren dem Tausende von Leben – Was war dem tausend- und abertausendfältiger Mord! – –
     </p>
-    <p xml:id="eco_de_0000143_5640">
+    <p xml:id="eco_de_0000213_5640">
      Und bei all dem schoß er so schlecht – so hundsföttisch schlecht, daß es dem Förster in den Fingern zuckte. Seinen jüngsten Forstgehilfen hätte er maulschelliert. Er hatte nie so gefühlt, nie ähnlich; ihm war's, als hätte er dem leibhaftigen Teufel gegenüber gestanden und hätte ihn betrachten dürfen.
     </p>
-    <p xml:id="eco_de_0000143_5650">
+    <p xml:id="eco_de_0000213_5650">
      Es war eine Jagd, die den Leuten zu Kopfe stieg. Es war so eine verdammte Festfreude, so eine Erregung und Schaulust, so etwas fieberhaft Gespanntes, so eine tolle Gedankenlosigkeit.
     </p>
-    <p xml:id="eco_de_0000143_5660">
+    <p xml:id="eco_de_0000213_5660">
      Und morgen die Hasenjagd auf dem Schlachtfelde von Jena! Der Förster mußte bitter auflachen. – Es war nicht besser auszudenken! Und alle Welt machte diese Hasenjagd mit, ohne zu mucksen – und er, dieser gelbliche, kleine Mann, wie mußte er im stillen lachen – lachen über die Komödie, die er sich erlauben durfte. Wie weit durfte er denn eigentlich gehen? Kam es ihm denn nicht selbst spaßig vor?
     </p>
-    <p xml:id="eco_de_0000143_5670">
+    <p xml:id="eco_de_0000213_5670">
      »Gott verdamme sie – sie verdienen's nicht besser« – das war des alten Riesenburschen Schmerzens- und Stoßseufzer während des wilden Treibens auf dem Ettersberge.
     </p>
-    <p xml:id="eco_de_0000143_5680">
+    <p xml:id="eco_de_0000213_5680">
      Die beiden Maler, Heinrich Strobel und Friedrich Herzlieb, hatten mit den Förstern die Jagd mitgemacht, und es war ihnen von der ganzen Herrlichkeit nichts entgangen. Die Förster hatten sie kameradschaftlich reichlich mit Champagner versorgt, und so hatten auch sie den Ueberfluß dieses üppigen Hoffestes kennen gelernt. Der wilde Zauber war ihnen zu Kopfe gestiegen, der Glanz und die Pracht, der köstliche Weingenuß, die Nähe des großen Kriegsgottes und all der gekrönten Häupter. Es war so etwas Fabelhaftes bei der ganzen Sache und trug das Zeichen einer Ausnahmsstunde an sich.
     </p>
-    <p xml:id="eco_de_0000143_5690">
+    <p xml:id="eco_de_0000213_5690">
      Die beiden wichen einander nicht von der Seite, hörten und sahen alles mitsammen und ließen es sich wohl sein.
     </p>
-    <p xml:id="eco_de_0000143_5700">
+    <p xml:id="eco_de_0000213_5700">
      »Mach nur, daß uns unser alter Griesgram nicht immer in den Weg läuft, Strobelmeier; wenn der sieht, daß wir uns erlustigen, hält er uns für Gotteslästerer, der Alte,« meinte Friedrich Herzlieb, als sie miteinander an einem der Schenktische standen und sich gütlich thaten. »Ich habe nicht gesehen, daß der Dickkopf einen Tropfen angerührt hätte.«
     </p>
-    <p xml:id="eco_de_0000143_5710">
+    <p xml:id="eco_de_0000213_5710">
      »Alle Achtung,« sagte Strobel, »ich glaub's auch nicht.« – Friedrich Herzlieb war fidel und obenauf wie ein Schulbub, nahm den ganzen Handel von der leichten Seite und freute sich über die Pracht, »die famosen Kerle«, wie er sagte. Der Napoleon machte ihm großen Spaß, das Volk draußen zwischen den Buden, an den Feuern, der kostbare Herbsttag, die tolle Jagd. Er sah alles schön und heiter – und war ganz Künstler. – Was er sah, das faßte er leidenschaftlich auf, was es bedeutete, damit gab er sich nicht ab – das Stürzen des Wildes riß ihn hin.
     </p>
-    <p xml:id="eco_de_0000143_5720">
+    <p xml:id="eco_de_0000213_5720">
      »Strobelmeier!« rief er. »Siehst du, man muß leben! Man muß unausgesetzt Neues sehen – und fühlen, dann ist man selbst neu geboren. In der Alltäglichkeit verrostet unsereiner. – Strobelmeier, ich weiß nicht, wie du es anfängst, so ein schändlicher Philister zu sein und dabei so ein Prachtkerl.«
     </p>
-    <p xml:id="eco_de_0000143_5730">
+    <p xml:id="eco_de_0000213_5730">
      Als der Jagdzug der Monarchen nach Weimar hinunterzog, trieben sich die beiden noch zwischen den Feuern und den Buden umher.
     </p>
-    <p xml:id="eco_de_0000143_5740">
+    <p xml:id="eco_de_0000213_5740">
      Die Oktobersonne stand tief am Horizont und vergoldete die wehenden braunen Grasbüschel auf den kahlen Seiten des Ettersberges an der Hottelstätter Ecke. – Die Feuer fingen nun schon an zu leuchten, die Nebel sanken, die Leute rüsteten sich zur Heimfahrt. – Aber in die Treiber, die um die hochaufgeschürten Feuer lagen, war jetzt erst das rechte Leben gefahren. Es wurde gejohlt und gebrüllt. Die Weiber und Schätzchen hatten sich, wo es nichts mehr zu sehen gab, zu ihnen gesellt, und es regte sich ein lautes, wildes Leben. Die Buden mit Eßwaren waren von malerischen Gestalten umlagert.
     </p>
-    <p xml:id="eco_de_0000143_5750">
+    <p xml:id="eco_de_0000213_5750">
      Die Forstgehilfen luden das zur Strecke gebrachte Wild auf den Wagen, um es in Sicherheit zu bringen. Ganze Fuhren hatte es gegeben, die Weimaraner konnten sich gütlich thun. Und wagenvoll haben sie's später, als kein Mensch mehr davon essen wollte und konnte, im Verein mit den Hasen vom jenaischen Schlachtfeld nachts in die Ilm werfen müssen. Das Volk durfte in den nun vereinsamten eingefriedigten freien Platz strömen, auf dem kurz vordem Kaiser, Könige und Herzöge unnahbar gethront hatten. Und mit Hast und Neugier, diesen geheiligten Platz zu sehen, stürzten sie hin und betrachteten ihn mit staunender Ehrfurcht, als wäre noch etwas von der vergangenen Herrlichkeit daran hängen geblieben.
     </p>
-    <p xml:id="eco_de_0000143_5760">
+    <p xml:id="eco_de_0000213_5760">
      Strobel und Herzlieb traten, als sich die Masse verlaufen hatte, in den gewaltigen Pavillon.
     </p>
-    <p xml:id="eco_de_0000143_5770">
+    <p xml:id="eco_de_0000213_5770">
      Friedrich Herzlieb stellte sich auf den Platz, auf dem Napoleon gestanden hatte, und blieb da stumm mit geschlossenen Augen stehen.
     </p>
-    <p xml:id="eco_de_0000143_5780">
+    <p xml:id="eco_de_0000213_5780">
      Heinrich Strobel saß mit übergeschlagenen Beinen auf der Brüstung und schaute sich seinen Herzbruder an.
     </p>
-    <p xml:id="eco_de_0000143_5790">
+    <p xml:id="eco_de_0000213_5790">
      »Was treibst du denn da?« Er bekam aber keine Antwort.
     </p>
-    <p xml:id="eco_de_0000143_5800">
+    <p xml:id="eco_de_0000213_5800">
      »Ein erbärmliches Leben,« sagte Friedrich Herzlieb und sah mit schwimmenden Augen auf Heinrich Strobel. »Es lohnt sich nicht! So ein elender Schlucker, ein Wurm unter Würmern! Wie so einem Riesenkerl zu Mute sein mag! – Wenn ich daran denke, ist mir's, als steckten wir andern alle wie die Hühnchen in der Eierschale.
     </p>
-    <p xml:id="eco_de_0000143_5810">
+    <p xml:id="eco_de_0000213_5810">
      »Wie müssen dem gewöhnliche Sterbliche vorkommen?«
     </p>
-    <p xml:id="eco_de_0000143_5820">
+    <p xml:id="eco_de_0000213_5820">
      »Wie Schweine,« sagte Heinrich Strobel. – »Er hat's ja selbst gesagt, von den Deutschen wenigstens.«
     </p>
-    <p xml:id="eco_de_0000143_5830">
+    <p xml:id="eco_de_0000213_5830">
      »Ja, ja,« sagte Friedrich Herzlieb.
     </p>
-    <p xml:id="eco_de_0000143_5840">
+    <p xml:id="eco_de_0000213_5840">
      Sie vergnügten sich auf diesen geweihten Plätzen wie zwei ausgelassene Buben, beschnüffelten alles und trieben es, bis die Dämmerung mehr und mehr hereinbrach. Friedrich Herzlieb zog es zu den Feuern zurück, und an den Buden blieben sie hangen und tranken Glühwein: da hatte sich jetzt alles zusammengefunden: Förster, Forstgehilfen, Bürgersleute mit ihren Weibern und Töchtern.
     </p>
-    <p xml:id="eco_de_0000143_5850">
+    <p xml:id="eco_de_0000213_5850">
      Die Feuer waren hochaufgeschürt, die Treiber johlten und sangen, und der weimarische Wirt, der auf den Einfall gekommen war, einen Kessel mit Glühwein oben auf dem Ettersberge aufzuthun, machte die besten Geschäfte. – Der Wein war scharf gewürzt und heiß wie der Teufel und that an dem nebligen Oktoberabend gut.
     </p>
-    <p xml:id="eco_de_0000143_5860">
+    <p xml:id="eco_de_0000213_5860">
      Der Mond stand jetzt schon am Himmel. Die Feuer leuchteten grell und in dem Lichtschimmer schwirrte es wieder wie damals beim Hegemahl, wie Mückenschwärme um die Flammen.
     </p>
-    <p xml:id="eco_de_0000143_5870">
+    <p xml:id="eco_de_0000213_5870">
      Die Forstleute saßen auf langen Holzbänken um den Glühweinkessel, und Heinrich Strobel mit seinem Herzbruder strich bald da, bald dort herum.
     </p>
-    <p xml:id="eco_de_0000143_5880">
+    <p xml:id="eco_de_0000213_5880">
      »Walpurgisnacht,« sagte Friedrich Herzlieb.
     </p>
-    <p xml:id="eco_de_0000143_5890">
+    <p xml:id="eco_de_0000213_5890">
      »Walpurgisnacht, wo?« frug Strobel und packte ihn mit einer Hand am Schopf. – »Da oben – wie gewöhnlich?«
     </p>
-    <p xml:id="eco_de_0000143_5900">
+    <p xml:id="eco_de_0000213_5900">
      »Gottlob, auch unter dem Schädel,« sagte Herzlieb.
     </p>
-    <p xml:id="eco_de_0000143_5910">
+    <p xml:id="eco_de_0000213_5910">
      »Aber sieh einmal dorthin, Strobelmeier!«
     </p>
-    <p xml:id="eco_de_0000143_5920">
+    <p xml:id="eco_de_0000213_5920">
      Sie gingen miteinander und stiegen über Stock und Stein.
     </p>
-    <p xml:id="eco_de_0000143_5930">
+    <p xml:id="eco_de_0000213_5930">
      Um ein gewaltiges Feuer hatten die Treiber einen Tanzplatz gemacht, da ging es hoch her.
     </p>
-    <p xml:id="eco_de_0000143_5940">
+    <p xml:id="eco_de_0000213_5940">
      Sie tanzten sich an dem kalten Oktoberabend heiß. Vorwitzige Bursche sprangen johlend durchs Feuer – die Mädchen kreischten, Funken sprühten.
     </p>
-    <p xml:id="eco_de_0000143_5950">
+    <p xml:id="eco_de_0000213_5950">
      Der dunkle Rauch wälzte sich, vom Luftzug niedergedrückt. über die wirbelnden Paare hin.
     </p>
-    <p xml:id="eco_de_0000143_5960">
+    <p xml:id="eco_de_0000213_5960">
      Die Forstleute kamen, auch vom Wein erhitzt, den beiden Malern nach. – Der Wirt stellte seinen Glühweinkessel bei diesem Feuer auf, das den Sieg über alle andern davongetragen hatte, die nach und nach verglommen, und alle Mücken strömten dem einen großen Schwarme zu. Das Leben und Treiben, Johlen und Schreien, Funkenstieben, Tanzen und Trinken wuchs mächtig an. Friedrich Herzlieb goß ein Glas nach dem andern von dem heißen Wein in sich ein und tanzte mit einer drallen Dirne, einer Magd aus Weimar.
     </p>
-    <p xml:id="eco_de_0000143_5970">
+    <p xml:id="eco_de_0000213_5970">
      Als er einmal an Heinrich Strobel, der sich zum Gehen, wie es schien, bereit gemacht hatte und auch sein Jagdgewehr schon über die Schulter gehängt hatte, vorüberraste, hielt ihn der am Aermel auf. »Ich geh' jetzt gleich, komm mit.«
     </p>
-    <p xml:id="eco_de_0000143_5980">
+    <p xml:id="eco_de_0000213_5980">
      »Laß mich zufrieden.«
     </p>
-    <p xml:id="eco_de_0000143_5990">
+    <p xml:id="eco_de_0000213_5990">
      Strobel aber kannte den Kumpan und wollte ihn nicht zurücklassen. Wenn einmal der Lebensdrang in seinem Herzbruder geweckt war, wurde er zügellos wie ein junges Fohlen, das sich frei fühlt. – Und der wilde Abend an dem prasselnden Feuer, der Glühwein, der Tanz mit der urwüchsigen Dirne, das war etwas für ihn. Zu jeder andern Zeit hätte Strobel ihn austoben lassen, aber heute nicht, und nicht unter den Augen der Gäste aus dem Rödchen, wenige Tage vor der Hochzeit.
     </p>
-    <p xml:id="eco_de_0000143_6000">
+    <p xml:id="eco_de_0000213_6000">
      Was sollten sie sich denn denken, die Leute! und der Förster – nie und nimmermehr durfte er Herzlieb lassen, wenn es nicht ein Unglück geben sollte. – Der Förster verstand keinen Spaß.
     </p>
-    <p xml:id="eco_de_0000143_6010">
+    <p xml:id="eco_de_0000213_6010">
      »Also,« sagte Strobel, »jetzt mach, wir müssen gehen.«
     </p>
-    <p xml:id="eco_de_0000143_6020">
+    <p xml:id="eco_de_0000213_6020">
      »Teufel auch, häng' ich denn an dir?« rief Herzlieb verdrossen und umfaßte die Dirne wieder zum Tanz.
     </p>
-    <p xml:id="eco_de_0000143_6030">
+    <p xml:id="eco_de_0000213_6030">
      »Rächt so!« sagte die. – »Nu' gerad erscht rächt.«
     </p>
-    <p xml:id="eco_de_0000143_6040">
+    <p xml:id="eco_de_0000213_6040">
      Heinrich Strobel aber langte nach Herzliebens Hand und faßte sie.
     </p>
-    <p xml:id="eco_de_0000143_6050">
+    <p xml:id="eco_de_0000213_6050">
      »Komm, Alter, wir haben mancherlei miteinander ausgefressen und ich hab' dich meines Wissens nie zurückgehalten. – Folg mir heut.«
     </p>
-    <p xml:id="eco_de_0000143_6060">
+    <p xml:id="eco_de_0000213_6060">
      Darüber lachte die Magd und schlug Herzlieb auf die Schulter. – »Jesses!«
     </p>
-    <p xml:id="eco_de_0000143_6070">
+    <p xml:id="eco_de_0000213_6070">
      Herzlieb wurde ungeduldig, der Wein stieg ihm heiß zu Kopf.
     </p>
-    <p xml:id="eco_de_0000143_6080">
+    <p xml:id="eco_de_0000213_6080">
      »Geh deiner Wege!« rief er.
     </p>
-    <p xml:id="eco_de_0000143_6090">
+    <p xml:id="eco_de_0000213_6090">
      »Nein,« sagte Strobel.
     </p>
-    <p xml:id="eco_de_0000143_6100">
+    <p xml:id="eco_de_0000213_6100">
      »Gut, dann bleib also!« und wieder packte er die Dirne, um zum Tanze anzutreten.
     </p>
-    <p xml:id="eco_de_0000143_6110">
+    <p xml:id="eco_de_0000213_6110">
      Strobel hielt ihn wieder zurück.
     </p>
-    <p xml:id="eco_de_0000143_6120">
+    <p xml:id="eco_de_0000213_6120">
      »Morgen wirst du dich darüber ärgern,« sagte Strobel. »Ein paar Tage vor der Hochzeit mit deinem kleinen Mädchen, das wird dir selbst nicht gefallen!«
     </p>
-    <p xml:id="eco_de_0000143_6130">
+    <p xml:id="eco_de_0000213_6130">
      »Du bist ja sehr besorgt« meinte Herzlieb.
     </p>
-    <p xml:id="eco_de_0000143_6140">
+    <p xml:id="eco_de_0000213_6140">
      »Der Herr macht Hochzeit!« lachte die Dirne. »Gucke, gucke!«
     </p>
-    <p xml:id="eco_de_0000143_6150">
+    <p xml:id="eco_de_0000213_6150">
      »Jetzt hol dich der Teufel!« rief Herzlieb, »und thu' nicht so heilig! – So rein wie du will ich auch zum Hochzeitstag kommen!« lachte er und sah auf Strobel mit verschwommenen Augen. Dann legte er die Hand auf Strobels Schultern und zog ihn zu sich heran – und bog sich zu ihm hin, als wollte er etwas heimlich sagen: »Frag sie doch – sie, zum Beispiel,« sagte er, aber mit einer Stimme, die er nicht in der Gewalt hatte, –»sie, – wie's denn mit ihr steht? – Weißt du, Alter, – frag sie einmal, du Duckmäuser! – In Ruh' sollt ihr mich lassen!«
     </p>
-    <p xml:id="eco_de_0000143_6160">
+    <p xml:id="eco_de_0000213_6160">
      »Herzlieb!« schrie Strobel.
     </p>
-    <p xml:id="eco_de_0000143_6170">
+    <p xml:id="eco_de_0000213_6170">
      Aber Herzlieb taumelte auf ihn zu. Heinrich Strobel stieß ihn von sich. Beide stürzten. Da geschah etwas! – – Ein Schlag. – Ein Dröhnen. – Pulverdampf. – Ein Todesschrei. –
     </p>
-    <p xml:id="eco_de_0000143_6180">
+    <p xml:id="eco_de_0000213_6180">
      Da lag einer vorn übergestürzt auf dem Antlitz und einer hockte da, starr, aschfahl – und eine dralle Magd schrie auf: »Das hat er awer selbst gedahn! – Ich hab's gesehen! – so wahr mir Gott helf!«
     </p>
-    <p xml:id="eco_de_0000143_6190">
+    <p xml:id="eco_de_0000213_6190">
      Jetzt stürzte alles im ungewissen, flackernden Licht des Feuers auf den Gestürzten zu. Der andre blieb starr – aschfahl. Ein Murmeln lief durch die Menge, so dumpf, so düster. Von den Forstleuten bogen sich etliche zu dem Getroffenen nieder und richteten ihn auf. – Da quoll ihm beim Aufrichten ein Blutstrom aus dem Munde. Und sie sahen in ein Gesicht, das von ungeheurer Todesangst verzerrt war, – und das Gesicht war starr auf Heinrich Strobel gerichtet, verzweifelt, so angstvoll und entsetzt. Es war, als wenn der Schwergetroffene reden wollte, man sah ihn sich quälen – unerhört quälen. Er arbeitet. – Es gelang nicht. – Ein gurgelnder Schrei – und der Kopf sank weit zurück.
     </p>
-    <p xml:id="eco_de_0000143_6200">
+    <p xml:id="eco_de_0000213_6200">
      Heinrich Strobel kniete jetzt neben ihm – und hielt ihm den Kopf und sah in die gebrochenen Augen – starr und sinnlos.
     </p>
-    <p xml:id="eco_de_0000143_6210">
+    <p xml:id="eco_de_0000213_6210">
      Die dralle Magd wich nicht von den beiden, stand aufrecht da und wiederholte immerfort in ihrem Schreck: »Das hat er awer selbst gedahn! Ich hab's gesehn! Mein Wort darauf.«
     </p>
-    <p xml:id="eco_de_0000143_6220">
+    <p xml:id="eco_de_0000213_6220">
      Ein großer Mensch machte sich durch die Menge Platz. Man wich ihm angstvoll aus – und er stand vor der Leiche des Verlobten seines jüngsten Kindes.
     </p>
-    <p xml:id="eco_de_0000143_6230">
+    <p xml:id="eco_de_0000213_6230">
      Der Oberförster aus Ilmenau trat auf ihn zu, packte ihn an der Hand und sagte: »Da ist ein Unglück geschehen, alter Freund!«
     </p>
-    <p xml:id="eco_de_0000143_6240">
+    <p xml:id="eco_de_0000213_6240">
      »Das seh' ich.« –
     </p>
-    <p xml:id="eco_de_0000143_6250">
+    <p xml:id="eco_de_0000213_6250">
      Tiefste Stille.
     </p>
-    <p xml:id="eco_de_0000143_6260">
+    <p xml:id="eco_de_0000213_6260">
      »Strobel?« frug der Förster.
     </p>
-    <p xml:id="eco_de_0000143_6270">
+    <p xml:id="eco_de_0000213_6270">
      Der antwortete nicht und starrte vor sich hin.
     </p>
-    <p xml:id="eco_de_0000143_6280">
+    <p xml:id="eco_de_0000213_6280">
      Der Oberförster aus Ilmenau aber sagte: »Ich bezeuge es vor Gott und zu jeder Stunde. Er ist auf Herrn Strobel zugestürzt und hat sein Gewehr zu packen bekommen, da geschah das Unglück. Er mochte des Guten zu viel gethan haben.«
     </p>
-    <p xml:id="eco_de_0000143_6290">
+    <p xml:id="eco_de_0000213_6290">
      Stumm bog sich Schlimpimperleins Vater zu dem Verlobten seines Kindes nieder, legte ihm die Hand aufs Herz und hielt die schlaffen Hände des Toten in den seinen.
     </p>
-    <p xml:id="eco_de_0000143_6300">
+    <p xml:id="eco_de_0000213_6300">
      Einer rief: »Schickt zu einem Arzt hinunter.«
     </p>
-    <p xml:id="eco_de_0000143_6310">
+    <p xml:id="eco_de_0000213_6310">
      »Ach was, Arzt, dem hilft kein Arzt mehr, der hat die ganze Ladung im Leibe.«
     </p>
-    <p xml:id="eco_de_0000143_6320">
+    <p xml:id="eco_de_0000213_6320">
      »Faßt einmal an.« Er hob ihn und trug ihn mit einem Forstmann in einen der Wagen, die an den Buden standen. Sie legten ihn zurecht und thaten Tannenzweige unter ihn, die vom Wildaufladen noch dalagen. Der Förster führte das Pferd am Zaum. Strobel und der Förster aus Ilmenau, der im Rödchen einquartiert war, folgten stumm.
     </p>
-    <p xml:id="eco_de_0000143_6330">
+    <p xml:id="eco_de_0000213_6330">
      Als der schwermütige Zug unter den drei alten Kiefern angelangt war, wo der Weg zum Rödchen abzweigt, sagte der Förster: »Ich geh' voraus.«
     </p>
-    <p xml:id="eco_de_0000143_6340">
+    <p xml:id="eco_de_0000213_6340">
      Er ging und sein Gast folgte ihm – Strobel hatte ihm ein stummes Zeichen gegeben.
     </p>
-    <p xml:id="eco_de_0000143_6350">
+    <p xml:id="eco_de_0000213_6350">
      So blieb er allein unter den Bäumen, die er einmal die drei traurigen Bäume genannt hatte, und wachte über seinen stillen Herzbruder, der lang ausgestreckt und kalt im offenen Wagen aus Tannenzweigen lag. Der Mond schimmerte auf dem entstellten Gesicht. Das alte Pferd wurde hin und wider unruhig, als witterte es den Tod.
     </p>
-    <p xml:id="eco_de_0000143_6360">
+    <p xml:id="eco_de_0000213_6360">
      Heinrich Strobel war es so, als wenn es ihn selbst getroffen hätte.
     </p>
-    <p xml:id="eco_de_0000143_6370">
+    <p xml:id="eco_de_0000213_6370">
      Und wenn er zehnmal unschuldig war – und wenn es Hunderte bezeugten. Er hatte ihm doch den Tod gebracht – und war ein gebrochener Mensch, vom Schicksal gezeichnet. Grauenhaft ernst lag der junge, leichtsinnige Bursche vor ihm, und er starrte auf ihn hin und riet an dem Rätsel, das kein Lebender je erraten hat.
     </p>
-    <p xml:id="eco_de_0000143_6380">
+    <p xml:id="eco_de_0000213_6380">
      Die letzten Worte, die der Unglückliche trunken gesprochen – bewegten sich in Heinrich Strobels Kopf wie dumpfes, wie banges Unglücksgeläute. Und bei diesem dumpfen Dröhnen sah er Dinge und Gestalten; – alles wie mit einemmal in die tiefste Hölle der Schmerzen gestoßen, aus einem harmlosen Lebensgenuß heraus.
     </p>
-    <p xml:id="eco_de_0000143_6390">
+    <p xml:id="eco_de_0000213_6390">
      Jetzt mußte er im Hause sein, der Förster. – Jetzt sprach er das Entsetzliche aus. – Jetzt! – Ihm war es, als strömte der Jammer wütend auf ihn ein. Er fühlte mit jedem, mit dem Förster in seinem stummen Schmerz über das Unglück seines Kindes, mit der Mutter – mit seiner armen Anne. Das hatte sich alles mit einem Schlage verändert! Ihm gehörte sein Lebensglück nicht mehr – sein erstes – sein einziges. – Da stöhnte er tief auf. –
     </p>
-    <p xml:id="eco_de_0000143_6400">
+    <p xml:id="eco_de_0000213_6400">
      Heinrich Strobel war das Blut in den Adern erstarrt.
     </p>
-    <p xml:id="eco_de_0000143_6410">
+    <p xml:id="eco_de_0000213_6410">
      Nun saß er da und das unerbittliche Schicksal schoß seine Pfeile, einen nach dem andern, auf ihn ab und alle fuhren mitten ins Herz, verwundeten, zerrissen, marterten – aber töteten nicht.
     </p>
-    <p xml:id="eco_de_0000143_6420">
+    <p xml:id="eco_de_0000213_6420">
      Der Tote stand zwischen ihm und Anne, der war nicht fortzudrängen. – Unerbittlich war er da.
     </p>
-    <p xml:id="eco_de_0000143_6430">
+    <p xml:id="eco_de_0000213_6430">
      Wo sollten sie den Mut hernehmen glücklich zu sein. – Wie sollte er, der Gebrandmarkte, nach der ruhigen reinen Anne die Hand ausstrecken?
     </p>
-    <p xml:id="eco_de_0000143_6440">
+    <p xml:id="eco_de_0000213_6440">
      Herzliebens kleine Braut, die sah er jetzt vor sich – endlich auch die! –
     </p>
-    <p xml:id="eco_de_0000143_6450">
+    <p xml:id="eco_de_0000213_6450">
      Er sah sie in ihren Thränen. Er sah sie ganz überwältigt – von ungeheurem, ungeahntem Schmerz verwirrt. – Er sah, wie sie sich vor dem Toten mit dem entstellten Gesicht entsetzte – graute und fürchtete. Wie sie zusammenschauerte.
     </p>
-    <p xml:id="eco_de_0000143_6460">
+    <p xml:id="eco_de_0000213_6460">
      Und jetzt hörte er wieder die letzten Worte Herzliebs sich im Kopfe dröhnen. – Was bedeuten sie? Was wollen sie? – Sollte da noch andres kommen?
     </p>
-    <p xml:id="eco_de_0000143_6470">
+    <p xml:id="eco_de_0000213_6470">
      Er blickte fragend auf den starren Toten.
     </p>
-    <p xml:id="eco_de_0000143_6480">
+    <p xml:id="eco_de_0000213_6480">
      Da kam der Förster über die kahle Anhöhe allein zurück und ohne zu reden faßte er den Gaul wieder am Zaum und führte langsam den toten Verlobten seinem Hause zu und denen, die den jammervollen Anblick nun erwarteten.
     </p>
-    <p xml:id="eco_de_0000143_6490">
+    <p xml:id="eco_de_0000213_6490">
      Heinrich Strobel ging wieder hinter dem Wagen her. Er war ohne Hut. Der leichte Wind wehte sein straffes aufrechtstehendes Haar hin und her, wie einen Büschel. Er sah so sonderbar aus, das unregelmäßige fahle Gesicht, die lange knochige Gestalt, das Düstere, Trostlose, das über ihm lag. Er war nicht einer von den Festgebauten, denen die Wassergüsse, die Sturmstöße des Schicksals äußerlich nichts anhaben können, die glatt und ansehnlich bleiben, wie die Fischottern zu Wasser und zu Land.
     </p>
-    <p xml:id="eco_de_0000143_6500">
+    <p xml:id="eco_de_0000213_6500">
      Er ging so zugerichtet, so umgewandelt und zerzaust.
     </p>
-    <p xml:id="eco_de_0000143_6510">
+    <p xml:id="eco_de_0000213_6510">
      Tief in der Nacht. – Der Tote liegt auf einem Bette aufgebahrt auf weißen Tüchern und mit weißen Tüchern bedeckt in dem sogenannten Saal, in dem zu Karnevalszeit die lustigen Masken in dem verschneiten Rödchen sich vergnügt hatten.
     </p>
-    <p xml:id="eco_de_0000143_6520">
+    <p xml:id="eco_de_0000213_6520">
      Die Kummerfelden hat ihm zu Häupten zwei Kerzen gestellt.
     </p>
-    <p xml:id="eco_de_0000143_6530">
+    <p xml:id="eco_de_0000213_6530">
      In dem dämmerigen Raum, ganz einsam, sitzt Heinrich Strobel und hat den struppigen Kopf in die Hände vergraben und läßt sich von seinen Gedanken, ohne sich zu regen, martern und bis aufs Mark quälen.
     </p>
-    <p xml:id="eco_de_0000143_6540">
+    <p xml:id="eco_de_0000213_6540">
      Er hält still.
     </p>
-    <p xml:id="eco_de_0000143_6550">
+    <p xml:id="eco_de_0000213_6550">
      Die andern sind alle vor kurzem, dem Namen nach, zur Ruh' gegangen, nachdem niemand mehr wußte, was thun, nachdem sie stumpf geworden waren.
     </p>
-    <p xml:id="eco_de_0000143_6560">
+    <p xml:id="eco_de_0000213_6560">
      Wäre die alte Kummerfelden nicht gewesen – da hätte der Tote jetzt noch auf der Matratze im Vorhaus gelegen. Niemand hätte sich zu helfen gewußt. Niemand hätte etwas zu thun gewagt.
     </p>
-    <p xml:id="eco_de_0000143_6570">
+    <p xml:id="eco_de_0000213_6570">
      Die Försterin hatte nichts machen können, als den Kopf ihres unglücklichen Kindes zu halten, den das arme Geschöpf an sie gepreßt hielt.
     </p>
-    <p xml:id="eco_de_0000143_6580">
+    <p xml:id="eco_de_0000213_6580">
      Schlimpimperlein war wie ein Mensch mit Brandwunden gewesen, der liegen bleiben will, wo er liegt, dem es Entsetzen ist, angerührt zu werden, der nicht angesprochen sein will, keine Hilfe will, nur liegen in seiner Qual. – Heinrich Strobel hatte wie gebannt auf das unglückliche Mädchen gesehen.
     </p>
-    <p xml:id="eco_de_0000143_6590">
+    <p xml:id="eco_de_0000213_6590">
      Es war in ihrem Schmerz etwas so Scheues, so Gedrücktes; wie ein geschlagener Hund lag sie da. – Herzliebs letzte Worte dröhnten Strobel fort und fort in den Ohren.
     </p>
-    <p xml:id="eco_de_0000143_6600">
+    <p xml:id="eco_de_0000213_6600">
      »Heinrich, Heinrich!« hatte seine Anne gerufen und war ihm schluchzend um den Hals gefallen, »armer Heinrich!«
     </p>
-    <p xml:id="eco_de_0000143_6610">
+    <p xml:id="eco_de_0000213_6610">
      Der Förster aus Ilmenau war da zu ihnen getreten. »Ihm geschieht nichts, Jungfer Anne, kein Mensch wird ihm etwas anhaben. Der ist daran so unschuldig wie ich und alle, die dabei standen.«
     </p>
-    <p xml:id="eco_de_0000143_6620">
+    <p xml:id="eco_de_0000213_6620">
      »Ja, gelobt sei Gott – das ist er! – Aber wie soll er mir denn je im Leben wieder froh werden,« – da war sie in heiße Thränen ausgebrochen und war zu ihrer kleinen Schwester gegangen, hatte sie der Mutter aus den Armen genommen und sie still hinaus in die gemeinschaftliche Schlafkammer gebracht, hatte sie da auf ihr Bett niedersitzen lassen und war immer noch in heißen Thränen vor ihr niedergesunken – und so weinten die beiden Mädchen, ohne ein Wort zu finden, miteinander.
     </p>
-    <p xml:id="eco_de_0000143_6630">
+    <p xml:id="eco_de_0000213_6630">
      Mit einemmal fühlte Anne sich von ihrer Schwester wie zurückgestoßen, die richtete sich auf, streckte die Arme von sich und schrie auf: »Anne! – Anne! Anne! Der Vatter schlägt mich tot – Anne, was soll ich thun!« Dann stürzten die Thränen so wild und unaufhaltsam aus ihren Augen. Ihr Körper zuckte in Qual. Und Anne stand da und blickte beim Schein des trüben Lichtes mit entsetzten Augen auf die unglückliche Schwester.
     </p>
-    <p xml:id="eco_de_0000143_6640">
+    <p xml:id="eco_de_0000213_6640">
      »Anne, – Anne!« wimmerte die.
     </p>
-    <p xml:id="eco_de_0000143_6650">
+    <p xml:id="eco_de_0000213_6650">
      »Was willst du denn? Was denn?« frug Anne zitternd. Ihr ahnte dunkel etwas und verschloß ihr den Mund, die Kniee bebten ihr, die Lippen trockneten ihr aus und alles drehte sich wie im Kreise. –
     </p>
-    <p xml:id="eco_de_0000143_6660">
+    <p xml:id="eco_de_0000213_6660">
      Sie frug nicht wieder.
     </p>
-    <p xml:id="eco_de_0000143_6670">
+    <p xml:id="eco_de_0000213_6670">
      So schwiegen sie beide und regten sich nicht. –
     </p>
-    <p xml:id="eco_de_0000143_6680">
+    <p xml:id="eco_de_0000213_6680">
      »Anne« – jammerte es von neuem – »Anne.« –
     </p>
-    <p xml:id="eco_de_0000143_6690">
+    <p xml:id="eco_de_0000213_6690">
      Die fühlte sich durchschauert von dem Hilferuf, aber konnte sich nicht regen.
     </p>
-    <p xml:id="eco_de_0000143_6700">
+    <p xml:id="eco_de_0000213_6700">
      Da sank ihr die Schwester zu Füßen, umfaßte ihr die Kniee und flüsterte ihr etwas so Jammervolles zu.
     </p>
-    <p xml:id="eco_de_0000143_6710">
+    <p xml:id="eco_de_0000213_6710">
      »Der Vatter schlägt mich tot! – Der Vatter schlägt mich tot, wenn er's erfährt!« schrie sie.
     </p>
-    <p xml:id="eco_de_0000143_6720">
+    <p xml:id="eco_de_0000213_6720">
      Anne stand ohne sich zu bewegen, die Wangen brannten ihr vor Scham und Qual. – Sie schwieg – sie reichte der Schwester nicht die Hand. Sie rührte sich nicht und ließ sie sich zu Füßen liegen und sah, wie sie sich krümmte vor Angst und Qual. – Sah oder sah sie es nicht?
     </p>
-    <p xml:id="eco_de_0000143_6730">
+    <p xml:id="eco_de_0000213_6730">
      »Anne!« schrie die Schwester laut.
     </p>
-    <p xml:id="eco_de_0000143_6740">
+    <p xml:id="eco_de_0000213_6740">
      »Was soll ich nur thun!« rief Schlimpimperlein, »sprich doch, ich soll . . .« und wieder weinte sie herzzerreißend.
     </p>
-    <p xml:id="eco_de_0000143_6750">
+    <p xml:id="eco_de_0000213_6750">
      »Ich soll mich umbringen – du – das willst du!« sagte Schlimpimperlein zitternd. – »Sag doch!« –
     </p>
-    <p xml:id="eco_de_0000143_6760">
+    <p xml:id="eco_de_0000213_6760">
      »Nein« – antwortete Anne wie im Traum. –
     </p>
-    <p xml:id="eco_de_0000143_6770">
+    <p xml:id="eco_de_0000213_6770">
      Aber sie blickte nicht auf die Schwester, sondern geradaus vor sich hin.
     </p>
-    <p xml:id="eco_de_0000143_6780">
+    <p xml:id="eco_de_0000213_6780">
      »Was soll ich denn thun?« jammerte das arme verlassene Geschöpf, auf das ganz unvermittelt alle Schrecken des Lebens gefallen waren, Schuld und Tod. – Sie bekam keine Antwort.
     </p>
-    <p xml:id="eco_de_0000143_6790">
+    <p xml:id="eco_de_0000213_6790">
      Die Schwester wendete sich von ihr ab und ging ans Fenster, stand da ruhig. preßte die gefalteten Hände an die Stirn und sah in die Dunkelheit hinaus.
     </p>
-    <p xml:id="eco_de_0000143_6800">
+    <p xml:id="eco_de_0000213_6800">
      Schlimpimperlein schleppte sich auf ihr Bett, legte sich da hin und blickte mit zitternder Angst auf ihre Schwester wie auf ihren Richter. –
     </p>
-    <p xml:id="eco_de_0000143_6810">
+    <p xml:id="eco_de_0000213_6810">
      Schwere Schritte kamen die Treppe herauf.
     </p>
-    <p xml:id="eco_de_0000143_6820">
+    <p xml:id="eco_de_0000213_6820">
      »Der Vatter,« sagte Anne.
     </p>
-    <p xml:id="eco_de_0000143_6830">
+    <p xml:id="eco_de_0000213_6830">
      Sie faßt Schlimpimperleins Hand und preßt sie – und sieht auf die Schwester mit einem Blick so gequält – so unglückselig, daß es der wie ein Schauer überläuft.
     </p>
-    <p xml:id="eco_de_0000143_6840">
+    <p xml:id="eco_de_0000213_6840">
      »Daß mir's der Vatter nicht erfährt,« sagt sie fest. »Du bist still.« –
     </p>
-    <p xml:id="eco_de_0000143_6850">
+    <p xml:id="eco_de_0000213_6850">
      Jetzt legt sich eine Hand auf die Thürklinke – der Förster tritt ein.
     </p>
-    <p xml:id="eco_de_0000143_6860">
+    <p xml:id="eco_de_0000213_6860">
      »Kind,« sagt er bebend und sinkt am Lager seiner Jüngsten hin und faßt ihre Hand und küßt diese Hand, und Schlimpimperlein fühlt die Thränen ihres großen, starken Vaters auf die Hand tropfen:
     </p>
-    <p xml:id="eco_de_0000143_6870">
+    <p xml:id="eco_de_0000213_6870">
      »Vatter! – Vatter!« ruft sie fassungslos.
     </p>
-    <p xml:id="eco_de_0000143_6880">
+    <p xml:id="eco_de_0000213_6880">
      Annes Blick ist unerbittlich auf sie gerichtet. – Der Förster fährt fort sein unglückliches Kind zu liebkosen.
     </p>
-    <p xml:id="eco_de_0000143_6890">
+    <p xml:id="eco_de_0000213_6890">
      Das Mitleid hat ihn nicht ruhen lassen. Er mußte bei ihr sein. Er sieht schlecht aus. Anne denkt: gerade als wenn der Bock kommen wollte.
     </p>
-    <p xml:id="eco_de_0000143_6900">
+    <p xml:id="eco_de_0000213_6900">
      Schlimpimperlein liegt stumm und still und läßt alles über sich ergehen wie einen reißenden Strom. Das plötzliche Todesentsetzen, ihr Schuldgefühl, ihre Verlassenheit, den bittern Schmerz, die Todesangst vor Schmach und Strafe, die Hoffnungslosigkeit und Hilflosigkeit, die rührende Güte ihres Vaters, sein Mitleiden, seine Thränen, die wie Feuer brennen – und das Grauen vor ihrer stummen entschlossenen Schwester, die wie ein furchtbarer Engel in ihrer Reinheit vor ihr steht, die etwas unerbittlich von ihr zu verlangen scheint, die etwas will und weiß, wo es nichts zu wollen gibt als den Tod, keinen Ausweg und keine Rettung. Aber das Erschreckendste von allem sind die Mitleidsthränen des Vaters, die sich mit einem Wort, wenn sie die Wahrheit sagte, umwandeln würden zu einem grausenerregenden Schauspiel.
     </p>
-    <p xml:id="eco_de_0000143_6910">
+    <p xml:id="eco_de_0000213_6910">
      Sie liegt still und stumm. Ein Wort und eine Regung und sie würde fassungslos sein. Es würde alles gestanden, alles gesagt sein.
     </p>
-    <p xml:id="eco_de_0000143_6920">
+    <p xml:id="eco_de_0000213_6920">
      Anne aber steht an ihrem Bettende und läßt sie nicht aus den Augen.
     </p>
-    <p xml:id="eco_de_0000143_6930">
+    <p xml:id="eco_de_0000213_6930">
      Der Vater geht, nachdem er sein armes Kind auf die Stirn geküßt und ihr zum letztenmal zart und ängstlich mit den harten Fingern die Hand gestreichelt hat. – Er sieht schwerfällig und gealtert aus.
     </p>
-    <p xml:id="eco_de_0000143_6940">
+    <p xml:id="eco_de_0000213_6940">
      Und als er gegangen, bricht Anne zusammen und schluchzt, als wollte sie sich zu Tode weinen.
     </p>
-    <p xml:id="eco_de_0000143_6950">
+    <p xml:id="eco_de_0000213_6950">
      »Er darf nichts erfahren – nie!« – das ringt sich wieder und wieder zwischen dem heißen Schluchzen hervor. – »Guter allmächtiger Gott, hilf uns!« ruft sie sinnlos.
     </p>
-    <p xml:id="eco_de_0000143_6960">
+    <p xml:id="eco_de_0000213_6960">
      Schlimpimperlein graut es vor ihr. – Was war aus der vernünftigen Ludschevadel geworden!
     </p>
-    <p xml:id="eco_de_0000143_6970">
+    <p xml:id="eco_de_0000213_6970">
      Ihr schwindelt – sie kommt sich vor wie in die Hölle geworfen und sie weint und weint.
     </p>
-    <p xml:id="eco_de_0000143_6980">
+    <p xml:id="eco_de_0000213_6980">
      So vergeht die Nacht. Die herbstliche Morgendämmerung bricht an. Es wird fahl und hell. – Ludschevadel wäscht sich das Gesicht, das trostlose, verzweifelte Gesicht – steckt sich die Haare fest, bringt ihre Kleidung in Ordnung und tritt an Schlimpimperleins Bett.
     </p>
-    <p xml:id="eco_de_0000143_6990">
+    <p xml:id="eco_de_0000213_6990">
      »Daß ich ruhig gehen kann« – sagt sie, »versprich mir, nichts zu thun ohne mich. – Versprich mir's – und halt's. Sei still.«
     </p>
-    <p xml:id="eco_de_0000143_7000">
+    <p xml:id="eco_de_0000213_7000">
      Das sagte sie mit tiefem traurigen Ernst und reichte Schlimpimperlein die Hand hin.
     </p>
-    <p xml:id="eco_de_0000143_7010">
+    <p xml:id="eco_de_0000213_7010">
      Die wagte nicht die Hand zu fassen und blickte die Schwester an wie ein geschlagener Hund.
     </p>
-    <p xml:id="eco_de_0000143_7020">
+    <p xml:id="eco_de_0000213_7020">
      »Was willst du denn nur?« frug sie – und zögerte mit ihrer Hand.
     </p>
-    <p xml:id="eco_de_0000143_7030">
+    <p xml:id="eco_de_0000213_7030">
      »Ludschevadel!« schreit sie mit zitternder Stimme – »du willst doch – – Ludschevadel, ich fürcht' mich so. – Ich kann's nicht! Sag' ihm, daß er mich erschießen soll wie Friedel – sag's ihm.«
     </p>
-    <p xml:id="eco_de_0000143_7040">
+    <p xml:id="eco_de_0000213_7040">
      Und jetzt brach ein Schmerzenstrom los – bei diesen Worten, so unaufhaltsam, so wild – so jammervoll. Ludschevadel stand still und blaß und ließ es vorüberrauschen.
     </p>
-    <p xml:id="eco_de_0000143_7050">
+    <p xml:id="eco_de_0000213_7050">
      Als die Gewalt nachließ, sagte sie: »Nimm das zurück!«
     </p>
-    <p xml:id="eco_de_0000143_7060">
+    <p xml:id="eco_de_0000213_7060">
      »Bitt' ihn, daß er auch mich erschießt!« jammerte das arme Geschöpf. – »Mir ist's ja gleich, wer ihn erschoß – wenn er tot ist!«
     </p>
-    <p xml:id="eco_de_0000143_7070">
+    <p xml:id="eco_de_0000213_7070">
      »Du sollst's nicht denken – du darfst nicht,« sagte Anne fest. – »Er that's nicht, so wahr Gott lebt. Sage es selbst, daß du's nicht glaubst!«
     </p>
-    <p xml:id="eco_de_0000143_7080">
+    <p xml:id="eco_de_0000213_7080">
      Schlimpimperlein starrte sie an – und blickte in die entschlossenen traurigen Augen! –
     </p>
-    <p xml:id="eco_de_0000143_7090">
+    <p xml:id="eco_de_0000213_7090">
      »Was du willst, Ludschevadel: Er hat es nicht gethan!«
     </p>
-    <p xml:id="eco_de_0000143_7100">
+    <p xml:id="eco_de_0000213_7100">
      »Er hat's wahrlich nicht gethan!« sagte Ludschevadel feierlich. – »Er ist ein Mensch so treu und gut wie Gold – so einzig gut! – Siehst du, wie kein Mensch auf der Erde, so klug und brav.« –
     </p>
-    <p xml:id="eco_de_0000143_7110">
+    <p xml:id="eco_de_0000213_7110">
      Ludschevadel rannen die Thränen über die bleichen Wangen, und sie stand still und rührend da. –
     </p>
-    <p xml:id="eco_de_0000143_7120">
+    <p xml:id="eco_de_0000213_7120">
      »Gib mir jetzt deine Hand und sag mir, daß du nichts thun willst ohne mich und daß du alles thun willst, was ich dir sage.« –
     </p>
-    <p xml:id="eco_de_0000143_7130">
+    <p xml:id="eco_de_0000213_7130">
      Da legte das arme Mädchen die Hand in die der Schwester.
     </p>
-    <p xml:id="eco_de_0000143_7140">
+    <p xml:id="eco_de_0000213_7140">
      »Ich will nicht, daß du stirbst – Ludovika. – Aber ich will vor allem nicht, daß der Vatter es erfährt – das wäre schlimmer als der Tod!« –
     </p>
-    <p xml:id="eco_de_0000143_7150">
+    <p xml:id="eco_de_0000213_7150">
      »Ich geh' jetzt – und du sprich mit keinem Menschen – auch wenn die Mutter kommen sollte – kein Wort.«
     </p>
-    <p xml:id="eco_de_0000143_7160">
+    <p xml:id="eco_de_0000213_7160">
      »Kein Wort,« antwortete Schlimpimperlein und sah durch Thränen auf die Schwester – und wagte nichts zu fragen und zu sagen.
     </p>
-    <p xml:id="eco_de_0000143_7170">
+    <p xml:id="eco_de_0000213_7170">
      Anne Ludschevadel ging leise die Treppe hinab – und leise nach dem Saal, in dem der Tote lag. Die Thür stand auf und sie blieb auf der Schwelle stehen.
     </p>
-    <p xml:id="eco_de_0000143_7180">
+    <p xml:id="eco_de_0000213_7180">
      Der Tote lag im grauen Morgenlicht in seinen weißen Tüchern. Die beiden Lichter ihm zu Häupten glommen qualmend, tief herabgebrannt. Der Talg war an den Leuchtern in großen Zapfen herabgeflossen.
     </p>
-    <p xml:id="eco_de_0000143_7190">
+    <p xml:id="eco_de_0000213_7190">
      Heinrich Strobel, mit dem Kopf an einem der Fensterpfosten gestützt, das straffe Haar zerwühlt wie in Fittichen abstehend, saß ganz in sich versunken mit geschlossenen Augen.
     </p>
-    <p xml:id="eco_de_0000143_7200">
+    <p xml:id="eco_de_0000213_7200">
      Daß er nicht schlief, gewahrte Anne an seinem tiefen Stöhnen.
     </p>
-    <p xml:id="eco_de_0000143_7210">
+    <p xml:id="eco_de_0000213_7210">
      »Heinrich,« flüsterte sie von der Schwelle aus über den Toten hinweg.
     </p>
-    <p xml:id="eco_de_0000143_7220">
+    <p xml:id="eco_de_0000213_7220">
      Heinrich Strobel stand auf und kam auf sie zu.
     </p>
-    <p xml:id="eco_de_0000143_7230">
+    <p xml:id="eco_de_0000213_7230">
      »Was willst du, Anne?« sagte er und sah auf sie mit einem liebestraurigen Blick.
     </p>
-    <p xml:id="eco_de_0000143_7240">
+    <p xml:id="eco_de_0000213_7240">
      »Komm mit, Heinrich.«
     </p>
-    <p xml:id="eco_de_0000143_7250">
+    <p xml:id="eco_de_0000213_7250">
      Er ging mit ihr und sie traten miteinander zum Hause hinaus und gingen in dem grauen Morgennebel ohne zu sprechen vorwärts. Der Nebel lag dicht und kalt an den nassen gelb und braunen Bäumen an.
     </p>
-    <p xml:id="eco_de_0000143_7260">
+    <p xml:id="eco_de_0000213_7260">
      Heinrich hatte ihre Hand gefaßt. – »Willst du sprechen, Anne?«
     </p>
-    <p xml:id="eco_de_0000143_7270">
+    <p xml:id="eco_de_0000213_7270">
      Sie sah ihn an, wie jemand, der schon mit dem Tode ringt, sprechen möchte und nicht kann – und sie gingen weiter Hand in Hand – und wagten sich nicht anzusehen.
     </p>
-    <p xml:id="eco_de_0000143_7280">
+    <p xml:id="eco_de_0000213_7280">
      »Was ist denn, Anne?« sagte er. Da standen sie bei den drei Kiefern, von denen sie so oft gesprochen.
     </p>
-    <p xml:id="eco_de_0000143_7290">
+    <p xml:id="eco_de_0000213_7290">
      »Jetzt sind wir unter den verfluchten Bäumen,« meinte Heinrich Strobel, »nun sag, was du zu sagen hast! Du willst mit dem Unglücksvogel nichts mehr zu thun haben. Mach's kurz. – Ich weiß schon.«
     </p>
-    <p xml:id="eco_de_0000143_7300">
+    <p xml:id="eco_de_0000213_7300">
      »Heinrich!« rief sie angstvoll. Sie schlang die Arme um seinen Hals und weinte an seiner Brust und weinte und weinte. –
     </p>
-    <p xml:id="eco_de_0000143_7310">
+    <p xml:id="eco_de_0000213_7310">
      Jetzt hob sie den Kopf und sah ihn an und faßte seine beiden Hände. – »Gott hat den Toten zwischen uns gedrängt,« sagte sie langsam, »– – – und noch etwas andres, Heinrich.«
     </p>
-    <p xml:id="eco_de_0000143_7320">
+    <p xml:id="eco_de_0000213_7320">
      Er stand stumm und fahl und düster vor ihr.
     </p>
-    <p xml:id="eco_de_0000143_7330">
+    <p xml:id="eco_de_0000213_7330">
      Sie sagte mit Worten, was er am Abend unter diesen traurigen Bäumen, als er bei seinem Herzbruder Wache hielt, gedacht hatte.
     </p>
-    <p xml:id="eco_de_0000143_7340">
+    <p xml:id="eco_de_0000213_7340">
      Die beiden treuen Menschen standen und trugen miteinander das Schicksal, das über sie hergefallen war. – Sie trugen eine schwere Last – und dachten nicht daran sie abzuwerfen, abzuschütteln, was abzuschütteln war.
     </p>
-    <p xml:id="eco_de_0000143_7350">
+    <p xml:id="eco_de_0000213_7350">
      Und ob er zehnmal unschuldig war, daß der frische, leichtsinnige Gesell jetzt unter den weißen Tüchern als Toter lag – durch ihn war es doch geschehen!
     </p>
-    <p xml:id="eco_de_0000143_7360">
+    <p xml:id="eco_de_0000213_7360">
      Er war doch die Veranlassung und blieb die Veranlassung. Durch ihn war Unglück gekommen. – Gott hatte ihn als Werkzeug gebraucht – um Jammer hereinbrechen zu lassen. – So ein Werkzeug ist und bleibt gezeichnet. Ein Richtschwert wird nimmermehr zum Brotmesser gebraucht.
     </p>
-    <p xml:id="eco_de_0000143_7370">
+    <p xml:id="eco_de_0000213_7370">
      Die beiden fühlten gleich. Sie waren dieselbe Art Menschen. Sie ergänzten einander nicht, sie waren eins. Ihre Liebe war Friede; eine kampflose Liebe fürs Leben.
     </p>
-    <p xml:id="eco_de_0000143_7380">
+    <p xml:id="eco_de_0000213_7380">
      Sie schauten einander in die traurigen Augen und verstanden einander. – Sie hatten nicht zu reden gebraucht, dachten dieselben Gedanken, – fühlten dieselbe Qual und die düstere Stunde war die Krone ihrer Liebe. – Sie waren eins – ganz eins, für immer eins.
     </p>
-    <p xml:id="eco_de_0000143_7390">
+    <p xml:id="eco_de_0000213_7390">
      »Was noch, Anne? – Du sagtest – –.« Er legte ihr den Arm um die Schulter und zog sie dicht zu sich heran.
     </p>
-    <p xml:id="eco_de_0000143_7400">
+    <p xml:id="eco_de_0000213_7400">
      »Anne.« – Und wie ein Schreckenslaut rief er fassungslos: »Deine Schwester . . .!« Weiter sprach er nicht. Er schaute sie an, fragend – wissend. Er sah ihr bis auf den Grund ihrer Seele, bohrte seinen Blick in ihre Augen.
     </p>
-    <p xml:id="eco_de_0000143_7410">
+    <p xml:id="eco_de_0000213_7410">
      »Heinrich!« Und leise wie ein Thränenstrom rang sich die traurige Geschichte der Schwester ihr vom Herzen.
     </p>
-    <p xml:id="eco_de_0000143_7420">
+    <p xml:id="eco_de_0000213_7420">
      Das arme gute Mädchen stand wie ein abgeschiedener Geist. Alles war von ihr gefallen, alles Irdische, Hoffnung und Liebe und jedes Lebensglück. – In ihren Zügen war eine rührende Entsagung ohnegleichen zu lesen.
     </p>
-    <p xml:id="eco_de_0000143_7430">
+    <p xml:id="eco_de_0000213_7430">
      »Heinrich!« Sie sank vor ihm in die Kniee und hob die gefalteten Hände hoch zu ihm empor.
     </p>
-    <p xml:id="eco_de_0000143_7440">
+    <p xml:id="eco_de_0000213_7440">
      »Rette uns, Heinrich.«
     </p>
-    <p xml:id="eco_de_0000143_7450">
+    <p xml:id="eco_de_0000213_7450">
      Dem hagern Gesellen mit dem struppigen aufstrebenden Haarschopf liefen die hellen Thränen über die fahlen Wangen, als er sie so vor sich knieen sah.
     </p>
-    <p xml:id="eco_de_0000143_7460">
+    <p xml:id="eco_de_0000213_7460">
      »Mach sie zu deiner Frau, Heinrich – dann sind wir gerettet! Nur dann. Wenn der Vatter es erführ'! Du weißt doch, der Vatter!«
     </p>
-    <p xml:id="eco_de_0000143_7470">
+    <p xml:id="eco_de_0000213_7470">
      So in Todesangst sprach und kniete sie da. – Und er hob sie nicht auf. Er ließ sie knieen, starrte auf sie hin wie im Traum.
     </p>
-    <p xml:id="eco_de_0000143_7480">
+    <p xml:id="eco_de_0000213_7480">
      »Anne, mein Weib!« schrie er auf.
     </p>
-    <p xml:id="eco_de_0000143_7490">
+    <p xml:id="eco_de_0000213_7490">
      Sie hielt noch immer die gefalteten Hände hoch.
     </p>
-    <p xml:id="eco_de_0000143_7500">
+    <p xml:id="eco_de_0000213_7500">
      »Rette uns, Heinrich – rette uns! – Wenn der Vatter es erführ'!« Sie wußte nichts mehr zu sagen. Sie fand die Worte nicht.
     </p>
-    <p xml:id="eco_de_0000143_7510">
+    <p xml:id="eco_de_0000213_7510">
      Und so kniete sie und hielt immer die gefalteten Hände hoch und sah auf seine Lippen.
     </p>
-    <p xml:id="eco_de_0000143_7520">
+    <p xml:id="eco_de_0000213_7520">
      »Heinrich! Heinrich!«
     </p>
-    <p xml:id="eco_de_0000143_7530">
+    <p xml:id="eco_de_0000213_7530">
      »Anne.«
     </p>
-    <p xml:id="eco_de_0000143_7540">
+    <p xml:id="eco_de_0000213_7540">
      Und sie nannten ihre Namen gegenseitig. Das war alles, was sie konnten.
     </p>
-    <p xml:id="eco_de_0000143_7550">
+    <p xml:id="eco_de_0000213_7550">
      »Wenn nicht Rettung kommt, gibt's ein Unglück sondergleichen! Wenn es auf Erden etwas gibt, das ihn und uns davor behüten kann. – Heinrich – wenn es etwas gibt?«
     </p>
-    <p xml:id="eco_de_0000143_7560">
+    <p xml:id="eco_de_0000213_7560">
      Sie kniete immer noch in ihren Thränen vor ihm.
     </p>
-    <p xml:id="eco_de_0000143_7570">
+    <p xml:id="eco_de_0000213_7570">
      Er wendete sich stumm, mit einem starren grauen Gesicht von ihr ab, lehnte sich mit dem Kopf an einen der rotbraunen Kiefernstämme und schloß die Augen.
     </p>
-    <p xml:id="eco_de_0000143_7580">
+    <p xml:id="eco_de_0000213_7580">
      So blieben sie unbeweglich.
     </p>
-    <p xml:id="eco_de_0000143_7590">
+    <p xml:id="eco_de_0000213_7590">
      Dann wurde unter den Unglücksbäumen so treu und todestraurig geredet, so hoffnungslos und gut, wie es hin und wider auf dieser Erde geschieht.
     </p>
-    <p xml:id="eco_de_0000143_7600">
+    <p xml:id="eco_de_0000213_7600">
      Als sie dem Trauerhause zugingen, sprachen sie nicht mehr miteinander. Zwischen ihnen war alles abgethan.
     </p>
-    <p xml:id="eco_de_0000143_7610">
+    <p xml:id="eco_de_0000213_7610">
      »Heinrich,« sagte sie endlich, als sie ins Haus traten, »ich sage es ihr: und den Eltern jetzt gleich – dann ist's geschehen.«
     </p>
-    <p xml:id="eco_de_0000143_7620">
+    <p xml:id="eco_de_0000213_7620">
      Als sie an Schlimpimperleins Bett trat, fand sie die schlafend. – Und sie sah in das verweinte Kindergesicht.
     </p>
-    <p xml:id="eco_de_0000143_7630">
+    <p xml:id="eco_de_0000213_7630">
      »Ludovika,« sagte das ernste blasse Mädchen.
     </p>
-    <p xml:id="eco_de_0000143_7640">
+    <p xml:id="eco_de_0000213_7640">
      Mit einem Jammerruf erwachte sie. Es war das erste Mal in ihrem Leben, daß sie im Unglück eingeschlafen und im Unglück wieder erwachte.
     </p>
-    <p xml:id="eco_de_0000143_7650">
+    <p xml:id="eco_de_0000213_7650">
      »Was!« flüsterte sie bang.
     </p>
-    <p xml:id="eco_de_0000143_7660">
+    <p xml:id="eco_de_0000213_7660">
      Ludschevadel stand ruhig vor ihr. »Es gibt nur einen Weg.«
     </p>
-    <p xml:id="eco_de_0000143_7670">
+    <p xml:id="eco_de_0000213_7670">
      »Daß ich sterbe,« sagte Schlimpimperlein.
     </p>
-    <p xml:id="eco_de_0000143_7680">
+    <p xml:id="eco_de_0000213_7680">
      »Nein – du mußt Heinrichs Frau werden,« antwortete das arme junge Weib kurz und schroff.
     </p>
-    <p xml:id="eco_de_0000143_7690">
+    <p xml:id="eco_de_0000213_7690">
      Da traf sie ein Blick ihrer Schwester, ein so sonderbarer verblüffter, entsetzter Blick, so etwas Verwirrtes im Blick und etwas, als wenn sie mitten in ihrem Elend lachen wollte.
     </p>
-    <p xml:id="eco_de_0000143_7700">
+    <p xml:id="eco_de_0000213_7700">
      Sie saß stumm und starr, als wäre ein Blitz vor ihr niedergegangen.
     </p>
-    <p xml:id="eco_de_0000143_7710">
+    <p xml:id="eco_de_0000213_7710">
      Dann warf sie sich mit dem Gesicht auf die Kissen und schluchzte: »Friedel! Friedel!«
     </p>
-    <p xml:id="eco_de_0000143_7720">
+    <p xml:id="eco_de_0000213_7720">
      Ihre Schwester stand unbeweglich vor ihr und sah mit den entschlossenen Augen auf sie nieder. Sie ließ ihr Zeit sich auszuweinen.
     </p>
-    <p xml:id="eco_de_0000143_7730">
+    <p xml:id="eco_de_0000213_7730">
      »Es gibt den einen einzigen Weg,« sagte sie tonlos. – »Oder hast du den Mut auf und davon zu gehen in die Fremde, daß man, wenn man dich tot findet, nie erfährt, wohin du gehörtest, dann geh' und mach' dich auf den Weg; aber geh' auch –!«
     </p>
-    <p xml:id="eco_de_0000143_7740">
+    <p xml:id="eco_de_0000213_7740">
      »Anne!« schrie Schlimpimperlein auf.
     </p>
-    <p xml:id="eco_de_0000143_7750">
+    <p xml:id="eco_de_0000213_7750">
      »Wenn's der Vatter erfährt, schlägt er dich doch zu Schanden – und über uns alle kommt Elend und Schmach genug. Ich weiß nicht, weshalb der brave Mann, der sich sein Lebtag nichts hat zu Schulden kommen lassen, wegen seiner Tochter untergehen soll. – Das soll er nicht – du!«
     </p>
-    <p xml:id="eco_de_0000143_7760">
+    <p xml:id="eco_de_0000213_7760">
      Anne sprach leidenschaftlich erregt – und war so blaß und traurig – und so fest und unbezwinglich in ihrem Mut.
     </p>
-    <p xml:id="eco_de_0000143_7770">
+    <p xml:id="eco_de_0000213_7770">
      Schlimpimperlein in ihrem trostlosen Elend saß armselig zerknickt vor ihr.
     </p>
-    <p xml:id="eco_de_0000143_7780">
+    <p xml:id="eco_de_0000213_7780">
      »Kannst du sterben, hast du Mut?«
     </p>
-    <p xml:id="eco_de_0000143_7790">
+    <p xml:id="eco_de_0000213_7790">
      Sie sah auf die strenge ernste Fragerin, die sie mit ihren Blicken nicht los ließ.
     </p>
-    <p xml:id="eco_de_0000143_7800">
+    <p xml:id="eco_de_0000213_7800">
      Die Augen füllten sich dem gepeinigten Geschöpf wieder mit Thränen und sie sah zur Schwester auf und sagte: »Nein, Anne, nicht.«
     </p>
-    <p xml:id="eco_de_0000143_7810">
+    <p xml:id="eco_de_0000213_7810">
      Anne wankte nicht, ging unaufhaltsam auf ihr Ziel zu, mit dem rührenden Fanatismus und riß ihre unglückliche Schwester mit sich. Ja, es war, als faßte Schlimpimperlein endlich angstvoll selbst nach der rettenden Hand, die sie aus Schmach und Not, die über sie zusammenschlagen wollten wie dunkles Wasser, zu retten suchte, sie und die andern mit ihr.
     </p>
-    <p xml:id="eco_de_0000143_7820">
+    <p xml:id="eco_de_0000213_7820">
      Und so kam es, daß Anne mit ihrer Schwester und Heinrich Strobel vor die Eltern trat und das wunderlichste Geständnis machte.
     </p>
-    <p xml:id="eco_de_0000143_7830">
+    <p xml:id="eco_de_0000213_7830">
      »Bist du von Sinnen!« rief die Försterin entsetzt – und faßte ihren Mann an der Schulter. »Hör doch!« rief sie.
     </p>
-    <p xml:id="eco_de_0000143_7840">
+    <p xml:id="eco_de_0000213_7840">
      Anne aber sprach ruhig: »Der Heinrich und ich, wir haben zu sühnen, Mutter, wir dürfen an Glück miteinander nicht mehr denken.«
     </p>
-    <p xml:id="eco_de_0000143_7850">
+    <p xml:id="eco_de_0000213_7850">
      Der Förster blickte Anne durchdringend an mit so ein Paar düstern Augen. – »Nun, und die andern beiden?« frug er.
     </p>
-    <p xml:id="eco_de_0000143_7860">
+    <p xml:id="eco_de_0000213_7860">
      »Die sind entschlossen« – sagte Anne für sie.
     </p>
-    <p xml:id="eco_de_0000143_7870">
+    <p xml:id="eco_de_0000213_7870">
      »Strobel,« sagte der Förster.
     </p>
-    <p xml:id="eco_de_0000143_7880">
+    <p xml:id="eco_de_0000213_7880">
      »Es ist so, wie Anne sagt – wir sind entschlossen.«
     </p>
-    <p xml:id="eco_de_0000143_7890">
+    <p xml:id="eco_de_0000213_7890">
      »Du auch, Mädchen!« wendete sich der starke blonde Mensch an seine jüngste Tochter.
     </p>
-    <p xml:id="eco_de_0000143_7900">
+    <p xml:id="eco_de_0000213_7900">
      »Ja,« sagte diese leise.
     </p>
-    <p xml:id="eco_de_0000143_7910">
+    <p xml:id="eco_de_0000213_7910">
      Der Förster lachte ingrimmig auf. Die Heftigkeit, das Mißtrauen schoß ihm in die Augen. Die breite Brust begann zu keuchen.
     </p>
-    <p xml:id="eco_de_0000143_7920">
+    <p xml:id="eco_de_0000213_7920">
      »Alter,« jammerte seine Frau auf.
     </p>
-    <p xml:id="eco_de_0000143_7930">
+    <p xml:id="eco_de_0000213_7930">
      Da trat Anne zu ihrem Vater.
     </p>
-    <p xml:id="eco_de_0000143_7940">
+    <p xml:id="eco_de_0000213_7940">
      »Vatter,« sagte sie in großer Einfachheit und mit einer Reinheit, die auf den heftigen Mann wirkte, als spräche ein Engel mit ihm. »Das ist eine große Sühne vor Gott – Vatter. Da darfst du nicht auffahren – da ist auch nichts daran zu ändern – das ist wie es ist. – Wir drei verstehen einander – und wir werden verantworten, was wir thun. – Du kennst ja Heinrich. – Und wenn die Leute die Mäuler aufsperren, so laß sie es thun. Es ist vor Gott nichts Unrechtes, was geschieht.«
     </p>
-    <p xml:id="eco_de_0000143_7950">
+    <p xml:id="eco_de_0000213_7950">
      Es lag wie ein schwerer Bann über allen. als fände niemand den Mut, zu fragen. Sie waren verstummt und betäubt unter der Schwere des Schicksals.
     </p>
    </div>
@@ -2486,109 +2486,109 @@
     <head>
      \*\*\*
     </head>
-    <p xml:id="eco_de_0000143_7960">
+    <p xml:id="eco_de_0000213_7960">
      Der Förster wurde krank, sei's, daß er sich auf der Hetzjagd erkältet hatte, oder war's die vielgestaltete Aufregung, in der sein heißes Blut nun schon tagelang kochte. Sein ingrimmigster Feind, der Bock, hatte sich wirklich gemeldet.
     </p>
-    <p xml:id="eco_de_0000143_7970">
+    <p xml:id="eco_de_0000213_7970">
      Er legte sich ins Bett unter heiße Habersäcke und stöhnte und schrie auf und raste vor Qual und frug nichts und sagte nichts.
     </p>
-    <p xml:id="eco_de_0000143_7980">
+    <p xml:id="eco_de_0000213_7980">
      Anne und die Försterin hatten alle Hände voll zu thun, um dem ungeduldigen Kranken alles zu verschaffen, was er wollte und wünschte.
     </p>
-    <p xml:id="eco_de_0000143_7990">
+    <p xml:id="eco_de_0000213_7990">
      Die gerichtliche Untersuchung des traurigen Falles und das Begräbnis gingen vor sich, ohne daß der Förster auf seinem Schmerzenslager etwas davon erfuhr; ohne daß er ein einziges Mal gefragt hätte. Es wurde auf das einstimmige Zeugnis aller, die bei dem Unglück zugegen gewesen waren, Heinrich Strobels völlige Schuldlosigkeit festgestellt. Der blieb ein freier, unbescholtener Mann.
     </p>
-    <p xml:id="eco_de_0000143_8000">
+    <p xml:id="eco_de_0000213_8000">
      Die Kummerfelden war es, die alle Nachrichten ins Rödchen hinausbrachte und von Anne einen verschlossenen Brief an Strobel mit herabnahm, der sich seit jenem Morgen nicht mehr bei den unglücklichen Leuten hatte sehen lassen.
     </p>
-    <p xml:id="eco_de_0000143_8010">
+    <p xml:id="eco_de_0000213_8010">
      In diesem Briefe standen die wenigen Worte: »Heinrich nicht zögern, um unsertwillen und ihretwillen nicht.«
     </p>
-    <p xml:id="eco_de_0000143_8020">
+    <p xml:id="eco_de_0000213_8020">
      Der Brief war ohne Ueberschrift und ohne Unterschrift.
     </p>
-    <p xml:id="eco_de_0000143_8030">
+    <p xml:id="eco_de_0000213_8030">
      Als Anne ihn der Kummerfelden übergab, konnte die ihrer Bewegung nicht Herr werden und sagte: »Komm, Ludschevadel, Anne, wollte ich sagen – und geh' ein Stück mit mir vors Haus.«
     </p>
-    <p xml:id="eco_de_0000143_8040">
+    <p xml:id="eco_de_0000213_8040">
      »Siehst du,« sagte die Kummerfelden mit ihrem wackeligen Altweiberstimmchen. »Ich muß statt deiner Mutter mit dir reden. Du gutes Mädchen – die kann's dir nicht, die bringt's nicht übers Herz. Als du gestern abend drin beim Vatter warst, da hat sie's mir unter Zittern und Zagen gestanden. Die Mutter denkt sich alles – die weiß alles. Das kannst du dir denken, ein Weib und eine Mutter. – –
     </p>
-    <p xml:id="eco_de_0000143_8050">
+    <p xml:id="eco_de_0000213_8050">
      »Weißt du, Anne – da kann man gar nichts darüber sagen – ich nicht und die Mutter nicht – dafür gibt's keine Worte.«
     </p>
-    <p xml:id="eco_de_0000143_8060">
+    <p xml:id="eco_de_0000213_8060">
      Sie drückte mit ihren lebendigen flinken Fingerchen Annen die Hand, und die hellen jungen Thränen liefen ihr über das kleine ältliche Gesicht.
     </p>
-    <p xml:id="eco_de_0000143_8070">
+    <p xml:id="eco_de_0000213_8070">
      »Soll's denn wirklich geschehen, Anne?«
     </p>
-    <p xml:id="eco_de_0000143_8080">
+    <p xml:id="eco_de_0000213_8080">
      »Ja – bald – aber bald –.«
     </p>
-    <p xml:id="eco_de_0000143_8090">
+    <p xml:id="eco_de_0000213_8090">
      »Gott sei gelobt, daß der Vatter den Bock hat!« sagte die Kummerfelden. »Aber ein Mannsbild ist immer kurios, was einem Frauenzimmer durchsichtig ist, da entdeckt so ein Mann noch lange nichts – auch ohne Bock. Gottlob, daß es so eingerichtet ist. Siehst du, und wenn es denn nun einmal wirklich geschehen soll, da wäre meine Meinung, man müßte mit einem einzigen Menschen ganz offen reden und dieser Mensch wäre der Herr Oberkonsistorialrat Voigt. – Wenn du mich's machen läßt, Anne, richt' ich dir's ein, ich kenne ihn ja, daß alles in größter Schnelle vor sich geht – ohne Aufgebot, wenn's sein muß oder mit nur einem Aufgebot. Er ist ein Mann, der dein großes Opfer zu schätzen weiß – dir helfen wird und der schweigen wird, Anne. – Und habt dann einen würdigen Fürsprecher, wenn die Leute anfangen, die Mäuler über euch aufzureißen. Und siehst du, es muß, wenn es geschehen soll, schnell geschehen – du armes Kind.«
     </p>
-    <p xml:id="eco_de_0000143_8100">
+    <p xml:id="eco_de_0000213_8100">
      »Ja – bald – bald,« sagte Ludschevadel flehend –»und eh' der Vatter wieder gesund ist.«
     </p>
-    <p xml:id="eco_de_0000143_8110">
+    <p xml:id="eco_de_0000213_8110">
      Die alte kleine Kummerfelden hatte ihrem Herzen auf ihre Art Luft machen müssen, umarmte und streichelte das arme Ludschevadel, auf deren glattgescheiteltes Haar der feine kalte Oktoberregen fiel. – –
     </p>
-    <p xml:id="eco_de_0000143_8120">
+    <p xml:id="eco_de_0000213_8120">
      Die alte Kummerfelden aber hat das schwere Opfer von Anne und Heinrich mit Feuereifer aufgefaßt und alles wie für ihre eigene Sache gethan – und alles eingeleitet. Sie ist gelaufen und hat gesprochen und hat ihren guten Freund, den Oberkonsistorialrat Voigt, in die jammervolle Geschichte eingeweiht.
     </p>
-    <p xml:id="eco_de_0000143_8130">
+    <p xml:id="eco_de_0000213_8130">
      So war es schon am Sonntag, daß die Försterin, die Kummerfelden, Ludschevadel und das junge Paar, in der Sakristei vor dem Altar standen und das bittere Opfer dargebracht wurde.
     </p>
-    <p xml:id="eco_de_0000143_8140">
+    <p xml:id="eco_de_0000213_8140">
      Der Oberkonsistorialrat Voigt selbst vollzog die Trauung und drückte Heinrich Strobel die Hand, als der die Ringe mit seiner jungen Frau gewechselt hatte.
     </p>
-    <p xml:id="eco_de_0000143_8150">
+    <p xml:id="eco_de_0000213_8150">
      Als das Paar vom Altar getreten war, da mochte es dem braven Oberkonsistorialrat zu Herzen gehen und er winkte Anne zu sich an den Altar heran und ließ sie niederknieen auf dem Kissen, auf dem ihr Heinrich vordem gekniet hatte und der Priester legte ihr bewegt die Hände aufs Haupt und segnete sie.
     </p>
-    <p xml:id="eco_de_0000143_8160">
+    <p xml:id="eco_de_0000213_8160">
      Da ging ein jammervolles Schluchzen durch die alte Sakristei, die Försterin hatte sich in ihrem Leid nicht mehr aufrecht halten können und hatte das Gesicht auf die Stuhllehne der Kummerfelden gestützt. – Die Kummerfelden saß aber mit hocherhobener Haube und sah auf ihre Nähschülerin mit verklärten, thränenden Augen. Heinrich Strobel hatte sich abgewendet und blickte nach dem vergitterten Fenster in den grauen Morgenhimmel hinein. Er sah gealtert und aschgrau aus. Sein straffes Haar stand ihm glanzlos und melancholisch in die Höh'. Die hagere Gestalt war in sich zusammengesunken.
     </p>
-    <p xml:id="eco_de_0000143_8170">
+    <p xml:id="eco_de_0000213_8170">
      Die Extrapost des jungen Paares hielt hinter der Kirche vor Oberkonsistorialrat Voigts Amtswohnung. Und so nahmen sie Abschied voneinander in der alten Sakristei. Die Försterin reichte ihrem Schwiegersohn die Hand. »Strobel,« sagte sie bebend –»Strobel« . . . weiter kam sie nicht. Sie konnte nicht sprechen.
     </p>
-    <p xml:id="eco_de_0000143_8180">
+    <p xml:id="eco_de_0000213_8180">
      Ihrer Jüngsten gab sie auch die Hand und flüsterte ihr mit gebrochener Stimme ins Ohr: »Erbarm' sich Gott deiner!«
     </p>
-    <p xml:id="eco_de_0000143_8190">
+    <p xml:id="eco_de_0000213_8190">
      Schlimpimperlein war angstvoll wie ein verscheutes Tier. Sie trug Kranz und Schleier und war in diesen weißen Schleier ganz eingehüllt und weinte vor sich hin, sah aber lieblich aus.
     </p>
-    <p xml:id="eco_de_0000143_8200">
+    <p xml:id="eco_de_0000213_8200">
      Die Kummerfelden nahm ihr den Schleier und den Kranz nach der Trauung ab, legte beides vorsichtig in eine Pappschachtel, gab ihr die in die Hand zum Mitnehmen und hing ihr das warme Reisemäntelchen um und setzte ihr eine Kapuze auf. – Dann gingen alle aus der hinteren Kirchthür hinaus, um das junge Paar zum Reisewagen zu bringen, der sie nach Leipzig führen sollte. Anne und Heinrich gaben sich erst vor der Kirchenthür stumm die Hand und schauten sich an wie in der Todesstunde. Dann half Heinrich Strobel seinem jungen Weib behutsam in den Wagen, stieg selbst hinein, die Pferde zogen an und die schwerfällige alte Kutsche rumpelte den unbequemen Weg hinter der Jakobskirche hinab, bog in die Jakobsgasse ein und war verschwunden.
     </p>
-    <p xml:id="eco_de_0000143_8210">
+    <p xml:id="eco_de_0000213_8210">
      Die Frauen gingen miteinander stumm durch die noch morgenstille Stadt dem Rödchen wieder zu.
     </p>
-    <p xml:id="eco_de_0000143_8220">
+    <p xml:id="eco_de_0000213_8220">
      Als sie den einsamen Feldweg, der zum Rödchen führt, einschlugen, blieb Anne hinter der Mutter und der Kummerfelden zurück, um allein zu gehen. Ein feiner kalter Oktoberregen rieselte nieder. Die Kummerfelden hielt über sich und die Försterin den großen roten Familienschirm mit dem messingenen Knauf gespannt.
     </p>
-    <p xml:id="eco_de_0000143_8230">
+    <p xml:id="eco_de_0000213_8230">
      Der Weg war aufgeweicht und schlüpfrig – Stoppeln, wohin man sieht, nichts als Stoppeln, verkrüppelte und entblätterte Weiden, Rabenzüge, grauer gleichmäßiger Himmel und als Ziel das vereinsamte spätherbstliche Rödchen, den fahlen Wald, das Haus, in das das Unglück eingezogen ist, der vom Bock geplagte mißmutige Förster und die ganze öde Hoffnungslosigkeit, die da oben auf ihr Opfer lauert.
     </p>
-    <p xml:id="eco_de_0000143_8240">
+    <p xml:id="eco_de_0000213_8240">
      Anne wagte nicht den Kopf zurück nach Weimar zu wenden, da war die Allee mit den hohen Pappeln, die nach Apolda führt, lang, unendlich lang zu verfolgen. Sie fürchtete sich, in weiter Entfernung undeutlich einen schwarzen verschwindenden Punkt zu sehen.
     </p>
-    <p xml:id="eco_de_0000143_8250">
+    <p xml:id="eco_de_0000213_8250">
      Und so schaute sie nur und einzig nach dem Rödchen hinauf, ohne zu denken, stumpf und trostlos.
     </p>
-    <p xml:id="eco_de_0000143_8260">
+    <p xml:id="eco_de_0000213_8260">
      Die Försterin wendete sich um und rief ihr zu: »Anne, sowie wir nach Hause kommen, muß neuer Haber für den Vatter geröst' werden.«
     </p>
-    <p xml:id="eco_de_0000143_8270">
+    <p xml:id="eco_de_0000213_8270">
      »Ja!«
     </p>
-    <p xml:id="eco_de_0000143_8280">
+    <p xml:id="eco_de_0000213_8280">
      Da sah sie im Geist, wie ihre Schwester im Schleier und Kranz heute in aller Himmelsfrühe vor dem Bett des Vaters gestanden hatte, um Abschied zu nehmen – und der Förster in einem wilden Schmerzensanfall mit ihr ein paar Worte gesprochen hatte, ein paar nichtssagende scheue Worte. – Er hatte ihr die Hand nicht gegeben.
     </p>
-    <p xml:id="eco_de_0000143_8290">
+    <p xml:id="eco_de_0000213_8290">
      Anne wußte nicht, was sie vom Vater denken sollte. Er war von der heimtückischen Krankheit wie vom Teufel besessen, litt körperlich mit wütendem Widerstreben und auch im Geiste. – Ahnte er etwas? Ließ er den Dingen ihren Lauf? Ahnte er nichts?
     </p>
-    <p xml:id="eco_de_0000143_8300">
+    <p xml:id="eco_de_0000213_8300">
      Anne konnte sich darüber nicht klar werden. In ihrem Kopf tauchte ein Gedanke auf, den sie mit heiliger Scheu wie eine Gotteslästerung von sich wies, der wieder untertauchte; aber wie einen hellen wunderbaren Schimmer zurückließ, der ihr die ganze Seele erfüllte. Und der Gedanke, ausgedacht, mochte vielleicht sein: Ist es die heilige Geschichte von der Erlösung? Einer gab sich unschuldig hin und opfert sich für die andern – und aller Zorn ist verraucht und die Strafe ist zurückgezogen und die Sünde vergeben.
     </p>
    </div>

--- a/tei/Boehlau_Helene_Ein_Sommerbuch.xml
+++ b/tei/Boehlau_Helene_Ein_Sommerbuch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000144" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000214" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000144_20">
+   <p xml:id="eco_de_0000214_20">
     Ein Sommerbuch
    </p>
   </front>
@@ -93,241 +93,241 @@
     <head>
      Regine die Köchin
     </head>
-    <p xml:id="eco_de_0000144_30">
+    <p xml:id="eco_de_0000214_30">
      Die Mutter muß sich eine Alte nehmen, eine Alte muß sie sich nehmen, – nein – darauf besteh' ich! Die Frau Mutter ist zu leichtsinnig.« Das sagte unser Vater, ehe Regine ins Haus kam. »Aber Hermann,« antwortete unsere Großmutter und schaute mit ihrem weichen, vom Häubchen eingerahmten Altfrauengesicht ganz betroffen von ihrem Suppenteller auf. Sie aß bei uns, wie immer die Woche zweimal; wann dies geschehen sollte, mußte jedesmal feierlich die Frau Legationsrätin, vulgo Legatse, die eine Etage höher wohnte, eingeladen werden. Aber gerade jetzt zur Zeit war sie gezwungen, unten bei uns zu essen, denn sie hatte keine Köchin.
     </p>
-    <p xml:id="eco_de_0000144_40">
+    <p xml:id="eco_de_0000214_40">
      Von unserer Großmutter Köchin sprach man im Hause auf eine geheimnisvolle Weise, fast ohne Worte, und verstand doch viel zu sagen.
     </p>
-    <p xml:id="eco_de_0000144_50">
+    <p xml:id="eco_de_0000214_50">
      Wir Halbwüchsigen waren aber unterrichtet. Wir wußten, Großmutters Köchin hatte ein Kind bekommen. Weshalb man das nicht ganz einfach sagte, sondern schwieg, geheimnisvoll flüsterte? Es kam uns dies ganz lächerlich vor. Kinder hat ja die ganze Welt. Wir verständigten uns untereinander darüber und waren großmütig genug, den Erwachsenen in ihre Sonderbarkeit nicht hineinzureden.
     </p>
-    <p xml:id="eco_de_0000144_60">
+    <p xml:id="eco_de_0000214_60">
      »Also, Frau Mutter, ich bestehe entschieden darauf, du nimmst dir eine Alte. – Es ist dies das zweite, wenn nicht das dritte Mal, daß bei euch oben, … nein… nein … das geht nicht – bei deinem Leichtsinn, Frau Mutter – entschuldige.«
     </p>
-    <p xml:id="eco_de_0000144_70">
+    <p xml:id="eco_de_0000214_70">
      »Wie kommst du mir denn aber vor,« sagte unsere Großmutter und lachte, wie nur sie lachen konnte, o dieses Lachen! Wollte Gott, ich könnt's noch einmal hören. So lachen die Jungen heut nicht, so seelenjung. Es war das Lachen einer andern Zeit, das bei uns im Hause noch hin und wieder erklang, – einer harmlosen, heiteren Zeit. Ich halte es für ein Glück sondergleichen, daß wir in Begleitung dieses Lachens aufblühten.
     </p>
-    <p xml:id="eco_de_0000144_80">
+    <p xml:id="eco_de_0000214_80">
      »Ich sehe darin gar keinen Grund zum Lachen, Frau Mutter,« sagte mein Vater feierlich. »Ich dächte, die Sache ist ernst genug.«
     </p>
-    <p xml:id="eco_de_0000144_90">
+    <p xml:id="eco_de_0000214_90">
      »Du gibst auf deine Leute nicht acht, du läßt sie tun, was sie wollen – du kümmerst dich um nichts.«
     </p>
-    <p xml:id="eco_de_0000144_100">
+    <p xml:id="eco_de_0000214_100">
      »Ach so,« sagte unsere Großmutter. »Nun wird mir's verständlich.« Sie wischte sich die Augen. »Ich kann nicht gerad sagen, daß ich auf eine Alte sehr versessen bin; – aber dir zuliebe soll's eine Alte sein – gewiß eine Alte.«
     </p>
-    <p xml:id="eco_de_0000144_110">
+    <p xml:id="eco_de_0000214_110">
      So kam Regine, die Köchin, ins Haus.
     </p>
-    <p xml:id="eco_de_0000144_120">
+    <p xml:id="eco_de_0000214_120">
      »Sieh sie dir an,« sagte meine Großmutter am ersten Tag, als sie bei uns eingezogen war und gerade durch den Hof ging. Die Großmutter winkte meinem Vater, ans Fenster zu treten.
     </p>
-    <p xml:id="eco_de_0000144_130">
+    <p xml:id="eco_de_0000214_130">
      »Nu – weißt du – –,« sagte mein Vater, als er sie gesehen.
     </p>
-    <p xml:id="eco_de_0000144_140">
+    <p xml:id="eco_de_0000214_140">
      »Es ist eine Alte,« meinte meine Großmutter mit viel Schelmerei in der Stimme.
     </p>
-    <p xml:id="eco_de_0000144_150">
+    <p xml:id="eco_de_0000214_150">
      »Ja, ja,« meinte mein Vater etwas ärgerlich.
     </p>
-    <p xml:id="eco_de_0000144_160">
+    <p xml:id="eco_de_0000214_160">
      »Sie ist gewiß recht tugendhaft.«
     </p>
-    <p xml:id="eco_de_0000144_170">
+    <p xml:id="eco_de_0000214_170">
      »Zuverlässig,« antwortete mein Vater, – »aber – es gibt weniger häßliche.«
     </p>
-    <p xml:id="eco_de_0000144_180">
+    <p xml:id="eco_de_0000214_180">
      Herr Sohn, man kann nicht alles beieinander haben, weißt du.«
     </p>
-    <p xml:id="eco_de_0000144_190">
+    <p xml:id="eco_de_0000214_190">
      Nur zum Scherz hatte unsere Großmutter Reginen freilich nicht genommen. Die Großmutter war eine Frau voller Grazie und voller Behagen; sollte sie von einem schönen, sauberen Mädchen nicht bedient werden, wie sie es liebte, so wollte sie wenigstens vortrefflich essen, und es sollte alles gut serviert sein – und das verstand Regine, beides. Gewiß, häßlich war sie, eine kleine, dicke Person mit einem Schöpflein roter Haare, einem endlosen, dünnen, dünnen, dummen Zöpfchen, das wie ein rotes Schneckenhaus auf ihrem fast kahlen Schädel lag.
     </p>
-    <p xml:id="eco_de_0000144_200">
+    <p xml:id="eco_de_0000214_200">
      Die Knochen schienen ihr zu klein geworden, und so hing die beträchtliche Fleischmasse, wulstig und faltig, nicht recht wohlgeordnet, über derselben. So wandelte Regine durchs Leben und durch unser Haus, niemandem zur Augenweide, doch meinem Vater zur Beruhigung, daß über seinem Haupte, im Kreise der Frau Mutter keine leichtsinnigen Torheiten zu befürchten waren. Er bedachte nicht, daß der Mensch nie sündenbar ist. Unsere Jugendsünden, die Maienblüte wird dahingerafft, und Alterssünden erheben die Häupter oft nur als Ausdruck des Grams, weil sie dahingegangen, die sel'ge Maienpracht.
     </p>
-    <p xml:id="eco_de_0000144_210">
+    <p xml:id="eco_de_0000214_210">
      So mochte es Reginen ergehen; sie hatte geliebt und gelebt und wollte vergessen. Das alles aber ist vorgegriffen; es währte lange, bis wir Regine verstanden.
     </p>
-    <p xml:id="eco_de_0000144_220">
+    <p xml:id="eco_de_0000214_220">
      Als sie in unserm Hause etwas eingewohnt war und sich behaglich zu fühlen begann, kam unser Vater eines Morgens sichtbar verstimmt von seinem Spaziergang im Garten ins Frühstückszimmer, und es stellte sich heraus, daß er Reginen begegnet war, wie dieselbe die Treppe hinabging und ihr das rote, kleinfingerdicke Zöpfchen über die Stufen nachgehüpft war. Das ist so zu verstehen, das entsetzliche Zöpfchen war unglaublicherweise um ein paar Zoll länger als sie selbst, und sie liebte es, dasselbe am Morgen nachzuziehen. Vielleicht träumte sie sich in die Zeit zurück, als das rote Schnürlein vielleicht ein armdicker Zopf gewesen. Jedenfalls hatte sie geglaubt, einen ganz andern Eindruck mit ihrem roten, langen Naturspiel auf unseren Vater hervorzubringen, als ihr tatsächlich gelungen war. Sie war unheimlich stolz auf ihren Hauptschmuck. Ja, es war lang, das Zöpfchen, entsetzlich lang. Uns Kinder grauste davor. und unser Vater hatte sich wirklich ganz außerordentlich davor erschreckt.
     </p>
-    <p xml:id="eco_de_0000144_230">
+    <p xml:id="eco_de_0000214_230">
      »Es geschieht ihm ganz recht,« sagte die Großmutter, »weshalb hat er mir die Alte aufgehängt. Mir wäre es schon lieber, sie hätte ein Kind, als so einen miserabel garschtigen Zopf.«
     </p>
-    <p xml:id="eco_de_0000144_240">
+    <p xml:id="eco_de_0000214_240">
      »Weißt du, Frau Mutter, das verstehst du nicht. Du stammst aus einer ganz frivolen Zeit,« antwortete ihr mein Vater.
     </p>
-    <p xml:id="eco_de_0000144_250">
+    <p xml:id="eco_de_0000214_250">
      »I wo,« sagte die Großmutter und lächelte ihrer lieben Zeit zu.
     </p>
-    <p xml:id="eco_de_0000144_260">
+    <p xml:id="eco_de_0000214_260">
      »So, du hast Regine also begegnet? Ja, ja, das ist ihre Morgentoilette. Sie kehrt auch so bei mir, die Regine. Ja, du kannst ganz beruhigt sein, die ist höchst sittenstreng.«
     </p>
-    <p xml:id="eco_de_0000144_270">
+    <p xml:id="eco_de_0000214_270">
      »Ob sie es aber immer war, lassen wir dahingestellt sein,« sagte mein Vater ärgerlich.
     </p>
-    <p xml:id="eco_de_0000144_280">
+    <p xml:id="eco_de_0000214_280">
      »Verlange nichts Unmögliches von ihr, Regine lasse ich nicht wieder gehen.«
     </p>
-    <p xml:id="eco_de_0000144_290">
+    <p xml:id="eco_de_0000214_290">
      »Frau Mutter,« sagte mein Vater, »wann wirst du lernen, die goldene Mittelstraße zu gehen! Entweder umgibst du dich mit Personen, die vor Leichtsinn und Jugend nicht wissen, wo ein und aus, ober du nimmst dir Ungeheuer ins Haus, die keine Phantasie zu erdenken imstande ist. Ich hatte den Wunsch, daß eine vernünftige Matrone mit weißer Schürze und behäbigem Aeußeren da oben bei dir schalten und wallten sollte. – Wäre dir das nicht selbst ein angenehmer Gedanke?«
     </p>
-    <p xml:id="eco_de_0000144_300">
+    <p xml:id="eco_de_0000214_300">
      »Ja, gewiß, wenn die Matrone zu kochen verstände wie Regine; aber ich traute den Matronen nicht recht, die ich sah. Du wirst nächsten Sonntag schmecken, wenn ihr oben bei mir eßt, daß Regine goldeswert ist.«
     </p>
-    <p xml:id="eco_de_0000144_310">
+    <p xml:id="eco_de_0000214_310">
      Ja, und sie war goldeswert. Sie kochte, als wäre ihr Vater ein Dichter gewesen und das Talent hätte sich bei ihr umgesetzt. Und sie war auch Tochter eines Dichters. Es wird alles an den Tag kommen.
     </p>
-    <p xml:id="eco_de_0000144_320">
+    <p xml:id="eco_de_0000214_320">
      Wir hatten große Wäsche im Haus, und unsere Mutter bat die Großmutter, daß diese ihr Regine auf ein paar Stunden leihen möge, um zu helfen. Regine aber widerstand mit ruhiger Würde unserer Aufforderung.
     </p>
-    <p xml:id="eco_de_0000144_330">
+    <p xml:id="eco_de_0000214_330">
      »Nein,« sagte sie zur Großmutter, »das tut mir leid, das kann ich heut nicht, ein andres Mal wieder recht gerne. Heut wird ein Stück von meinem Vater selig aufgeführt, und Sie erlauben wohl, Frau Geheimrat, daß ich auch ins Theater gehe.« »Ja, um Himmels willen,« sagte meine Großmutter – »was ist denn das?«, griff nach dem Theaterzettel mit dem Abonnementsbillett, der wie immer auf seinem Platze lag; da sah die Großmutter, daß heute ein seit Jahrzehnten vergessenes, wieder neu ausgegrabenes Stück von Raupach gegeben wurde.
     </p>
-    <p xml:id="eco_de_0000144_340">
+    <p xml:id="eco_de_0000214_340">
      »Und Sie sind Raupachs Tochter!« rief die Großmutter – »du allmächtige Güte! Wie ist denn das alles miteinander möglich?«
     </p>
-    <p xml:id="eco_de_0000144_350">
+    <p xml:id="eco_de_0000214_350">
      Ja, es war alles miteinander möglich. Eine Kette der interessantesten Angelegenheiten verhüllten wie eine Wolke Regine, die Köchin, vor meinen erstaunten Augen. Sie war nicht nur Raupachs Tochter. – Nein – sie war jahrelang in Goethes Haus aufgewachsen, mit seinen Enkelkindern erzogen worden, dann war sie zum Ballett gekommen, und es war ihr schlecht ergangen, – schlecht ergangen. – Ein Tränenstrom verschlang die letzten Worte und Schicksale. – Ich sehe sie noch stehen, Raupachs Tochter, die rote Zöpfleinschlange zusammengerollt auf dem kahlen Schädel, die sonnte sich im Augenblick glühendrot im hellen Sonnenlicht. Unter Regines Kattunjacke wogten sehr unregelmäßige, gestaltlose Formen. Meine jungen Augen aber sahen das alles nicht mehr. Ein Glorienschein umwob die armselige Person. Ich hätte ihr wie einer Heiligen die Hände küssen mögen.
     </p>
-    <p xml:id="eco_de_0000144_360">
+    <p xml:id="eco_de_0000214_360">
      »Ach, setzen Sie sich. Regine, setzen Sie sich,« sagte ich zaghaft. Mir war es unmöglich, ihre geheiligte Person hier stehen zu sehen. Unsere Großmutter saß und machte große, große Augen, und die Brille war über den Augen, auf der Stirn zu sehen. Ich drückte Regine auf einen Stuhl nieder.
     </p>
-    <p xml:id="eco_de_0000144_370">
+    <p xml:id="eco_de_0000214_370">
      »O, Regine, Regine!« sagte ich. Ich hatte den Faust in diesen Tagen zum allerersten Male gelesen, hatte drunten im Stern, in Goethes Garten, unter hohen Bäumen, in Anbetung ganz versunken, auf dem Boden gekniet. Meine leidenschaftliche, kinderjunge Seele war dahingeschmolzen im ersten großen Eindruck.
     </p>
-    <p xml:id="eco_de_0000144_380">
+    <p xml:id="eco_de_0000214_380">
      Unsere Großmutter hatte ja auch Goethen gekannt; – aber dies – das fühlte ich, war etwas andres. Ich empfand das Intime des Zusammenlebens im selben Nest; ohne daß Regine nur den Mund auftat, wußte ich alles – alles, was geschehen war, oder hätte geschehen können. – Mit ihm hatte sie dieselbe Luft geatmet, er hatte sie gestreichelt – ihr etwas zu tun anbefohlen. Sie hatte ihn gesehen, wenn er zum Frühstück kam, gesehen beim Essen und Trinken und reden gehört! Reden gehört und auch lachen – vielleicht auch schelten.
     </p>
-    <p xml:id="eco_de_0000144_390">
+    <p xml:id="eco_de_0000214_390">
      Das Staunen verließ mich nicht, ich schaute und schaute auf Regines heilige Person und Schauer überliefen mich. Auch die Großmutter hab' ich mein Lebtag nicht so erstaunt gesehen.
     </p>
-    <p xml:id="eco_de_0000144_400">
+    <p xml:id="eco_de_0000214_400">
      »Na, so reden Sie doch, wie ist denn das alles möglich?«
     </p>
-    <p xml:id="eco_de_0000144_410">
+    <p xml:id="eco_de_0000214_410">
      Regine, die Köchin, dieser armselige Rest, war also von all der Herrlichkeit in Weimar noch übrig geblieben.
     </p>
-    <p xml:id="eco_de_0000144_420">
+    <p xml:id="eco_de_0000214_420">
      »Ach, Frau Geheimerätin, möglich ist gar vieles.«
     </p>
-    <p xml:id="eco_de_0000144_430">
+    <p xml:id="eco_de_0000214_430">
      »Ja, hat denn der Raupach nicht für Sie gesorgt?«
     </p>
-    <p xml:id="eco_de_0000144_440">
+    <p xml:id="eco_de_0000214_440">
      »Du lieber Gott, du lieber Gott,« sagte Regine, »was so'n Dichter is. – Nee, Frau Geheimerat, die machen sich nicht viel ›Schkrupel«; aber meine Mutter stand der sel'gen Frau Geheimerat Goethe recht nah, so hat sich das gemacht.«
     </p>
-    <p xml:id="eco_de_0000144_450">
+    <p xml:id="eco_de_0000214_450">
      »Regine, und da haben Sie wahrhaftig in Goethes Nähe gelebt?«
     </p>
-    <p xml:id="eco_de_0000144_460">
+    <p xml:id="eco_de_0000214_460">
      »No ja, ›nadierlich«,« sagte Regine.
     </p>
-    <p xml:id="eco_de_0000144_470">
+    <p xml:id="eco_de_0000214_470">
      »Das Kompott, was mer letzten Sonntag hatten, die Hagebutten mit Rosinen, waren Exzellenz Goethe sein Lieblingskompott. Das Kochen hab ich im Goethschen Hause von jung auf noch so mit gelernt. – Auch der Hammelbraten mußte allemal mit reichlich Thymian angesetzt werden, wie's letztemal, wo's den Herrschaften so schmeckte. Ja, auf eine gute Küche gab der Herr Geheimerat schon was.«
     </p>
-    <p xml:id="eco_de_0000144_480">
+    <p xml:id="eco_de_0000214_480">
      »Haben Sie denn gar nichts von Goethe?« fragte ich.
     </p>
-    <p xml:id="eco_de_0000144_490">
+    <p xml:id="eco_de_0000214_490">
      »O ja,« sagte Regine, ihre Wortkargheit war unerschütterlich.
     </p>
-    <p xml:id="eco_de_0000144_500">
+    <p xml:id="eco_de_0000214_500">
      »Was Sie haben, zeigen Sie mir?« bat ich.
     </p>
-    <p xml:id="eco_de_0000144_510">
+    <p xml:id="eco_de_0000214_510">
      Sie nickte.
     </p>
-    <p xml:id="eco_de_0000144_520">
+    <p xml:id="eco_de_0000214_520">
      Und so kam ich hinauf in ihre Bodenstube, die sie vor aller Augen sonst streng abschloß. Ich glaube, jetzt zwar nicht der Heiligtümer wegen, sondern um einen Zufluchtsort zu haben, in dem sie ungestört ins Vergessen sinken oder sich davon wieder erholen konnte.
     </p>
-    <p xml:id="eco_de_0000144_530">
+    <p xml:id="eco_de_0000214_530">
      Wir fanden sie nach Jahren dort wirklich einmal im tiefsten Vergessen liegend, schwer betrunken. Der Schlosser hatte die Türe erbrechen müssen. Darauf kam sie von uns fort als Oberköchin ins Krankenhaus nach Blankenhain, nicht ohne daß die Großmutter scharfe Anzüglichkeiten unseres Vaters wegen des unmoralischen Betragens ihrer Leute hinnehmen mußte, was sie in gewohnter Anmut über sich ergehen ließ.
     </p>
-    <p xml:id="eco_de_0000144_540">
+    <p xml:id="eco_de_0000214_540">
      Mit Schauer betrat ich Reginens Kammer. Sie führte mich noch an diesem selben Tag, ehe sie ins Theater zur Aufführung des Stückes ihres Vaters ging, hinein, wies stumm auf ein eingerahmtes Stückchen vergilbtes Papier, auf das eine graue Haarlocke geheftet war.
     </p>
-    <p xml:id="eco_de_0000144_550">
+    <p xml:id="eco_de_0000214_550">
      »Die hab' ich mir selbst aufgelesen, als der Geheimerat einmal geschoren wurde.«
     </p>
-    <p xml:id="eco_de_0000144_560">
+    <p xml:id="eco_de_0000214_560">
      »Ach,« fragte ich, »wie war das?«
     </p>
-    <p xml:id="eco_de_0000144_570">
+    <p xml:id="eco_de_0000214_570">
      »No, da kam der Friseur Eberwein, der ihm immer die Haare brannte, dann hat der Geheimerat geschellt, damit eins rauf sollte, und da kam ich, weil sie unten gerade alle was zu tun hatten. ›Daß die Haare nicht herumfahren,« sagte er, und da sammelte ich sie auf; – es waren nicht viele.«
     </p>
-    <p xml:id="eco_de_0000144_580">
+    <p xml:id="eco_de_0000214_580">
      Unter die Locke hatte Regine selbst frei nach Goethe geschrieben, vor langer Zeit, die Tinte war ganz gelb geworden:
     </p>
-    <p xml:id="eco_de_0000144_590">
+    <p xml:id="eco_de_0000214_590">
      »Wer nie sein Brot mit Tränen aß, Wer nie in kummervollen Nächten In seinem Bette weinend saß, Der kennt euch nicht, ihr himmlischen Mächte.«
     </p>
-    <p xml:id="eco_de_0000144_600">
+    <p xml:id="eco_de_0000214_600">
      Arme Regine.
     </p>
-    <p xml:id="eco_de_0000144_610">
+    <p xml:id="eco_de_0000214_610">
      Darauf öffnete sie ihre Lade, die sie wohl ihr Lebtag in allerlei Elend begleitet hatte, und nahm ein Bündel heraus. Ohne ein Wort zu sagen, entfaltete sie ein vergilbtes Männerhemd mit wunderlichem Gefältel an der Brust.
     </p>
-    <p xml:id="eco_de_0000144_620">
+    <p xml:id="eco_de_0000214_620">
      Ein Hemd von Goethe!
     </p>
-    <p xml:id="eco_de_0000144_630">
+    <p xml:id="eco_de_0000214_630">
      Das zarte Linnen hatte seinen Körper berührt. Es war ihm so nahe gewesen, ein Stück seiner selbst. Gespensterhaftes Bangen berührte mich, wie Regine, die Tochter Raupachs, in ihrem Feiertagskleide, in der ärmlichen Dienstbotenkammer, das goethische Hemd ausbreitete, ohne ein Wort zu sagen.
     </p>
-    <p xml:id="eco_de_0000144_640">
+    <p xml:id="eco_de_0000214_640">
      Sie ließ mich ungestört in meiner Versunkenheit. Das schauerliche Vergehen alles Lebens, auch des Göttlichsten, erschütterte mich.
     </p>
-    <p xml:id="eco_de_0000144_650">
+    <p xml:id="eco_de_0000214_650">
      Endlich sagte sie: »Es war eins von den ganz alten. Sie taugten so nischt mehr.«
     </p>
-    <p xml:id="eco_de_0000144_660">
+    <p xml:id="eco_de_0000214_660">
      Dann breitete sie ein purpurrotes Kleid, mit dunkelblauen Borden aus. »Das hat meiner Mutter schon in ihrer Jugend gehört,« sagte Regine. »Das stammt noch von Frau von Goethe.«
     </p>
-    <p xml:id="eco_de_0000144_670">
+    <p xml:id="eco_de_0000214_670">
      »O, lassen Sie sehen. Regine,« bat ich. Ich berührte es. Es war aus weicher, indischer Seide. Sein tiefes Rot sah aus wie heiße, glückliche Liebe. Auf diesem zarten Stoff haben seine Augen in Liebe geruht. – Wie klein und zierlich muß Christiane gewesen sein, eine zierliche, volle Gestalt – und so geliebt! – geliebt von dem Herrlichsten! O, wie muß dein Herz unter dem roten, zarten Kleid geschlagen haben, du glückliche Christiane! Dein Grab finden sie nicht mehr. – Vergangen bist du lange, lange schon, verwest, in Staub zerfallen – und dein Kleid leuchtet noch in roter Glut, wie in den Tagen, als er dich darin küßte. Seine Hände haben auch diese kühle, feine, anschmiegende Seide gespürt.
     </p>
-    <p xml:id="eco_de_0000144_680">
+    <p xml:id="eco_de_0000214_680">
      Ich war ganz überwältigt und sagte: »Ach Regine, daß alles, alles vergeht!«
     </p>
-    <p xml:id="eco_de_0000144_690">
+    <p xml:id="eco_de_0000214_690">
      Regine sagte: »Ich meine, das wäre so übel nicht. Mich verlangt nach gar nischt mehr.«
     </p>
-    <p xml:id="eco_de_0000144_700">
+    <p xml:id="eco_de_0000214_700">
      Von diesem Tage an hockte ich, wo ich Reginens habhaft werden konnte, bei ihr, sah ihr zu beim Plätten, beim Kochen, beim Zimmerreinigen, und ihre Stummheit löste sich mehr und mehr. Uralter Dienstbotenklatsch aus jenem gesegneten Hause kam wieder ans Sonnenlicht; aber auch der intimen, köstlichen Dinge die Fülle, die jener Zeit entstammten und sie lebhafter als manche gründliche Abhandlung vor Augen treten ließen.
     </p>
-    <p xml:id="eco_de_0000144_710">
+    <p xml:id="eco_de_0000214_710">
      Wir hatten bei der Großmutter Sonntags goethische Apfelsuppe mit Korinthen und Semmelbrösel gegessen, goethischen Hasenbraten mit Salbei, das heilige Kompott aus Hagebutten und Rosinen. Ich, Halbwüchsige, aß diese Gerichte, als verzehrte ich das heilige Abendmahl, mit tiefer Hingabe; aber auch mit vorzüglichem Appetit. Denn wahrhaftig, Goethe hatte Poesie gegessen. – In Goethes Haus hatten sie es verstanden, zu kochen. Mein guter Vater war längst mit Regine ausgesöhnt. Dies Zusammenfließen des goethischen Haushaltes mit dem unsrigen hatte für uns Kinder etwas unbeschreiblich Geheimnisvolles. – Mir erschien es immer wieder wie ein Wunder und eine Offenbarung, wenn Regine ihre Speisen auftrug, und es war mir oft, als wären wir des großen Dichters Gäste. Er war mir in diesen Speisen gegenwärtig wie in seinen Werken, ja gegenwärtiger, in einer ahnungsvollen Körperlichkeit. Wie die ersten Christen das heilige Abendmahl in stiller, tiefer Ekstase zu sich nahmen, tranken und verzehrten, fühlte und schmeckte ich ihn. Er war da! – – Nie vergesse ich Reginens heilige Mahlzeiten bei der lieben, teuren Frau. – Und wer ihn auch liebt, den alten Sonnenmenschen, von ganzem Herzen, von ganzem Gemüte; – in Trank und Speise habt ihr ihn alle nicht empfunden! In jener Zeit liebte ich ihn, wie eine heilige Seele Gott ihren Herrn lieben mag.
     </p>
-    <p xml:id="eco_de_0000144_720">
+    <p xml:id="eco_de_0000214_720">
      Nach solch einer wundervollen Mahlzeit schickte mich meine Großmutter einst hinaus in Regines Küche, damit ich nachschaute, wo der Kaffee bliebe. – – Wie ich in die Küche eintrat, glaubte ich in einen Traum geraten zu sein, denn was ich sah, war eine Unmöglichkeit. – Ich stand und starrte – ich blieb stumm und ganz verwirrt, ich fragte nicht nach dem Kaffee, wagte überhaupt nicht den Mund zu öffnen. Regine aber, in geheimnisvollem Gleichmut, nahm einen Teller aus der Spülwanne und trocknete ihn, darauf nahm sie einen kleinen Marmorgrabstein aus demselben Spülwasser und trocknete ihn. Es war ein kleiner Grabstein aus weißem Marmor mit Goldschrift, und zwischen den Tellern sah ich noch eine dunkle Grabtafel und ein schmales Grabkreuzlein hervorschauen. –
     </p>
-    <p xml:id="eco_de_0000144_730">
+    <p xml:id="eco_de_0000214_730">
      »O Regine,« sagte ich nach einer Weile, »was tun Sie da –?«
     </p>
-    <p xml:id="eco_de_0000144_740">
+    <p xml:id="eco_de_0000214_740">
      »Gar nischt,« sagte sie.
     </p>
-    <p xml:id="eco_de_0000144_750">
+    <p xml:id="eco_de_0000214_750">
      Ich wußte nicht, wie ich noch einmal fragen sollte. Sie kümmerte sich nicht um mich und trocknete ihren Grabstein, fuhr mit einem Holzstücklein und dem Trockentuch in den ausgehöhlten, vergoldeten Namen. Ich folgte ihren Fingern und las »Aennchen«, den Geburts- und Sterbetag. Es war der Grabstein eines kleinen Kindchens. –
     </p>
-    <p xml:id="eco_de_0000144_760">
+    <p xml:id="eco_de_0000214_760">
      »Wem gehört das?« fragte ich endlich wieder.
     </p>
-    <p xml:id="eco_de_0000144_770">
+    <p xml:id="eco_de_0000214_770">
      »Das war meins,« sagte Regine. Auf der dunkeln, kleinen Tafel stand ein ganz verblichener Männername – »Hofschauspieler« war am deutlichsten zu lesen, – und auf dem Kreuzlein war Reginens eigner Name eingegraben: »Regine Moll« – und das alles zwischen Tellern und Schüsseln im Spülwasser.
     </p>
-    <p xml:id="eco_de_0000144_780">
+    <p xml:id="eco_de_0000214_780">
      »Regine,« sagte ich wieder, »was soll das eigentlich? – – Und Sie möchten doch auch den Kaffee bringen.«
     </p>
-    <p xml:id="eco_de_0000144_790">
+    <p xml:id="eco_de_0000214_790">
      »Sogleich ist er fertig.«
     </p>
-    <p xml:id="eco_de_0000144_800">
+    <p xml:id="eco_de_0000214_800">
      Die Grabsteine hatte Regine vom Friedhof im Marktkorb mit heimgebracht, das sagte sie mir, – und wusch, was ihr vom Leben übrig geblieben war, zugleich mit unsern Tellern blank, den Namen ihrer Mutter, ihres Schatzes und ihres Kindes.
     </p>
-    <p xml:id="eco_de_0000144_810">
+    <p xml:id="eco_de_0000214_810">
      Sie war eine geheimnisvolle Person mit geheimnisvollen Gewohnheiten.
     </p>
    </div>
@@ -335,1234 +335,1234 @@
     <head>
      Sommerseele
     </head>
-    <p xml:id="eco_de_0000144_820">
+    <p xml:id="eco_de_0000214_820">
      Meine Großmutter hatte einen alten Küchenschrank. – »Unter der Linde, aus welcher der alte Schrank gezimmert wurde, hat eine goethische Liebste gesessen.« Das sagte die Großmutter, als wir Enkel oben in ihrer Küche zuschauten, wie die Ananaserdbeeren aus einem kupfernen Topf, in dem sie in lauter Zucker und Glut ihre duftenden Seelen aushauchten, in Gläser gefüllt werden sollten. Die kleine Küche duftete herzbewegend. Der würzige Geruch drang durchs offene Fenster hinaus in sonnedurchschienene Juniluft. Die Schwalben zogen in kristallener Bläue ihre zarten, schrillen Wonne- und Jagdrufe nach sich. Der Küchenschrank bekam ein Gesicht; ich sah ihn gewissermaßen zum erstenmal. Da stand er – aus weichem, wie sammetweich gescheuertem Holz, trug etliche Kupfergefäße, eine messingene Teemaschine – altes Hausgerät, das nur noch blank gerieben, aber kaum mehr gebraucht wurde.
     </p>
-    <p xml:id="eco_de_0000144_830">
+    <p xml:id="eco_de_0000214_830">
      Aus seinem Innern drang Brotgeruch; aber ein eigentümlicher Brotgeruch, ein Geruch nach Brotgenerationen, die bis hinab in die Jugendzeit meiner Urgroßmutter reichten. Unvergeßlich ist mir dieser Geruch. Er verband uns mit einer fernen, fernen Zeit, mit nie gesehenen, nahverwandten, vergessenen Menschen.
     </p>
-    <p xml:id="eco_de_0000144_840">
+    <p xml:id="eco_de_0000214_840">
      »Unter der Linde, aus der dieser Schrank gemacht wurde, hat eine goethische Liebste gesessen.« Der Schrank trieb Blätter und Blüten und ward zu einem Baum voller Geheimnisse. Damals waren die Ananaserdbeeren gerade in Gefahr gekommen, anzubrennen. Es entstand ein Durcheinander, kleine, eifrige Schreie der Großmutter: »Ei – ei – ei – ei – ei der Tausend!« Die alte Köchin brummte, die Ananaserdbeeren dufteten auf höchster Höhe des Duftes. Um den Topf wob sich eine Wolke weißen Dampfes, der Großmutter lief die Brille an. Sie schob sie auf die Stirn. – Sie rührten und schauten.
     </p>
-    <p xml:id="eco_de_0000144_850">
+    <p xml:id="eco_de_0000214_850">
      Die Beeren waren, gottlob, gerettet. Wir aber wurden hinausgeworfen. Regine, die Köchin, verstand keinen Spaß, denn sie war eine alte, sonderbare Person mit sonderbaren Schicksalen, die ihre erste Jugend im goethischen Hause verlebt hatte. Mit zwölf Jahren war sie Spielgefährtin und Wärterin von Goethes Enkelin Alma, worauf sie sich gar viel zugute tat, und von uns Kindern wurde sie deshalb wie ein heiliges Wunder angestaunt und verehrt.
     </p>
-    <p xml:id="eco_de_0000144_860">
+    <p xml:id="eco_de_0000214_860">
      »Großmutter,« sagte ich am Abend, als, ich mit der lieben Frau in ihrem blumengeschmückten Zimmer saß, »was für eine Geschichte mag das sein, von der goethischen Liebe unter dem Lindenbaum, aus dem dein Küchenschrank gemacht wurde?«
     </p>
-    <p xml:id="eco_de_0000144_870">
+    <p xml:id="eco_de_0000214_870">
      »So,« sagte meine Großmutter, »willst du das wissen? – Ja, das war etwas. – 's ist nie so recht ans Tageslicht gekommen. – Bei uns daheim, in meiner Jugend war auch gar mancherlei davon bekannt. Die Sache ist mit den Leuten, die davon wußten, begraben worden.
     </p>
-    <p xml:id="eco_de_0000144_880">
+    <p xml:id="eco_de_0000214_880">
      Mein alter Küchenschrank, der von der Urgroßmutter stammt, ist freilich aus dem Holze gemacht, von jenem Lindenbaum, unter dem der alten Bäckermeisterin Bauchen, von der wir die Semmeln bekommen, ihre Großtante mit den Schwestern gesessen hat.«
     </p>
-    <p xml:id="eco_de_0000144_890">
+    <p xml:id="eco_de_0000214_890">
      »Ja, das sagtest du schon einmal,« unterbrach ich sie.
     </p>
-    <p xml:id="eco_de_0000144_900">
+    <p xml:id="eco_de_0000214_900">
      »Das hab' ich oft gesagt,« wiederholte meine Großmutter, »und oft hat es mir meine Mutter gesagt. Zu deren Aussteuer kaufte dein Urgroßvater bei der Bauchschen Familie, die damals Metzgersleute waren, das Holz zu diesem Schranke, altes, ausgetrocknetes Lindenholz –,« und die Großmutter erzählte mancherlei, was sie wußte.
     </p>
-    <p xml:id="eco_de_0000144_910">
+    <p xml:id="eco_de_0000214_910">
      Wir gingen an einem schönen Sommertage, gegen Abend, die liebe Frau und ich, auf der leichten Anhöhe, von der aus man in das grüne Ilmtal blickt, oben am Horn spazieren.
     </p>
-    <p xml:id="eco_de_0000144_920">
+    <p xml:id="eco_de_0000214_920">
      Es war zur Zeit, als die Mohnblumen wie Blutstropfen in den Feldern standen; das Laub der Bäume war von einer ganz erstaunlichen Dichte und Mächtigkeit, denn noch hatte man unbewußt die kahlen Bäume im Sinn. Und die neue Gestalt hatte noch etwas Befremdliches an sich. Sie rauschten so weich und voll, wie sie im Juli, wenn die Blätter härter sind, nicht mehr rauschen. Man spürte im Rauschen dieser Blätter weiche Zartheit, und es löste sich noch ein junger, würziger Duft von ihnen.
     </p>
-    <p xml:id="eco_de_0000144_930">
+    <p xml:id="eco_de_0000214_930">
      Meine Großmutter und ich, wir trugen beide große Mohnblumensträuße. Um diese Zeit zogen wir gar zu gern miteinander aus. Und ich sah sie noch, wie eifrig sie in die Kornfelder einbrach mit einer jugendlichen Freude am Blumenraub. Ich war die Aengstlichere. »Das geht nicht, Gomelchen, das geht nicht, so tief darfst du nicht hinein!«
     </p>
-    <p xml:id="eco_de_0000144_940">
+    <p xml:id="eco_de_0000214_940">
      »Geh, laß mich, du siehst doch, wie geschickt ich's mach'.«
     </p>
-    <p xml:id="eco_de_0000144_950">
+    <p xml:id="eco_de_0000214_950">
      Ich: »Wenn dich wer sieht.«
     </p>
-    <p xml:id="eco_de_0000144_960">
+    <p xml:id="eco_de_0000214_960">
      Sie; »I gar – laß nur!«
     </p>
-    <p xml:id="eco_de_0000144_970">
+    <p xml:id="eco_de_0000214_970">
      Und wie sie ging, so leicht und ungebeugt von Zeit und Erfahrungen, ein lieber Trost für die, die auch einmal alt werden müssen. Alter, wo ist dein Stachel, Kummer, wo ist dein Sieg?! – Leid und Kummer waren ihr hoch über die Seele gegangen; aber wie ein buntschillerndes Entlein war ihre Seele immer wieder glatt und schimmernd aus der trüben Flut aufgetaucht und war im Sonnenlichte weitergeschwommen.
     </p>
-    <p xml:id="eco_de_0000144_980">
+    <p xml:id="eco_de_0000214_980">
      »Sieh einmal da,« sagte sie und wies auf ein knorriges Taxusgebüsch, das, in einem Zaun aus Korneliuskirschen eingeklemmt, ersticken wollte. Seine unterdrückten, aus der Erde schwer herausgerungenen Aeste waren mit wenigem saftigem Grün bedeckt.
     </p>
-    <p xml:id="eco_de_0000144_990">
+    <p xml:id="eco_de_0000214_990">
      »Siehst du, von demselben Busche hier haben meine Schwester und ich in unserer Kinderzeit im Winter gar oft frisches Grün geholt zum Geburtstag und auch für unsere Pyramide zu Weihnachten. Damals war der Taxus schon genau so uralt; aber er hatte doch viel mehr Grün. Es war auch noch mehr von ihm da, man sah damals noch, daß er zu einer Taxushecke gehört hatte.« Dabei brach sie mit leicht in dem Gelenk sitzender Hand einige Korneliuskirschenzweige, um ihrem alten, treuen Freunde Luft zu machen.
     </p>
-    <p xml:id="eco_de_0000144_1000">
+    <p xml:id="eco_de_0000214_1000">
      Ich hatte sie schon einmal so gesehen, wie sie die wild gewachsenen Rosenranken auf einem ihr sehr teueren Grab beiseite schob, weil sie den Efeu zu ersticken drohten. Mich hatte damals ein großes Weh überlaufen, wenn ich daran dachte, daß sie dem Schläfer dort unten das Haar gar oft zärtlich aus der Stirn gestrichen haben mochte, wie jetzt die Rosenranken von seinem Grabe. Und ihre Augen hatten freundlich ernst dabei geblickt, genau wie jetzt.
     </p>
-    <p xml:id="eco_de_0000144_1010">
+    <p xml:id="eco_de_0000214_1010">
      Sie ging auf Gräbern, wo sie auch ging, die liebe, alte Frau, und sie ging mit einer hohen seelischen Anmut, – die ich nie wieder gesehen habe, – bei meiner Mutter in schweren Tagen, da sah ich, wie dieselbe rührende, heilige Anmut wie ein Schleier ihren großen Schmerz verhüllte. Und ich dachte: So hinterläßt eine Generation der andern das Ornat der wehmütig schmerzlichen Menschenwürde. Unserer Großmutter Menschenwürde war ein leichtes, weiches Schleierchen.
     </p>
-    <p xml:id="eco_de_0000144_1020">
+    <p xml:id="eco_de_0000214_1020">
      Aber ich gehe andere Wege, als ich zu gehen beabsichtige. Ich wollte sagen, wie ich zur Kenntnis einer seltsam schönen Geschichte kam, die ich gar lange Jahre mit mir umhertrug, ehe ich sie niederschrieb.
     </p>
-    <p xml:id="eco_de_0000144_1030">
+    <p xml:id="eco_de_0000214_1030">
      Wir standen also vor dem alten Korneliuskirschenzaun, der den verknorrten Taxus zu ersticken drohte.
     </p>
-    <p xml:id="eco_de_0000144_1040">
+    <p xml:id="eco_de_0000214_1040">
      »Weißt du,« sagte meine Großmutter, »hier, an dieser Stelle, ist meiner Mutter Küchenschrank gewachsen.«
     </p>
-    <p xml:id="eco_de_0000144_1050">
+    <p xml:id="eco_de_0000214_1050">
      »Hier war das?« fragte ich betroffen, denn ich wußte nun schon so manches.
     </p>
-    <p xml:id="eco_de_0000144_1060">
+    <p xml:id="eco_de_0000214_1060">
      »Ja, hier, hinter dem Zaun, standen zwei große Linden vor einem Häuschen, und darin wohnten sie. Das Häuschen hat der Metzgermeister Bauch abtragen lassen, weil es jedenfalls baufällig war, und am Ende des Gartens wurde zu meiner Zeit das neue dort gebaut, mit dem Blick auf die Stadt.«
     </p>
-    <p xml:id="eco_de_0000144_1070">
+    <p xml:id="eco_de_0000214_1070">
      »Was du nur weißt, das sag' mir doch!« bat ich, »und daß niemand mehr diese Geschichten kennt?«
     </p>
-    <p xml:id="eco_de_0000144_1080">
+    <p xml:id="eco_de_0000214_1080">
      »Die sie kannten, sind vergessen,« sagte meine Großmutter wehmütig. »Die alte Bäckermeisterin, die muß noch allerlei von ihrer Mutter wissen, denn deren Mutter war ja eine von den Schwestern.«
     </p>
-    <p xml:id="eco_de_0000144_1090">
+    <p xml:id="eco_de_0000214_1090">
      Unsere Köchin Regine sagte einmal, daß es in Goethes Garten zu Goethes Lebzeiten gespukt hat. Sie bleibt dabei. »Was ich weiß, das weiß ich –« So ist ihre Redensart. – »Und es hat nicht etwa in der Nacht gespukt, sondern am hellichten Tag, mittags zwölf Uhr, und nur im Sommer in heißer Sonnenglut.«
     </p>
-    <p xml:id="eco_de_0000144_1100">
+    <p xml:id="eco_de_0000214_1100">
      »Das gibt es ja gar nicht. Regine.«
     </p>
-    <p xml:id="eco_de_0000144_1110">
+    <p xml:id="eco_de_0000214_1110">
      »So?« sagte sie, »das gibt's nicht? – Und wenn ich Ihnen sage, die Alma Goethe hat's selbst gesehen, als ich dabei war, und ist vor Schrecken ein paar Tage im Bett gelegen – und der alte Herr ist so oft zu ihr hinein. Ich Hab' damals immer bei ihr sitzen müssen und weiß, was sie geredet haben – die Alma war damals ein Kind – Gott, so'n drei bis vier Jahr. Ich mocht' so'n zehn, zwölfe gewesen sein, etwa; das weiß ich nicht mehr so ganz genau. Die Alma, was die Enkelin vom alten Herrn war, und ich, wir saßen im Garten, und ich lehrte sie stricken. – Die Alma war ein ganz außerordentliches Kind, und schön, sag' ich Ihnen. Wenn ich an die Hundert werde, die Alma vergess' ich nicht. – Aus ihren Augen brach's wie Sonne heraus, so braune, große dunkle Augen in einem Gesicht wie eine zarte Rose, und die Haare goldblond, eine ganze Mähne, nicht zum Durchkämmen. Man konnte gar nicht von ihr fortsehen. Sie sprang und hüpfte. Nie sah man sie ruhig gehen. Die war so voller Leben, das ist gar nicht zu beschreiben. Und solche müssen so früh sterben! – – Der Tod von der Alma ist mir seinerzeit arg gewesen. – Du mein Gott, – du mein Gott! Ach, und wer alles so weiß. Na, wie wir so damals saßen – – – – es war in Mitte Sommer, die Rosen blühten am Hause hin, überall blühten auch die Zentifolien – und der Eisenhut und der Mohn und die Aglei. – Ja, was der goethische Garten damals gewesen ist, ist nicht zu sagen. – Der Paradiesgarten kann nicht schöner sein. Es war im letzten Jahr des alten Herrn. Geblüht hat's damals, ich sag' Ihnen – nie seitdem hat's wieder so geblüht. Es war, als wüßten's alle Sträucher im Garten, daß der alte Herr bald fort müßte, und wollten Abschied nehmen. – Wir saßen im Schatten; aber heiß war's, kein Wölkchen am Himmel, die Schwalben schrien, und ein Duft stieg auf von all den Rosen und Blumenzeug. Es mochte so gerade Mittag sein, und still war's ringsumher, als wenn alles eingeschlafen wär'.
     </p>
-    <p xml:id="eco_de_0000144_1120">
+    <p xml:id="eco_de_0000214_1120">
      Mit einem Mal – da sehe ich, daß die Alma ganz blaß ist, und sieht so eigen vor sich hin.
     </p>
-    <p xml:id="eco_de_0000144_1130">
+    <p xml:id="eco_de_0000214_1130">
      »Alma!« ruft ich – »Alma, was ist denn?« Sie antwortet nicht und regt sich nicht. Ich fass' vor Schreck ihre Hand; aber sie rührt sich nicht.
     </p>
-    <p xml:id="eco_de_0000144_1140">
+    <p xml:id="eco_de_0000214_1140">
      »Ich fürcht' mich,« sagt sie jetzt ganz leise, kaum hörbar wie im Traum. – »Es ist jemand im Garten, hier bei uns.« Aber sie rührt sich immer noch nicht. –
     </p>
-    <p xml:id="eco_de_0000144_1150">
+    <p xml:id="eco_de_0000214_1150">
      Da seh' ich den alten Herrn aus dem Hause treten, die Arme auf dem Rücken, im weißen Hausrock. Und wie er so einige zwanzig Schritt von uns noch entfernt ist – da erhebt sich die Alma, geht mit starren Augen, schneeweiß, ihm entgegen, bleibt stehen, faltet die Hände. – Und ich höre, wie sie sagt – aber es klingt wie ein schwerer, tiefer Seufzer – O! – o!– o! Der alte Herr ist auch stehen geblieben. Er faßt sich an die Brust und fährt so sacht an seinem Arm hin. Er sieht auch! ganz eigentümlich aus – – Und so stehen sie.
     </p>
-    <p xml:id="eco_de_0000144_1160">
+    <p xml:id="eco_de_0000214_1160">
      Nie im Leben ist mir so bange gewesen, – denn da war etwas, und da sehe ich, daß die Alma ganz matt hinsinkt, ganz auf die Seite, so sanft sah das aus. Ich kann mich vor Schreck nicht rühren und denke, sie ist tot; – aber der Herr ist schon bei ihr und hebt sie auf und hat das Kind in den Armen. Auch er ist ganz bleich.
     </p>
-    <p xml:id="eco_de_0000144_1170">
+    <p xml:id="eco_de_0000214_1170">
      Ohne ein Wort zu reden, trägt er sie durch den Garten, und durch die Zimmer, und durchs ganze Haus, und legt sie in ihrem Stübchen auf ihr Bett. – Sie hat die Augen weit auf. – Sie war aber bei sich. Er hielt ihre beiden Händchen in den seinen, und so bleibt er neben ihr sitzen; und keins regt sich. Ich stehe an der Türe, die ich hinter mir zugemacht habe, und wage kaum zu atmen.
     </p>
-    <p xml:id="eco_de_0000144_1180">
+    <p xml:id="eco_de_0000214_1180">
      »Ist dir bange, Alma?«
     </p>
-    <p xml:id="eco_de_0000144_1190">
+    <p xml:id="eco_de_0000214_1190">
      Sie schüttelt den Kopf.
     </p>
-    <p xml:id="eco_de_0000144_1200">
+    <p xml:id="eco_de_0000214_1200">
      Nach einer Weile sagt sie leise: »Sie war so schön«
     </p>
-    <p xml:id="eco_de_0000144_1210">
+    <p xml:id="eco_de_0000214_1210">
      »Wer, mein Kind?«
     </p>
-    <p xml:id="eco_de_0000144_1220">
+    <p xml:id="eco_de_0000214_1220">
      »Die bei dir war, die aus dem Schatten zu dir hinwehte,« so sagte die Alma. »Kennst du sie?«
     </p>
-    <p xml:id="eco_de_0000144_1230">
+    <p xml:id="eco_de_0000214_1230">
      »Kind? – was sprichst du?«
     </p>
-    <p xml:id="eco_de_0000144_1240">
+    <p xml:id="eco_de_0000214_1240">
      »Du weißt ja« sagte Alma ruhig. Dann fielen ihr die Augen zu, und sie schlief. Er saß noch lange nachdenklich neben ihrem Bettchen und hielt die kleinen Hände – dann erhob er sich und sah sehr ernst aus. Er erblickte mich und sagte: »Verlasse sie keinen Augenblick!»
     </p>
-    <p xml:id="eco_de_0000144_1250">
+    <p xml:id="eco_de_0000214_1250">
      Nach einer Stunde schon kam er wieder, nahm wieder an ihrem Bettchen Platz, da erwachte sie gerade und sagte:« Haare wie ein gold'nes Schleierchen und dunkle – dunkle Augen.»
     </p>
-    <p xml:id="eco_de_0000144_1260">
+    <p xml:id="eco_de_0000214_1260">
      »Du teures Kind!« das sagte er sehr bewegt und ganz erschüttert. »Ja, dunkle – dunkle Augen – das war die Sommerseele.« – Und gegruselt hat mich's wie um Mitternacht auf dem Friedhof. Unsere Dienstboten hatten immer vom Sommermittagspuk im Garten gesprochen. Die kleine Alma aber hatte ihn gesehen. – Sie war einige Tage sehr matt, und still, und der alte Herr behielt sie viel um sich. Gesprochen hat sie nie von dem, was sie gesehen. – Und dann hat sie es wohl wieder vergessen. Und nun sagen Sie nicht, das hat sich die kleine Alma eingebildet. So'n kleenes Kind. Wenn Sie die beiden gesehen hatten; die Alma und den alten Herrn. Nie sah ich etwas Feierlicheres, als den alten Herrn im weißen, langen Schlafrock, wie er das arme, schöne Kind durch den Garten und durchs Haus trug und dann an ihrem Bettchen saß, so tief in Gedanken, daß eins ehrfürchtig davor hätte niederknien können.« Regines Geschichten zogen mich hinter ihr her, so lief ich ihr auch immer nach, wenn sie zum Bäckermeister Bauch ging.
     </p>
-    <p xml:id="eco_de_0000144_1270">
+    <p xml:id="eco_de_0000214_1270">
      Regine hat mich mit zur alten Bäckermeisterin Bauch genommen, wie schon einigemal. Da haben die beiden Alten viel geplaudert, und ich habe zugehört.
     </p>
-    <p xml:id="eco_de_0000144_1280">
+    <p xml:id="eco_de_0000214_1280">
      »Mein Vater selig hatte noch die Möbel aus dem kleinen Haus am Horn,« sagte die alte Bäckermeisterin, »in das die Pfarrerswitwe mit ihren Töchtern nach dem Tode des Mannes gezogen war, dann hat er sie verkauft – schade drum! – Jetzt war' mancher froh, wenn er sie hätte. Sie waren ganz eigen, weiß und grün gemalt und schön, reich vergoldet und auf dem Schrank ein großes rotes Herz mit Strahlen als Krönung, und auf dem Betthimmel auch, und überall Herzen und Dornenkronen. – So alte Erbstücke sollte eins nicht weggeben. – Es tut mir selbst drum leid.
     </p>
-    <p xml:id="eco_de_0000144_1290">
+    <p xml:id="eco_de_0000214_1290">
      Eine uralte Zeichnung hatte meine Mutter auch von ihrer Mutter und den Schwestern; wo die hingekommen ist, weiß ich auch nicht mehr; aber wie oft haben wir sie als Kinder gesehen! Da saßen alle vier Schwestern unter einem Baume nebeneinander. Der Baum stand in der Mitte. Es war nicht schön gemacht; aber die Mutter sagte, ihre Mutter täte sie erkennen an einem Tuch. Unter jeder Figur stand etwas, und unter dem Bilde stand: »Das hat der Uerle gemacht.» Und der Uerle, das war der Mann von der Lieschen. Die Mutter sagte immer: Das war ein überspannter Kerl, trotzdem er unser Verwandter war. Ja – ja, so vergehen die Sachen und die Dinge!«
     </p>
-    <p xml:id="eco_de_0000144_1300">
+    <p xml:id="eco_de_0000214_1300">
      Durch gar eigentümliche Zufälle stehen heutzutage dieselben wunderlichen Möbel, von denen die alte Bäckermeisterin sprach, in meinem Schlafzimmer. Tiefgrüne Schnörkel bedecken wie dichtes Laubwerk einen elfenbeinweißen Grund. Dazwischen sind Dornenkronen und durchstochene und brennende Herzen, als Bekrönungen von Schrank und Bett ein großes, rotes, brennendes Herz in einer Gloriole von goldenen Strahlen. Reichvergoldete Schnitzereien lassen die märchenhaften Stücke gar prächtig erscheinen.
     </p>
-    <p xml:id="eco_de_0000144_1310">
+    <p xml:id="eco_de_0000214_1310">
      Ein wunderlicher Kauz muß der gewesen sein, der diese Stücke zimmerte und malte, und man gedenkt des Unbekannten mit Wohlgefallen, ob man eine Schranktür öffnet oder sich zur Ruhe legt, als einer starken, phantastischen Persönlichkeit. –
     </p>
-    <p xml:id="eco_de_0000144_1320">
+    <p xml:id="eco_de_0000214_1320">
      Unter den Linden, die so wohlvertraut in meine Seele rauschten, als hätte ich sie selbst gekannt und geliebt, stand ein kleines Haus in einem großen, langen Garten, auf dem lieblichen Höhenzug, das Horn genannt, dem zu Füßen die Ilm rauscht und das alte Städtchen Weimar liegt. Es war zu jener Zeit noch nicht geheiligt und erhoben vor allen Städten des Deutschen Reiches, sondern lag schlecht und recht, wie es so ein altes Landstädtlein tut, an seinem kleinen, muntern Fluß und träumte so hin. – Und seine Weimaraner wurden geboren und wurden gewickelt und wie Ameisenpuppen in die Wiegen gelegt, und wurden aufgezogen, und begannen sich zu verlieben, und taten irgend etwas mit großer Wichtigkeit, und zankten und klatschten, kauften und verkauften, und wurden dann wieder in ihre Särge eingesponnen und in die Erde gelegt.
     </p>
-    <p xml:id="eco_de_0000144_1330">
+    <p xml:id="eco_de_0000214_1330">
      Vom Horn aus sah man nichts als ein Häuflein grauer, buckliger Schieferdächer, die wie eine Herde mißfarbener Tiere mit Rückenpanzern enggepfercht zwischen Mauern und Türmen beieinander hockten. Es war ein uraltes Gedränge im kleinen Raum, und es sah aus, als könnten die Mauern ihre gepanzerte Herde nicht beieinander halten, als quölle sie ihnen heraus. Die wenigen Häuser, welche hie und da in Gärten auf dem Horn standen, gehörten wohl auch zu Weimar, aber waren der Enge entsprungen und badeten sich da oben von allen Seiten in Regen, Sturm und Sonnenlicht. Es waren aber alles recht armselige Hütten oder Sommerhäuser, die von Weimaranern zur Gartenzeit einige Wochen benutzt wurden. Das kleine Haus unter den Linden gehörte der Pfarrerswitwe von Süßenborn. Sie war nach dem Tode ihres Mannes mit ihren vier Töchtern und mit all ihrem Hausrat dahinein übergesiedelt.
     </p>
-    <p xml:id="eco_de_0000144_1340">
+    <p xml:id="eco_de_0000214_1340">
      Das Häuslein enthielt vier Stuben und eine Küche. Haus und Garten und der Witwe kleine Pension waren das Lebensbrot der fünf Weiblein. Der Garten brachte Früchte, Gemüse, Erdäpfel. Die Mädchen hatten die Schule in Süßenborn frei. Wenn eins von der Schule abfiel, gesellte es sich der Mutter zu, die eine große Geschicklichkeit hatte im Handschuhnähen und -zuschneiden. Und wer etwas recht Feines wollte, der scheute den Weg nicht und bestellte bei der Pfarrerswitwe seine Festhandschuhe. Sie arbeitete immer nur auf Bestellung und hielt sich nie einen Vorrat, denn sie scheute jede Unternehmung, die Sorge und Grübelei machen würde. Sie hatte ihre vier Mädchen gar wohl behütet und erzogen in der Stille und Abgeschiedenheit auf dem Horn.
     </p>
-    <p xml:id="eco_de_0000144_1350">
+    <p xml:id="eco_de_0000214_1350">
      Mit den Pfarrersleuten aus Süßenborn standen sie in regem Verkehr, auch mit dem Lehrer und seinen Kindern, und auch in Weimar hatte die brave Witwe einigen Anschluß. – Aber sie ließ die Mädchen nicht oft hinab und nur selten zu einem Tanz oder sonst einer Festlichkeit. Ihr Leben floß friedlich dahin und in einer gar lieblichen Schönheit, wie man es, je weiter die Geschichte fortschreitet, verspüren wird. – Die älteste Pfarrerstochter hatte sich ein junger Pfarramtskandidat, als er in der Nähe von Weimar angestellt wurde, zum Weibe geholt. Sie war aber gar bald als blutjunge Witwe mit einem Kindlein wieder bei ihrer Mutter im alten Haus unter den Linden eingekehrt, und so hatten sie nun, die zwei Witwen und die drei Jungfrauen, ein winziges Bübchen bei sich.
     </p>
-    <p xml:id="eco_de_0000144_1360">
+    <p xml:id="eco_de_0000214_1360">
      Im Rebengarten, der sich, wie jener der Witwe, sanft abfallend dem Tale zuneigte, war ein sonderbarer Mensch eingemietet, der seit Jahren schon an der Witwe und ihren Töchtern mit großer Treue hing – ein braver Handlungsgehilfe, Schreiber, Geschäftsführer der ersten Kolonialwarenhandlung unten in der Stadt, für die er durch Tüchtigkeit der Mann für alles geworden war. An dunklen, einsamen Winterabenden, wenn da oben am Horn kein menschliches Wesen mehr anzutreffen war, und wenn das Licht durch die Herzen der Fensterläden aus dem Wohnstübchen der fleißigen Frauenzimmer in die dunkelste, einsamste Oede hinausfiel, da war es ihnen gar heimisch, wohlbekannte Schritte auf das Häuschen zukommen zu hören. »Der Uerle,« sagten dann eine oder zwei oder alle zu gleicher Zeit– »der Uerle.« Die Oede draußen hatte gleichsam eine Seele bekommen, eine sehr freundliche, vertraute Seele. Sie lag nicht mehr gar so tot und unermeßlich in ihrer stillen Dunkelheit um das warme Nest. Bald folgte ein Klopfen am Fensterladen in immer gleichbleibendem Rhythmus. So klopft nur der Uerle, sollte das heißen, seid ganz ruhig, ihr macht nichts Unrechtem auf! – Nein, es war nichts Unrechtes, was da kam und von einer der Töchter mit der kleinen Oelfunzel – die andern saßen derweil im Dunkeln – hereingeleuchtet wurde. »Allerseits einen guten, geruhsamen Abend!« erklang dann eine etwas hölzerne, unbiegsame Stimme, und ein Duft nach allen erdenklichen nützlichen Dingen drang mit dem Eintretenden ins Zimmer. Der Duft des Kolonialwarengewölbes, der mit dem Uerle aufs Horn gewandert war: Kaffee und Sirup und getrockneter Stockfisch und Salzgurken und Zimmet, Mandeln, Zitronat und Kardamom, Zitronenschale, Lorbeerblatt. All diese Dinge hatten um den langen Menschen eine Atmosphäre gewoben, der er nicht mehr entfliehen konnte.
     </p>
-    <p xml:id="eco_de_0000144_1370">
+    <p xml:id="eco_de_0000214_1370">
      Die Mädchen sagten: »Er riecht wie ein Weihnachtspunsch.« Es roch für das ganze Häuslein nach Festlichkeit, nach heimischem Behagen, nach Geselligkeit.
     </p>
-    <p xml:id="eco_de_0000144_1380">
+    <p xml:id="eco_de_0000214_1380">
      Die Frauenzimmer waren uneingestandenermaßen dem Uerle dankbar, daß er überhaupt da war. Ohne Uerle wären die Winterabende am Horn gar zu weltverloren einsam gewesen, ohne den Uerle hätten die beiden Linden vor dem Häuschen bei Sturm und Regen gar zu schaurig wie zwei große Riesenbesen die Wolken gekehrt. – Und auch des Nachts war es ein guter Gedanke, daß im Nachbarhäuslein der Uerle lag und schlief, der Uerle, der sein Leben für sie alle dahingegeben hätte.
     </p>
-    <p xml:id="eco_de_0000144_1390">
+    <p xml:id="eco_de_0000214_1390">
      Trat er abends ein, wurde die Arbeit beiseite gelegt, und sie rüsteten sich zum Musizieren, oder die Mutter erzählte Märchen, gesegnete, uralte Märchen, oder der Uerle las vor, der Uerle, der tagsüber am Heringsfaß, an der Kaffeeröstmaschine, am Hauptbuch, im Keller seinen Mann stand, wurde abends ein wirklicher und wahrhaftiger Schöngeist.
     </p>
-    <p xml:id="eco_de_0000144_1400">
+    <p xml:id="eco_de_0000214_1400">
      Er mußte jeden Tag eine ganz gewaltige Umwandlung über sich ergehen lassen, so eingreifend wie die Umwandlung der Puppe zum Schmetterling. Und jeden Tag dieselbe Geschichte, das halte einer aus! Zu jener guten, alten Zeit, da war das möglich, da waren die Nerven der Menschen noch kinderjung, noch nicht gezerrt und gepeinigt wie die unsern, da konnte ein Mensch zwei ganz verschiedene Arten von Dasein führen und in jedem sich ausleben, wie ein Kind am Vormittag Pfarrer und am Nachmittag Räuber spielen kann, beides mit der vollen Kraft seiner Seele.
     </p>
-    <p xml:id="eco_de_0000144_1410">
+    <p xml:id="eco_de_0000214_1410">
      Nur der Duft des Kolonialwarengewölbes, der war nicht zu vertreiben, der hing sich auch dem Schöngeist an.
     </p>
-    <p xml:id="eco_de_0000144_1420">
+    <p xml:id="eco_de_0000214_1420">
      So saßen sie, und Uerle kam, mit Büchern gepolstert, die hagere Gestalt hatte allerlei Auswüchse, und jeder Auswuchs war literarisch bedeutungsvoll. Des alten Musäus Märchen hatte er unter seinem Rock dahergebracht, Wielands Werke, was nur irgend Neues und Altes für ihn erreichbar war.
     </p>
-    <p xml:id="eco_de_0000144_1430">
+    <p xml:id="eco_de_0000214_1430">
      Das war eine gar wunderliche Sache zwischen Uerle und den Pfarrerstöchtern. Wie mit Ketten hing sein Herz an ihnen. Er wohnte als ihr Wächter und Freund da oben auf dem weltverlassenen Horn, und sie waren ihm alle vier in die Seele hineingewachsen.
     </p>
-    <p xml:id="eco_de_0000144_1440">
+    <p xml:id="eco_de_0000214_1440">
      Im Winter war es ihm, als stände er Lieschen, der Aeltesten, am nächsten. Die liebte das stille Daheimsitzen, die langen, gemütlichen Abende. Die Bratäpfel legte stets sie ins Rohr. Das Feuer schürte sie. Die Lampe putzte sie. Sie war, so schien es ihm, im Winter besonders liebenswert. Anne, die blutjunge Witwe – als er dies sanfte Wesen mit ihrem Kindchen im Frühjahr auf der Bank unter den Linden einst sitzen sah, die ersten Stare pfiffen in den Wipfeln, da rührte ihn das sanft sich lösende Weh, das aus den jungen Augen sprach, und die Liebesfrühlingsregung der jungen Mutter zum Kinde und das Frühlingslallen des Kindleins und das zarte Knospen um sie her, und bewegten Herzens verband er sie wieder mit seiner Liebe zum Frühling.
     </p>
-    <p xml:id="eco_de_0000144_1450">
+    <p xml:id="eco_de_0000214_1450">
      Der Sommer zog herauf, die Felder dufteten, die Mohnblumen standen wie Blutstropfen im blühenden Korn, die Rosen, die Kirschen und alle Sommerblumen im Garten blühten. Die Linden vor dem Hause trugen ihre goldene Blütenlast und dufteten Sommersicherheit. Mächtige Bienenvölker sogen an den abertausend Blüten, und die vollaubigen, dunklen, goldüberstäubten Bäume dröhnten wie zwei Orgeln, so gewaltig war das Summen der Bienenvölker in ihren Kronen. Und abends klang aus den offenen Fenstern des Häuschens unter den dröhnenden Bäumen Musik und Gesang. Vier Mädchenstimmen sangen zu Spinett und Laute Sommersehnsuchtslieder. Die schwachen Mauern des kleinen Hauses konnten kaum der Töne Ueberschwall fassen. – Das war ein Duften und Dröhnen und Klingen zu Ehren des Sommers, und wer vorüberging, sah und hörte mit Staunen die dunklen Baumorgeln vor dem singenden Haus, das seine Klänge nicht zu fassen wußte.
     </p>
-    <p xml:id="eco_de_0000144_1460">
+    <p xml:id="eco_de_0000214_1460">
      Uerle liebte die dritte Schwester Alma wie ein geheimnisvolles Sommerlied, das so schön und tief war, wie es keines auf Erden gibt, das gesungen und gebetet wird.
     </p>
-    <p xml:id="eco_de_0000144_1470">
+    <p xml:id="eco_de_0000214_1470">
      Da war nicht eins, das er so aus vollem Herzen vor sich hin hätte singen können, wenn er an Alma dachte und an die Sommerherrlichkeit um sie her. Am ehesten noch das:
     </p>
-    <p xml:id="eco_de_0000144_1480">
+    <p xml:id="eco_de_0000214_1480">
      »Geh aus, mein Herz, und suche Freud' In dieser schönen Sommerszeit An deines Gottes Gaben.«
     </p>
-    <p xml:id="eco_de_0000144_1490">
+    <p xml:id="eco_de_0000214_1490">
      Das Lied des alten Paul Gerhard. Uerle war kein Dichter, er kannte die Todesnöte der Dichter nicht, ihre Kämpfe nicht und ihre Qualen nicht. Er pflückte nur ganz friedlich die Schönheiten, die aus diesen Qualen und Seligkeiten wuchsen, und wenn er Schöngeist wurde, wurde er Dichterfreund, so rückhaltlos und hingebend, wie die Dichter wahrlich wenig Freunde auf Erden gehabt haben.
     </p>
-    <p xml:id="eco_de_0000144_1500">
+    <p xml:id="eco_de_0000214_1500">
      Saß er abends unter den dröhnenden Bäumen und hörte auf den Gesang der Mädchen, so rannen ihm vor Seligkeit die Tränen über die Wangen.
     </p>
-    <p xml:id="eco_de_0000144_1510">
+    <p xml:id="eco_de_0000214_1510">
      Alma, das wundervolle, blonde Mädchen mit den dunklen, geheimnisvollen Sommeraugen, der sehnsuchtsvollen Stimme, hatte in den Sommerwochen einen Anbeter, wie ihn sich ein Götterbild nur hätte wünschen können, und er duftete sogar wie Weihrauch, nach Lorbeer, Kaffeepulver, Zitronenschale und Kardamom. Er trieb tatsächlich einen verschwiegenen Gottesdienst mit ihr. Er betete an, er kniete nieder. Freilich nur in seiner Vorstellung, denn nie hätten seine steifen, spießbürgerlichen Glieder, die ihm die schönheitstrunkene Seele zusammenhielten, sich zu solchem Götzendienst hergegeben.
     </p>
-    <p xml:id="eco_de_0000144_1520">
+    <p xml:id="eco_de_0000214_1520">
      Sie war für ihn die Blüte des Sommers oder dessen Frucht. Im Winter war es ihm, als schliefe sie, als wenn man sie nicht wecken dürfte, da hatte sie etwas so tief Sehnsüchtiges – Wartendes, daß sie ihm immer zu Herzen ging. Ihm war's, als stürbe sie jedesmal mit dem Sommer. Sie blieb dann sein Sorgenkind; aber er sah im Herbst Ulrikchen zu einem rotbackigen, köstlichen Herbstapfel werden. Das übrige Jahr stand er mit ihr auf Kriegsfuß.
     </p>
-    <p xml:id="eco_de_0000144_1530">
+    <p xml:id="eco_de_0000214_1530">
      Uerle kam schwer aus seinem Seelenfrieden und hielt wohl für das wichtigste Gesetz, Frieden zu halten mit sich selbst; so hatte er sich auch mit dem wunderlichen Schicksal, sich in vier Frauen zu verlieben, kunstvoll abgefunden.
     </p>
-    <p xml:id="eco_de_0000144_1540">
+    <p xml:id="eco_de_0000214_1540">
      Im Grund seiner Seele liebte er aber auch noch die zarte, sanfte Mutter der vier Mädchen. An ihr hing er Frühling, Sommer, Herbst und Winter und wurde nicht müde, der alten, lieblichen Frau zu dienen, wo und wie er konnte. So hatten die Frauenzimmer auf dem Horn wirklich einen erprobten Freund, auf den sie bauen und dem sie trauen konnten. So verschwiegen Uerle auch seine vierfache Liebe hielt, so lebten die Mädchen doch in der Sonnenwärme dieser Liebe und gediehen in Weltfremdheit und Einsamkeit gar herrlich.
     </p>
-    <p xml:id="eco_de_0000144_1550">
+    <p xml:id="eco_de_0000214_1550">
      Es war an einem Sommerabend, da kam Freund Uerle und sah feierlich aus. Er trug auch sein Feiertagsgewand und hatte in der Brusttasche einen kleinen literarischen Auswuchs. »Er hat etwas in der Tasche,« sagte Alma, »er bringt etwas Schönes.« »Ja,« sagte Uerle bewegt, »die Jungfern werden Äugen machen. Wir setzen den Tisch unter die Linden, und den bequemen Stuhl der Frau Mutter tragen wir hinaus. Ich werde beim Bienengesumme etwas lesen, wie wir alle, alle noch nichts gehört haben. – Wollte Gott,« setzte er hinzu, »ich dürfte niederknien und dem herrlichen Menschen die Hände küssen. Und noch eins: ehe ich anfange, wäre es sehr schön, wenn die vier werten Jungfern« – die junge Witwe wurde dabei nicht weiter berücksichtigt – »ein Lied zum besten geben wollten. Meinen guten Rock Hab' ich schon angezogen; aber die Seele muß auch rein werden von allem, was ihr anhängt.« Die Mädchen waren gern bereit und sangen, und er saß unter den Linden. »Herr Gott,« sagte er, »was für ein glücklicher Mensch bin ich doch! Wissen Sie noch, Frau Pfarrerin, wie wir einander kennen lernten, – wie ich Ihnen den Kaffee, Zucker, Reis und Mehl selber heraustrug, weil ich mich hier oben gern auskennen wollte – und wie mir's gleich so sehr gefiel? Sie setzten mir damals ein Schälchen Kaffee für den langen Weg vor, und wir kamen ins Plaudern. – Wie die Zeit dahingeht, Frau Pfarrerin!« – Als der letzte Ton des Liedes verklungen war und die Mädchen heraustraten, holte Uerle den Stuhl für die Frau Mutter, setzte sich an den Tisch, brachte weihevoll und langsam ein Büchlein aus der Tasche und sagte: »Das ist von einem geschrieben, gegen den alle andern bisher gar nichts sind – aber auch gar nichts!«
     </p>
-    <p xml:id="eco_de_0000144_1560">
+    <p xml:id="eco_de_0000214_1560">
      »Das hat er schon so oft gesagt!« meinte Ulrikchen und lachte.
     </p>
-    <p xml:id="eco_de_0000144_1570">
+    <p xml:id="eco_de_0000214_1570">
      »Und hat er nicht recht gehabt, war nicht eins schöner wie's andere?« meinte die kleine Witwe.
     </p>
-    <p xml:id="eco_de_0000144_1580">
+    <p xml:id="eco_de_0000214_1580">
      »Ja,« sagte die Mutter, »zu Dank sind wir dem guten Uerle verpflichtet.«
     </p>
-    <p xml:id="eco_de_0000144_1590">
+    <p xml:id="eco_de_0000214_1590">
      »Werteste Frau Pfarrerin, der Dank ist ganz auf meiner Seite.«
     </p>
-    <p xml:id="eco_de_0000144_1600">
+    <p xml:id="eco_de_0000214_1600">
      Wenn Uerle höflich wurde, stand es bedenklich um ihn, da brannten auch seine Ohren, und wenn die Ohren ihm brannten, stand das Herz ihm in Feuer. Und die Höflichkeit war gewissermaßen das Ventil für seine Leidenschaften. Seine Glieder, seine Stimme, seine Bewegungen, alles lag bei dem armen Menschen in Fesseln und Banden und Steifheit. – O, hätte er die Höflichkeit nicht gehabt, so wäre er gewiß vor Ekstase schon zersprungen.
     </p>
-    <p xml:id="eco_de_0000144_1610">
+    <p xml:id="eco_de_0000214_1610">
      »Ich bitte,« sagte er gemessen, »die liebe Frau Pfarrerin und die verehrten Jungfern, ganz andächtig zuzuhören!«
     </p>
-    <p xml:id="eco_de_0000144_1620">
+    <p xml:id="eco_de_0000214_1620">
      Er schlug das Buch auf und las: »Des jungen Werthers Leiden.«
     </p>
-    <p xml:id="eco_de_0000144_1630">
+    <p xml:id="eco_de_0000214_1630">
      Die Bäume dröhnten vom Summen der Bienenvölker. Im Himmelsblau jubilierten die Lerchen ihr Abendlied, und das Korn duftete den großen Opferduft der weiten Ebene. »Des jungen Werthers Leiden« las er noch einmal und machte wieder eine Pause.
     </p>
-    <p xml:id="eco_de_0000144_1640">
+    <p xml:id="eco_de_0000214_1640">
      »Nun?« fragte Ulrikchen.
     </p>
-    <p xml:id="eco_de_0000144_1650">
+    <p xml:id="eco_de_0000214_1650">
      »Verzeihen Sie – wenn Sie wüßten. Wissen Sie, daß Tausende von jungen Herzen jetzt in ganz Deutschland hingerissen sind, daß man nicht ein und aus weiß unter der Jugend vor Begeisterung? – Unten in Weimar hörte ich, daß es schon Jünglinge gäbe, die sich ganz so kleideten, wie in diesem Buche der junge Werther es tut. Ja, so etwas geschah noch nicht. Heute nacht hab' ich gelesen und gelesen und gelesen, und wenn es die Schicklichkeit erlaubt hätte, wär' ich da schon herübergelaufen und hätte vor dem Fenster im Mondenschein das Wundervolle Ihnen allen vorgelesen.«
     </p>
-    <p xml:id="eco_de_0000144_1660">
+    <p xml:id="eco_de_0000214_1660">
      »Nun, so beginnen Sie doch,« meinte Ulrikchen.
     </p>
-    <p xml:id="eco_de_0000144_1670">
+    <p xml:id="eco_de_0000214_1670">
      »Ich habe immer gedacht,« sagte Alma ruhig und sinnend, »es müßte einmal etwas Wundervolles geschehen. – Ein Tag ist wie der andere, und es muß doch einmal etwas geschehen, daß man vor Wonne sterben könnte.«
     </p>
-    <p xml:id="eco_de_0000144_1680">
+    <p xml:id="eco_de_0000214_1680">
      »Du mein Gott, Kind,« sagte die Pfarrerin, »versündige dich nicht! – Danken muß man Gott, verläuft ein Tag wie der andere. Gutes kommt selten, und vor dem Bösen möge der Herr uns behüten.« »Ich meine,« sagte Alma, »ein jeder Mensch müßte einmal blühen wie ein Rosenstrauch oder wie unsere Lindenbäume.«
     </p>
-    <p xml:id="eco_de_0000144_1690">
+    <p xml:id="eco_de_0000214_1690">
      Ulrikchen lachte. »Und die Bienen müßten einem dann um den Kopf summen wie hier.«
     </p>
-    <p xml:id="eco_de_0000144_1700">
+    <p xml:id="eco_de_0000214_1700">
      »Nein,« erwiderte Alma ernst, »die müßten einem im Herzen summen, in der Seele, es müßte alles klingen und schwirren vor Seligkeit. Ich weiß gewiß,« sagte Alma ganz feierlich, »ich war einmal ein Rosenstrauch, ehe ich der Mutter Tochter wurde, der hat ungezählte Rosen getragen, ungezählte – ist ganz zu lauter Rosen geworden – – und ist so selig gewesen. Und der Duft aller Rosen war die große, große Freude seines Herzens.«
     </p>
-    <p xml:id="eco_de_0000144_1710">
+    <p xml:id="eco_de_0000214_1710">
      »Ach, Alma,« meinte Ulrikchen, »so red' nicht so dumm und stör' nicht!«
     </p>
-    <p xml:id="eco_de_0000144_1720">
+    <p xml:id="eco_de_0000214_1720">
      »Jungfer Ulrikchen,« sagte Uerle erbleichend, »Sie müssen die Schwester reden lassen! – Ja, um Gottes willen, lassen Sie sie reden! Reden Sie, Jungfer Alma, das wird Ihnen wohltun! Es ist eine heilige Stunde jetzt, und das, was Sie sagen, weiß ich ja, weiß ich ja längst!«
     </p>
-    <p xml:id="eco_de_0000144_1730">
+    <p xml:id="eco_de_0000214_1730">
      »Nun hört sich aber alles auf!« rief Ulrikchen.
     </p>
-    <p xml:id="eco_de_0000144_1740">
+    <p xml:id="eco_de_0000214_1740">
      »Ja, was ist Ihnen denn?« fragte die Frühlingsliebe, die blutjunge Witwe.
     </p>
-    <p xml:id="eco_de_0000144_1750">
+    <p xml:id="eco_de_0000214_1750">
      »Nein – nichts – nichts!« sagte Uerle verwirrt. »Ich erschrak nur, daß sie es auch weiß.«
     </p>
-    <p xml:id="eco_de_0000144_1760">
+    <p xml:id="eco_de_0000214_1760">
      »Aber was weiß?« meinte die Pfarrerin. »Träumt ihr denn?«
     </p>
-    <p xml:id="eco_de_0000144_1770">
+    <p xml:id="eco_de_0000214_1770">
      »Nein, nein,« sagte Uerle, »es ist auch gar nichts – Gott möge die liebe Jungfer Alma behüten.«
     </p>
-    <p xml:id="eco_de_0000144_1780">
+    <p xml:id="eco_de_0000214_1780">
      »Na, der Wunsch wäre am Platze gewesen, damals, als sie gar so ein schöner Rosenstrauch gewesen ist, da hätte man einen Stadtsoldaten davorstellen müssen, denn ich hätte mir auch einen Arm voll gelangt,« sagte Ulrikchen.
     </p>
-    <p xml:id="eco_de_0000144_1790">
+    <p xml:id="eco_de_0000214_1790">
      Uerle kam aber nicht leicht aus seiner Verwirrung, denn Alma hatte ausgesprochen, was er dunkel gefühlt. Sie empfand wie er selbst, daß sie gar eng und geheimnisvoll mit dem Sommer zusammenhing. Es überschauerte ihn. Er fühlte sich ihr nah. –
     </p>
-    <p xml:id="eco_de_0000144_1800">
+    <p xml:id="eco_de_0000214_1800">
      »Am vierten Mai: Wie froh bin ich, daß ich weg bin! Bester Freund, was ist das Herz des Menschen!« begann er zu lesen und las weiter.
     </p>
-    <p xml:id="eco_de_0000144_1810">
+    <p xml:id="eco_de_0000214_1810">
      Und zuviel hatte er nicht gesagt. Sie waren, als er für dieses Mal das Buch schloß, jedes in seiner Art davon benommen. – Sogar Ulrikchen, die einen losen Schnabel der Literatur gegenüber hatte, gab sich drein, es sehr, sehr reizend zu finden.
     </p>
-    <p xml:id="eco_de_0000144_1820">
+    <p xml:id="eco_de_0000214_1820">
      Alma war ganz still.
     </p>
-    <p xml:id="eco_de_0000144_1830">
+    <p xml:id="eco_de_0000214_1830">
      »Nun und Sie, Jungfer Alma, was sagen Sie?«
     </p>
-    <p xml:id="eco_de_0000144_1840">
+    <p xml:id="eco_de_0000214_1840">
      Sie sah ihn bittend an. »Man bringt ihn ins Gered' mit dem Sprechen darüber. Er hat sich das nicht gedacht, als er's schrieb, daß so viel fremde Leute es lesen würden.«
     </p>
-    <p xml:id="eco_de_0000144_1850">
+    <p xml:id="eco_de_0000214_1850">
      Uerle sagte etwas lächelnd: »O nein, Jungfer Alma, er hat ein großer Dichter damit werden wollen.« »Nein, gewiß nicht!« sagte sie hastig.
     </p>
-    <p xml:id="eco_de_0000144_1860">
+    <p xml:id="eco_de_0000214_1860">
      »Aber nein, so eine Idee! Meinen Sie, die Dichter schreiben und dichten nicht für die Menschen und für den Ruhm?«
     </p>
-    <p xml:id="eco_de_0000144_1870">
+    <p xml:id="eco_de_0000214_1870">
      »Ja, die anderen; aber das sind ja doch dann wohl auch keine Dichter, das sind Krämer.«
     </p>
-    <p xml:id="eco_de_0000144_1880">
+    <p xml:id="eco_de_0000214_1880">
      »Ich bin müde,« sagte sie, stand langsam auf, nickte allen eine Gute Nacht zu, küßte die Mutter auf die Stirn und trat ins Haus.
     </p>
-    <p xml:id="eco_de_0000144_1890">
+    <p xml:id="eco_de_0000214_1890">
      »Sonderbares Frauenzimmer,« meinte Ulrikchen und gähnte. Uerle verabschiedete sich auch. Als sie unter sich waren, meinte die junge Witwe: »Der Uerle scheint sich in unsere Alma verliebt zu haben.«
     </p>
-    <p xml:id="eco_de_0000144_1900">
+    <p xml:id="eco_de_0000214_1900">
      »Nee, das hat er nicht,« antwortete Ulrikchen »der Uerle liebt uns alle ein für allemal miteinander und damit basta!«
     </p>
-    <p xml:id="eco_de_0000144_1910">
+    <p xml:id="eco_de_0000214_1910">
      Uerle war diesen Sommer ganz außer dem Häuschen, wie sie in Weimar sagen. Was er vom Verfasser des jungen Werther erlangen konnte, das brachte er angeschleppt und war in einer wahren Aufregung. »Werthers Leiden« behielt den Platz auf seinem Herzen.
     </p>
-    <p xml:id="eco_de_0000144_1920">
+    <p xml:id="eco_de_0000214_1920">
      Ulrikchen erkundigte sich oft, ob das eine unheilbare Geschwulst unter seiner Brusttasche wäre. »Wenn man nur dem armen Uerle eine recht unglückliche Liebe verschaffen könnte,« neckte sie ihn im Beisein der andern, »damit er sich abkrageln könnte. – Wär' das ein Hochgenuß!« »Jungfer Ulrikchen,« sagte Uerle einmal bekümmert, »ich bin ein ganz armseliger Mensch; zu meiner Schande muß ich gestehen, mir fiele wahrscheinlich in des jungen Werthers Fall irgend eine vernünftige, friedliche Lösung ein. Ach, ich bin ein nichtsnutziger Kerl!«
     </p>
-    <p xml:id="eco_de_0000144_1930">
+    <p xml:id="eco_de_0000214_1930">
      »Jetzt weiß ich mir aber keinen Rat, Uerle, ist Er denn ganz närrisch geworden?« sagte bei so einer Gelegenheit die gute Frau Pfarrerin bekümmert. »Hab' ich doch mein' Tag solch sündliche Torheit nicht gehört! Wo hat Er denn sein Christentum, Uerle? Mein Gott, der ganze Herr Goethe reicht unserm Uerle das Wasser nicht, was Treue und Bravheit und friedliche Lebensführung ist – und macht ihn uns noch ganz närrisch!
     </p>
-    <p xml:id="eco_de_0000144_1940">
+    <p xml:id="eco_de_0000214_1940">
      Ich wollte, er hätte das Geschreibe unserm Uerle überlassen, da wäre eine friedliche und moralische Sache dabei herausgekommen!«
     </p>
-    <p xml:id="eco_de_0000144_1950">
+    <p xml:id="eco_de_0000214_1950">
      »Hochzuverehrende Frau Pfarrerin,« antwortete ganz verwirrt und erregt Uerle, »das hätte ich nicht gedacht, daß so eine vernünftige, kluge Frau solch eine Blasphemie zu sagen imstande wäre.«
     </p>
-    <p xml:id="eco_de_0000144_1960">
+    <p xml:id="eco_de_0000214_1960">
      »Was wäre?« fragte die Pfarrerin. Uerle verdeutschte es ihr.
     </p>
-    <p xml:id="eco_de_0000144_1970">
+    <p xml:id="eco_de_0000214_1970">
      »Da sei Gott vor!« rief die Pfarrerin, »und was hat das mit euch jungen, törichten Leuten zu tun?«
     </p>
-    <p xml:id="eco_de_0000144_1980">
+    <p xml:id="eco_de_0000214_1980">
      »Mit uns? – Mit uns?« schrie Uerle. »Ja, will uns denn die Frau Pfarrerin vielleicht in einen Topf tun?«
     </p>
-    <p xml:id="eco_de_0000144_1990">
+    <p xml:id="eco_de_0000214_1990">
      »Ei was,« sagte die Pfarrerin, »ich halt' mich an die Menschen, und da gehört ihr doch wohl zueinander. Ein bissel klüger oder weniger klug, das spricht nicht mit.«
     </p>
-    <p xml:id="eco_de_0000144_2000">
+    <p xml:id="eco_de_0000214_2000">
      »Herr Gott im Himmel – Herr Gott im Himmel! So eine Frau! – Uns zueinander!« Uerle war ganz außer sich.
     </p>
-    <p xml:id="eco_de_0000144_2010">
+    <p xml:id="eco_de_0000214_2010">
      »Ach was, Genie,« sagte die Frau Pfarrerin, »ein guter Mensch soll einer sein.«
     </p>
-    <p xml:id="eco_de_0000144_2020">
+    <p xml:id="eco_de_0000214_2020">
      »Hier handelt sich's aber nicht darum, sondern um eine Liebesgeschichte, um ein herrliches Kunstwerk, Frau Pfarrerin!«
     </p>
-    <p xml:id="eco_de_0000144_2030">
+    <p xml:id="eco_de_0000214_2030">
      »Ja, ja,« sagte die gute Frau, »solch ein herrliches Kunstwerk hat jeder durchgemacht, und alle werden's durchmachen, aber da sei Gott vor, daß sie's auch alle beschreiben und wenn sie's noch so schön täten! Ich kann nun einmal die Dichtersleut' nicht so unmäßig bewundern. Und lieber ist mir allemal einer, der sein Heiligstes ins Herz verschließt, wie Sie, Herr Uerle.«
     </p>
-    <p xml:id="eco_de_0000144_2040">
+    <p xml:id="eco_de_0000214_2040">
      »Liebwerte Frau Pfarrerin, das lassen Sie nur sein, mich hier zu nennen. Nicht wert bin ich, ihm die Füße zu küssen.«
     </p>
-    <p xml:id="eco_de_0000144_2050">
+    <p xml:id="eco_de_0000214_2050">
      »Pfui!« rief die Frau Pfarrerin, »und das sagt ein Mannsbild, weil einer eine Liebesgeschichte artig vorzutragen weiß. Ei, sind Sie denn ganz des Kuckucks! Ist denn so ein Mannsbild als Mensch ein rein Garnichts, und nur, was so einem eingetrichtert ist, oder seine Kunstfertigkeit gilt etwas. Da lob' ich mir die Frauenzimmer, die müssen als Menschen etwas gelten, wenn sie gelten wollen. Die hat ausgespielt, die als Mensch nichts gilt. Mannsbilder sind doch ein ganz unnatürliches Volk!«
     </p>
-    <p xml:id="eco_de_0000144_2060">
+    <p xml:id="eco_de_0000214_2060">
      Die Frau Pfarrerin war mit ihrem guten Freund Uerle gar nicht mehr so recht zufrieden und gar, als er an einem trüben Novembertag, ohne anzuklopfen, abends ins Zimmer gestürzt kam und gar nicht zu Worte kommen konnte, weil er ganz außer Atem war.
     </p>
-    <p xml:id="eco_de_0000144_2070">
+    <p xml:id="eco_de_0000214_2070">
      »Nu, aber was?« fragte seine alte Gönnerin etwas ungeduldig.
     </p>
-    <p xml:id="eco_de_0000144_2080">
+    <p xml:id="eco_de_0000214_2080">
      »Ach, verzeihen Sie, sie haben unten in Weimar den Goethe –«
     </p>
-    <p xml:id="eco_de_0000144_2090">
+    <p xml:id="eco_de_0000214_2090">
      »Was?«
     </p>
-    <p xml:id="eco_de_0000144_2100">
+    <p xml:id="eco_de_0000214_2100">
      »Ja – das haben sie! – Sie haben ihn lassen holen. Unser junger Herzog ist genau so vernarrt in ihn wie…« Uerle sprach respektvoll nicht aus.
     </p>
-    <p xml:id="eco_de_0000144_2110">
+    <p xml:id="eco_de_0000214_2110">
      »Ach, das lassen Sie sich doch nicht weismachen, der ist ja bürgerlich! – Wo werden die! – Die sehen ihn sich einmal an, warum nicht? Langweilen tun sie sich ja so; dann lassen sie ihn aber laufen.«
     </p>
-    <p xml:id="eco_de_0000144_2120">
+    <p xml:id="eco_de_0000214_2120">
      »Nee, nee! Damit wird's nichts!« rief Uerle sehr erregt. »Unser kleiner Herzog soll nicht mehr ohne ihn leben können.«
     </p>
-    <p xml:id="eco_de_0000144_2130">
+    <p xml:id="eco_de_0000214_2130">
      »Ohne einen Bürgerlichen?– Sei'n Sie nich komisch – das sagen Sie wem anders!« rief die Pfarrerin geärgert.
     </p>
-    <p xml:id="eco_de_0000144_2140">
+    <p xml:id="eco_de_0000214_2140">
      »So vernagelt, wie Sie glauben, Frau Pfarrerin, ist unser junger Herzog nun noch nicht. Goethe ist eben doch unten und bleibt auch, und damit basta, und Feste gibt's auf Feste. Sie sollen alle ganz toll sein. – Na, geklatscht wird jetzt schon, daß es eine Art hat. Gesehen habe ich ihn noch nicht, aber …«
     </p>
-    <p xml:id="eco_de_0000144_2150">
+    <p xml:id="eco_de_0000214_2150">
      »Der Uerle wird jetzt irgendwo Posto fassen und lauern, und wir werden das Nachsehen mit dem Uerle haben,« meinte Ulrikchen.
     </p>
-    <p xml:id="eco_de_0000144_2160">
+    <p xml:id="eco_de_0000214_2160">
      »Beileibe nicht,« antwortete er – »aber Sie werden sehen. Sie werden sehen –«
     </p>
-    <p xml:id="eco_de_0000144_2170">
+    <p xml:id="eco_de_0000214_2170">
      Mit Uerle war es den ganzen Winter nicht richtig. Die übrige Literatur ließ er liegen und summte »Wanderers Sturmlied«, wo er ging und stand, und deklamierte es den Pfarrersleuten, – und »Götz von Berlichingen« las er abends mit heiliger Inbrunst. In keinem Hause drunten in Weimar mochte des jungen Herzogs Freund so gefeiert werden wie im Häuschen am Horn.
     </p>
-    <p xml:id="eco_de_0000144_2180">
+    <p xml:id="eco_de_0000214_2180">
      Der heilige Augustinus sagt: »Verlangt dich nach der Erde, wirst du zu Erde. Verlangt dich nach Gott – was sage ich – so bist du Gott.«
     </p>
-    <p xml:id="eco_de_0000144_2190">
+    <p xml:id="eco_de_0000214_2190">
      Verlangt dich nach Goethe, wirst du zwar nicht Goethe; aber du könntest es bis zu dessen Abschreiber bringen. So erging es Uerle. Ein Februarabend fand ihn über ein goethisches Manuskript gebeugt. Seine Ohren brannten, seine Seele war ungeheuer zusammengefaßt. Der Dichter konnte nicht weltentrückter geschaffen haben, als Uerle abschrieb. Ja, er hatte den Mut gehabt, Herrn Goethe seine Dienste anzutragen, und war für gut befunden worden zu einer Abschrift.
     </p>
-    <p xml:id="eco_de_0000144_2200">
+    <p xml:id="eco_de_0000214_2200">
      Jetzt hörten fürs erste die Abende bei Pfarrers auf, denn Uerle schrieb nächtelang. Am Morgen aber, ehe er ins Geschäft ging, brachte er Alma das Manuskript, und sie mußte es in seinem Beisein in ihre Lade schließen und versprechen, den ganzen Tag das Haus nicht zu verlassen.
     </p>
-    <p xml:id="eco_de_0000144_2210">
+    <p xml:id="eco_de_0000214_2210">
      Der Sommer zog wieder herauf.
     </p>
-    <p xml:id="eco_de_0000144_2220">
+    <p xml:id="eco_de_0000214_2220">
      Die langen Tage, die kurzen Nächte, die heißen Stunden bewegten sein Herz.
     </p>
-    <p xml:id="eco_de_0000144_2230">
+    <p xml:id="eco_de_0000214_2230">
      Almas Schönheit strahlte, ihre Laune war so warm, so sonnig; was sie tat, tat sie mit großer Freudigkeit. Mit den warmen, großen Tagen erwachte sie zu ihrem Lebensfest.
     </p>
-    <p xml:id="eco_de_0000144_2240">
+    <p xml:id="eco_de_0000214_2240">
      Unter ihren Sommerblumen im Garten mußte man sie sehen, um ihr Wesen ganz zu fassen. Da lag über der jungen Person eine Seligkeit gebreitet, wie sie eines Menschen Wesen nur im Augenblick höchsten Glückes durchleuchtet. Vielleicht einmal im Leben, wenn die schweren, körperlichen Stoffe von Lebenswonne ganz durchdrungen sind.
     </p>
-    <p xml:id="eco_de_0000144_2250">
+    <p xml:id="eco_de_0000214_2250">
      Wer aber die Erinnerung in sich trägt, als Rosenstrauch einst geblüht zu haben, dem ist die heilige Sommersonne Glücks genug, um ganz in Freude aufgelöst zu werden.
     </p>
-    <p xml:id="eco_de_0000144_2260">
+    <p xml:id="eco_de_0000214_2260">
      Die Pfarrersmädchen saßen an einem stillen Abend mit der Mutter im Wohnzimmer und sangen, während Alma sie am Spinett begleitete. Die Linden tropften in voller Blütenpracht, und ihr Duft hatte wie jedes Jahr die Bienenvölker angelockt. Die Bäume dröhnten vom Bienensummen und Brausen wie zwei Orgeln, und das Häuschen schien die süßen, starken Klänge der vier Frauenstimmen in seinen Mauern nicht fassen zu können. Es strömte über. Ein leichter, warmer Regen fiel.
     </p>
-    <p xml:id="eco_de_0000144_2270">
+    <p xml:id="eco_de_0000214_2270">
      Drei junge Männer, die ein Spaziergang heraufgeführt haben mochte, standen und lauschten. Mitten in wogenden, blühenden Kornfeldern ein singendes Haus und musizierende Linden davor, das war eine gar wunderlich liebliche Sache.
     </p>
-    <p xml:id="eco_de_0000144_2280">
+    <p xml:id="eco_de_0000214_2280">
      Der Gesang verstummte. Da ging einer von den Dreien dem Hause zu und bedeutete die beiden anderen, sie möchten ein wenig zurückbleiben. Er öffnete die niedere Gartentür in der Taxushecke, trat unter die Linden und fand sich einem dunkeläugigen Mädchen gegenüber, das soeben aus der Haustür trat und erstaunt aufsah.
     </p>
-    <p xml:id="eco_de_0000144_2290">
+    <p xml:id="eco_de_0000214_2290">
      Der Fremde grüßte artig und sagte: »Wir suchen einen gewissen Uerle, der hier auf dem Horn wohnt; könnte die Jungfer uns Auskunft geben?«
     </p>
-    <p xml:id="eco_de_0000144_2300">
+    <p xml:id="eco_de_0000214_2300">
      »Du mein Gott,« antwortete das Mädchen bewegt, »den Uerle? Ja, der Uerle wohnt hier oben – aber – er ist nicht da.« Sie sprach erregt. »O, vielleicht kommen Sie wegen der Abschrift?«
     </p>
-    <p xml:id="eco_de_0000144_2310">
+    <p xml:id="eco_de_0000214_2310">
      »Ja, deshalb komme ich freilich.« Das Mädchen war ganz verwirrt; eine tiefe Glut floß über ihr Gesicht. Sie schaute den Fremden wie hilflos an und schaute in zwei Augensonnen hinein, in denen, wie in den ihren, die große Weltfreude strahlte, die Wonne am Sein, der Sommerfriede. Sie blickten einander an, und in jedem Gesicht war ein Ausdruck von Betroffenheit. Beide vergaßen einen Augenblick, zu fragen und zu antworten.
     </p>
-    <p xml:id="eco_de_0000144_2320">
+    <p xml:id="eco_de_0000214_2320">
      »Nein, er ist nicht hier, der Uerle. Er ist noch unten im Geschäft. Das Schriftstück aber, das habe ich in meiner Truhe.«
     </p>
-    <p xml:id="eco_de_0000144_2330">
+    <p xml:id="eco_de_0000214_2330">
      »Da ist es ja prächtig aufgehoben!« rief der vornehme, schöne Mensch, froh auflachend.
     </p>
-    <p xml:id="eco_de_0000144_2340">
+    <p xml:id="eco_de_0000214_2340">
      »Wollen Sie bei uns eintreten?« fragte das Mädchen nach einer Pause bewegt.
     </p>
-    <p xml:id="eco_de_0000144_2350">
+    <p xml:id="eco_de_0000214_2350">
      »Wenn Sie erlauben, da möcht' ich aber auch für meine Freunde bitten. Der Regen wird stärker.« Er winkte den beiden anderen, zu kommen.
     </p>
-    <p xml:id="eco_de_0000144_2360">
+    <p xml:id="eco_de_0000214_2360">
      Alma führte klopfenden Herzens die Fremden ins Haus. Sie schritt ihnen voraus in das Wohnzimmer, ging auf ihre Mutter zu, die sich erhoben hatte, legte den Arm um deren Schulter, neigte den Kopf an deren Wange, deutete leicht auf die Eintretenden und sagte, unbeschreiblich in ihrer Bewegung: »Mutter, der Herr Goethe kommt zu uns!« Es war ein so tiefer Herzenston und die Art, wie sie es sagte, so ungewöhnlich, so rührend schön, daß alle erstaunt aufblickten, Schwestern und Mutter, und die Fremden traten, wie geweiht durch das Gebaren des schönen Geschöpfes, ein und wurden freundlich bewillkommt.
     </p>
-    <p xml:id="eco_de_0000144_2370">
+    <p xml:id="eco_de_0000214_2370">
      Die Frau Pfarrerin reichte dem jungen, berühmten Mann die Hand und sagte auf ihre einfache, würdige Weise: »Wir haben gar schöne Stunden durch Ihre Werke genossen. Unser Freund Uerle wurde nicht müde, uns vorzulesen und zu erzählen.«
     </p>
-    <p xml:id="eco_de_0000144_2380">
+    <p xml:id="eco_de_0000214_2380">
      Die Begleiter waren zwei junge Stollbergs, die nicht Worte genug fanden, ihr Erstaunen auszudrücken über das liebliche Wunder des Häuschens unter den brausenden, blühenden Bäumen. Der Regen strömte jetzt stärker und hielt die Bienen in ihrem weiten, duftenden Gefängnis. Die Erregung der unendlich vielen kleinen Seelen brauste ganz gewaltig auf. »Ja, wenn es regnet,« fügte die Pfarrerin, »sind sie ganz des Kuckucks da draußen.«
     </p>
-    <p xml:id="eco_de_0000144_2390">
+    <p xml:id="eco_de_0000214_2390">
      »Aber hier, Frau Pfarrerin, das läßt man sich nicht träumen,« sagte der jüngste Stollberg, »in dieser Einöde solch ein behaglicher Winkel.«
     </p>
-    <p xml:id="eco_de_0000144_2400">
+    <p xml:id="eco_de_0000214_2400">
      Sie betrachteten den Schrank und das Himmelbett der Pfarrerin. Auf elfenbeinweißem Grund hatte ein kühner Maler dunkelgrüne, breite, geschwungene Linien gezogen, die wie Laubwerk den Grund fast verdeckten, dazwischen Dornenkronen, durchstochene rote Herzen und brennende Herzen und als Bekrönung von Schrank und Bett rote Herzen in Strahlenglorien.
     </p>
-    <p xml:id="eco_de_0000144_2410">
+    <p xml:id="eco_de_0000214_2410">
      »Sieh, Wolfgang, was ich gefunden hab', sieh, nur am Fußende des Bettes, die beiden Herzen! Siehst du, in jedem Herz ist eine schwarze Drei gemalt. Treu! Verstehst du? Ist das nicht entzückend?« rief wieder der jüngste Stollberg lebhaft. Frau Pfarrerin, wo haben Sie diese Märchenstücke her? Man sollte glauben, in ein verzaubertes Haus geraten zu sein.«
     </p>
-    <p xml:id="eco_de_0000144_2420">
+    <p xml:id="eco_de_0000214_2420">
      Alma trat mit dem Manuskript ein und gab es dem jungen Goethe in die Hand, der hielt es, ohne darauf zu achten, und blickte auf das Mädchen, das in seiner Seelenbewegtheit von größter Schönheit war.
     </p>
-    <p xml:id="eco_de_0000144_2430">
+    <p xml:id="eco_de_0000214_2430">
      Die Pfarrerin erzählte, daß ein durchreisender katholischer Schreiner und Maler in ihrer Eltern Haus zur Aussteuer für sie diesen Schrank und das Bett gefertigt hätte. Sie sagte: »Ich entsinne mich des noch sehr genau, es gab Streit zwischen meinen Eltern und dem reisenden Meister. – Sie fanden die Sachen zu katholisch für ein protestantisches Pfarrhaus und wollten die Herzen und die Dornenkronen forthaben. Der wunderliche Mann aber sagte: »Trägt bei euch unser Heiland keine Dornenkrone, und hat man bei euch keine Herzen, die durchstochen sind, und keine, die brennen, so sollt ihr mir leid tun, und ich male euch was anderes hin.«
     </p>
-    <p xml:id="eco_de_0000144_2440">
+    <p xml:id="eco_de_0000214_2440">
      »Da sagte meine Mutter: ›Laßt sie nur darauf, Herr Meister, Dornenkronen und zerstochene Herzen gibt's wohl allerorten. Es ist gut, das immer vor Augen zu haben.««
     </p>
-    <p xml:id="eco_de_0000144_2450">
+    <p xml:id="eco_de_0000214_2450">
      »Frau Pfarrerin,«,« meinte Stollberg, »Ihre Frau Mutter war eine echte Protestantin, aber die brennenden Herzen hat sie ganz vergessen.«
     </p>
-    <p xml:id="eco_de_0000144_2460">
+    <p xml:id="eco_de_0000214_2460">
      »Das mag sein,« meinte die Pfarrerin, »sie war eine hart geplagte Frau, meine gute Mutter, ihr standen die Dornenkränze wohl am nächsten.«
     </p>
-    <p xml:id="eco_de_0000144_2470">
+    <p xml:id="eco_de_0000214_2470">
      Mächtig strömte der Regen jetzt über die Sommerlandschaft hin, durch die offenen Fenster drang Korn- und Erdgeruch herein.
     </p>
-    <p xml:id="eco_de_0000144_2480">
+    <p xml:id="eco_de_0000214_2480">
      »Nun müssen die Herren schon noch ein bißchen mit uns fürlieb nehmen,« meinte die Pfarrerin.
     </p>
-    <p xml:id="eco_de_0000144_2490">
+    <p xml:id="eco_de_0000214_2490">
      Der junge Goethe bat, das Lied noch einmal zu singen, das sie im Vorübergehen gehört hatten.
     </p>
-    <p xml:id="eco_de_0000144_2500">
+    <p xml:id="eco_de_0000214_2500">
      »Ja, tut das, ihr Kinder,« sagte die Pfarrerin, und ohne daß sie sich zierten ober bitten ließen, öffneten sie das Spinett, Alma spielte, und sie sangen:
     </p>
-    <p xml:id="eco_de_0000144_2510">
+    <p xml:id="eco_de_0000214_2510">
      »Geh aus, mein Herz, und suche Freud' In dieser schönen Sommerszeit An deines Gottes Gaben; Schau an der schönen Gärten Zier Und siehe, wie sie dir und mir Sich ausgeschmücket haben.
     </p>
-    <p xml:id="eco_de_0000144_2520">
+    <p xml:id="eco_de_0000214_2520">
      Die Bäume stehen voller Laub, Das Erdreich decket seinen Staub Mit einem grünen Kleide. Narcissus und die Tulipan, Die ziehen sich viel schöner an Als Salomonis Seide.«
     </p>
-    <p xml:id="eco_de_0000144_2530">
+    <p xml:id="eco_de_0000214_2530">
      Das fromme, lebensheiße, schöne Lied zog in seiner Schönheit in aller Herzen ein und stimmte sie festlich und feierlich.
     </p>
-    <p xml:id="eco_de_0000144_2540">
+    <p xml:id="eco_de_0000214_2540">
      Während des Gesanges trat, vom Regen ganz besprengt, Uerle ein, sachte, wie er es zu tun gewohnt war. Er blieb aber auf der Schwelle, unfähig sich zu regen, stehen; eine tiefe Glut stieg in seinem Gesicht auf und setzte sich an den Ohren fest, die wie Mohnblumen zu brennen begannen. Ja, er stand und stand und schaute und wagte nicht vor- und nicht rückwärts zu gehen. Der junge Goethe erbarmte sich seiner Not, stand auf, gab ihm die Hand und wies ihm den Platz neben sich auf der Ofenbank an. Da saß nun der gute Uerle mit einem völlig ratlosen Gesicht.
     </p>
-    <p xml:id="eco_de_0000144_2550">
+    <p xml:id="eco_de_0000214_2550">
      Als die Mädchen geendet hatten, sagte der junge Goethe zur Pfarrerin: »Haben Sie etwas dagegen, verehrte Frau, wenn wir hier im singenden Hause noch ein wenig bleiben, trotzdem der Regen nachgelassen hat? Es ist eine so schöne Stunde jetzt.«
     </p>
-    <p xml:id="eco_de_0000144_2560">
+    <p xml:id="eco_de_0000214_2560">
      Die Frau Pfarrerin gab lächelnd ihre Zustimmung und sagte: »Fremdes Brot ist den Kindern Kuchen. Bleiben Sie, wenn es Ihnen gefällt, uns ist es eine Freude.«
     </p>
-    <p xml:id="eco_de_0000144_2570">
+    <p xml:id="eco_de_0000214_2570">
      Das wurde nun ein wunderschöner Abend. Draußen war die Luft angefrischt, das unverhoffte Begebnis, so vornehm liebenswürdige Menschen bei sich zu sehen, die sich zwanglos natürlich betrugen, stimmte alle lebendig und froh. Unter den Linden deckten die junge Witwe und Alma den Tisch. Uerle saß unter den anderen im Zimmer, hatte das Bübchen, gewissermaßen seiner Verlegenheit zum Schutze, auf den Schoß genommen und gab sich still und bescheiden mit ihm ab. Alma trug eine Schüssel voll Erdbeeren, die sie am Morgen im Garten gepflückt hatte, frische Milch, Brot und Butter zum Abendessen auf, und die Pfarrerin lud ihre Gäste freundlich und mit einer angenehmen Würde ein, mit ihnen zu speisen. Sie ließen sich nicht lange bitten, und bald saßen, alle harmlos beieinander unter den brausenden Bäumen, und es war, als wäre man längst schon bekannt miteinander gewesen. Die Mädchen und das junge Frauchen tauten aus einer etwas ehrfürchtigen Stimmung auf und genossen das außerordentliche Ereignis. Alma war still und bediente die Gäste.
     </p>
-    <p xml:id="eco_de_0000144_2580">
+    <p xml:id="eco_de_0000214_2580">
      »Nun sich,« sagte die Pfarrerin, »es ist noch nicht gar so lang' her, da sagtest du: Nichts Absonderliches geschieht, ein Tag geht wie der andere – und nun ist doch etwas geschehen. Ist dir's nun so recht?«
     </p>
-    <p xml:id="eco_de_0000144_2590">
+    <p xml:id="eco_de_0000214_2590">
      Sie antwortete nicht und blickte ihre Mutter still an.
     </p>
-    <p xml:id="eco_de_0000144_2600">
+    <p xml:id="eco_de_0000214_2600">
      Die beiden Stollbergs waren vergnügt und ausgelassen. »So ein mondstrahlenzartes Frauchen mit seinem Bübchen auf dem Schoß«, sagte der jüngste Stollberg, »ist doch ein wundersüßes Bild – schade, daß wir keine Maler sind. Ich wüßte gar nicht, wo wir hier beginnen sollten. Ich glaube, wir sind in ein Märchen geraten, und das Haus ist wie ein Pilz aus der Erde mit all seinen Bewohnern aufgeschossen.«
     </p>
-    <p xml:id="eco_de_0000144_2610">
+    <p xml:id="eco_de_0000214_2610">
      Als man sich vom Tisch wieder erhob, bat der junge Goethe Alma: »Nun zeigen Sie mir auch noch Ihren Garten, in dem die guten Beeren gewachsen sind.«
     </p>
-    <p xml:id="eco_de_0000144_2620">
+    <p xml:id="eco_de_0000214_2620">
      Sie führte ihn durch das Haus, hinter welchem der Garten lag, und die anderen kamen nach. So wandelten sie Mischen den regenfrischen Beeten hin und her, an den Gemüsen und Blumen vorüber.
     </p>
-    <p xml:id="eco_de_0000144_2630">
+    <p xml:id="eco_de_0000214_2630">
      Das kleine Anwesen der Pfarrerin bekam Wert und Bedeutung. Der Blick vom Garten auf das Ilmtal und das alte Städtchen konnte nicht genug gerühmt werden.
     </p>
-    <p xml:id="eco_de_0000144_2640">
+    <p xml:id="eco_de_0000214_2640">
      »Man sollte meinen, daß wir einen ganz raren Schatz besäßen,« sagte die Pfarrerin, »wenn die Städter von unten einmal heraufkommen. Der Garten will aber bestellt sein, wenn er etwas tragen soll, und wir Frauenzimmer haben oft unsere liebe Not damit.«
     </p>
-    <p xml:id="eco_de_0000144_2650">
+    <p xml:id="eco_de_0000214_2650">
      Alma sagte zu ihrem Begleiter: »Das ist der Mutter nicht erst. Nicht um die Welt würde sie tauschen. Die Arbeit ist auch so gut eingeteilt; für das Gröbste kommt ein Bauer aus Süßenborn, und mit dem übrigen werden wir gut fertig.«
     </p>
-    <p xml:id="eco_de_0000144_2660">
+    <p xml:id="eco_de_0000214_2660">
      »Die Menschen lieben es, sich ihres Glückes nicht bewußt zu werden, Jungfer Alma, und es ist ihnen nicht zu verdenken.« »So groß wird Ihnen das Glück hier oben nicht erscheinen,« meinte Alma ruhig.
     </p>
-    <p xml:id="eco_de_0000144_2670">
+    <p xml:id="eco_de_0000214_2670">
      »Doch, wenn ich diese wundervollen Sommerblumen hier sehe und denke, wie die Linden vor dem Hause blühen und von Bienenschwärmen brausen, so ist das ein Stück Paradies, um das ein König Sie beneiden könnte, denn ich weiß wohl, solche Blumenbüsche und solche Zentifolien wollen in Muße gedeihen, die kann keine plötzliche Laune sich herstellen, die brauchen viele Winter und Sommer und viele Mühe und Sorge.«
     </p>
-    <p xml:id="eco_de_0000144_2680">
+    <p xml:id="eco_de_0000214_2680">
      »Ja,« sagte Alma, »es sind alte Stöcke. Wenn man hinter diesen Rittersporn tritt, ist man verborgen in den blauen Aehren.«
     </p>
-    <p xml:id="eco_de_0000144_2690">
+    <p xml:id="eco_de_0000214_2690">
      Sie blickte ihn eine Weile stumm an. »Darf ich Ihnen von den Blumen geben?«
     </p>
-    <p xml:id="eco_de_0000144_2700">
+    <p xml:id="eco_de_0000214_2700">
      »Gewiß, liebe Jungfer.«
     </p>
-    <p xml:id="eco_de_0000144_2710">
+    <p xml:id="eco_de_0000214_2710">
      »Aber«, sagte sie, »sie sind alle gar so voll und mächtig; wollen Sie mit solchem Blütenbusch nach Hause gehen?«
     </p>
-    <p xml:id="eco_de_0000144_2720">
+    <p xml:id="eco_de_0000214_2720">
      »Ja, glauben Sie, ich wäre nicht imstande, Sommerfreude zu tragen?« Er lachte frisch auf.
     </p>
-    <p xml:id="eco_de_0000144_2730">
+    <p xml:id="eco_de_0000214_2730">
      Sie nahm ein kleines Messer aus der Tasche, klappte es auf und schnitt vom Rittersporn eine Aehre. Die Tropfen standen wie Diamanten darauf. Sie hielt die Blüte vor sich hin und meinte: »Ist das nicht ein königliches Geschenk? Wenn wir die Blume nicht so gewöhnt wären und es die einzige ihrer Art wäre, dann könnte man sie einem großen Dichter ohne Scheu geben.«
     </p>
-    <p xml:id="eco_de_0000144_2740">
+    <p xml:id="eco_de_0000214_2740">
      »So ist es,« rief er bewegt. »Ein Dichter sieht die Dinge ungewohnt, immer neu, immer zum erstenmal. Das ist die große Wonne und die tiefe Pein.«
     </p>
-    <p xml:id="eco_de_0000144_2750">
+    <p xml:id="eco_de_0000214_2750">
      Eben kam Ulrikchen vorüber in Begleitung des älteren Stollberg, blieb stehen und sagte auf ihre schnippische, mutwillige Art: »Da ist sie wieder zwischen ihren Blumen! Wissen Sie, Herr Goethe, daß meine Schwester Alma, ehe sie Pfarrers Alma wurde, ein blühender Rosenstrauch gewesen ist? Das glaubt sie nämlich.«
     </p>
-    <p xml:id="eco_de_0000144_2760">
+    <p xml:id="eco_de_0000214_2760">
      Alma erglühte tief, und des jungen Mannes Blicke umfingen sie wie betroffen. Sie war nicht verlegen über den Scherz ihrer Schwester. Sanft nachdenklich stand sie, als zöge mancherlei an ihrer Seele vorüber. »Das versteht meine Schwester nicht,« sagte sie, »weil sie die Blumen, die Sonne und den warmen Wind nicht so lieb hat wie ich. – Ich liebe das alles!« Sie blickte mit Innigkeit über ihr kleines Reich. »Wer so vom Frühjahr an das Knospen und dann endlich das Blühen sieht und viele, viele stille Stunden dabei verbringt – –«
     </p>
-    <p xml:id="eco_de_0000144_2770">
+    <p xml:id="eco_de_0000214_2770">
      »O, ich verstehe,« sagte er, »der wird eins mit diesen lieben Dingen – der gehört zu ihnen.«
     </p>
-    <p xml:id="eco_de_0000144_2780">
+    <p xml:id="eco_de_0000214_2780">
      »Ja,« sagte sie auf ihre lebendige Art, »der gehört zu ihnen.«
     </p>
-    <p xml:id="eco_de_0000144_2790">
+    <p xml:id="eco_de_0000214_2790">
      Sie schnitt von den Rosen lange, schlanke Zweige mit der süßen, nickenden, schweren Blume am zarten Ende.
     </p>
-    <p xml:id="eco_de_0000144_2800">
+    <p xml:id="eco_de_0000214_2800">
      »Wir auf dem einsamen Horn kennen Ihre tiefsten Gedanken, Ihr Leiden und Ihr ganzes Herz – – Ist das ein Glück oder etwas Schreckliches, daß jeder Mensch, wer es auch sei, Sie so kennen darf? Uns hier konnten Sie Ihr Geheimnis ruhig geben. Wir halten es heilig.«
     </p>
-    <p xml:id="eco_de_0000144_2810">
+    <p xml:id="eco_de_0000214_2810">
      Erstaunt schaute er auf sie. – »Da habe ich auf dem einsamen Horn, im kleinen Haus eine Heimat, ohne es zu ahnen. – Und die Menschen im kleinen Haus hüten mein Geheimnis so still und verschwiegen. – Wie ist das wundervoll einzig!«
     </p>
-    <p xml:id="eco_de_0000144_2820">
+    <p xml:id="eco_de_0000214_2820">
      In ihren Augen standen Tränen. »Ich verstehe es nicht, wie es geschehen konnte, daß Sie hier zu uns kommen!«
     </p>
-    <p xml:id="eco_de_0000144_2830">
+    <p xml:id="eco_de_0000214_2830">
      »Das mußte so sein,« antwortete er bewegt. »Wie konnte ich denn an meiner stillen Heimat vorübergehen? Welcher Mensch könnte das? Wir leben ja nicht nur in unserem kleinen Bewußtsein. Wir leben über uns selbst hinaus.«
     </p>
-    <p xml:id="eco_de_0000144_2840">
+    <p xml:id="eco_de_0000214_2840">
      Sie schnitt einen ganzen Arm voll Zentifolienrosen, die keine Rose auf Erden an Schönheit, Zartheit und Farbe erreicht. Und sie tat es mit einer Hingabe einer Versunkenheit, daß er nicht wagte, sie zu stören. In ihrer Haltung, in ihrem Blick stand deutlich, daß sie ein seliges Opfer brachte.
     </p>
-    <p xml:id="eco_de_0000144_2850">
+    <p xml:id="eco_de_0000214_2850">
      »Wenn es zu viel ist, tragen Sie die Rosen, bis Sie unten an der Ilm vorüberkommen. Da können Sie davon hineinwerfen oder alle – aber nicht früher! Nehmen Sie sie so in den Arm. – Sehen Sie – so, dann macht es nicht müde.«
     </p>
-    <p xml:id="eco_de_0000144_2860">
+    <p xml:id="eco_de_0000214_2860">
      »Und so am Herzen«, meinte er, »solch einen Busch Zentifolien heimtragen, ist auch ein größeres Glück, als es uns stumpfen Menschen erscheint.« Seine Blicke hielten ihre Gestalt, zärtlich hingenommen, umfangen.
     </p>
-    <p xml:id="eco_de_0000144_2870">
+    <p xml:id="eco_de_0000214_2870">
      Als die drei unverhofften Gäste gegangen waren, ließen sie die stillen Bewohner des einsamen Hauses am Horn in großer Bewegung zurück.
     </p>
-    <p xml:id="eco_de_0000144_2880">
+    <p xml:id="eco_de_0000214_2880">
      Uerle sagte: »So ist's, wenn ein Göttlicher bei armen Sterblichen eingekehrt ist! – Aber sein Manuskript hat er doch richtig vergessen.«
     </p>
-    <p xml:id="eco_de_0000144_2890">
+    <p xml:id="eco_de_0000214_2890">
      »Na, natürlich, wenn ihn die Alma so beladen hat, wie sollte er denn noch etwas schleppen?« meinte Ulrikchen.
     </p>
-    <p xml:id="eco_de_0000144_2900">
+    <p xml:id="eco_de_0000214_2900">
      Die junge Witwe lobte über alles den jüngsten Stollberg.
     </p>
-    <p xml:id="eco_de_0000144_2910">
+    <p xml:id="eco_de_0000214_2910">
      Ulrikchen aber sagte ärgerlich: »Macht ihr ein Aufhebens, weil sie ›von« sind und weil der eine Gott weiß was ist! Ich sag' ein für allemal: der junge Bauch, den ich neulich in Süßenborn kennen lernte, und wenn er zehnmal Bauch heißt und zehnmal Metzger ist, gefällt mir besser als alle drei miteinander. – Und ich sage: die reichen ihm das Wasser nicht, so verständig und brav wie er ist.«
     </p>
-    <p xml:id="eco_de_0000144_2920">
+    <p xml:id="eco_de_0000214_2920">
      Die Pfarrerin mußte lächeln. – Sie kannte Ulrikens Vorliebe und hatte sich schon halbwegs damit ausgesöhnt, ihr tüchtiges Töchterchen einmal als Wirtsfrau zu sehen. Der junge Bauch ging mit dem Gedanken um, sich ein Wirtsanwesen zu kaufen, und eine arme Witwe muß froh sein, ihr Kind an ein so nahrhaftes Gewerbe zu verlieren.
     </p>
-    <p xml:id="eco_de_0000144_2930">
+    <p xml:id="eco_de_0000214_2930">
      Alma war die einzige, die sich ganz still verhielt. Ihre Augen leuchteten aber aus dem zarten Gesicht heraus, daß Uerle den Blick nicht von ihr wenden konnte.
     </p>
-    <p xml:id="eco_de_0000144_2940">
+    <p xml:id="eco_de_0000214_2940">
      Die Pfarrerin machte schließlich allem Geplauder ein Ende. Sie wollte sich niederlegen und unter den Dornenkronen und den brennenden und durchstochenen Herzen schlafen. Die Läden wurden geschlossen, Uerle verabschiedete sich, die Mädchen suchten ihre Kammern auf, Alma aber ging, als alles in Ruhe lag, hinaus unter die Linden. Es hielt sie im Hause nicht, die sanfte Mondnacht lockte, das Herz war ihr so bewegt. – Sie brauchte wohl die Stille der ganzen nächtlichen Welt, um ihr Gemüt zu beruhigen und zu heilen.
     </p>
-    <p xml:id="eco_de_0000144_2950">
+    <p xml:id="eco_de_0000214_2950">
      So saß sie lange, die Hände gefaltet, und schaute in die Ferne. Auf den blühenden Feldern schimmerte der Mond. Der Kornblütenduft lag wie ein schwerer, warmer Atem in der Luft. Himmel und Erde schimmerten ineinander. – Ein leichter Schritt tauchte aus dem Unbestimmbaren auf. Sie erschauerte. – Es war so spät – so spät. – Sie duckte sich zusammen, als sollte etwas über sie hereinbrechen. Da sah sie eine Gestalt, die ihr wie mit Feuer in die Seele geprägt war, das kleine Gittertürchen öffnen. – Sie wurde nicht bemerkt, sah ihn stehen und schauen. Er blickte in die weite, monddurchschimmerte Ferne, so wie sie vordem. – Ihr Herz schlug zum Zerspringen. Sie preßte die Hände darauf.
     </p>
-    <p xml:id="eco_de_0000144_2960">
+    <p xml:id="eco_de_0000214_2960">
      Welche Stille war hier oben! – In dieser Stille ein junges, menschliches Herz, das aus seiner sanften Sommersehnsucht, aus seinem Zustand des Knospens und zarten Blühens von einer brennenden Flamme ergriffen worden war, die aus dem Leben herausschlug und vom Leben zehrte. Sie fühlte das Flammen ihrer armen Seele mit einer Bangigkeit sondergleichen.
     </p>
-    <p xml:id="eco_de_0000144_2970">
+    <p xml:id="eco_de_0000214_2970">
      Und als er sie bemerkte und auf sie zukam, war sie wie von tödlichem Schreck hingenommen. Schreck oder Wonne, es war nicht auseinander zu kennen.
     </p>
-    <p xml:id="eco_de_0000144_2980">
+    <p xml:id="eco_de_0000214_2980">
      »Und ich habe Sie erschreckt,« sagte er bewegt. »Mich hielt es da unten nicht mehr, ich mußte in der hellen Nacht das liebliche Haus und die große Weite darum her sehen. Und an Sie, liebes Geschöpf, wollt' ich denken.«
     </p>
-    <p xml:id="eco_de_0000144_2990">
+    <p xml:id="eco_de_0000214_2990">
      Sie fand kein Wort zu erwidern, sank an den Stamm der Linde zurück und blickte ihn mit großen Augen an.
     </p>
-    <p xml:id="eco_de_0000144_3000">
+    <p xml:id="eco_de_0000214_3000">
      Bewegt von ihrer Hilflosigkeit, strich er ihr zart über die Stirne. »Daß so einer so ein stilles, stilles Heimatshaus hat und weiß nichts davon,« sagte er wie für sich hin. – »Ach, mir ist wohl! – Die Rosen stehen vor meinem Bette in einem Krug mit Wasser und duften. – Der Mond schien herein. – Es war heut' alles so schön und sommerlich. Eure jungen Stimmen hier im Haus, das Lied, der Gartenfrieden und die tiefen Lebensaugen!«
     </p>
-    <p xml:id="eco_de_0000144_3010">
+    <p xml:id="eco_de_0000214_3010">
      Sie erschauderte, erhob sich – preßte in einer Bewegung von Ratlosigkeit die Hand aufs Herz. »Bedrängt Sie meine Nähe?« fragte er. »Bedrängen? – Ist es Freude – – oder Pein, ich weiß nicht – ich weiß nicht!« Sie verstummte. »So viele Menschen lieben Sie – Fürsten und schöne Frauen – und alle bewundern Sie – und Sie können denken und sagen, was kein anderer Mensch denken und sagen kann. Das alles legt sich mir wie eine schwere Last auf.«
     </p>
-    <p xml:id="eco_de_0000144_3020">
+    <p xml:id="eco_de_0000214_3020">
      »Nein! – Sie sollen sich freuen, wie ich mich freue!« rief er, »daß der Regen mich heut in Ihr Haus führte. Alles andere ist gleichgültig.«
     </p>
-    <p xml:id="eco_de_0000144_3030">
+    <p xml:id="eco_de_0000214_3030">
      »Ja,« flüsterte sie hastig, »ich danke Gott dafür.«
     </p>
-    <p xml:id="eco_de_0000144_3040">
+    <p xml:id="eco_de_0000214_3040">
      »Nun also, so ist alles gut!« In großer Bewegung gab er ihr die Hand.
     </p>
-    <p xml:id="eco_de_0000144_3050">
+    <p xml:id="eco_de_0000214_3050">
      »Welch eine Nacht! Schlafe wohl und auf Wiedersehen!«
     </p>
-    <p xml:id="eco_de_0000144_3060">
+    <p xml:id="eco_de_0000214_3060">
      Sie sah seine schlanke Gestalt wieder durchs niedere Pförtchen gehen, und eilige Schritte verklangen. Und diese Schritte waren wie ein Rhythmus zu seinem ganzen Wesen. Es lag eine große Kraft in diesem Schritteklang, leicht und unbezwinglich, fest und freudig.
     </p>
-    <p xml:id="eco_de_0000144_3070">
+    <p xml:id="eco_de_0000214_3070">
      Der Regen hatte ihr ein großes Schicksal ins Haus gebracht.
     </p>
-    <p xml:id="eco_de_0000144_3080">
+    <p xml:id="eco_de_0000214_3080">
      Das weltfremde Haus unter den brausenden Bäumen nahm am folgenden Abend seine Gäste wieder auf. Sie kamen spät nach der Nachtessenszeit, um der Pfarrerin keine Ungelegenheit zu machen. Man saß miteinander unter den Linden.
     </p>
-    <p xml:id="eco_de_0000144_3090">
+    <p xml:id="eco_de_0000214_3090">
      Die Pfarrerin sah besorgt auf ihr Kind, das war wie in Sonne getaucht, da war kein Verbergen möglich. Es blühte und strahlte.
     </p>
-    <p xml:id="eco_de_0000144_3100">
+    <p xml:id="eco_de_0000214_3100">
      Die Mutter dachte in Herzenseinfalt, was sie wohl tun könnte, und wie zu helfen wäre, und das machte sie gar still und schweigsam. Auch Uerle war es schwer zumute, und er sah seine geliebte Sommerseele von sich hinwegblühen, einer großen, verbrennenden Sonne zu. Der arme Uerle war ganz verwirrt und gedachte eines Ausspruches aus seinem geliebtesten Werke: Mußte denn das so sein, daß das, was der Menschen Glückseligkeit macht, wieder die Quelle ihres Elends würde?"
     </p>
-    <p xml:id="eco_de_0000144_3110">
+    <p xml:id="eco_de_0000214_3110">
      Er schaute gar Eigenes an diesem Abend – der eine liebte sommerlich seine, Uerles, Sommerliebe, und der andere war der Frühlingsliebe gar gewogen, und sie ihm. Den jüngsten Stollberg sah er mit der kleinen Witwe unter der Linde sitzen, und ihr Bübchen küßte gar liebreizend bald des schönen Jünglings Lippen und trug lebendige Schauer von einem zum andern.– Frühlingsschauer! O, Uerle kennt seine Frühlingsliebe, die verbrannte sich und andere nicht, diese sanfte Seele! Aber auch sie genoß Seligkeit und trank sie von ihres Bübchens Lippen.
     </p>
-    <p xml:id="eco_de_0000144_3120">
+    <p xml:id="eco_de_0000214_3120">
      Sie hatten aber einen großen Dichter unter sich – der hieß Uerle. Keiner weiß von ihm, seine Bilder und Eingebungen, die ihm die schönheitsvollen Dinge dieser Welt erweckten, sind mit ihm in den tiefen Todesschlaf schlafen gegangen. Sie waren nur für ihn da, und er war vornehm genug, daß ihn dies nicht bedrückte.
     </p>
-    <p xml:id="eco_de_0000144_3130">
+    <p xml:id="eco_de_0000214_3130">
      Der stille, lange, schweigsame Mensch, wer dem an diesem Abend ins Herz hätte sehen können!
     </p>
-    <p xml:id="eco_de_0000144_3140">
+    <p xml:id="eco_de_0000214_3140">
      Es kam auf, daß die Pfarrerin eine gar gute Märchenerzählerin wäre. Die beiden Stollbergs bestürmten sie, zu erzählen, und wollten ein Märchen im Zimmer mit den Froschkönigmöbeln hören, so nannten sie der Pfarrerin seltsame Aussteuerstücke.
     </p>
-    <p xml:id="eco_de_0000144_3150">
+    <p xml:id="eco_de_0000214_3150">
      Sie war bedrückten Herzens, die Frau Pfarrerin, und es war ihr nicht darum zu tun, zu erzählen, denn sie sann hin und her, wie sie ihrem guten Kinde helfen und es bewahren könnte. Sie fürchtete nicht, daß ihr Kind sich verlieren würde, aber sie fürchtete den Kummer, den großen Liebeskummer, der hier folgen mußte. Schließlich aber mußte sie dem Drängen folgen, nahm Platz in ihrem Lehnstuhl und erzählte vom Machandelboom – und kam an die Stelle: »Da begrub ihr Mann sie unter dem Machandelboom, und er fing an sehr zu weinen eine Zeitlang, dann wurde das was sachter, und als er noch eine Weile geweint hatte, da hörte er auf – und noch eine Zeit, da nahm er sich wieder eine Frau.«
     </p>
-    <p xml:id="eco_de_0000144_3160">
+    <p xml:id="eco_de_0000214_3160">
      Darauf erzählte sie, wie der Frau das Bübchen der Verstorbenen allerwegen im Wege stand, wie sie die eigene Tochter so sehr liebte, daß der Anblick des Bübchens ihr immer wie ein Schwert durchs Herz ging. Und die Pfarrerin erzählte, wie die Mutter das Bübchen so gar schauerlich tötete und es kochte, und wohl zubereitet als ein fremdes Gericht es dem Vater vorsetzte – und wie der Vater es aß und es ihm so gar wohlschmeckte.
     </p>
-    <p xml:id="eco_de_0000144_3170">
+    <p xml:id="eco_de_0000214_3170">
      »Er aß und wurde sterbenstraurig davon, gönnte niemand einen Bissen.«
     </p>
-    <p xml:id="eco_de_0000144_3180">
+    <p xml:id="eco_de_0000214_3180">
      In solchen Worten lag eine Zärtlichkeit, Inbrunst und Todestraurigkeit, als wäre alle Traurigkeit und Zärtlichkeit der Welt in sie zusammengedrückt. – »Und das Schwesterlein Marleneken sammelt die Knöchlein, die der Vater unter den Tisch warf, in ein seidenes Tüchlein und trägt sie unter den Machandelboom und begräbt sie dort – und der Machandelboom bewegt sich und tut die Zweige so recht auseinander und wieder zu Hauf, und ein Nebel steigt vom Baum auf, der wie Feuer brennt, und aus dem Nebel fliegt ein schöner Vogel heraus, der singt so herrlich und fliegt hoch in die Luft, und das Tuch mit den Knochen ist weg. Marleneken aber ist es so recht leicht und vergnügt, als wenn der Bruder noch lebe.
     </p>
-    <p xml:id="eco_de_0000144_3190">
+    <p xml:id="eco_de_0000214_3190">
      Der Vogel aber fliegt weg und setzt sich dem Goldschmied aufs Haus und fängt an zu singen:
     </p>
-    <p xml:id="eco_de_0000144_3200">
+    <p xml:id="eco_de_0000214_3200">
      Meine Mutter, die mich schlacht, Mein Vater, der mich aß, Mein Schwester, das Marlenichen. Sucht alle meine Benichen, Bind't sie in ein seiden Tuch, Legt's unter den Machandelboom, Kywitt – kywitt, wat for'n schön Vogel bün ick.«
     </p>
-    <p xml:id="eco_de_0000144_3210">
+    <p xml:id="eco_de_0000214_3210">
      Das alte wundervolle Märchen, in dem alle Traurigkeit, Sünde, Zärtlichkeit, Wonne, Angst und Grauen der Welt liegen, schritt vorwärts.
     </p>
-    <p xml:id="eco_de_0000144_3220">
+    <p xml:id="eco_de_0000214_3220">
      Der Vogel fordert seine Geschenke zum Lohn für seinen herrlichen Gesang, die goldene Kette, die Schuhe und den Mühlstein.
     </p>
-    <p xml:id="eco_de_0000144_3230">
+    <p xml:id="eco_de_0000214_3230">
      Und welche Steigerung, welches Grauen! Jedes Wort haftet, nichts vergißt sich. Der Vogel ist der geliebte, heißersehnte Sohn der verstorbenen, vergessenen Frau, die im Grab noch liebt. Er ist der Gemordete, vom Vater Verzehrte, von Marleneken Geliebte. Alles ist in den einfachen Worten gegenwärtig. Und wie der Vater, Stiefmutter und Marleneken beim Mittagsmahle sitzen und der Vogel draußen auf dem Machandelboome zu singen beginnt und Marleneken in ihr Tüchlein weint und dem Vater so licht und froh wird, als sollte er einen alten Bekannten wiedersehen, und er sagt: »Die Sonne scheint so warm, und es riecht nach lauter Zimmet und Zinnemamen.«
     </p>
-    <p xml:id="eco_de_0000144_3240">
+    <p xml:id="eco_de_0000214_3240">
      Das ist eine Freude! Die hat das Volk sich gewürzt und mit Düften gedacht, und von der Sonne warm beschienen und nach Zinnemamen duftend.
     </p>
-    <p xml:id="eco_de_0000144_3250">
+    <p xml:id="eco_de_0000214_3250">
      Daneben das Grauen der Mutter: die Ohren, die Augen hält sie sich zu, als sie draußen den Vogel hört. Aber es braust ihr in den Ohren wie der allerstärkste Strom, und die Augen brennen ihr und zucken wie Blitze, und die Mütze fällt ihr vom Kopf, und die Haare stehen ihr zu Berg als Feuerflammen, und ihr ist, als bebte das Haus, als sollte die Welt untergehen. Sie will auch hinunter, ob ihr leichter werden soll. Die Pfarrerin erzählte das alte Märchen, wie es eben erzählt werden muß, wie von Vorzeiten her eine Mutter oder Ahne es ihren Kindern oder Enkeln erzählte an langen Winterabenden, wie es von Mund zu Mund gegangen ist, so wundervoll tief und stark.
     </p>
-    <p xml:id="eco_de_0000144_3260">
+    <p xml:id="eco_de_0000214_3260">
      Alle waren von dem Eindruck benommen, die beiden Stollbergs ganz hingerissen. Die Töchter schauten mit einer gewissen Ehrfurcht auf ihre Mutter und fühlten durch den Erfolg, den sie hatte, so recht deutlich, was sie ihnen war.
     </p>
-    <p xml:id="eco_de_0000144_3270">
+    <p xml:id="eco_de_0000214_3270">
      Die Stollbergs meinten, sie begriffen nicht, daß noch kein großer Tonkünstler diese wundervollen Kräfte und Mächte in Musik gesetzt hätte. Diese Freude, die nach Zimmet und Zinnemamen duftet, und von der hellen, warmen Sonne beschienen ist – und dazu die einsame Sündenqual der Mutter.
     </p>
-    <p xml:id="eco_de_0000144_3280">
+    <p xml:id="eco_de_0000214_3280">
      »Es ist ein Großes um diese alten Geschichten,« sagte der junge Goethe, »ihr geheimnisvolles Entstehen macht sie unendlich reizvoll, und das von Mund zu Mund ist ein lebendiger Gruß von längst vergessenen Menschen.«
     </p>
-    <p xml:id="eco_de_0000144_3290">
+    <p xml:id="eco_de_0000214_3290">
      »Nie hat die Mutter auch nur ein Wort verändern dürfen an ihren Geschichten, und sie hat's mit ihrer Mutter genau so gemacht wie wir.«
     </p>
-    <p xml:id="eco_de_0000144_3300">
+    <p xml:id="eco_de_0000214_3300">
      »So ist durch das eigensinnige Festhalten der Kinder«, meinte der verehrte Gast, »der alte kostbare Schatz auf uns gekommen und wird über uns hinweg von Mund zu Mund, von Generation zu Generation weiter wandern.« Alma sagte: »Das sind die Werke der Frauen, damit sie doch auch etwas getan haben und nicht ganz leer ausgehen.«
     </p>
-    <p xml:id="eco_de_0000144_3310">
+    <p xml:id="eco_de_0000214_3310">
      »Als wenn sie leer ausgingen!« rief er. »Sie sind da! – und alles ist voller Innigkeit und Poesie und sanfter Kraft. Wenn man um sich schaut, alles, was heimisch und lieb und vertraut ist, was das Leben wert macht, ist durch sie. – Wir sind an all das so gewöhnt, daß wir es kaum bewußt gewahr werden. – Wenn es fehlte, welche Oede, welche Kargheit! – In jeder Stadt müßte ein Denkmal »der Mutter« stehen, und kein Jahr dürfte vergehen, das nicht den Tag brächte, an dem das Bild festlich bekränzt würde, an dem nicht ein heiteres, inniges Fest vor diesem Bild gefeiert würde, ein Dank- und Freudenfest, an dem jeder seiner eigenen Mutter gedächte. – Solch ein Fest wäre notwendiger gewesen als das Fronleichnamsfest der frommen Nonne Roswitha.«
     </p>
-    <p xml:id="eco_de_0000144_3320">
+    <p xml:id="eco_de_0000214_3320">
      Die Pfarrerin schaute auf und sagte: »Das ist ein gar wunderlicher Gedanke, und wenn dem so wäre, wie Sie sagen, würde gar manche arme Mutter, die es sich ungelohnt und unerkannt, Tag und Nacht bitterlich sauer werden ließ, getröstet und aufgerichtet werden.«
     </p>
-    <p xml:id="eco_de_0000144_3330">
+    <p xml:id="eco_de_0000214_3330">
      »Ja,« sagte der lebhafte Gast der Pfarrerin in großer Wärme und Liebenswürdigkeit, »es ist eine rohe, barbarische Welt, in der ein jeder sich von seiner Mutter hat opferfreudig lieben, behüten, mit Güte überschütten lassen, und es ist nie zu einer großen Dankesäußerung der Menschheit gekommen.«
     </p>
-    <p xml:id="eco_de_0000144_3340">
+    <p xml:id="eco_de_0000214_3340">
      Es ist doch gewiß, daß in der Welt dem Menschen nichts notwendiger ist als die Liebe.
     </p>
-    <p xml:id="eco_de_0000144_3350">
+    <p xml:id="eco_de_0000214_3350">
      Herr Gott, wenn ich an meine eigene Mutter denke! Was mir blühte, blühte durch sie. – Sie feiern alles Erdenkliche, aber das Beste! Einzige! das lassen sie unbedankt – und diese Danklosigkeit, dies Totgeschwiegenwerden liegt auf den Frauen. Die Katholiken haben ihre Feier und ihren Dank der Gottesmutter gebracht. – Ach, hätten sie's ein wenig deutlicher gemacht! Und wir altklugen Protestanten haben auch dies schöne Symbol als unverständig beiseite getan.«
     </p>
-    <p xml:id="eco_de_0000144_3360">
+    <p xml:id="eco_de_0000214_3360">
      Die Pfarrerin sagte: »Sie sind ein guter Mensch. Ich meine, etwas Besseres kann ich Ihnen nicht sagen, auch wenn Sie anderes zu hören gewöhnt sind. Ich wollte wünschen, es käme die Zeit, in der man Ihr schönes Fest feiern würde.« Der Pfarrerin wurde es leichter und weniger bang ums Herz. Am liebsten aber wäre sie zu ihm hingetreten und hätte gesagt: So lieb und wert Sie uns sind, ich bitte, vergessen Sie unser Häuschen und mein armes Kind, eilen Sie, gehen Sie! – Sehen Sie nicht, wie des Kindes Augen an Ihnen hängen, als wären Sie allein auf Erden?
     </p>
-    <p xml:id="eco_de_0000144_3370">
+    <p xml:id="eco_de_0000214_3370">
      Ja, wenn nur des Mädchens Augen an ihm gehangen hätten: aber auch er umfaßte sie mit seinen Blicken, hielt sie fest, sog sie mit seinen Augen an sich. – Sie schienen beide in der Kraft ihrer Blicke zu leben.
     </p>
-    <p xml:id="eco_de_0000144_3380">
+    <p xml:id="eco_de_0000214_3380">
      Alle gingen sie jetzt wieder in dem langen Gartengrundstück auf und nieder. Niemand dachte an ein Aufbrechen. Der Abend war so schön, die schlafende Sommerherrlichkeit lag wie ein unfaßbares und doch vertrautes Wunder um sie her. Geheimnisvoll dufteten die Blumen, geheimnisvoll schien der Mond, und die vollaubigen Bäume rauschten hin und wieder einen schwermütigen Akkord dazu.
     </p>
-    <p xml:id="eco_de_0000144_3390">
+    <p xml:id="eco_de_0000214_3390">
      Uerle hielt sich zu der Pfarrerin. Er ging neben ihr her wie ein guter Sohn, der seiner Mutter Kummer tragen hilft.
     </p>
-    <p xml:id="eco_de_0000144_3400">
+    <p xml:id="eco_de_0000214_3400">
      »Guter, lieber Uerle, was sollen wir machen?« fragte die Pfarrerin nach langem Schweigen. »Da gehen sie miteinander ganz weltvergessen, was mögen sie wohl reden?«
     </p>
-    <p xml:id="eco_de_0000144_3410">
+    <p xml:id="eco_de_0000214_3410">
      Uerle schwieg.
     </p>
-    <p xml:id="eco_de_0000144_3420">
+    <p xml:id="eco_de_0000214_3420">
      »Lieber Uerle,« sagte die Pfarrerin wieder, »so gar manches Mal schien es mir, als stände meine Alma Ihnen nahe, als wäre sie Ihnen teuer. – Helfen Sie doch!«
     </p>
-    <p xml:id="eco_de_0000144_3430">
+    <p xml:id="eco_de_0000214_3430">
      »Helfen?« – sagte Uerle wie gedankenlos. »Frau Pfarrerin, das ist nun jetzt ein Schicksal. Ich glaube, da können wir alle nichts machen; was wir auch täten, würde grob und töricht sein. Die sind beide Sommermenschen.«
     </p>
-    <p xml:id="eco_de_0000144_3440">
+    <p xml:id="eco_de_0000214_3440">
      »Ach, Uerle – was soll das heißen?« Die Pfarrerin schüttelte traurig den Kopf.
     </p>
-    <p xml:id="eco_de_0000144_3450">
+    <p xml:id="eco_de_0000214_3450">
      »Haben Sie darauf gemerkt,« sagte Uerle wieder bedächtig, »wie in des jungen Werthers Leiden zu allem, was geschieht, die Bäume rauschen, wie der Sommer in alles hineinprangt? Man atmet Sommer. Man sieht eine Gegend mit großen Laubmassen und Laubduft und alles in Sonne getaucht. Es ist solch eine Sommerseligkeit und solch Sommerleid in allem, was geschieht, so aus der tiefsten Seele heraus. Er ist ein Sommerkind. Sehen Sie doch die Menschen an, wie wenig Sonne haben alle in den Augen, kühle Frühlingsaugen, trübe Winteraugen; aber die beiden haben Sommersonnenaugen, da können wir andern alle nicht mitmachen.«
     </p>
-    <p xml:id="eco_de_0000144_3460">
+    <p xml:id="eco_de_0000214_3460">
      »Sie wird sich und mir kein Leid tun,« meinte die Pfarrerin.
     </p>
-    <p xml:id="eco_de_0000144_3470">
+    <p xml:id="eco_de_0000214_3470">
      »Sie ist vom größten Dichter der Welt geliebt,« sagte Uerle.
     </p>
-    <p xml:id="eco_de_0000144_3480">
+    <p xml:id="eco_de_0000214_3480">
      »Was Dichter!« sagte die Pfarrerin, »er soll ein guter Mensch sein!«
     </p>
-    <p xml:id="eco_de_0000144_3490">
+    <p xml:id="eco_de_0000214_3490">
      »Liebe Frau, dem einen brennt sein Haus nieder, dem andern stirbt sein Vieh. Sein Geld verliert einer, seine Ruh' der andere – jeder hat zu leiden und bringt Leiden. Quälen Sie sich nicht. Da liegt das Geheimnis der Welt.«
     </p>
-    <p xml:id="eco_de_0000144_3500">
+    <p xml:id="eco_de_0000214_3500">
      Als es gar spät war und es an ein Abschiednehmen ging, da küßte sich das wundervolle junge Paar vor den Augen der Mutter und den Augen der Schwestern und Freunde im traulichen Zimmer beim Scheine der kleinen Oellampe.
     </p>
-    <p xml:id="eco_de_0000144_3510">
+    <p xml:id="eco_de_0000214_3510">
      »Du teures, einziges Geschöpf!« sagte der junge Mann hingerissen. »Daß der Regen dich brachte!« sagte sie still, »mir dich brachte!«
     </p>
-    <p xml:id="eco_de_0000144_3520">
+    <p xml:id="eco_de_0000214_3520">
      Sie stand leuchtend vor Wonne, und alle, die es wußten, dachten an den blühenden Rosenstrauch, der mit tausend Rosen blühte, und der Duft der Rosen waren die glückseligen Gedanken.
     </p>
-    <p xml:id="eco_de_0000144_3530">
+    <p xml:id="eco_de_0000214_3530">
      Der junge Mann stürzte auf die Pfarrerin zu, küßte ihr die Hand. »Liebe, liebe Frau,« sagte er, »Gott behüte uns alle!« Dann ergriff er beide Hände des schönen Mädchens noch einmal.
     </p>
-    <p xml:id="eco_de_0000144_3540">
+    <p xml:id="eco_de_0000214_3540">
      »Kommt!« sagte er zu seinen Begleitern, »kommt!« Dann ging er, ohne fast irgend jemand anzublicken.
     </p>
-    <p xml:id="eco_de_0000144_3550">
+    <p xml:id="eco_de_0000214_3550">
      »Alma – Kind!« rief die Pfarrerin, als die Türe hinter den Gästen geschlossen war.
     </p>
-    <p xml:id="eco_de_0000144_3560">
+    <p xml:id="eco_de_0000214_3560">
      Alma achtete nicht auf sie. Wie angstvoll lauschte sie auf die verhallenden Schritte.
     </p>
-    <p xml:id="eco_de_0000144_3570">
+    <p xml:id="eco_de_0000214_3570">
      »Mein Kind –,« sagte die Pfarrerin noch einmal.
     </p>
-    <p xml:id="eco_de_0000144_3580">
+    <p xml:id="eco_de_0000214_3580">
      Da sank das Mädchen vor ihr in die Knie. »Ich danke dir,« schluchzte sie auf, »daß ich lebe! Ich danke dir! – Ich danke dir!« Und sie küßte die Hände der Mutter. Ihr Haar war aufgegangen, und sie wischte die eigenen Tränen damit von den Händen der Pfarrerin.
     </p>
-    <p xml:id="eco_de_0000144_3590">
+    <p xml:id="eco_de_0000214_3590">
      »Will er Dich denn heiraten?« frug Ulrikchen kühl.
     </p>
-    <p xml:id="eco_de_0000144_3600">
+    <p xml:id="eco_de_0000214_3600">
      Uerle aber trat vor Ulrikchen hin und sagte: »Lassen Sie sie doch, Judas Ischarioth!«
     </p>
-    <p xml:id="eco_de_0000144_3610">
+    <p xml:id="eco_de_0000214_3610">
      »Nun ist er ganz verrückt!« meinte Ulrikchen. »Die andern glauben doch, Sie sähen meine Schwester nicht ungern. Wie leiden Sie denn das?« »Wahrlich,« sagte Uerle, »ich habe sie geliebt und liebe sie – ja – ja – ja! ich liebe sie!« Seine Steifheit brach im übermächtigen Gefühl zusammen – und er war frei! frei! – Zum erstenmal im Leben Herr seiner Stimme, seiner Glieder, zum erstenmal schmolzen ihm die Gedanken wie im Feuer. »Ja, ich liebte sie! ich liebte sie! – aber was will das sagen gegen ihre Liebe!«
     </p>
-    <p xml:id="eco_de_0000144_3620">
+    <p xml:id="eco_de_0000214_3620">
      »Ach, Uerle, unser guter Freund,« sagte die Pfarrerin seufzend und hielt ihr Kind, das vor ihr am Lehnsessel kniete und den Kopf ihr an der Brust barg, mit einem Arm umschlungen. »Ach, Uerle, ich wollte, Sie wären bei all Ihrem Edelmute nicht gar so bescheiden. Bei Ihnen wäre sie behütet.«
     </p>
-    <p xml:id="eco_de_0000144_3630">
+    <p xml:id="eco_de_0000214_3630">
      »Ich bin ein gar elender Mensch,« sagte Uerle ruhig, »ich finde mich mit allen Dingen gut und bürgerlich ab. Wenn meine Mutter mich strafte, fand ich in jeder Strafe einen süßen Kern; sogar, wenn sie mich prügelte, freute ich mich auf die wunderliebe Versöhnung danach, denn die Prügel kamen ihr selbst hart an, und sie griff mit Freuden nach dem ersten Zeichen meiner Reue.«
     </p>
-    <p xml:id="eco_de_0000144_3640">
+    <p xml:id="eco_de_0000214_3640">
      »Ach, Uerle,« meinte Ulrikchen, »Sie spielen mit den Gedanken, als ob Sie uns Geschichten erzählen wollten; das ist immer wie aus dem Buch, wenn man Ihnen zuhört.«
     </p>
-    <p xml:id="eco_de_0000144_3650">
+    <p xml:id="eco_de_0000214_3650">
      »Ja, das ist's ja eben,« sagte Uerle traurig. »Und nun schlafen Sie alle wohl, und Gott behüte Sie miteinander.«
     </p>
-    <p xml:id="eco_de_0000144_3660">
+    <p xml:id="eco_de_0000214_3660">
      »Schlafen Sie wohl, Uerle,« die Pfarrerin gab ihm die Hand. Alma erhob sich, und als sie ihm die Hand reichte, sah er in ein Gesicht, in dem die Erdenwonne wie ein Wunder strahlte, so rein und groß und festlich.
     </p>
-    <p xml:id="eco_de_0000144_3670">
+    <p xml:id="eco_de_0000214_3670">
      »O, Erde, wie bist du schön!« sagte Uerle und sah das Mädchen an. »Berge von Freude! – und Täler voll Leid! Und Sie, Alma, stehen jetzt auf einem hohen Berg der Freude und sehen die Erde unter sich.«
     </p>
-    <p xml:id="eco_de_0000144_3680">
+    <p xml:id="eco_de_0000214_3680">
      Sie aber neigte sich, faßte seine Hand, küßte sie und sagte: »Uerle, ich danke Ihnen für alle Güte, für alle schönen Stunden. – Ich verstehe Sie ganz, Uerle.«
     </p>
-    <p xml:id="eco_de_0000144_3690">
+    <p xml:id="eco_de_0000214_3690">
      Dunkelrot ward Uerles Gesicht – Tränen traten in seine Augen, er wendete sich ab und ging zur Tür hinaus.
     </p>
-    <p xml:id="eco_de_0000144_3700">
+    <p xml:id="eco_de_0000214_3700">
      Die Pfarrerin setzte sich ans Spinett und spielte ein Schlummerlied, das sie früher mit ihren Kindern vorm Einschlafen gesungen hatte – und alle Töchter fielen in die alten, trauten Worte ein.
     </p>
-    <p xml:id="eco_de_0000144_3710">
+    <p xml:id="eco_de_0000214_3710">
      Was die Pfarrerin dazu getrieben, das alte Kinderlied zu spielen, war ihrem ratlos bangen Herzen wohl kaum klar geworden.
     </p>
-    <p xml:id="eco_de_0000144_3720">
+    <p xml:id="eco_de_0000214_3720">
      Als sie eine Weile schon geendet hatte, hörten sie Uerles rhythmisches Klopfen am Fensterladen, was so viel bedeutete als: Es ist nur der Uerle, macht getrost auf. Und das taten sie, sie öffneten den Laden, da stand Uerle und schaute herein. Die Pfarrerin hatte schon ihre Haube abgesetzt und stülpte sie jetzt eilig wieder auf, und Ulrikchen nestelte ihr Kleid wieder zu und lugte durch die Türe, die in ihr und der jungen Witwe Schlafzimmer führte, begierig heraus.
     </p>
-    <p xml:id="eco_de_0000144_3730">
+    <p xml:id="eco_de_0000214_3730">
      »Mir ist da etwas eingefallen, liebe Frau Pfarrerin, was ich sagen muß – heut abend noch – verzeihen Sie.« Er war tief erregt, seine Stimme bebte: »Die Gesetze der Menschen sind nicht Gottes Gesetze. Böse ist oft gut, und gut ist böse.« Er sprach sehr hastig und laut. Es war, als wenn sein Gefühl ihm mit der Stimme durchginge. »Gott aber ist überall und sieht, wie die Menschen sich ihre Gesetze machen, oft gegen seinen Willen, und er sieht zu und lächelt über ihr Tun.
     </p>
-    <p xml:id="eco_de_0000144_3740">
+    <p xml:id="eco_de_0000214_3740">
      – Und dann – – – dann wollt' ich noch sagen, wenn Menschen auch nur einen wahrhaft guten, ganz ergebenen treuen Freund haben, sind sie nicht verlassen, und wären sie von der ganzen Welt verlassen. – Frau Pfarrerin, ich möchte Ihnen das alles sagen, wie im Namen Gottes! – Quälen Sie sich gar nicht. – Legen Sie sich alle ruhig schlafen. – Die Menschen machen einander die größte Qual auf Erden. Wenn ihr denkt, ihr wollt nur helfen – heilen und gut miteinander sein, so ist alles übrige gar gleichgültig. Verzeihen Sie, Frau Pfarrerin. Gute Nacht.« Damit war er auf und davon.
     </p>
-    <p xml:id="eco_de_0000144_3750">
+    <p xml:id="eco_de_0000214_3750">
      Ulrikchen sagte: »Ich weiß nicht – mit dem sollte einmal der junge Metzger Bauch reden!«
     </p>
-    <p xml:id="eco_de_0000144_3760">
+    <p xml:id="eco_de_0000214_3760">
      »Laß das, Ulrikchen,« sagte die Pfarrerin, »davon verstehst du nichts. – Was der Uerle auch sagt, herzlich gut ist's gemeint, und das ist die Hauptsache.«
     </p>
-    <p xml:id="eco_de_0000144_3770">
+    <p xml:id="eco_de_0000214_3770">
      Nachts träumte die Pfarrerin, ein weicher, lautlos fliegender Vogel flöge an ihr vorüber und streifte sie mit den Flügeln – und streifte sie immer wieder und wieder. Sie dachte im Traum: das ist nur eine Schleiereule, und war begierig, sie zu sehen. Der Vogel war aber so schnell im Flug, daß sie nie einen Eindruck von ihm haben konnte – dann war es ihr, als sagte die Schleiereule »Mutter« zu ihr – »Mutter!« – ganz leise, wie aus der Ferne, und sie erwachte und sah ihre Tochter Alma angekleidet vor sich stehen. Die sagte wie geistesabwesend in einer wie von Weh durchtränkten Betonung: »Mutter – Mutter?«
     </p>
-    <p xml:id="eco_de_0000144_3780">
+    <p xml:id="eco_de_0000214_3780">
      »Ja, was machst du denn da, Kind?« fragte die Pfarrerin schlaftrunken.
     </p>
-    <p xml:id="eco_de_0000144_3790">
+    <p xml:id="eco_de_0000214_3790">
      Alma antwortete nicht gleich. Sie hatte das kleine, offen brennende Oellämpchen in der Hand, »Mutter,« sagte sie, »es wird jetzt schon hell.«
     </p>
-    <p xml:id="eco_de_0000144_3800">
+    <p xml:id="eco_de_0000214_3800">
      »Ach, es ist noch tiefe Nacht. – Du hast ja Licht gemacht.«
     </p>
-    <p xml:id="eco_de_0000144_3810">
+    <p xml:id="eco_de_0000214_3810">
      »Nein,« sagte Alma, »es brennt noch vom Abend her.«
     </p>
-    <p xml:id="eco_de_0000144_3820">
+    <p xml:id="eco_de_0000214_3820">
      Jetzt war die Pfarrerin ganz munter und setzte sich im Bette auf. »Hast du noch gar nicht geschlafen?«
     </p>
-    <p xml:id="eco_de_0000144_3830">
+    <p xml:id="eco_de_0000214_3830">
      Das Mädchen stand gerade aufgerichtet mit dem Lämpchen in der Hand. – »Mutter,« sagte sie, »ist es denn möglich, einen Menschen so zu lieben, daß man ohne ihn gar nichts mehr ist?«
     </p>
-    <p xml:id="eco_de_0000144_3840">
+    <p xml:id="eco_de_0000214_3840">
      »Kind,« antwortete die Pfarrerin ernst, »ich habe euren Vater sehr lieb gehabt und bin nun doch eure gute Mutter geblieben.« – Alma schien nicht auf sie zu achten.
     </p>
-    <p xml:id="eco_de_0000144_3850">
+    <p xml:id="eco_de_0000214_3850">
      »Es heißt,« sagte die Pfarrerin, »du sollst nicht andere Götter haben neben mir. – Wir sollen Gott über alles lieben.«
     </p>
-    <p xml:id="eco_de_0000144_3860">
+    <p xml:id="eco_de_0000214_3860">
      »Gott – Gott – ach – ja Gott!« sagte das Mädchen langsam vor sich hin.
     </p>
-    <p xml:id="eco_de_0000144_3870">
+    <p xml:id="eco_de_0000214_3870">
      »Alma, du träumst ja, du bist ja gar nicht recht wach, – Kind, was ist dir denn?«
     </p>
-    <p xml:id="eco_de_0000144_3880">
+    <p xml:id="eco_de_0000214_3880">
      »So bang',« sagte sie. – »Ach, Mutter, steh' doch auf und geh' mit mir hinaus vors Haus, ins Feld, da wird mir's besser werden.«
     </p>
-    <p xml:id="eco_de_0000144_3890">
+    <p xml:id="eco_de_0000214_3890">
      »Alma, wie kommst du mir denn vor? – Jetzt bei Nacht!«
     </p>
-    <p xml:id="eco_de_0000144_3900">
+    <p xml:id="eco_de_0000214_3900">
      »Es wird schon hell – komm' mit!« bat das Mädchen dringlich.
     </p>
-    <p xml:id="eco_de_0000144_3910">
+    <p xml:id="eco_de_0000214_3910">
      »Nun, weshalb denn nicht?«
     </p>
-    <p xml:id="eco_de_0000144_3920">
+    <p xml:id="eco_de_0000214_3920">
      Die Pfarrerin erhob sich. Während sie ihre Strümpfe anzog, schaute sie besorgt auf die Tochter, die immer noch mit dem Lämpchen stand. »Setz' doch die Lampe nieder, Alma, und mach' die Läden auf!«
     </p>
-    <p xml:id="eco_de_0000144_3930">
+    <p xml:id="eco_de_0000214_3930">
      Alma tat es, wie in Gedanken verloren, und die erste Morgendämmerung drang ins Zimmer.
     </p>
-    <p xml:id="eco_de_0000144_3940">
+    <p xml:id="eco_de_0000214_3940">
      Die Pfarrerin spülte sich das Gesicht ab, um völlig wach zu werden. »So, nun können wir gehen!« meinte sie.
     </p>
-    <p xml:id="eco_de_0000144_3950">
+    <p xml:id="eco_de_0000214_3950">
      Alma nahm der Mutter Hand, als sie aus dem Pförtchen getreten waren.
     </p>
-    <p xml:id="eco_de_0000144_3960">
+    <p xml:id="eco_de_0000214_3960">
      »Merkst du,« sagte die Pfarrerin, »jetzt ist's in den Linden still, jetzt schlafen die Bienen.«
     </p>
-    <p xml:id="eco_de_0000144_3970">
+    <p xml:id="eco_de_0000214_3970">
      Kein Lüftchen regte sich noch. Das matte Licht war gleichmäßig weißgrau. Die Aehrenfelder lagen wie schlafend. Es war die große, tiefe Stille der ersten Morgendämmerung. Kein Bewußtsein wachte rings umher. Das gibt dieser stillen, stillen Stunde das Urweltliche – das Herzbeklemmende. – Das Wort erstirbt im Munde.
     </p>
-    <p xml:id="eco_de_0000144_3980">
+    <p xml:id="eco_de_0000214_3980">
      So gingen Mutter und Tochter auch schweigend im großen Schweigen.
     </p>
-    <p xml:id="eco_de_0000144_3990">
+    <p xml:id="eco_de_0000214_3990">
      Die erste Lerche schmetterte aus grauem Licht ihr Lied. Wie gewaltig das klang, als erfüllte ihr Gesang den ganzen Himmelsraum.
     </p>
-    <p xml:id="eco_de_0000144_4000">
+    <p xml:id="eco_de_0000214_4000">
      »Mutter,« – sagte das Mädchen, »vor kurzem noch kannte ich ihn nicht. Kannst du dir das vorstellen?«
     </p>
-    <p xml:id="eco_de_0000144_4010">
+    <p xml:id="eco_de_0000214_4010">
      »Ach, Kind, red' doch nicht so!«
     </p>
-    <p xml:id="eco_de_0000144_4020">
+    <p xml:id="eco_de_0000214_4020">
      »Sag' mir, muß solch eine Liebe auch wieder vergehen? Ist das möglich?«
     </p>
-    <p xml:id="eco_de_0000144_4030">
+    <p xml:id="eco_de_0000214_4030">
      »Gewiß, Kind – sie muß zu Ende gehen, denk' doch selbst!«
     </p>
-    <p xml:id="eco_de_0000144_4040">
+    <p xml:id="eco_de_0000214_4040">
      Die Pfarrerin spürte, wie die brennende Hand ihres Mädchens in der ihren aufzuckte.
     </p>
-    <p xml:id="eco_de_0000144_4050">
+    <p xml:id="eco_de_0000214_4050">
      Mein Gott, dachte die Frau, wie sie leidet! Sie ist zu klug, um nicht alles zu sehen.
     </p>
-    <p xml:id="eco_de_0000144_4060">
+    <p xml:id="eco_de_0000214_4060">
      »Sag' mir,« bat Alma, »wie war mein allererster Tag auf Erden? – Schien die Sonne?«
     </p>
-    <p xml:id="eco_de_0000144_4070">
+    <p xml:id="eco_de_0000214_4070">
      »Ja,« sagte die Pfarrerin, »du warst ja mein einziges Sommerkind, kaum warst du geboren und in die Wiege gelegt, da wurde die Wiege ans offene Fenster gestellt. Es war mittags zwölf Uhr und zur Rosenzeit; aber das weißt, du ja. Die Kletterrosen nickten zum Fenster herein.
     </p>
-    <p xml:id="eco_de_0000144_4080">
+    <p xml:id="eco_de_0000214_4080">
      Draußen war es wundervoll sonnig. Die Bauern waren alle zur Heuernte hinaus. Das Dorf war ganz still, und ich lag in meinem Bett und war voller Dank und Freude über dich.
     </p>
-    <p xml:id="eco_de_0000144_4090">
+    <p xml:id="eco_de_0000214_4090">
      Der Vater hatte sich zu seinen drei Mädchen gar sehr einen Buben gewünscht. Als er dich aber so friedlich in deinen Kissen liegen sah, war auch er voller Freude über sein viertes Töchterchen und legte dir eine frische Rose auf deine Wiege.«
     </p>
-    <p xml:id="eco_de_0000144_4100">
+    <p xml:id="eco_de_0000214_4100">
      »Und man wird geboren, um zu sterben. – Mir ist so angst –,« sagte Alma leise; ich bin nicht mehr mein eigen – wohin er geht, zieht er mich nach. – Ich möchte wieder mir selbst gehören, es war doch alles so schön und ruhig.«
     </p>
-    <p xml:id="eco_de_0000144_4110">
+    <p xml:id="eco_de_0000214_4110">
      »Ja, mein Kind, das muß alles wieder so werden, wie es war.«
     </p>
-    <p xml:id="eco_de_0000144_4120">
+    <p xml:id="eco_de_0000214_4120">
      »Wo er auch hingeht, kann er mich nicht gebrauchen. Ich seh' ihn da und dort. Ach, Mutter, so werd' ich ihm bald lästig werden!«
     </p>
-    <p xml:id="eco_de_0000144_4130">
+    <p xml:id="eco_de_0000214_4130">
      Sie setzte sich auf einen Grasrain am Wege wie erschöpft nieder und lehnte den Kopf an ihrer Mutter Schulter.
     </p>
-    <p xml:id="eco_de_0000144_4140">
+    <p xml:id="eco_de_0000214_4140">
      »Als du den Vater liebtest, war es da auch, als hättest du im Herzen eine Wunde und dein Leben flösse da heraus; auch wenn du die Hände darauf preßtest – es nützte nichts?«
     </p>
-    <p xml:id="eco_de_0000144_4150">
+    <p xml:id="eco_de_0000214_4150">
      Das Mädchen preßte die Hände aufs Herz, als wenn sie eine Wunde schließen wollte.
     </p>
-    <p xml:id="eco_de_0000144_4160">
+    <p xml:id="eco_de_0000214_4160">
      »Nein,« sagte die Mutter, »Alma, mir war, als strömte das Leben mir von allen Seiten zu, als würde ich täglich besser und glücklicher.«
     </p>
-    <p xml:id="eco_de_0000144_4170">
+    <p xml:id="eco_de_0000214_4170">
      »Ich liebe ihn zu sehr – zu sehr!« schluchzte das Mädchen auf und sank ihrer Mutter an die Brust.
     </p>
-    <p xml:id="eco_de_0000144_4180">
+    <p xml:id="eco_de_0000214_4180">
      »Deine Stirn glüht so und deine Hände,« sagte die Pfarrerin.
     </p>
-    <p xml:id="eco_de_0000144_4190">
+    <p xml:id="eco_de_0000214_4190">
      »Mein Kopf schmerzt so sehr.«
     </p>
-    <p xml:id="eco_de_0000144_4200">
+    <p xml:id="eco_de_0000214_4200">
      Der Pfarrerin ward es ganz angst, wie sie in der lebenverlassenen, ersten Morgenfrühe in der großen Stille mit ihrem armen Mädchen mitten zwischen den Kornfeldern saß.
     </p>
-    <p xml:id="eco_de_0000144_4210">
+    <p xml:id="eco_de_0000214_4210">
      Ihr Kind hielt sich jetzt so still bei ihr, als wäre es hingelehnt bei ihr eingeschlafen.
     </p>
-    <p xml:id="eco_de_0000144_4220">
+    <p xml:id="eco_de_0000214_4220">
      »Alma,« sagte die Pfarrerin leise, aber sie bekam keine Antwort. Sie faßte die Hand, die matt herabhing; die brannte wie Feuer, das Gesicht glühte, und das Herz schlug so schnell und heftig, daß sie es spürte.
     </p>
-    <p xml:id="eco_de_0000144_4230">
+    <p xml:id="eco_de_0000214_4230">
      Krank ist sie, dachte die Pfarrerin bang. Krank war sie, als sie mich weckte. Unbegreiflich war es der Pfarrerin erschienen, daß ihr gutes, rücksichtsvolles Kind sie geweckt hatte – und jetzt verstand sie es schreckvoll. »Alma, hör' doch –«
     </p>
-    <p xml:id="eco_de_0000144_4240">
+    <p xml:id="eco_de_0000214_4240">
      »Laß mich, laß mich, Mutterchen!« kam leise, wie schlaftrunken die Antwort. »Ich will noch ein bißchen im Bett bleiben.«
     </p>
-    <p xml:id="eco_de_0000144_4250">
+    <p xml:id="eco_de_0000214_4250">
      Sie lag ganz regungslos, die Pfarrerin, über sie gebeugt, spürte ihren heißen Atem.
     </p>
-    <p xml:id="eco_de_0000144_4260">
+    <p xml:id="eco_de_0000214_4260">
      Windwellen fuhren über die Felder hin. Es wogte ringsumher. Die Wolken strahlten rosig, die Sonne ging auf. Von all der Herrlichkeit sah die Pfarrerin nichts. –
     </p>
-    <p xml:id="eco_de_0000144_4270">
+    <p xml:id="eco_de_0000214_4270">
      »Komm', Alma, komm', Kind!«
     </p>
-    <p xml:id="eco_de_0000144_4280">
+    <p xml:id="eco_de_0000214_4280">
      Keine Antwort. Sie war ganz in sich versunken, lag mit halbgeschlossenen Augen und atmete sehr schnell. Zeit auf Zeit verstrich. Das Mädchen lag teilnahmlos mit dem Kopf auf der Mutter Schoß.
     </p>
-    <p xml:id="eco_de_0000144_4290">
+    <p xml:id="eco_de_0000214_4290">
      Endlich wußte die Pfarrerin sich nicht mehr zu helfen und versuchte, sich und Alma aufzurichten.
     </p>
-    <p xml:id="eco_de_0000144_4300">
+    <p xml:id="eco_de_0000214_4300">
      »Ja, ja. Mutterchen, ja – ja,« sagte das Mädchen dabei in einem rührend zustimmenden Ton.
     </p>
-    <p xml:id="eco_de_0000144_4310">
+    <p xml:id="eco_de_0000214_4310">
      Sie waren nicht gar weit vom Hause. Die Pfarrerin hob ihr armes Mädchen mühselig in die Höhe, stützte sie, so daß sie sie fast trug, und schleppte sich mit ihr dem Hause zu.
     </p>
-    <p xml:id="eco_de_0000144_4320">
+    <p xml:id="eco_de_0000214_4320">
      Dort legte die Pfarrerin sie in das Bett mit den Dornenkronen und den brennenden, durchstochenen Herzen nieder und setzte sich an den Tisch und vergrub den Kopf in den Händen.
     </p>
-    <p xml:id="eco_de_0000144_4330">
+    <p xml:id="eco_de_0000214_4330">
      Die junge Witwe kam, um der Mutter wie jeden Morgen die Fensterläden zu öffnen.
     </p>
-    <p xml:id="eco_de_0000144_4340">
+    <p xml:id="eco_de_0000214_4340">
      »Ja, was ist dir, Mutter?«
     </p>
-    <p xml:id="eco_de_0000144_4350">
+    <p xml:id="eco_de_0000214_4350">
      »Alma ist krank, ruft Uerle, daß er uns den Doktor schickt, wenn er zur Stadt geht!«
     </p>
-    <p xml:id="eco_de_0000144_4360">
+    <p xml:id="eco_de_0000214_4360">
      Alma lag ganz teilnahmlos mit ihren Kleidern auf der Mutter Bett.
     </p>
-    <p xml:id="eco_de_0000144_4370">
+    <p xml:id="eco_de_0000214_4370">
      »Bist du schon die ganze Nacht auf, Mutterchen? Ja, was ist denn? Was ist denn?« Die junge Witwe trat ans Bett ihrer Schwester und fühlte die starke Hitze, die von ihr ausging.
     </p>
-    <p xml:id="eco_de_0000144_4380">
+    <p xml:id="eco_de_0000214_4380">
      »Fieber!« meinte sie ganz ratlos.
     </p>
-    <p xml:id="eco_de_0000144_4390">
+    <p xml:id="eco_de_0000214_4390">
      »Hilf mir sie auskleiden,« sagte die Pfarrerin.
     </p>
-    <p xml:id="eco_de_0000144_4400">
+    <p xml:id="eco_de_0000214_4400">
      Als die Kleider, in denen sie gestern so schön und glückselig war, nun ihr abgestreift waren, schlugen ihr die Zähne vor Frost aufeinander. Die Frauen hüllten sie warm ein, aber der böse Frost ließ nicht von ihr ab, warf ihren Körper hin und her. Man sah, wie die Schauer ihr über die brennende Haut fuhren. –
     </p>
-    <p xml:id="eco_de_0000144_4410">
+    <p xml:id="eco_de_0000214_4410">
      »Ach, was macht ihr denn mit mir? – Was macht ihr denn mit mir?«
     </p>
-    <p xml:id="eco_de_0000144_4420">
+    <p xml:id="eco_de_0000214_4420">
      Die beiden anderen Schwestern kamen; eine lief zu Uerle, der war auch gar bald zur Stelle.
     </p>
-    <p xml:id="eco_de_0000144_4430">
+    <p xml:id="eco_de_0000214_4430">
      »Sie ist nicht bei sich, Uerle,« sagte die Pfarrerin in großer Bangigkeit, als er eintrat.
     </p>
-    <p xml:id="eco_de_0000144_4440">
+    <p xml:id="eco_de_0000214_4440">
      Da war es aber, als wenn sie Uerles Nähe spürte. »Uerle,« sagte sie leise, von Frost geschüttelt. »Er soll nicht zu mir heraufkommen. – Er soll mich nicht so krank sehen. – – Wenn ich es nicht weiß, könnte er hereinkommen. – Niemand darf ihn hereinlassen!« sagte sie angstvoll. – »Versprechen, Uerle, versprechen! – Ich kann nicht wach bleiben.«
     </p>
-    <p xml:id="eco_de_0000144_4450">
+    <p xml:id="eco_de_0000214_4450">
      »Gewiß nicht, Alma, bis Sie gesund sind!«
     </p>
-    <p xml:id="eco_de_0000144_4460">
+    <p xml:id="eco_de_0000214_4460">
      Sie nickte. Die Augenlider lagen schwer über den Augen.
     </p>
-    <p xml:id="eco_de_0000144_4470">
+    <p xml:id="eco_de_0000214_4470">
      Schwere Tage zogen über das kleine Haus hin. Die beiden jungen Stollbergs gingen ein und aus, als wären sie die Brüder der Pfarrerskinder. »Wir müssen ihm Nachricht bringen. Er verzehrt sich dort unten vor Sorge.«
     </p>
-    <p xml:id="eco_de_0000144_4480">
+    <p xml:id="eco_de_0000214_4480">
      »Und kommt nicht ein einziges Mal,« meinte die Pfarrerin.
     </p>
-    <p xml:id="eco_de_0000144_4490">
+    <p xml:id="eco_de_0000214_4490">
      »Er kann nicht,« sagte der jüngere Stollberg. »Rechnen Sie ihm das nicht an. Und Alma will es nicht. – Beide sind sich gar wunderlich gleich. – Rühren wir nicht daran!«
     </p>
-    <p xml:id="eco_de_0000144_4500">
+    <p xml:id="eco_de_0000214_4500">
      »Ja,« sagte die Pfarrerin; »Gott möge ihm helfen, daß er so lieben und leben kann, wie er lieben und leben muß. Wir anderen werden nicht gefragt, was wir wollen und können.«
     </p>
-    <p xml:id="eco_de_0000144_4510">
+    <p xml:id="eco_de_0000214_4510">
      »Seien Sie nicht bitter, liebste Frau. Er ist wie aus einer anderen Welt, er steht unter anderen Gesetzen, und Alma, Ihr Kind, auch. Wir werden lebensstark durch unsere Liebe, und Ihr Kind liegt davon niedergeschmettert.«
     </p>
-    <p xml:id="eco_de_0000144_4520">
+    <p xml:id="eco_de_0000214_4520">
      »Ich rühre ja an nichts,« sagte die Pfarrerin trübe.
     </p>
-    <p xml:id="eco_de_0000144_4530">
+    <p xml:id="eco_de_0000214_4530">
      – »Wir lebten so still und glücklich, und nun spüren wir mit einem Male die Hand Gottes, die uns einen schweren, nie gesehenen Weg auftut.«
     </p>
-    <p xml:id="eco_de_0000144_4540">
+    <p xml:id="eco_de_0000214_4540">
      Ja, die Pfarrerin ging einen schweren Weg. Ihr Kind blieb nicht in der tiefen, lautlosen Fieberdumpfheit liegen wie in den ersten Tagen. Die lebensselige Sommernatur glühte in der Fieberglut der schweren Krankheit zu einem leidenschaftlichen Leben auf. Ohne Bewußtsein sang sie mit unendlich klarer, reiner Stimme Strophen aus dem alten heiligen Sommerlied:
     </p>
-    <p xml:id="eco_de_0000144_4550">
+    <p xml:id="eco_de_0000214_4550">
      Die Bäume stehen voller Laub, Das Erdreich decket seinen Staub Mit einem grünen Kleide. Narcissus und die Tulipan, Die ziehen sich viel schöner an Als Salomonis Seide.
     </p>
-    <p xml:id="eco_de_0000144_4560">
+    <p xml:id="eco_de_0000214_4560">
      Und sie sang dieselben Worte wieder und wieder. Oft auch fand sie keine Worte, nur jubelnde Töne, hell, bebend vor Seligkeit, daß sich allen, die es hörten, das Herz vor Weh zusammenzog.
     </p>
-    <p xml:id="eco_de_0000144_4570">
+    <p xml:id="eco_de_0000214_4570">
      Die Stimme war so überströmend von Erdenwonne, daß sie erschauern machte.
     </p>
-    <p xml:id="eco_de_0000144_4580">
+    <p xml:id="eco_de_0000214_4580">
      Die Fenster mußten immer geöffnet sein, denn sie ertrug den geschlossenen Raum keinen Augenblick, und so drang die unaufhaltsame, kristallklare, schöne, selige Stimme hinaus über die Felder bei Tag und bei Nacht. »Anbetungswürdig ist diese Seele,« sagte Uerle zur Pfarrerin, »daß sie solch große Seligkeit in sich trägt. – So singt eine Lerche im Himmelsraum, wie unsere heilige Sommerseele. Hören Sie doch ihren Gesang, sündlos und rein – und daß ein Geschöpf solche Wonne im Herzen trägt!«
     </p>
-    <p xml:id="eco_de_0000144_4590">
+    <p xml:id="eco_de_0000214_4590">
      »Ja,« sagte die Pfarrerin trostlos, »dazu muß es von Sinnen sein.«
     </p>
-    <p xml:id="eco_de_0000144_4600">
+    <p xml:id="eco_de_0000214_4600">
      »Wer sagt Ihnen das?« fragte Uerle. »Sie sieht uns nur nicht. – Sie weiß von nichts um sich her. Sie sieht nur in sich selbst hinein, und in ihr ist es so weiß und hell und wonnevoll, wie ihre Stimme ist. – In ihr ist eine große Herrlichkeit. – Geboren – gelebt, wie ein seliges Kind aufgefahren gen Himmel – sitzend zur rechten Hand Gottes!« Uerles Stimme bebte von verhaltenen Tränen. Er verbarg hastig sein Gesicht am Fensterkreuz, vor dem sie standen.
     </p>
-    <p xml:id="eco_de_0000144_4610">
+    <p xml:id="eco_de_0000214_4610">
      »Uerle, was reden Sie?« sagte die Pfarrerin erschrocken. – Uerle aber wollte die Pfarrerin mit solch wunderlich wehen Worten trösten. Kein Arzt brauchte ihm zu sagen, daß seine Sommerseele im Entschweben war.
     </p>
-    <p xml:id="eco_de_0000144_4620">
+    <p xml:id="eco_de_0000214_4620">
      Nachdem das Fieber alle Kräfte verbrannt hatte, sank die Lebenswärme zu einer schauerlichen Kühle.
     </p>
-    <p xml:id="eco_de_0000144_4630">
+    <p xml:id="eco_de_0000214_4630">
      Die Schwestern sagten: »Das Fieber ist vorüber.« Uerle aber und die Pfarrerin wußten es anders.
     </p>
-    <p xml:id="eco_de_0000144_4640">
+    <p xml:id="eco_de_0000214_4640">
      Ganz leise flüsterte das Mädchen, zu Uerle gewendet, der an ihrem Bette saß, und so, als läge zwischen ihrem letzten und wieder ersten bewußten Wort keine lange, bange Zeit: »Wo ist er?«
     </p>
-    <p xml:id="eco_de_0000144_4650">
+    <p xml:id="eco_de_0000214_4650">
      »Er ist voll Bangigkeit um Sie, Alma.«
     </p>
-    <p xml:id="eco_de_0000144_4660">
+    <p xml:id="eco_de_0000214_4660">
      »Was mich hinderte, ihn zu lieben, ist nun fortgeglüht. – Nun liebe ich ihn bis in alle Ewigkeit. Sag' ihm, nun werd' ich ihm nah' sein.«
     </p>
-    <p xml:id="eco_de_0000144_4670">
+    <p xml:id="eco_de_0000214_4670">
      Uerle hatte ihre letzten Worte gehört – ihr letztes Bewußtsein empfunden. Von nun an sank sie in eine kühle, bleierne Ruhe, die dem Tode voranging.
     </p>
-    <p xml:id="eco_de_0000144_4680">
+    <p xml:id="eco_de_0000214_4680">
      Im Hause regte sich stundenlang kein Laut. Die beiden Stollbergs standen draußen an einem der niederen Fenster, durch die der warme Sommerwind ins Zimmer drang, und schauten auf das stille Verlöschen und den schweigenden Schmerz derer, die zurückblieben.
     </p>
-    <p xml:id="eco_de_0000144_4690">
+    <p xml:id="eco_de_0000214_4690">
      Die Pfarrerin hielt die erkaltende Hand ihres Kindes in der ihren, mit der Ruhe, welche das Leben jenen Schmerzgeprüften gibt, die den größten Teil des Weges schon gegangen sind. Die sind so schmerzbekannt, so schmerzverwandt, daß sie sich mit einer Würde betragen, die den Jungen, Ungeprüften wie ein Wunder erscheint.
     </p>
-    <p xml:id="eco_de_0000144_4700">
+    <p xml:id="eco_de_0000214_4700">
      Die drei Töchter hingen mit ihren Blicken an ihrer Mutter, als käme von ihr in dieser fremden, bangen Stunde Rat und Hilfe. Als die Pfarrerin sich über ihr Kind beugte und ihm die Hände ineinander faltete, da wußten sie alle, daß es geschehen war. Die Pfarrerin blieb stumm über ihr Kind gebeugt, – Uerle stand am Fußende des Bettes, und die drei Schwestern knieten, wo sie gestanden hatten, die eine verbarg ihr Gesicht in den Händen, die beiden anderen suchten Schutz in enger Umschlingung.
     </p>
-    <p xml:id="eco_de_0000144_4710">
+    <p xml:id="eco_de_0000214_4710">
      Lautlos kamen die beiden Stollbergs herein, und der jüngere sagte hingerissen: »Sie hat sich ihm selbst entrückt durch ihre große Liebe und ihr tiefes Verstehen. Das wurde ihr tödlich, daß sie alles erkannte. – Ihn wollte sie nicht binden und euch nicht kränken.
     </p>
-    <p xml:id="eco_de_0000144_4720">
+    <p xml:id="eco_de_0000214_4720">
      Wir gehen zu ihm!«
     </p>
-    <p xml:id="eco_de_0000144_4730">
+    <p xml:id="eco_de_0000214_4730">
      Die schöne Hülle der Sommerseele lag schlafend im weißen Sarg, unter Blumen, einen weißen Rosenkranz auf dem bleichen Haupt.
     </p>
-    <p xml:id="eco_de_0000144_4740">
+    <p xml:id="eco_de_0000214_4740">
      Mutter und Schwestern, Uerle und die Stollbergs hegten und schmückten das stille Geschöpf.
     </p>
-    <p xml:id="eco_de_0000144_4750">
+    <p xml:id="eco_de_0000214_4750">
      Nachts vor dem Begräbnis wurde sie im offenen Sarg von Uerle und einem braven Menschen, den er kannte, sowie den beiden Stollbergs nach Süßenborn getragen. Die zwei Söhne des Lehrers von dort trugen Fackeln und wechselten mit den Trägern.
     </p>
-    <p xml:id="eco_de_0000144_4760">
+    <p xml:id="eco_de_0000214_4760">
      Das alles hatte Uerle so gewollt.
     </p>
-    <p xml:id="eco_de_0000144_4770">
+    <p xml:id="eco_de_0000214_4770">
      Ulrikchen blieb bei der Mutter und beim Bübchen. Die beiden anderen Schwestern folgten dem Sarge.
     </p>
-    <p xml:id="eco_de_0000144_4780">
+    <p xml:id="eco_de_0000214_4780">
      Es war eine schöne, milde Sommernacht.
     </p>
-    <p xml:id="eco_de_0000144_4790">
+    <p xml:id="eco_de_0000214_4790">
      Die Pfarrerin sah, wie sie ihr gutes Kind den schmalen Weg durch die wogenden Felder trugen. Der Himmel war sternfunkelnd. Die sanfte Nachtluft strich über das geliebte, tote Gesicht.
     </p>
-    <p xml:id="eco_de_0000144_4800">
+    <p xml:id="eco_de_0000214_4800">
      Und aus der Ferne hörte die Mutter zwei verschleierte Mädchenstimmen eine Strophe aus ihres Kindes Lieblingslied singen:
     </p>
-    <p xml:id="eco_de_0000144_4810">
+    <p xml:id="eco_de_0000214_4810">
      Der Weizen wächset mit Gewalt, Darüber jauchzet jung und alt Und rühmt die große Güte Des, der so überflüssig labt Und mit so manchem Gut begabt Das menschliche Gemüte.
     </p>
-    <p xml:id="eco_de_0000144_4820">
+    <p xml:id="eco_de_0000214_4820">
      Welch hohe Lust, welch heller Schein Wird wohl in Christi Garten sein, Wie muß es da wohl klingen? Da so viel tausend Seraphim Mit unverdross'nem Mund und Stimm' Ihr Hallelujah singen.
     </p>
-    <p xml:id="eco_de_0000144_4830">
+    <p xml:id="eco_de_0000214_4830">
      Das mochte der Pfarrerin ein gar schmerzvolles Lied sein. Das stille Mädchen lag ihre letzte Nacht auf Erden an dem Süßenborner Kirchlein zwischen sechs brennenden Kerzen.
     </p>
-    <p xml:id="eco_de_0000144_4840">
+    <p xml:id="eco_de_0000214_4840">
      Ihre alte Kinderfrau, die noch im Süßenborner Pfarrhaus bei den neuen Pfarrersleuten ihres Amtes waltete, hatte es sich nicht nehmen lassen, bei ihrem guten Kinde zu wachen.
     </p>
-    <p xml:id="eco_de_0000144_4850">
+    <p xml:id="eco_de_0000214_4850">
      Uerle und die beiden Mädchen gingen langsam und schweigend dem Häuschen auf dem Horn wieder zu.
     </p>
-    <p xml:id="eco_de_0000144_4860">
+    <p xml:id="eco_de_0000214_4860">
      Die beiden Stollbergs aber eilten. »Wir müssen zu ihm! Wir sahen sie in ihrer Schönheit bis zu dieser Stunde. Es war ein so ruhiges Verlöschen, so begreiflich, als wenn die Sonne untergeht. – Er kämpft mit Unbegreiflichem. Uns zeigte die Natur im Bilde, wie weit sie begriffen sein will. Er geht ins Ungemessene. Er leidet tiefer als wir alle.«
     </p>
-    <p xml:id="eco_de_0000144_4870">
+    <p xml:id="eco_de_0000214_4870">
      Aus Goethes Gartenhaus an der Ilm schimmerte spät in der Nacht ein einsames Licht aus offenem Fenster heraus auf die nebligen Wiesen. Die hohen Wipfel der Bäume im Garten und in der ganzen Weite, am Horn und an den Ufern der Ilm wurden von keinem Windhauch berührt. Die Nebel lagen wie schimmernde Schleier.
     </p>
-    <p xml:id="eco_de_0000144_4880">
+    <p xml:id="eco_de_0000214_4880">
      Aus dem Garten begannen zarte Geigentöne sanft hinaus in die Nacht zu klingen. Zwei Freundgestalten standen unter dichten Bäumen nicht allzufern vom erleuchteten Fenster und spielten eine ernste Weise. Sie wollten eine große, beraubte Seele beruhigen, eine, der alles Lebensleid zu Musik werden sollte.
     </p>
-    <p xml:id="eco_de_0000144_4890">
+    <p xml:id="eco_de_0000214_4890">
      Auf ihren Geigen spielend, gingen sie lautlos im Grase auf und nieder, so daß die Töne dem, der im erleuchteten Stübchen war, bald nah, bald fern klingen mochten. Ein kaum vernehmbares Aufschluchzen vom Hause her ließ die Geigentöne verstummen.
     </p>
-    <p xml:id="eco_de_0000144_4900">
+    <p xml:id="eco_de_0000214_4900">
      Der Morgen graute.
     </p>
-    <p xml:id="eco_de_0000144_4910">
+    <p xml:id="eco_de_0000214_4910">
      Ueber die Wiesen sah man die beiden Gestalten durch die Nebelschleier gehen, immer geigend, der schlafenden Stadt zu.
     </p>
    </div>
@@ -1570,601 +1570,601 @@
     <head>
      Jugend
     </head>
-    <p xml:id="eco_de_0000144_4920">
+    <p xml:id="eco_de_0000214_4920">
      In dunkler Sommernacht fuhr die alte, gelbe Postkutsche auf der Erfurter Chaussee ihrem Ziele, dem Städtchen Weimar, zu.
     </p>
-    <p xml:id="eco_de_0000144_4930">
+    <p xml:id="eco_de_0000214_4930">
      Eine laubduftende, schwere, warme Nacht, der Mond schon untergegangen, die knorrigen Obstbäume am Straßenrand wie dunkle, kaum angedeutete Silhouetten, die weitausgedehnten Kornfelder strömen des vergangenen Tages Wärme und Wohlgerüche aus.
     </p>
-    <p xml:id="eco_de_0000144_4940">
+    <p xml:id="eco_de_0000214_4940">
      In der Postkutsche sind beide schmale Fenster niedergelassen, und ein einziger Passagier, ein junger Mann, atmet den Ledergeruch des alten Rumpelkastens, diesen Reisegeruch jener Tage, der sich zu solcher Stunde mit der weichen, geheimnisvollen, nach Korn duftenden Finsternis mischt.
     </p>
-    <p xml:id="eco_de_0000144_4950">
+    <p xml:id="eco_de_0000214_4950">
      Aus dem Chausseeeinnehmerhaus blinkt ein trübes Oellämpchen wie ein schläfriges Auge. Der einzige helle Punkt weit und breit. Der Postillion klatscht mit der Peitsche – klatscht wieder und wieder, spuckt aus.
     </p>
-    <p xml:id="eco_de_0000144_4960">
+    <p xml:id="eco_de_0000214_4960">
      »Die Luder schlafen, – wie gewehniglich.« Er hat sich vom Bock geschwungen und macht sich am Halfter der Pferde zu schaffen.
     </p>
-    <p xml:id="eco_de_0000144_4970">
+    <p xml:id="eco_de_0000214_4970">
      So ein feuchter, dumpfer, zärtlicher Klatsch durch die Dunkelheit. Er hat dem Handpferd das weiche Maul geklopft. Die zarten, mächtigen Lippen schlappen feucht gegen die Trense. Durch das ganze Tier geht ein freudiger Ruck der Genugtuung.
     </p>
-    <p xml:id="eco_de_0000144_4980">
+    <p xml:id="eco_de_0000214_4980">
      Darauf eine Erschütterung der alten Kutsche. Der Postillion ist wieder aufgesprungen, flucht noch einmal über die verschlafenen Luder – und fort geht's, hart und rasselnd; und ein junger Schwärmer wird so der alten, wunderlichen Stadt zugeführt.
     </p>
-    <p xml:id="eco_de_0000144_4990">
+    <p xml:id="eco_de_0000214_4990">
      Der Postillion denkt bei sich: ›Gewiß och wieder eener von denen, die nich alle werden. Du meine Gite! Was hat denn der dervon, wenn er och en bar Mal an Herrn von Gethes Haus vorbeimarschieren dhut, oder auch, wenn's Glicke gut ist und wenn'r 'reinkimmt! Jesses ne! Wenn ich Herr von Gethe wär', ich dächte mir: Blost mir in' Aermel! Hab' ich 'n mehr als zwee Beene, daß 'r so ahngenärrscht kommt?
     </p>
-    <p xml:id="eco_de_0000144_5000">
+    <p xml:id="eco_de_0000214_5000">
      Nä, mir werd's ibel, wenn ich denke, mich wullten's alle zu sehen krieche, die Narrn. Der drinn tät och besser, sei Gerschtel firs Studium ahnzuwenden statt von Gettungen rein zu machen, oder woher er kimmt. Na, wenn's en freit, mir gann's wurscht sein.«
     </p>
-    <p xml:id="eco_de_0000144_5010">
+    <p xml:id="eco_de_0000214_5010">
      Damit gab er seinen beiden Braunen ein Aufmunterungswichslein und vorüber rasselte es am Galgenberg, der dazumal sein Warnungszeichen noch trug.
     </p>
-    <p xml:id="eco_de_0000144_5020">
+    <p xml:id="eco_de_0000214_5020">
      Drin in der düsteren Kutsche schlug ein frisches, kühnes Herz, ein Herz voller Schwärmerei, wie jetzt keine mehr schlagen. Jetzt brennen die jungen Herzen, die wirklich brennen, Anthrazitkohle, ein konzentriertes, bestausgenutztes Brennen, in spitzer, scharfer, blauer Flamme.
     </p>
-    <p xml:id="eco_de_0000144_5030">
+    <p xml:id="eco_de_0000214_5030">
      Damals aber brannten die jungen Herzen Holzfeuerung, da knisterten Kienäste, da prasselte viel unnütz feuchter Saft in Feuergarben, und dunkler, schwermütiger Rauch schwelte.
     </p>
-    <p xml:id="eco_de_0000144_5040">
+    <p xml:id="eco_de_0000214_5040">
      Es war ein lustiges, träumerisches, verschwenderisches Brennen.
     </p>
-    <p xml:id="eco_de_0000144_5050">
+    <p xml:id="eco_de_0000214_5050">
      Ja, ein kleiner Ueberrest von solchen flammenden Holzstößen hat sich in unserer Zeit noch in Backfischherzen hinübergerettet.
     </p>
-    <p xml:id="eco_de_0000144_5060">
+    <p xml:id="eco_de_0000214_5060">
      Da knistern noch hin und wieder rührende Flämmchen für irgendein Idol.
     </p>
-    <p xml:id="eco_de_0000144_5070">
+    <p xml:id="eco_de_0000214_5070">
      Aber was ist das armselige Knistern gegen die Feuersbrunst in jener Postkalesche.
     </p>
-    <p xml:id="eco_de_0000144_5080">
+    <p xml:id="eco_de_0000214_5080">
      Vorgebeugt, die Hand in die Haare vergraben, saß jetzt der junge Mensch.
     </p>
-    <p xml:id="eco_de_0000144_5090">
+    <p xml:id="eco_de_0000214_5090">
      Seine Nasenflügel weiteten sich, es war, als witterte er Goethe, je näher er Weimar kam.
     </p>
-    <p xml:id="eco_de_0000144_5100">
+    <p xml:id="eco_de_0000214_5100">
      Er wallfahrte wie zu einem Gott.
     </p>
-    <p xml:id="eco_de_0000144_5110">
+    <p xml:id="eco_de_0000214_5110">
      Und wenn er sich hätte durchbetteln müssen, einmal in seinem Leben mußte er in Goethes Nähe sein. Da er verstand, den Augenblick zu nützen, hatte das erste Geld, das als rundes, freies Sümmchen seine Hand berührte, ihn reisefertig gemacht.
     </p>
-    <p xml:id="eco_de_0000144_5120">
+    <p xml:id="eco_de_0000214_5120">
      Und nun war er da!
     </p>
-    <p xml:id="eco_de_0000144_5130">
+    <p xml:id="eco_de_0000214_5130">
      Vor dem Erfurter Tor, am Chausseehäuschen, wurden seine Papiere beim Schein einer Laterne, in der zwei jungfräuliche Talgkerzen brannten, begutachtet. Seinen Namen trug er in ein Fremdenbuch ein und wurde dann unbeanstandet mitsamt der alten Rumpelpost eingelassen.
     </p>
-    <p xml:id="eco_de_0000144_5140">
+    <p xml:id="eco_de_0000214_5140">
      Der Postillion blies liebevoll und falsch: »Muß i denn – muß i denn zum Städtli hinaus – Städtli hinaus«. Was geht das einen alten Postillion an, ob er hinaus- oder hineinfährt. Völlig »wurscht« ist ihm das.
     </p>
-    <p xml:id="eco_de_0000144_5150">
+    <p xml:id="eco_de_0000214_5150">
      Er fuhr seinen jungen Passagier bis vor den Russischen Hof, weil der doch einmal am Wege zur Post lag.
     </p>
-    <p xml:id="eco_de_0000144_5160">
+    <p xml:id="eco_de_0000214_5160">
      Und somit stand der Schwärmer alsobald auf heiligem Boden.
     </p>
-    <p xml:id="eco_de_0000144_5170">
+    <p xml:id="eco_de_0000214_5170">
      »Da missen Se schellen, wenn Se n'ein wollen! – aber dichtig – hären Se, die hären och nich!« rief der Postillion. »Und auf Ihren Kuffert geben Se Owachtchen! Seit mir gar so viel bedeitende Leite ins Nest kriechen, wäre mir Weltstadt.«
     </p>
-    <p xml:id="eco_de_0000144_5180">
+    <p xml:id="eco_de_0000214_5180">
      Damit rumpelte er weiter und nahm sein Stücklein wieder auf, denn er mußte blasend in den Posthof einfahren.
     </p>
-    <p xml:id="eco_de_0000144_5190">
+    <p xml:id="eco_de_0000214_5190">
      Der junge Mann aber stand in schweigender Nacht mitten in Goethes Stadt.
     </p>
-    <p xml:id="eco_de_0000144_5200">
+    <p xml:id="eco_de_0000214_5200">
      Ihm war zumute, als wäre er in einen geheimnisvollen Tempel geraten, in dem ein Gott leibhaftig seinen Wohnsitz genommen hatte.
     </p>
-    <p xml:id="eco_de_0000144_5210">
+    <p xml:id="eco_de_0000214_5210">
      Endlich läutete er, und ein verschlafener Hausbursche nahm sich seiner verschlafen und »sachtchen« an.
     </p>
-    <p xml:id="eco_de_0000144_5220">
+    <p xml:id="eco_de_0000214_5220">
      Es war ein echter und rechter Hausbursche mit Zipfelmütze und Laterne, kräftigen Stallgeruch um sich verbreitend.
     </p>
-    <p xml:id="eco_de_0000144_5230">
+    <p xml:id="eco_de_0000214_5230">
      »Da sin Se mit der letzten Post rein? – Ja – is'n schone nach zwelfe?« fragte er bedächtig. »Da wollen Se wohl ä Zimmerchen?«
     </p>
-    <p xml:id="eco_de_0000144_5240">
+    <p xml:id="eco_de_0000214_5240">
      Und er bekam ein Zimmerchen, ein Riesenzimmer, in dem drei weißüberzogene Betten wie Nippsachen verschwanden.
     </p>
-    <p xml:id="eco_de_0000144_5250">
+    <p xml:id="eco_de_0000214_5250">
      »Se brauchen doch nischt weiter,« fragte der Hausknecht – und zwar ohne Fragezeichen; zündete eine Talgkerze, die in einem Messingleuchter stand, bedächtig an seiner Laterne an. Die Lichtputzschere fiel dabei polternd zur Erde.
     </p>
-    <p xml:id="eco_de_0000144_5260">
+    <p xml:id="eco_de_0000214_5260">
      »Daß dich der Deiwel!« gähnte er und suchte schlaftrunken ihrer wieder habhaft zu werden.
     </p>
-    <p xml:id="eco_de_0000144_5270">
+    <p xml:id="eco_de_0000214_5270">
      »Da sin Se wohl zum Feste rein?«
     </p>
-    <p xml:id="eco_de_0000144_5280">
+    <p xml:id="eco_de_0000214_5280">
      »Zu welchem Fest?«
     </p>
-    <p xml:id="eco_de_0000144_5290">
+    <p xml:id="eco_de_0000214_5290">
      »In Diefurth unten.«
     </p>
-    <p xml:id="eco_de_0000144_5300">
+    <p xml:id="eco_de_0000214_5300">
      »Nein.« Da wußte der Fremde nichts davon. »Was ist da los? Kann man dahin?«
     </p>
-    <p xml:id="eco_de_0000144_5310">
+    <p xml:id="eco_de_0000214_5310">
      »Fremde von Distinktion schon.«
     </p>
-    <p xml:id="eco_de_0000144_5320">
+    <p xml:id="eco_de_0000214_5320">
      »Wieso?«
     </p>
-    <p xml:id="eco_de_0000144_5330">
+    <p xml:id="eco_de_0000214_5330">
      »Was jetzt so hier durchkommt un sich hier aufhält, wenn's nicht Handlungsreisende sin, sind's allemal welche von Distinktion. Was soll denn eens hier duhn?«
     </p>
-    <p xml:id="eco_de_0000144_5340">
+    <p xml:id="eco_de_0000214_5340">
      Dieser Rede dunkler Sinn wurde dem Fremden nicht sofort klar, wie er es wohl auch dem Hausknecht nicht war, denn was der sich unter »Fremde von Distinktion« dachte, Gott weiß es. Seiner Erfahrung nach vielleicht Genies, und was von durchreisenden Genies zu halten war, das wußte er eben seiner Erfahrung nach: Unbezahlte Rechnungen, keine Trinkgelder, Scherereien aller Art, zweifelhafte Leibröcke, nicht salonfähiges Schuhwerk.
     </p>
-    <p xml:id="eco_de_0000144_5350">
+    <p xml:id="eco_de_0000214_5350">
      Ja, man erzählte sich im Russischen Hof, daß ›Geheimderat« Bertuch jährlich eine gewisse Summe, vom Hof aus, zu verausgaben habe, einzig dazu bestimmt, die Toilettendefekte der durchreisenden Genies zu kaschieren. Da gab's Geschichten, es brauchte nur einer im Russischen Hof und im Elefanten nachzufragen.
     </p>
-    <p xml:id="eco_de_0000144_5360">
+    <p xml:id="eco_de_0000214_5360">
      Prüfend schaute der Hausknecht, bei der jetzt glänzenden Beleuchtung der Laterne und der Talgkerze, noch einmal auf die Toilettenverhältnisse des Fremden und kam zu der Ueberzeugung, daß dieser kein Genie sei.
     </p>
-    <p xml:id="eco_de_0000144_5370">
+    <p xml:id="eco_de_0000214_5370">
      »Befehlen der Herr noch was zum Nachtessen?« geruhte er aus diesem Grunde zu fragen.
     </p>
-    <p xml:id="eco_de_0000144_5380">
+    <p xml:id="eco_de_0000214_5380">
      Der Fremde bestellte sich eine Flasche Wein, was auf den Hausknecht wieder einen günstigen Eindruck machte.
     </p>
-    <p xml:id="eco_de_0000144_5390">
+    <p xml:id="eco_de_0000214_5390">
      Ein Genie hätte sich einen Grog bestellt.
     </p>
-    <p xml:id="eco_de_0000144_5400">
+    <p xml:id="eco_de_0000214_5400">
      »Sag Er mal, mein Lieber,« fragte der junge Mann und hielt die schlürfende Bedienung im Hinausgehen auf, »wie ist das mit dem Feste?«
     </p>
-    <p xml:id="eco_de_0000144_5410">
+    <p xml:id="eco_de_0000214_5410">
      »Na, da kommen Se schone hin, wenn Se wollen – i worum nich? Da geht morgen alles, was Beine hat und nur irgend was is.«
     </p>
-    <p xml:id="eco_de_0000144_5420">
+    <p xml:id="eco_de_0000214_5420">
      »Und Herr von Goethe?«
     </p>
-    <p xml:id="eco_de_0000144_5430">
+    <p xml:id="eco_de_0000214_5430">
      »Der allemal. Wo wäre der nich derbei? Auffihren dhun se ä Sticke von ihm. Was wees ichn, was immer lus is. Fragen Se nur beim Wirt, der verschafft Ihnen ä Bullet so sicher wie's Amen in der Kerche. Gegen Zugereiste sin mer in Weimer immer artig.«
     </p>
-    <p xml:id="eco_de_0000144_5440">
+    <p xml:id="eco_de_0000214_5440">
      Der junge Fremde, als der Hausknecht ihm den Wein gebracht und Gute Nacht gewünscht hatte, öffnete weit ein Fenster, goß sein Glas bis an den Rand voll und trank es dem zu, dessen Nähe er hier spürte.
     </p>
-    <p xml:id="eco_de_0000144_5450">
+    <p xml:id="eco_de_0000214_5450">
      Dann schaute er angestrengt in die Dunkelheit hinaus. Alte Linden, die einen Weg oder einen Wassergraben beschatteten, ein kurzer, breiter Turm, allerlei Unbestimmtes, das aufdämmerte, trügerische Formen und tiefe Stille.
     </p>
-    <p xml:id="eco_de_0000144_5460">
+    <p xml:id="eco_de_0000214_5460">
      Ein Uhr schlug es jetzt mit traulichem Schlag. Der Nachtwächter machte die Runde und sang sein Lied.
     </p>
-    <p xml:id="eco_de_0000144_5470">
+    <p xml:id="eco_de_0000214_5470">
      Ob derselbe auch vor Goethes Haus singt?
     </p>
-    <p xml:id="eco_de_0000144_5480">
+    <p xml:id="eco_de_0000214_5480">
      Der junge Fremde hörte andächtig zu.
     </p>
-    <p xml:id="eco_de_0000144_5490">
+    <p xml:id="eco_de_0000214_5490">
      Rührung, als wäre er in seiner eigenen Heimat nach langem Umherirren angelangt, überkam ihn. Es wurde ihm so sonderbar zumute, als er dachte, daß der große Mann keine Ahnung hatte, was für ein treuer Freund ihm hier angekommen war, und daß er wohl nie etwas davon erfahren würde.
     </p>
-    <p xml:id="eco_de_0000144_5500">
+    <p xml:id="eco_de_0000214_5500">
      Das schmerzvoll einsame Gefühl einer unglücklichen Liebe stieg in ihm auf.
     </p>
-    <p xml:id="eco_de_0000144_5510">
+    <p xml:id="eco_de_0000214_5510">
      Er war gekommen, einen Gott anzubeten, einen Begriff – und fühlte hier die Nähe des Menschen auf sich wirken, des Menschen, von dem er ein Echo für seine Begeisterung wollte.
     </p>
-    <p xml:id="eco_de_0000144_5520">
+    <p xml:id="eco_de_0000214_5520">
      Mit einem Mal kam er sich so unnütz in dem dunkeln, alten Städtchen vor; seine Reise erschien ihm lächerlich, was ihm zwingend gewesen war, zerfiel zu nichts. Ja, er mußte ihn sehen und sprechen – das war's! – das mußte sein! Und aufgeregt ging er im Zimmer auf und ab.
     </p>
-    <p xml:id="eco_de_0000144_5530">
+    <p xml:id="eco_de_0000214_5530">
      Doch höchst eigentümlich, daß er gerade zu diesem Feste kommen mußte!
     </p>
-    <p xml:id="eco_de_0000144_5540">
+    <p xml:id="eco_de_0000214_5540">
      Seine Phantasie machte die tollsten Sprünge – und er ging schlafen als Goethes ganz unentbehrlicher Freund, als der, den der große Mann längst gesucht und endlich gefunden. Er tat dem Verehrten die wichtigsten Dienste, siedelte ganz nach Weimar über und war der glücklichste Mensch.
     </p>
-    <p xml:id="eco_de_0000144_5550">
+    <p xml:id="eco_de_0000214_5550">
      Ein wunderbar sonniger Sommertag brach an. Der Student war mit dem Frühsten munter, und es währte nicht lange, da durchwanderte er die engen, winkligen Sträßchen Weimars.
     </p>
-    <p xml:id="eco_de_0000144_5560">
+    <p xml:id="eco_de_0000214_5560">
      An dem großen, gußeisernen Brunnen stand er und starrte auf die lange Reihe schlichter Fenster, hinter denen der Große lebte.
     </p>
-    <p xml:id="eco_de_0000144_5570">
+    <p xml:id="eco_de_0000214_5570">
      Zufällig erfuhr er, daß Herr von Goethe sein Gartenhaus unten am Stern schon bezogen habe. Er ging sofort dahin und sah sich die Augen halb aus. Sonnenfrieden über den hohen Baumwipfeln, dem weißen Häuschen mit seiner hohen, grauen Schindelmütze, weite Wiesen, Vogelgezwitscher.
     </p>
-    <p xml:id="eco_de_0000144_5580">
+    <p xml:id="eco_de_0000214_5580">
      Die Wiesenblumen stehn in voller Pracht.
     </p>
-    <p xml:id="eco_de_0000144_5590">
+    <p xml:id="eco_de_0000214_5590">
      Es ist nichts Lieblicheres zu denken als dieser grüne, weiche Friede. Nirgends ein Haus. Kein Geräusch – keine Menschenseele.
     </p>
-    <p xml:id="eco_de_0000144_5600">
+    <p xml:id="eco_de_0000214_5600">
      Hier verbringt also dieser Glücklichste seine Sommertage! Eine Einsamkeit, die er in wenigen Augenblicken mit der reizvollsten Geselligkeit vertauschen kann.
     </p>
-    <p xml:id="eco_de_0000144_5610">
+    <p xml:id="eco_de_0000214_5610">
      Ihn lieben die Götter! Das steht fest, und zwar alle ganz einmütig.
     </p>
-    <p xml:id="eco_de_0000144_5620">
+    <p xml:id="eco_de_0000214_5620">
      Und so weise, diese stillen Erdenwinkel zu finden – zu halten und zu genießen!
     </p>
-    <p xml:id="eco_de_0000144_5630">
+    <p xml:id="eco_de_0000214_5630">
      Von hier aus strahlte also das Begeisternde über ganz Deutschland, von hier ging es aus, das frische, starke Leben, das sich in Tausende steifer und schlafender Alltagsherzen ergoß und sie lebendig schlagen ließ.
     </p>
-    <p xml:id="eco_de_0000144_5640">
+    <p xml:id="eco_de_0000214_5640">
      Ja, wahrhaftig, so ein Student vergibt sich nichts, wenn er hier auf- und niederrennt in mächtiger Begeisterung.
     </p>
-    <p xml:id="eco_de_0000144_5650">
+    <p xml:id="eco_de_0000214_5650">
      Als er wieder in seinen Russischen Hof sonnedurchwärmt zurückkehrte, hatte der Wirt ihm bereits ein Billett vom Hofamt zur Aufführung in Tieffurth holen lassen.
     </p>
-    <p xml:id="eco_de_0000144_5660">
+    <p xml:id="eco_de_0000214_5660">
      Mit welcher Weihe, Vorsicht und Eleganz kleidete er sich am Nachmittag an, wie ein Bräutigam.
     </p>
-    <p xml:id="eco_de_0000144_5670">
+    <p xml:id="eco_de_0000214_5670">
      Und stattlich und schön sah er aus, das mußte er selbst zugestehen. Er war mit sich zufrieden, – ein Fremder von Distinktion.
     </p>
-    <p xml:id="eco_de_0000144_5680">
+    <p xml:id="eco_de_0000214_5680">
      So machte er sich gegen Abend auf, nach Tieffurth zu wandern. Der Wirt wollte ihn bereden, ein Fuhrwerk zu nehmen, der Gast aber wollte gehen, den heiligen Boden berühren und auf Schritt und Tritt hoffen, daß ihm etwas Intimes, Entscheidendes begegne.
     </p>
-    <p xml:id="eco_de_0000144_5690">
+    <p xml:id="eco_de_0000214_5690">
      »Fehlen können Sie nicht; wo alles hinrennt, laufen Sie mit,« sagte der Wirt, als er seinen Gast bis vor die Haustür begleitete.
     </p>
-    <p xml:id="eco_de_0000144_5700">
+    <p xml:id="eco_de_0000214_5700">
      »Sehen Sie dort, mein Herr, dort die geputzten Frauenzimmer, denen gehen Sie nur getrost nach, dann sind Sie sicher nicht irregegangen.«
     </p>
-    <p xml:id="eco_de_0000144_5710">
+    <p xml:id="eco_de_0000214_5710">
      Ein ganzer Schwarm junges Volk! Das lachte und schwatzte, flatterte in hellsten, lustigsten Farben wie ein wandelndes Blumenbeet, Eifer, Lebenslust, Ausgelassenheit.
     </p>
-    <p xml:id="eco_de_0000144_5720">
+    <p xml:id="eco_de_0000214_5720">
      Ah, denen war's wohl!
     </p>
-    <p xml:id="eco_de_0000144_5730">
+    <p xml:id="eco_de_0000214_5730">
      Solche lustigen Vögel wohnten auch in dem engen, grauen Nest.
     </p>
-    <p xml:id="eco_de_0000144_5740">
+    <p xml:id="eco_de_0000214_5740">
      An solches Nebenvolk hatte unser guter Junge noch gar nicht gedacht.
     </p>
-    <p xml:id="eco_de_0000144_5750">
+    <p xml:id="eco_de_0000214_5750">
      Für ihn thronte hier Goethe, der Gottmensch, daß sich irgend etwas anderes hier noch breit machen konnte! –
     </p>
-    <p xml:id="eco_de_0000144_5760">
+    <p xml:id="eco_de_0000214_5760">
      Und wie es sich breit machte, nahm die ganze Straße ein, eine an die andere gedrängt, eine ganze Kette lustig flatternder Fähnchen, blumengeschmückter Häupter und nickender Hüte – und Lachen und Kichern ohne Ende.
     </p>
-    <p xml:id="eco_de_0000144_5770">
+    <p xml:id="eco_de_0000214_5770">
      Das waren im Grund ganz annehmbare Führer.
     </p>
-    <p xml:id="eco_de_0000144_5780">
+    <p xml:id="eco_de_0000214_5780">
      Er beeilte sich, sie nicht aus dem Auge zu verlieren.
     </p>
-    <p xml:id="eco_de_0000144_5790">
+    <p xml:id="eco_de_0000214_5790">
      Welch schöne, schattige Allee, in die sie jetzt einbogen.
     </p>
-    <p xml:id="eco_de_0000144_5800">
+    <p xml:id="eco_de_0000214_5800">
      O, sie wußten ihren Weg.
     </p>
-    <p xml:id="eco_de_0000144_5810">
+    <p xml:id="eco_de_0000214_5810">
      Hinter ihnen, vor ihnen wanderte buntes Volk; aber zwischen ihnen und dem Studenten war ein freier Raum.
     </p>
-    <p xml:id="eco_de_0000144_5820">
+    <p xml:id="eco_de_0000214_5820">
      Er hielt sich tapfer ihnen nah, wenn auch in gemessener Entfernung.
     </p>
-    <p xml:id="eco_de_0000144_5830">
+    <p xml:id="eco_de_0000214_5830">
      Da war eine unter den jungen Frauenzimmern, die lachte, wie er noch nie lachen gehört hatte.
     </p>
-    <p xml:id="eco_de_0000144_5840">
+    <p xml:id="eco_de_0000214_5840">
      Das war ein Lachen!
     </p>
-    <p xml:id="eco_de_0000144_5850">
+    <p xml:id="eco_de_0000214_5850">
      Und wenn sie damit anhub, flog ein ganzer Chor von Lachstimmen mit der ihren auf, wie ein Schwarm weißer, sonnebeschienener Tauben.
     </p>
-    <p xml:id="eco_de_0000144_5860">
+    <p xml:id="eco_de_0000214_5860">
      So lustig waren sie hier in diesem Nest, da mußte eine gute, leichte Luft sein.
     </p>
-    <p xml:id="eco_de_0000144_5870">
+    <p xml:id="eco_de_0000214_5870">
      Hier mußte sich's leben lassen.
     </p>
-    <p xml:id="eco_de_0000144_5880">
+    <p xml:id="eco_de_0000214_5880">
      Es war nicht nur das Lachen, das ihm das fremde, kleiderumflatterte Ding merkwürdig machte, nein sie war eben ganz Lachen – da war kein Blutstropfen, der nicht mitkicherte.
     </p>
-    <p xml:id="eco_de_0000144_5890">
+    <p xml:id="eco_de_0000214_5890">
      Bald hing sie der einen am Hals, bald der andern. Da hatte sie etwas zu tuscheln, da gab sie einen Schubbs als Antwort. Jetzt nahm sie den Hut ab, da flogen die lebendigsten, blonden Locken im Sommerwind, – so volle, runde, leichte Locken. Sie war gegen die anderen Frauenzimmer wie nicht bekleidet. Ihre Körperformen drangen mutwillig durch alle Falten hindurch, ließen sich gar nicht verbergen. Es war so etwas Lustiges, Bewegliches in ihnen.
     </p>
-    <p xml:id="eco_de_0000144_5900">
+    <p xml:id="eco_de_0000214_5900">
      Sie war es auch, die den Fremden zuerst bemerkte.
     </p>
-    <p xml:id="eco_de_0000144_5910">
+    <p xml:id="eco_de_0000214_5910">
      Er verstand, wie sie sagte: »Da steigt uns einer nach!« und darauf das köstliche Lachen, als wollte sie sich in Lachen auflösen.
     </p>
-    <p xml:id="eco_de_0000144_5920">
+    <p xml:id="eco_de_0000214_5920">
      Sie schien eine lose Bemerkung geflüstert zu haben.
     </p>
-    <p xml:id="eco_de_0000144_5930">
+    <p xml:id="eco_de_0000214_5930">
      Den ganzen Schwarm brachte sie in Aufregung.
     </p>
-    <p xml:id="eco_de_0000144_5940">
+    <p xml:id="eco_de_0000214_5940">
      Und nicht lange währte es, da schaute sie sich um und wieder um.
     </p>
-    <p xml:id="eco_de_0000144_5950">
+    <p xml:id="eco_de_0000214_5950">
      Die Mädchen verlangsamten ihr Tempo, als sollte er an ihnen vorübergehen. Und er ging auf diesen Vorschlag ein, benutzte aber sein Recht als Fremder, zog den Hut und fragte die geputzten Frauenzimmer nach dem Tieffurther Weg.
     </p>
-    <p xml:id="eco_de_0000144_5960">
+    <p xml:id="eco_de_0000214_5960">
      Das bewegliche Mädchen erwiderte ihm: »Da sind Sie ja ganz recht. O, – als ob Sie den Weg nicht wüßten. Wir haben Sie längst gesehn, mein Herr.«
     </p>
-    <p xml:id="eco_de_0000144_5970">
+    <p xml:id="eco_de_0000214_5970">
      Er versicherte aber, daß er völlig fremd hier sei.
     </p>
-    <p xml:id="eco_de_0000144_5980">
+    <p xml:id="eco_de_0000214_5980">
      »Ihr müßt's wissen,« wandte sie sich an ihre Begleiterinnen, »ob der Herr hierher gehört oder nicht. Ich bin selbst fremd hier.«
     </p>
-    <p xml:id="eco_de_0000144_5990">
+    <p xml:id="eco_de_0000214_5990">
      »Nein, sie hatten ihn noch nie gesehen,« kam es schüchtern bestätigend von manchen Lippen.
     </p>
-    <p xml:id="eco_de_0000144_6000">
+    <p xml:id="eco_de_0000214_6000">
      »Na also, wenn's so ist, wie Sie sagen, da gehen Sie nur, wo wir gehen. Wir kommen schon an.« So war er also mitgenommen.
     </p>
-    <p xml:id="eco_de_0000144_6010">
+    <p xml:id="eco_de_0000214_6010">
      Unterwegs hielt er sich zu dem schönen Geschöpf. Die andern waren mehr oder weniger von jetzt an wie auf den Mund geschlagen, sehr ehrbar und steif.
     </p>
-    <p xml:id="eco_de_0000144_6020">
+    <p xml:id="eco_de_0000214_6020">
      Ein adrett gekleidetes Demoisellchen sagte: »Ich bin nur begierig, wo wir auf Frau Rätin Tiburtius und die andern ältern Damen treffen.«
     </p>
-    <p xml:id="eco_de_0000144_6030">
+    <p xml:id="eco_de_0000214_6030">
      Die junge Schönheit, die das gehört hatte, wendete sich zu dem Studenten. »Nicht wahr, Sie fressen uns nicht, auch wenn wir ohne alte Schachteln sind?«
     </p>
-    <p xml:id="eco_de_0000144_6040">
+    <p xml:id="eco_de_0000214_6040">
      »Aber Lorchen!«
     </p>
-    <p xml:id="eco_de_0000144_6050">
+    <p xml:id="eco_de_0000214_6050">
      »Jawohl, ihr kommt nie aus dem Steckkissen raus. Sind wir nit Manns genug? Alte Weiber kann i nit leiden, wenn's einen immer auf der Nasen sitzen.«
     </p>
-    <p xml:id="eco_de_0000144_6060">
+    <p xml:id="eco_de_0000214_6060">
      Der Student stellte sich auf das wohlerzogenste vor.
     </p>
-    <p xml:id="eco_de_0000144_6070">
+    <p xml:id="eco_de_0000214_6070">
      »Hoffentlich tanzen Sie?« fragte das schöne, lebhafte Mädchen.
     </p>
-    <p xml:id="eco_de_0000144_6080">
+    <p xml:id="eco_de_0000214_6080">
      »Zur Not, Demoiselle.«
     </p>
-    <p xml:id="eco_de_0000144_6090">
+    <p xml:id="eco_de_0000214_6090">
      »Ach was, wenn man tanzt, tanzt man nit zur Not!«
     </p>
-    <p xml:id="eco_de_0000144_6100">
+    <p xml:id="eco_de_0000214_6100">
      Sie war Fränkin, das verriet sich gleich.
     </p>
-    <p xml:id="eco_de_0000144_6110">
+    <p xml:id="eco_de_0000214_6110">
      »Aus Koburg?« fragte er.
     </p>
-    <p xml:id="eco_de_0000144_6120">
+    <p xml:id="eco_de_0000214_6120">
      »Ja, nit wahr? Und wie alt sinds? Sinds verehelicht oder ledig? – Wie auf dem Paßbureau? Ich weit nit, daß die Leut hier gar so schwerblütig sind.«
     </p>
-    <p xml:id="eco_de_0000144_6130">
+    <p xml:id="eco_de_0000214_6130">
      »Lorchen!« sagte wieder eine Kameradin flüsternd ermahnend.
     </p>
-    <p xml:id="eco_de_0000144_6140">
+    <p xml:id="eco_de_0000214_6140">
      »Ja, steifleinen sind hier die Leut! Wissens, gestern ist mir der Herr von Goeth nachgestiegen – der Oberbonz – der merkte auch, da läuft was nicht Weimarsches.«
     </p>
-    <p xml:id="eco_de_0000144_6150">
+    <p xml:id="eco_de_0000214_6150">
      »Goethe! – Nein!« rief der Student außer sich.
     </p>
-    <p xml:id="eco_de_0000144_6160">
+    <p xml:id="eco_de_0000214_6160">
      »Na, als ob nit? Freilich und wie! Gestiegen ist er wie noch mal 'n Kavalier. Zu kurze Beine hat er gehabt, – das hatt' ich gleich weg!«
     </p>
-    <p xml:id="eco_de_0000144_6170">
+    <p xml:id="eco_de_0000214_6170">
      Im Eifer des Gesprächs hatte sich Lorchen in die Arme des Studenten eingehenkt und hatte es so kindlich, reizend und lebhaft getan, als müßte es so sein. Eine ihrer Kameradinnen sagte zur andern: »Kokette Trine, die!« –
     </p>
-    <p xml:id="eco_de_0000144_6180">
+    <p xml:id="eco_de_0000214_6180">
      Die Erwähnung der kurzen Beine gab dem Studenten einen Stich ins Herz. So einem Frauenzimmer ist nichts heilig.
     </p>
-    <p xml:id="eco_de_0000144_6190">
+    <p xml:id="eco_de_0000214_6190">
      »Aber Demoiselle,« sagte er verweisend.
     </p>
-    <p xml:id="eco_de_0000144_6200">
+    <p xml:id="eco_de_0000214_6200">
      »Der, wenn nit zu kurze Beine hat und nit zu eingebildet ist, will ich Matz heißen. Kurzbeiniges Mannsvolk ist mir nu ma zuwider. Und wenn eins schreiben kann wie zwanzig Schulmeister zusammengenommen.«
     </p>
-    <p xml:id="eco_de_0000144_6210">
+    <p xml:id="eco_de_0000214_6210">
      »Na, und wenn ich denke, wie der abgeschleckt werden würd, wenn alles schlecken dürft, was wollt! Nein, der könnt schon um ein Busserl vor mir auf der Erde rutschen – nit um die Welt! So'n Aff!«
     </p>
-    <p xml:id="eco_de_0000144_6220">
+    <p xml:id="eco_de_0000214_6220">
      Der Student hatte einen solchen Aerger über die dumme Gans, daß er sie am liebsten abgeschüttelt hätte; – aber wie er so auf sie niedersah, stieg es ihm glutheiß zu Herzen. Da wogte und vibrierte alles in und um das herrliche Persönchen. Das Leben jagte sich nur so in ihr. Die Augen hatten einen Glanz, als wären sie an ganz andere Sonne gewohnt. Ihre Schritte tanzten, der feuchte Mund glänzte und lächelte, und die junge Brust hob und senkte sich so lustig, so in süßer Harmonie. Um dies ganze Geschöpf war ein fremdes, sonniges, warmes Klima für sich, das sie von allen andern absonderte. Sie mochte tun, was sie wollte, sie tat es wie in einer eignen Atmosphäre.
     </p>
-    <p xml:id="eco_de_0000144_6230">
+    <p xml:id="eco_de_0000214_6230">
      Nein, so etwas war dem braven Studenten aus gutem Haus wahrlich noch nicht über den Weg gelaufen.
     </p>
-    <p xml:id="eco_de_0000144_6240">
+    <p xml:id="eco_de_0000214_6240">
      Unwillkürlich hielt er den warmen, lebendurchströmten Arm fester an sich gepreßt.
     </p>
-    <p xml:id="eco_de_0000144_6250">
+    <p xml:id="eco_de_0000214_6250">
      »Drückens nit so!« sagte sie schelmisch.
     </p>
-    <p xml:id="eco_de_0000144_6260">
+    <p xml:id="eco_de_0000214_6260">
      Die meisten der jungen Frauenzimmer schauten schon mißbilligend auf sie.
     </p>
-    <p xml:id="eco_de_0000144_6270">
+    <p xml:id="eco_de_0000214_6270">
      Das mochte heute abend gut werden. Die würde alles an sich reißen.
     </p>
-    <p xml:id="eco_de_0000144_6280">
+    <p xml:id="eco_de_0000214_6280">
      »Unverschämte Person.«
     </p>
-    <p xml:id="eco_de_0000144_6290">
+    <p xml:id="eco_de_0000214_6290">
      Die aber kümmerte sich um keine Billigung und keine Mißbilligung, plauderte mit ihrem Studenten und war drolliger Einfälle voll.
     </p>
-    <p xml:id="eco_de_0000144_6300">
+    <p xml:id="eco_de_0000214_6300">
      Nicht lange währte es, da hatte sie weg, daß er ein Goetheschwärmer war! Das amüsierte sie köstlich.
     </p>
-    <p xml:id="eco_de_0000144_6310">
+    <p xml:id="eco_de_0000214_6310">
      »Nein, ein Mannsbild fürs andre! Daß i nit lach! Sie verrückter Tropf!«
     </p>
-    <p xml:id="eco_de_0000144_6320">
+    <p xml:id="eco_de_0000214_6320">
      Und sie lachte und guckte ihm so schelmisch von unten herauf mitten in die Augen, als wollte sie sagen: ›Da könntest du wohl was Besseres tun.«
     </p>
-    <p xml:id="eco_de_0000144_6330">
+    <p xml:id="eco_de_0000214_6330">
      Als sie in Tieffurth angelangt waren, strömte es von erwartungsvollen Menschen das Ilmufer entlang.
     </p>
-    <p xml:id="eco_de_0000144_6340">
+    <p xml:id="eco_de_0000214_6340">
      Es dunkelte schon. Und bei völliger Dunkelheit sollte die Aufführung beginnen.
     </p>
-    <p xml:id="eco_de_0000144_6350">
+    <p xml:id="eco_de_0000214_6350">
      Man sprach von einem wirklichen Kahn auf der Ilm und von einer kleinen Freitreppe, die zum Wasser hinunterführt.
     </p>
-    <p xml:id="eco_de_0000144_6360">
+    <p xml:id="eco_de_0000214_6360">
      Heutigen Tags sind diese paar Stufen noch zu sehen. Von einem chinesischen Tempel mit kleinen Glöckchen, der Tempel mit Wachstuch überzogen, von da aus sollten die Herrschaften das Schauspiel betrachten.
     </p>
-    <p xml:id="eco_de_0000144_6370">
+    <p xml:id="eco_de_0000214_6370">
      Der Tieffurther Park mit seinen hohen, herrlichen Bäumen, der plaudernden Ilm, den weiten Wiesen, den bunten, heitern Menschen machte auf unsern Studenten einen entzückenden Eindruck.
     </p>
-    <p xml:id="eco_de_0000144_6380">
+    <p xml:id="eco_de_0000214_6380">
      Vom Schlosse her sanfte Musik.
     </p>
-    <p xml:id="eco_de_0000144_6390">
+    <p xml:id="eco_de_0000214_6390">
      Und so in Goethes Nähe mit dem schönen Mädchen am Arm! Mit dem Mädchen, das sich gestern in Goethes Augen widergespiegelt hatte, das, wenn sie wirklich wahr gesprochen hatte, vom Goethe bemerkt war, das ihn entzückt hatte.
     </p>
-    <p xml:id="eco_de_0000144_6400">
+    <p xml:id="eco_de_0000214_6400">
      Ja, eigentlich weshalb denn nicht, war sie denn nicht entzückend?
     </p>
-    <p xml:id="eco_de_0000144_6410">
+    <p xml:id="eco_de_0000214_6410">
      Und sie hatte ihn – Goethen vorgezogen? Toller, unsinniger Gedanke! Und dieser Gedanke packt ihn, benebelt ihn. Welch ein sonderbares Schicksal!
     </p>
-    <p xml:id="eco_de_0000144_6420">
+    <p xml:id="eco_de_0000214_6420">
      Er ging mit seiner heitern Schönen die Ilm entlang, aus dem Bereich der Masse. Und ging, ohne zu denken, daß er ging. Er fühlte sie; – ihr wunderbares, lebendiges Klima erwärmte, verschönte, belebte auch ihn.
     </p>
-    <p xml:id="eco_de_0000144_6430">
+    <p xml:id="eco_de_0000214_6430">
      Das einzige, was er empfand, war – sie bald – bald zu küssen! Er wollte sie nur ganz von lästigen Spähern abtrennen, und so gingen sie und gingen ins Unbewußte hinein.
     </p>
-    <p xml:id="eco_de_0000144_6440">
+    <p xml:id="eco_de_0000214_6440">
      Sie an ihn fest angedrängt.
     </p>
-    <p xml:id="eco_de_0000144_6450">
+    <p xml:id="eco_de_0000214_6450">
      Ja, er durfte wagen, sie zu küssen! – und er küßte sie so ganz einfach, ohne ein Wort zu sagen, als kennten sie sich schon lange.
     </p>
-    <p xml:id="eco_de_0000144_6460">
+    <p xml:id="eco_de_0000214_6460">
      Sie trank seine Küsse – ja, sie trank sie durstig.
     </p>
-    <p xml:id="eco_de_0000144_6470">
+    <p xml:id="eco_de_0000214_6470">
      »Ich weiß nit,« sagte sie, »du bist so ganz mein Gusto – so ganz was ich will; gleich gefielst du mir.
     </p>
-    <p xml:id="eco_de_0000144_6480">
+    <p xml:id="eco_de_0000214_6480">
      Und morgen reis' ich, du gehörst Gott weiß wohin – – und ich, Gott weiß wohin. Frag nit nach mir. Küß mich halt. Ich möchte so gern grundselig heut sein!«
     </p>
-    <p xml:id="eco_de_0000144_6490">
+    <p xml:id="eco_de_0000214_6490">
      Ja – und er küßte sie. Die weichen, lebendigen Locken schlangen sich ihm um die Hände.
     </p>
-    <p xml:id="eco_de_0000144_6500">
+    <p xml:id="eco_de_0000214_6500">
      Der Mond schien, die Ilm rauschte. Sie waren weit, weit vom Festplatz entfernt. Zarter Gesang, eine wundervoll singende Frauenstimme, gedämpfte Musik, fernes Aufleuchten und Flimmern.
     </p>
-    <p xml:id="eco_de_0000144_6510">
+    <p xml:id="eco_de_0000214_6510">
      »Jetzt spielen sie,« sagte sie lustig und dennoch wie hinsterbend vor Wonne.
     </p>
-    <p xml:id="eco_de_0000144_6520">
+    <p xml:id="eco_de_0000214_6520">
      Die Ilm glitzerte ihnen zu Füßen.
     </p>
-    <p xml:id="eco_de_0000144_6530">
+    <p xml:id="eco_de_0000214_6530">
      »Die, mit ihrem dummen Kahn,« begann das schöne, liebestrunkene Geschöpf wieder – »solche Kindereien – Nicht, du? und einen Tempel aus Wachstuch! Weißt du, so am Wasser, wie hier, bin ich aufgewachsen; auf unserm Gut. An der Schulstub, in der wir beim Hauslehrer lernen mußten, floß solch ein Wässerlein vorbei.
     </p>
-    <p xml:id="eco_de_0000144_6540">
+    <p xml:id="eco_de_0000214_6540">
      Die ganzen Sommertage lebten wir darin. Naß kamen wir durchs Fenster in die Stub, wenn der Lehrer zum zwanzigstenmal gerufen hatte, ein ganzes Rudel Mädels und Buben.
     </p>
-    <p xml:id="eco_de_0000144_6550">
+    <p xml:id="eco_de_0000214_6550">
      Triefend standen wir um den Tisch.
     </p>
-    <p xml:id="eco_de_0000144_6560">
+    <p xml:id="eco_de_0000214_6560">
      Die ganze Stube schwamm.
     </p>
-    <p xml:id="eco_de_0000144_6570">
+    <p xml:id="eco_de_0000214_6570">
      Er schlug nach uns. Wir lachten.
     </p>
-    <p xml:id="eco_de_0000144_6580">
+    <p xml:id="eco_de_0000214_6580">
      Ach, weißt du, das war schön!«
     </p>
-    <p xml:id="eco_de_0000144_6590">
+    <p xml:id="eco_de_0000214_6590">
      Sie dehnte sich in seinen Armen bei dieser Erinnerung. Ja, das hatte ihr gefallen, das war so ganz ihr Gusto gewesen, wie es schien.
     </p>
-    <p xml:id="eco_de_0000144_6600">
+    <p xml:id="eco_de_0000214_6600">
      »Dann kamen böse Zeiten,« sagte sie träumerisch.
     </p>
-    <p xml:id="eco_de_0000144_6610">
+    <p xml:id="eco_de_0000214_6610">
      Mit einem Mal aber war ein ganz übersprudelndes Leben in sie geraten, als wären irgendwie Lebensschleusen geöffnet morden.
     </p>
-    <p xml:id="eco_de_0000144_6620">
+    <p xml:id="eco_de_0000214_6620">
      Sie hing an seinem Hals mit einer süßen, wallenden Leidenschaft und sagte flüsternd, mit spitzbübischer Freude an einem tollen Streich: »Gehen mir ins Wasser – weißt? – Laß die Dummen dort mit ihrem eingebildeten Zeug! Das wirkliche Leben ist so schön – – so schön! Und hier das bissel Musik, was herüberklingt, ist besser als die ganze Geschichte.«
     </p>
-    <p xml:id="eco_de_0000144_6630">
+    <p xml:id="eco_de_0000214_6630">
      Sie zog ihn mit sich fort. »Hier«, flüsterte sie im Laufen, »findet uns keine Menschenseele. Wer käm' auf die weite Wiese gegangen? Jetzt glotzen sie alle. –«
     </p>
-    <p xml:id="eco_de_0000144_6640">
+    <p xml:id="eco_de_0000214_6640">
      Und wie im Nu waren die flatternden, leichten Kleider abgestreift, nach alter Gewohnheit, kinderhaft leicht. – Und vor ihm stand im nebelhaften, flimmernden Mondlicht, unter dichtem Zweiggewirr – ein leuchtender, süßer, lockenumwallter Körper.
     </p>
-    <p xml:id="eco_de_0000144_6650">
+    <p xml:id="eco_de_0000214_6650">
      Ihm benahm der plötzliche Anblick den Atem.
     </p>
-    <p xml:id="eco_de_0000144_6660">
+    <p xml:id="eco_de_0000214_6660">
      Das war wie Zauberei geschehen, und so behende wie eine Eidechs huschte sie das Ufer hinab – und jetzt leuchtete es auf in den Wellen – lockend – silbern – und das süße, unwiderstehliche Lachen erklang.
     </p>
-    <p xml:id="eco_de_0000144_6670">
+    <p xml:id="eco_de_0000214_6670">
      »Komm, dummer Bub, eil dich.«
     </p>
-    <p xml:id="eco_de_0000144_6680">
+    <p xml:id="eco_de_0000214_6680">
      Ja, und auch er legte seine Kleider ab, wie im Rausch, wie im Fieber, mit klopfendem Herzen.
     </p>
-    <p xml:id="eco_de_0000144_6690">
+    <p xml:id="eco_de_0000214_6690">
      Und sie empfing ihn mit einem tollen Sprühregen, schlug mit den leuchtenden Armen in die Wellen und warf ihm das Wasser händevoll ins Gesicht. Dabei immer das köstliche, halbunterdrückte Lachen.
     </p>
-    <p xml:id="eco_de_0000144_6700">
+    <p xml:id="eco_de_0000214_6700">
      Dazwischen die ferne, singende Frauenstimme, dann Chorgesang und Musik.
     </p>
-    <p xml:id="eco_de_0000144_6710">
+    <p xml:id="eco_de_0000214_6710">
      »Das tun sie für uns!« lachte sie. »Wenn die das wüßten!«
     </p>
-    <p xml:id="eco_de_0000144_6720">
+    <p xml:id="eco_de_0000214_6720">
      Sie peitschte ihn mit ihrem Haar, als er sie packte, in die Höhe riß und auf seinen Armen trug.
     </p>
-    <p xml:id="eco_de_0000144_6730">
+    <p xml:id="eco_de_0000214_6730">
      »Läßt du mich! eklicher Bub!« rief sie und schlug und biß um sich wie eine wilde Katze.
     </p>
-    <p xml:id="eco_de_0000144_6740">
+    <p xml:id="eco_de_0000214_6740">
      So tobten und rangen sie miteinander in süßer Wut – und wieder ausgelassen wie zwei Schulbuben, und trieben es endlos.
     </p>
-    <p xml:id="eco_de_0000144_6750">
+    <p xml:id="eco_de_0000214_6750">
      »Nun noch einen nassen Kuß,« flüsterte sie, legte ihr feuchtes Gesicht an das seine und küßte ihn so zierlich wie ein kleines Kind. Dann in ein paar Sätzen war sie beim Ufer hinauf zum Platz geeilt, wo ihre Kleider lagen. Wie ein verkörperter Lichtstrahl im Mondenschein leuchtend, schüttelte sie sich, schüttelte ihre Locken und im Nu war sie in ihren Gewändern; dann stand sie und wartete auf ihn, erbat sich sein Taschentuch, um ihr feuchtes Haar zu trocknen, trocknete und rieb, steckte die luftigen Locken zierlich auf; und stand bald wieder da in ihrem fraulichen Reiz, das festlich gekleidete, junge Mädchen.
     </p>
-    <p xml:id="eco_de_0000144_6760">
+    <p xml:id="eco_de_0000214_6760">
      Für ihn war es beschwerlicher, wieder in sein Kleidergehäuse zu kommen. Das dichte Buschwerk machte es ihm nicht leichter. Zu guter Letzt wollte die hohe kunstvolle Krawatte nicht sitzen, und er kam nicht so recht vollendet in der Erscheinung zur zierlichen wartenden Nixe zurück.
     </p>
-    <p xml:id="eco_de_0000144_6770">
+    <p xml:id="eco_de_0000214_6770">
      Sie hing sich in den Arm ihres hingerissenen, betäubten Begleiters ein, nestelte an ihrem Oehrchen und drückte ihm etwas in die Hand.
     </p>
-    <p xml:id="eco_de_0000144_6780">
+    <p xml:id="eco_de_0000214_6780">
      »Das behalte zu meinem Gedenken.« Das sprach sie würdig wie der Priester beim Abendmahl, schlang noch einmal den Arm um ihn und küßte ihn mit hinsterbender Leidenschaft.
     </p>
-    <p xml:id="eco_de_0000144_6790">
+    <p xml:id="eco_de_0000214_6790">
      »Du hast mir gleich so gut gefallen,« wiederholte sie noch einmal und sagte das so einfach.
     </p>
-    <p xml:id="eco_de_0000144_6800">
+    <p xml:id="eco_de_0000214_6800">
      »Wann sehen wir uns wieder, Lorchen?« fragte er außer sich.
     </p>
-    <p xml:id="eco_de_0000144_6810">
+    <p xml:id="eco_de_0000214_6810">
      »Nie. – Nein gewiß, nie. Ich reise noch heut in der Früh.« Da lachte sie über den Reim – und weinte dazwischen und lachte wieder.
     </p>
-    <p xml:id="eco_de_0000144_6820">
+    <p xml:id="eco_de_0000214_6820">
      »Laß dir ein Ringerl davon machen.« Sie tippte ihn auf die verschlossene Hand, in der er das Angedenken hielt.
     </p>
-    <p xml:id="eco_de_0000144_6830">
+    <p xml:id="eco_de_0000214_6830">
      Als sie an den Festplatz kamen, waren alle Lichter gelöscht, – das Schauspiel aus, die Herrschaften zur Tafel gegangen.
     </p>
-    <p xml:id="eco_de_0000144_6840">
+    <p xml:id="eco_de_0000214_6840">
      Er hatte Goethe zu sehen versäumt!
     </p>
-    <p xml:id="eco_de_0000144_6850">
+    <p xml:id="eco_de_0000214_6850">
      Und wie er sich dessen inne ward, ganz verblüfft stand, war ihm das feuchte Nixlein schon von der Seite gekommen, entwischt wie ein Zauber – unter einer Gruppe von Leuten verschwunden.
     </p>
-    <p xml:id="eco_de_0000144_6860">
+    <p xml:id="eco_de_0000214_6860">
      Er lief ihr nach, – er suchte sie – suchte sie bis spät in die Nacht, wie ein Unsinniger. Einmal war es ihm, als sähe er sie auf dem Tanzplatz unter der großen Linde im Gutshof, im Arm eines vornehmen Herrn mit dahinrasen, als er aber näher hinzukam, war sie wieder im Gedräng verschwunden.
     </p>
-    <p xml:id="eco_de_0000144_6870">
+    <p xml:id="eco_de_0000214_6870">
      Abgemattet kam er gegen Morgen in Weimar an, mit wirrem Kopf; trostlos, etwas Köstliches verloren zu haben und Goethe nicht gesehen zu haben.
     </p>
-    <p xml:id="eco_de_0000144_6880">
+    <p xml:id="eco_de_0000214_6880">
      Und er hatte kein Glück, während seines Aufenthalts in Weimar bekam er ihn auch nicht zu sehen.
     </p>
-    <p xml:id="eco_de_0000144_6890">
+    <p xml:id="eco_de_0000214_6890">
      Das hatte er verscherzt.
     </p>
-    <p xml:id="eco_de_0000144_6900">
+    <p xml:id="eco_de_0000214_6900">
      Das Angedenken, das ihm Lorchen hinterlassen hatte, war ein rotes, ovales Muschelstück mit einer Gemme darauf, ein Apollokopf mit Sonnenstrahlenkrone, und er ließ noch in Weimar dieses kleine Pfand zum Ringlein umbilden und trug es sein Lebtag.
     </p>
    </div>
@@ -2172,2416 +2172,2416 @@
     <head>
      Die Kristallkugel
     </head>
-    <p xml:id="eco_de_0000144_6910">
+    <p xml:id="eco_de_0000214_6910">
      In des Ettersbergs langgestreckter kahler Halde lag ein Gutshof, nahe dem Sperberschen Gute; aber nicht wie dieses völlig eingebettet in wogende Felder auf der breitesten, flachsten Stelle des Höhenzuges. Er lag dem bewaldeten Bergrücken näher, so daß dieses Gehöft über das Sperbersche ein wenig hochmütig herabsehen konnte, wozu es freilich nicht Ursache hatte, denn der Sperbersche Besitz stand ihm an Ausdehnung nicht nach und nicht an strohgedeckten, mächtigen Scheunen und Ställen und dem stattlichen Wohnhaus.
     </p>
-    <p xml:id="eco_de_0000144_6920">
+    <p xml:id="eco_de_0000214_6920">
      Das Gut aber, nahe dem Walde, gehörte einem alten Soldaten, dem Rittmeister Rauchfuß, der nach Kriegs- und Friedensstrapazen in den Ruhestand getreten und rauhbeinig in seine Vaterstadt zurückgekehrt war, um dort irgendwo unterzukriechen und seine kleine Pension ganz in der Stille zu verzehren.
     </p>
-    <p xml:id="eco_de_0000144_6930">
+    <p xml:id="eco_de_0000214_6930">
      Aber nach einigen Jahren der Ruhe war aus dem grämlichen Veteranen ein recht munterer Herr in den besten Jahren geworden, der unter den weimarischen Bürgersleuten sich eines bedeutenden Rufes erfreute als Bruder Lustig und guter Gesellschafter; und so kam es auch, daß er schließlich oben auf dem Ettersberge in den stattlichen Gutshof einheiratete, die Tochter seiner Hauswirtin, eine junge Witwe, heimführte und so Gutsherr und Gatte eines netten Weibchens wurde. Er residierte wie ein Falke über der kleinen, engen Stadt, in der sich so viel Wunderliches, Fremdes regte, was dem alten Soldaten als sehr unnötig erschien.
     </p>
-    <p xml:id="eco_de_0000144_6940">
+    <p xml:id="eco_de_0000214_6940">
      Große Herren gingen dort in den engen Gassen ein und aus, die weder Fürsten noch Generale, nicht einmal Rittmeister waren, und nach denen sich die Leute doch ehrerbietig und neugierig umschauten: – Federfuchser! – Einfach zum Lachen.
     </p>
-    <p xml:id="eco_de_0000144_6950">
+    <p xml:id="eco_de_0000214_6950">
      Die Witwe aber und der Gutshof befanden sich nicht allzu wohl in den Händen des alten Soldaten.
     </p>
-    <p xml:id="eco_de_0000144_6960">
+    <p xml:id="eco_de_0000214_6960">
      Der fuhr mehr, als es nötig war, in seiner kleinen Kutsche vom Ettersberg hinab und hielt vor dem »Elefanten« und fuhr den Hausknecht gar gewaltig an. Er ließ auch etwas draufgehen, mehr als gut war, um dem »Elefanten« seine Gewichtigkeit darzutun.
     </p>
-    <p xml:id="eco_de_0000144_6970">
+    <p xml:id="eco_de_0000214_6970">
      Die nette Witwe hatte ihre behagliche Witwenschaft sehr unvorsichtig beendet und mußte sich nun mit dem schwierigen Herrn Rauchfuß abfinden, so gut es gehen wollte, und alles Seufzen und Klagen half nichts mehr.
     </p>
-    <p xml:id="eco_de_0000144_6980">
+    <p xml:id="eco_de_0000214_6980">
      »Hättest's eher überlegen müssen,« antwortete der fidele Gatte. »Weshalb hast du 'nen alten Soldaten geheiratet, das ist nun 'mal keine Großmutter.«
     </p>
-    <p xml:id="eco_de_0000144_6990">
+    <p xml:id="eco_de_0000214_6990">
      So hieß es sich begnügen und nach wie vor der großen Wirtschaft allein vorstehen. Frau Rauchfuß wurde Mutter eines Töchterchens, eines rotgoldenen Füchschens. Daß es kein Bübchen war, was ihm sein kleines Weib geboren hatte, erboste Ritter Rauchfuß.
     </p>
-    <p xml:id="eco_de_0000144_7000">
+    <p xml:id="eco_de_0000214_7000">
      »Sappermentl! – Das geht nicht; zum Lachen! Ich Frauenzimmer in die Welt setzen! Nee, meine Beste! – Und gar 'nen Fuchs!«
     </p>
-    <p xml:id="eco_de_0000144_7010">
+    <p xml:id="eco_de_0000214_7010">
      Und er war doch selbst ein rotborstiger Herr mit einem blonden, gewaltigen Schnauzbart.
     </p>
-    <p xml:id="eco_de_0000144_7020">
+    <p xml:id="eco_de_0000214_7020">
      »Nee,« sagte er, »zu dumm! Da hat man seine Haut soundso oft zu Markte getragen, um schließlich daheim in den vier Wänden mit so 'nem kleenen Luderchen von Mägen zu kindsen – daß Ihr mir damit nicht kommt – den Balg rühr' ich nicht an!«
     </p>
-    <p xml:id="eco_de_0000144_7030">
+    <p xml:id="eco_de_0000214_7030">
      Er war zornig, der Herr Rittmeister Rauchfuß, und übelgelaunt. Gutsherr und meinetwegen Gatte der netten Witwe, aber Familienvater – das paßte ihm ganz und gar nicht. Das hielt er seiner nicht würdig.
     </p>
-    <p xml:id="eco_de_0000144_7040">
+    <p xml:id="eco_de_0000214_7040">
      Und öfter als sonst noch ließ er die Kutsche anspannen und fuhr hinunter nach Weimar; oder jagte auf eigenem Grund und Boden, oder spielte bei Sperbers mit dem Alten und sonst irgendeinem Bärbeiß und dem Herrn Pfarrer Besigue.
     </p>
-    <p xml:id="eco_de_0000144_7050">
+    <p xml:id="eco_de_0000214_7050">
      Mit dem alten Sperber stand er besonders gut, denn auch diesem waren die neuen Verhältnisse im Städtchen gründlich zuwider, wie wir schon wissen.
     </p>
-    <p xml:id="eco_de_0000144_7060">
+    <p xml:id="eco_de_0000214_7060">
      »Dumme Protzerei da unten,« sagte der. »Nun, wir werden ja sehen, wie weit es noch kommt – wir werden ja sehen. Die in der Stadt mögen ruhig aufhören, zu skribeln, kein Hahn kräht danach. Die Brote werden deshalb nicht kleiner. Aber wir! Wir da heroben und in der ganzen Breite des Landes sollten mit unserer Arbeit Feierabend machen, was denken Sie wohl, Verehrtester, was geschehen würde? Einfach Weltuntergang! – Aus! Fertig! –
     </p>
-    <p xml:id="eco_de_0000144_7070">
+    <p xml:id="eco_de_0000214_7070">
      »Und deshalb setze ich, wenn's angeht, keinen Schritt hinunter! Aber ärgern tue ich mich schon lange nicht mehr. Gott bewahre! Zufrieden bin ich da oben, jawohl, das muß ich sagen, und tauschen tät' ich 'mal mit keinem von den unnatürlich aufgeblasenen Fröschen unten im Sumpf.«
     </p>
-    <p xml:id="eco_de_0000144_7080">
+    <p xml:id="eco_de_0000214_7080">
      Die alten Herren oben auf dem Ettersberg führten bei ihrem Besigue oft gotteslästerliche Reden, wenn man bedenkt, daß es sich hier um den größten Mann Deutschlands handelte, ohne den Deutschland nicht Deutschland wäre, und den hervorzubringen die Natur sich Tausende von Jahren gemüht, mit Millionen und Millionen von Dummköpfen und mittelmäßigen Köpfen Fangball gespielt hatte, gewissermaßen ohne Sinn und Verstand.
     </p>
-    <p xml:id="eco_de_0000144_7090">
+    <p xml:id="eco_de_0000214_7090">
      Daß da unten in Weimar endlich der sterile Baum der Menschheit eine Frucht trug, schien den Kartenspielern auf dem Ettersberg nicht von Belang zu sein. Der Baum grünte doch ganz fröhlich.
     </p>
-    <p xml:id="eco_de_0000144_7100">
+    <p xml:id="eco_de_0000214_7100">
      Ihnen erschien diese Frucht auch gar nicht als Frucht, sondern als irgendeine Blase, als unnützer Auswuchs. Sie hatten es auch, weiß Gott, vorzüglich auf ihrem Ettersberg. Die prächtigen Güter gediehen.
     </p>
-    <p xml:id="eco_de_0000144_7110">
+    <p xml:id="eco_de_0000214_7110">
      Herr und Frau Sperber taten miteinander das ihrige, schafften ehrlich und gutgelaunt ihr Tageswerk. In aller Herrgottsfrühe sah man die flinke Frau Sperber in ihrer rosa Schürze mit dem klingelnden Schlüsselbunde über den Hof laufen, in Ställen und Wirtschaftsräumen Umschau halten, und Herrn Sperbers mächtige Wasserstiefel liefen mit ihrem kleinen, dicken Mann über Stock und Stein, über Aecker, durch Wiesen, durch Wälder.
     </p>
-    <p xml:id="eco_de_0000144_7120">
+    <p xml:id="eco_de_0000214_7120">
      Im Rauchfußschen Gehöfte arbeitete eine tapfere Frau über ihre Kräfte; aber es ging auch, die beiden Güter gaben einander nicht viel nach. Freilich hätte es Frau Rauchfuß bei weitem leichter gehabt, wäre ihre Lebenszierde, Herr Rauchfuß, nicht gar so fidel gewesen, und hätte er es nicht für seine Lebensaufgabe gehalten, denen unten in Weimar zu beweisen, daß oben auf dem Ettersberg große Herren wohnten, und daß es ihm, auch aufs schwerste beladen und angefüllt von Weindämpfen, niemand ansah, wie voll er war. Er konnte vom Stammtisch aufstehen und so fest abmarschieren, wie er gekommen. Dies Kunststück ließ ihn nicht ruhen.
     </p>
-    <p xml:id="eco_de_0000144_7130">
+    <p xml:id="eco_de_0000214_7130">
      Wäre Frau Rauchfußens Töchterchen Beate nicht gewesen, so hätte sie nach allen Lebensfreuden gut Umschau halten können.
     </p>
-    <p xml:id="eco_de_0000144_7140">
+    <p xml:id="eco_de_0000214_7140">
      Die Zeit kam, und das Kind konnte im Hof und Garten umherspringen und glich einer Blume mit langen, goldenen Staubfäden. Es jauchzte vor Lebenslust und Uebermut; da geruhte auch Ritter Rauchfuß sein Töchterlein anzuschauen. Er brachte ihr allerhand Dummheiten und Künste bei und hatte seine Freude daran, wie geschickt und anstellig das Ding war, wie es kletterte und des Vaters alte Soldatenflüche mit weichen Lippen und süßen Lauten nachplapperte.
     </p>
-    <p xml:id="eco_de_0000144_7150">
+    <p xml:id="eco_de_0000214_7150">
      Als Frau Rauchfußens Herzensschatz zu einem kleinen zierlichen Schulmädchen herangewachsen war, begab es sich, daß sie schweren Herzens in die Stadt gefahren war, um ihren Doktor um Rat zu fragen wegen eines Leidens, das sie in aller Stille seit geraumer Zeit mit sich herumgetragen und das ihr die Arbeit zu einer schweren, drückenden Last gemacht.
     </p>
-    <p xml:id="eco_de_0000144_7160">
+    <p xml:id="eco_de_0000214_7160">
      Nach langem, bangem Zagen hatte sie endlich zu diesem schweren Gange Mut gefaßt und gar innig gebetet und ihr kleines Mädchen bewegten Herzens geküßt.
     </p>
-    <p xml:id="eco_de_0000144_7170">
+    <p xml:id="eco_de_0000214_7170">
      Und als sie in ihrem Kutschchen wieder heimwärts fuhr, war ihr's nicht anders, als wäre inzwischen die schöne Welt in eine düstere Fremde vertauscht worden.
     </p>
-    <p xml:id="eco_de_0000144_7180">
+    <p xml:id="eco_de_0000214_7180">
      Angstvoll hatte sie sich auf den Weg gemacht, und von niemand war sie ermutigt worden; aber doch hatte nur im tiefsten Grund des Herzens undeutlich die unbegreifliche Sorge gelauert, daß das liebe Ich fortgewischt werden könnte.
     </p>
-    <p xml:id="eco_de_0000144_7190">
+    <p xml:id="eco_de_0000214_7190">
      Nun wußte sie es. Sie war am Ende ihrer Tage. Die gutmütige Alltäglichkeit, die so tut, als gäbe es kein Ende, hatte einen furchtbaren Riß bekommen, durch den die geschäftige Seele in leere Finsternis starrte.
     </p>
-    <p xml:id="eco_de_0000144_7200">
+    <p xml:id="eco_de_0000214_7200">
      So fuhr Frau Rauchfuß dahin, der altbekannte Weg erschien ihr grauenvoll und fremd, die goldenen Aehrenfelder am Weg, über die der Wind strich, neigten sich vor ihr, weil sie sterben mußte – sie – sie allein auf dieser Welt. Was war der Tod der anderen? – Ein leeres Wort. Ihr allein galt der Tod. – Jetzt erst wurde es ernst damit auf Erden, jetzt zum ersten Male.
     </p>
-    <p xml:id="eco_de_0000144_7210">
+    <p xml:id="eco_de_0000214_7210">
      Und niemand erbarmte sich ihrer. Ihr alter Kutscher saß mit krummem Buckel auf dem Bock und ließ die Pferde traben.
     </p>
-    <p xml:id="eco_de_0000144_7220">
+    <p xml:id="eco_de_0000214_7220">
      Der brauchte nicht zu sterben – der, nur sie allein. Das arme, unwissende Weib, das sich ängstlich an die harten ledernen Wagenkissen drückte, war die Welt, die schöne, große Welt; mit ihr verging die ganze Herrlichkeit.
     </p>
-    <p xml:id="eco_de_0000144_7230">
+    <p xml:id="eco_de_0000214_7230">
      Und diesen Todeskampf der Welt trug sie unter ihrem blau getupften Feiertagskleid, das sie zu ihrem schweren Gang in die Stadt angelegt hatte. Trug sie diesen schweren Kampf in ihrer Brust? – Trug sie ihn in ihrem Bein und Fleisch? – In ihrem klopfenden Herzen? – In ihrem armen Haupt?
     </p>
-    <p xml:id="eco_de_0000144_7240">
+    <p xml:id="eco_de_0000214_7240">
      Ja, wo in aller Welt denn trug dieser große Kampf sich zu? Konnte sie mit dem Finger darauf deuten und sagen: »Hier?« – O, Geheimnis der Geheimnisse, wo denn ist das arme Ich mit seinem Weltenleid, lehnt es an den harten Kissen des Kütschchens? – Ist es Fleisch und Bein? – Ein lebendiger Punkt, in dem all diese Pein jetzt lebt?
     </p>
-    <p xml:id="eco_de_0000144_7250">
+    <p xml:id="eco_de_0000214_7250">
      Des Weibes dumpfes Wesen wurde wach, wurde scharf durchdringend, zum ersten Male lebendig. Das heißt, von Todesgewißheit durchdrungen, und sie spürte, daß sie lebte, so fast, wie sie einst ihr Kindlein in sich selbst gespürt hatte, so geheimnisvoll und dennoch sicher.
     </p>
-    <p xml:id="eco_de_0000144_7260">
+    <p xml:id="eco_de_0000214_7260">
      Da schloß sie die bangen Augen, und vor ihrer Seele stand ihr Goldköpfchen, ihr Einziges, ihre Wonne.
     </p>
-    <p xml:id="eco_de_0000144_7270">
+    <p xml:id="eco_de_0000214_7270">
      Heiße Tränen brachen ihr aus den Augen, und das eigene Leben, der heilige Lebenskern war wieder von lauter Liebe und Bangigkeit um ihr Teuerstes verschüttet. – Wer sollte für das Kind sorgen? – Wer in aller Welt?
     </p>
-    <p xml:id="eco_de_0000144_7280">
+    <p xml:id="eco_de_0000214_7280">
      »Nur noch ein paar Jahre,« schluchzte sie auf, »daß sie mir's nicht verderben!«
     </p>
-    <p xml:id="eco_de_0000144_7290">
+    <p xml:id="eco_de_0000214_7290">
      Und als auch diese Qual übermächtig wurde, stahl sich ein Trost in die arme Seele: Wer weiß, ob es so schlimm mit ihr steht – und wenn sie die eigene Mutter am selben Leiden sterben sah, weshalb konnte es bei ihr nicht andere Wege gehen?
     </p>
-    <p xml:id="eco_de_0000144_7300">
+    <p xml:id="eco_de_0000214_7300">
      So fuhr sie dahin von einer Leidensstation zur andern, brach unter ihrem Kreuz zusammen, um sich wieder aufzurichten und wiederum zusammenzubrechen, wie unser Herr und Heiland es getan.
     </p>
-    <p xml:id="eco_de_0000144_7310">
+    <p xml:id="eco_de_0000214_7310">
      Als sie auf dem Gutshofe einfuhr, waren ihre Züge ruhig, ihre Tränen getrocknet. Das machte sich wie von selbst und durch alte Gewohnheit. Hier galt es für sie, zu schweigen, was sie bedrückte, und alles in sich selbst hineinzuleben.
     </p>
-    <p xml:id="eco_de_0000144_7320">
+    <p xml:id="eco_de_0000214_7320">
      »Wo ist Beate?« fragte sie die Hausmagd.
     </p>
-    <p xml:id="eco_de_0000144_7330">
+    <p xml:id="eco_de_0000214_7330">
      »Beim Herrn, im Garten.«
     </p>
-    <p xml:id="eco_de_0000144_7340">
+    <p xml:id="eco_de_0000214_7340">
      Da machte sich die Frau auf, denn es verlangte sie, ihr Kind in die Arme zu schließen, und sie ging durchs Haus in den Garten.
     </p>
-    <p xml:id="eco_de_0000144_7350">
+    <p xml:id="eco_de_0000214_7350">
      Als sie in die Nähe der großen Linde kam, die jetzt in voller Blüte stand und aussah, als wäre ein goldenes, feinmaschiges Netz, mit goldenen, strahlenden Perlen durchwoben, über sie geworfen, da hörte sie ihren Herrn und Gebieter gewaltig lachen, und die süße Stimme ihres Kindes wie Vogelgezwitscher dazwischen.
     </p>
-    <p xml:id="eco_de_0000144_7360">
+    <p xml:id="eco_de_0000214_7360">
      »Badewännchen!« rief er im gewaltigen Baß, »du bist ein Luderchen.« Das Kind jubelte laut.
     </p>
-    <p xml:id="eco_de_0000144_7370">
+    <p xml:id="eco_de_0000214_7370">
      Bang und erregt schlich die Frau näher.
     </p>
-    <p xml:id="eco_de_0000144_7380">
+    <p xml:id="eco_de_0000214_7380">
      Unter der Linde auf der großen Bank saß der Rittmeister, hatte eine Flasche Wein neben sich stehen und ließ das Kind aus seinem Glase trinken.
     </p>
-    <p xml:id="eco_de_0000144_7390">
+    <p xml:id="eco_de_0000214_7390">
      »Einen verdammten Zug hat das Mägen,« schmunzelte er vor sich hin. »Nun tanz' wieder, Badewännchen!«
     </p>
-    <p xml:id="eco_de_0000144_7400">
+    <p xml:id="eco_de_0000214_7400">
      Das Kind taumelte und tanzte, die rotgoldenen Haare flogen um das erhitzte Gesicht.
     </p>
-    <p xml:id="eco_de_0000144_7410">
+    <p xml:id="eco_de_0000214_7410">
      »Verfluchte kleine Hexe! Echtes Soldatenkind!« brummte der lustige Herr in seinen roten Bart hinein. Und in den roten Bart des Vaters und in die rote Haarfülle des tanzenden Kindes schien die Abendsonne.
     </p>
-    <p xml:id="eco_de_0000144_7420">
+    <p xml:id="eco_de_0000214_7420">
      Die bleiche Frau mit dem dunklen Haarscheitel stand noch immer unbeweglich.
     </p>
-    <p xml:id="eco_de_0000144_7430">
+    <p xml:id="eco_de_0000214_7430">
      »Die sind eines Blutes,« das sah sie, und sie stand, als sei alles mit ihr schon vorbei, und sie sähe als abgeschiedener Geist nur zu.
     </p>
-    <p xml:id="eco_de_0000144_7440">
+    <p xml:id="eco_de_0000214_7440">
      Da fuhr aber ein Zorn in sie, ein tödlicher Zorn. Sie stürzte auf ihren Mann zu. »Was tust du mit ihr?« schrie sie schmerzvoll auf. »Schau' doch! Sieh' doch! Du hast sie zu viel trinken lassen! – – Du!«
     </p>
-    <p xml:id="eco_de_0000144_7450">
+    <p xml:id="eco_de_0000214_7450">
      »No, große Geschichte!« sagte der Rittmeister mit schwerer Zunge, verblüfft über den heftigen Ueberfall.
     </p>
-    <p xml:id="eco_de_0000144_7460">
+    <p xml:id="eco_de_0000214_7460">
      Die kleine Beate stand erschrocken vom Tanze still und machte unsichere, sonderbare Augen.
     </p>
-    <p xml:id="eco_de_0000144_7470">
+    <p xml:id="eco_de_0000214_7470">
      »Zierpuppenvolk! Dummes Gewäsch! Weiberleute, unsinnige! Wird wohl erlaubt sein!« brummte Herr Rauchfuß.
     </p>
-    <p xml:id="eco_de_0000144_7480">
+    <p xml:id="eco_de_0000214_7480">
      Das Kind machte eine an ihm fremdartige Bewegung, streckte die Arme nach der Mutter aus, taumelte und fiel nieder, das Gesicht in die Arme verborgen. Das Kind schluchzte. Die Mutter beugte sich angstvoll über sie hin.
     </p>
-    <p xml:id="eco_de_0000144_7490">
+    <p xml:id="eco_de_0000214_7490">
      »No, Badewännchen, sei kein Ziehfitz,« polterte der Alte. »Schäm' dich, ein tapferes Mägen wird doch von so ein paar Schlückchen nicht knille werden. Nu, Soldatenkind!«
     </p>
-    <p xml:id="eco_de_0000144_7500">
+    <p xml:id="eco_de_0000214_7500">
      Die Mutter nahm ihr Mädchen in die Arme und trug es dem Hause zu, ohne weiter auf Herrn Rauchfuß zu achten, und der lachte schwerfällig hinterdrein.
     </p>
-    <p xml:id="eco_de_0000144_7510">
+    <p xml:id="eco_de_0000214_7510">
      In ihrem und des Kindes Zimmer legte sie Beate angekleidet aufs Bett nieder. Das Kind schluchzte noch immer, das Gesichtchen glühte und brannte, und die Augen brannten im hellen Fieber.
     </p>
-    <p xml:id="eco_de_0000144_7520">
+    <p xml:id="eco_de_0000214_7520">
      Frau Rauchfuß blieb an dem Bett auf den Knien in Angst und Not. Was sollte sie tun?
     </p>
-    <p xml:id="eco_de_0000144_7530">
+    <p xml:id="eco_de_0000214_7530">
      Sie wußte nicht ein und aus. Wem sollte sie ihr armes Kind anempfehlen? Sie fühlte sich so krank, so zerbrochen. Nun sie Sicherheit über sich selbst gewonnen hatte, empfand sie erst ihre Schwäche und Widerstandslosigkeit.
     </p>
-    <p xml:id="eco_de_0000144_7540">
+    <p xml:id="eco_de_0000214_7540">
      Mit den Worten des Arztes war eine Last auf sie gefallen, die sich nicht mehr abschütteln ließ.
     </p>
-    <p xml:id="eco_de_0000144_7550">
+    <p xml:id="eco_de_0000214_7550">
      Als die Dunkelheit längst hereingebrochen war, kniete sie noch immer und hielt ihres Kindes Hand in der ihren und grübelte wehen Herzens. Endlich kleidete sie das tief und schwer schlafende Mädchen aus und begab sich selbst zur Ruhe.
     </p>
-    <p xml:id="eco_de_0000144_7560">
+    <p xml:id="eco_de_0000214_7560">
      Da hatte sie das Gefühl, als wäre sie bei sich daheim nur noch zu Gaste.
     </p>
-    <p xml:id="eco_de_0000144_7570">
+    <p xml:id="eco_de_0000214_7570">
      Eine Wehmut überkam sie, eine Bangigkeit: es lag ihr so eine Last auf dem Herzen, als läge sie selbst unter einem mächtigen, düsteren Berg begraben für alle Ewigkeit. Pläne aller Art fuhren ihr fieberhaft durch den Kopf. Was konnte sie tun? Sie wollte zu allen gehen, die sie kannte und die sie für weiche Herzen hielt, und sie bitten, auf ihr Kind zu achten, zu Sperbers, ihren Nachbarsleuten, zur alten Kummerfelden, die am Entenfang in Weimar ihre Nähschule hielt, zu ihrem Herrn Pfarrer. Wenige fand sie, als sie sich die Leute so durch Herz und Sinne streichen ließ, denen sie zutrauen konnte, daß sie ihre bange Bitte nicht bald vergessen würden.
     </p>
-    <p xml:id="eco_de_0000144_7580">
+    <p xml:id="eco_de_0000214_7580">
      Müde wurde sie schließlich von allem Denken und Grübeln und schmiegte sich in die Müdigkeit wie in Mutterarm.
     </p>
-    <p xml:id="eco_de_0000144_7590">
+    <p xml:id="eco_de_0000214_7590">
      Ein altes, wehmütiges Lied, das sie früher gesungen, ging ihr durch den Sinn, ehe sie einschlummerte.
     </p>
-    <p xml:id="eco_de_0000144_7600">
+    <p xml:id="eco_de_0000214_7600">
      Ein Erdengast hienieden, Ein armer Erdengast. O Herr, gib mir Frieden Für meine kurze Rast.
     </p>
-    <p xml:id="eco_de_0000144_7610">
+    <p xml:id="eco_de_0000214_7610">
      Laß mich nicht heimisch werden Hier in dem fremden Land; Das Herze wird zu Erden, Wenn's noch so heiß gebrannt.
     </p>
-    <p xml:id="eco_de_0000144_7620">
+    <p xml:id="eco_de_0000214_7620">
      Laß mich im Pilgerkleide, O Herre, geh'n und steh'n. Ach, alle Augenweide Die Winde tun verweh'n.
     </p>
-    <p xml:id="eco_de_0000144_7630">
+    <p xml:id="eco_de_0000214_7630">
      Ach, alles Herzens Sonne Geht unter in tiefer Nacht; Ach, alle süße Wonne Ist hin, eh' Du's gedacht.
     </p>
-    <p xml:id="eco_de_0000144_7640">
+    <p xml:id="eco_de_0000214_7640">
      Am andern Tage in der hellen Abendsommerstunde nahm Frau Rauchfuß ihr Kind bei der Hand. Sie gingen durch den Garten, aus dem ein Pförtchen auf einen schmalen Feldweg hinaus durch wogende, sonnendurchschienene Felder bis zum Walde führte, dann wandelten sie langsam miteinander unter den Buchen.
     </p>
-    <p xml:id="eco_de_0000144_7650">
+    <p xml:id="eco_de_0000214_7650">
      Die kleine Beate eng an die Mutter geschmiegt, denn es war ein seltsames Fest, das sie mit der hart arbeitenden Frau so feiertäglich wandern durfte.
     </p>
-    <p xml:id="eco_de_0000144_7660">
+    <p xml:id="eco_de_0000214_7660">
      »Sieh! Sieh, Mutter,« rief sie alle Augenblicke, »da kommt was! – Da is was! – Horch, ein Specht – ein Reh!«
     </p>
-    <p xml:id="eco_de_0000144_7670">
+    <p xml:id="eco_de_0000214_7670">
      Die Arme des zehnjährigen, kräftigen Mädchens bebten vor Freude.
     </p>
-    <p xml:id="eco_de_0000144_7680">
+    <p xml:id="eco_de_0000214_7680">
      Frau Rauchfuß spürte die Lebenswonne ihres Mädchens.
     </p>
-    <p xml:id="eco_de_0000144_7690">
+    <p xml:id="eco_de_0000214_7690">
      Es traf sie all' dies gar gewaltig ins Herz, und sie preßte ihr Kind fest an sich.
     </p>
-    <p xml:id="eco_de_0000144_7700">
+    <p xml:id="eco_de_0000214_7700">
      »Ach, wollte Gott, mein Schatz, es könnte alles so bleiben, wie's ist.«
     </p>
-    <p xml:id="eco_de_0000144_7710">
+    <p xml:id="eco_de_0000214_7710">
      Sie kamen jenseits des Waldes, der des Ettersbergs Rücken als breiter Streifen bedeckt, an ein uraltes Kapellchen ohne Heilige. Die Heiligen hatten zu lange schutzlos dem Wetter und dem Protestantismus standhalten müssen und waren zernagt, zerbröckelt und verschwunden.
     </p>
-    <p xml:id="eco_de_0000144_7720">
+    <p xml:id="eco_de_0000214_7720">
      Nur eine zerfallene, niedrige Mauer war noch zu sehen, auf der die schmerzensreiche Mutter Gottes einst gestanden hatte. Darauf ließ Frau Rauchfuß sich ermüdet nieder und zog ihr Kind zu sich auf ihren Schoß, und sie blickten miteinander still in die Welt, die den Weimaranern für alle Zeit verschlossen ist, in die Welt, die hinter dem Ettersberg liegt, eine sonnige, kornwogende Landschaft, über der die letzten warmen, sehnsüchtigen Strahlen, der Abendsonne lagen.
     </p>
-    <p xml:id="eco_de_0000144_7730">
+    <p xml:id="eco_de_0000214_7730">
      »Was hast du, Mutterchen, du bist so still?«
     </p>
-    <p xml:id="eco_de_0000144_7740">
+    <p xml:id="eco_de_0000214_7740">
      »Gestern um die Stunde mußte ich dich in dein Bett tragen, weil du zu viel getrunken hattest.«
     </p>
-    <p xml:id="eco_de_0000144_7750">
+    <p xml:id="eco_de_0000214_7750">
      Das Kind verbarg sein Gesicht an dem Hals der Mutter.
     </p>
-    <p xml:id="eco_de_0000144_7760">
+    <p xml:id="eco_de_0000214_7760">
      »Andere Kinder«, sagte Frau Rauchfuß ruhig, »haben, solange sie jung sind, eine Mutter, die auf sie achtet – du wirst einmal keine haben.
     </p>
-    <p xml:id="eco_de_0000144_7770">
+    <p xml:id="eco_de_0000214_7770">
      Andere Kinder haben einen Vater, der ihnen hilft und sie berät. Das kann dein Vater nicht.
     </p>
-    <p xml:id="eco_de_0000144_7780">
+    <p xml:id="eco_de_0000214_7780">
      Du wirst einmal ganz allein sein und mußt dir in allen Stücken selbst helfen und dazu auf deinen Vater achten, daß ihm nichts geschieht.«
     </p>
-    <p xml:id="eco_de_0000144_7790">
+    <p xml:id="eco_de_0000214_7790">
      Das Mädchen hob den Kopf und blickte die Mutter erstaunt an.
     </p>
-    <p xml:id="eco_de_0000144_7800">
+    <p xml:id="eco_de_0000214_7800">
      »Allein wirst du sein, du mußt jetzt schon denken, was recht und unrecht ist.«
     </p>
-    <p xml:id="eco_de_0000144_7810">
+    <p xml:id="eco_de_0000214_7810">
      Dem Kinde traten die Tränen in die angstvollen Augen. Die Augen der Mutter standen gerade so voll Wasser wie die des Kindes. Und sie sahen sich mit ihren schweren, unsicheren Blicken unsicher an.
     </p>
-    <p xml:id="eco_de_0000144_7820">
+    <p xml:id="eco_de_0000214_7820">
      Frau Rauchfußens Kopf sank auf die zarte, biegsame Schulter ihres Mädchens, und ein heftiges Schluchzen rang sich ihr aus der beladenen Seele.
     </p>
-    <p xml:id="eco_de_0000144_7830">
+    <p xml:id="eco_de_0000214_7830">
      Das gute, goldblonde Kind streichelte die Mutter und preßte sich eng an sie.
     </p>
-    <p xml:id="eco_de_0000144_7840">
+    <p xml:id="eco_de_0000214_7840">
      »Ich bin krank, mein Schatz, ich darf nicht mehr lange leben und weiß vor Angst nicht aus und ein, daß ich dich allein beim Vater lassen muß. Niemand wird auf dich schauen.«
     </p>
-    <p xml:id="eco_de_0000144_7850">
+    <p xml:id="eco_de_0000214_7850">
      Da war's, als wenn das Kind sich reckte und streckte. Die Mutter spürte eine starke Bewegung in den festen Kindarmen.
     </p>
-    <p xml:id="eco_de_0000144_7860">
+    <p xml:id="eco_de_0000214_7860">
      Das Kind löste sich von ihr, nahm seinen Schürzenzipfel und fuhr der Mutter sanft über die Augen.
     </p>
-    <p xml:id="eco_de_0000144_7870">
+    <p xml:id="eco_de_0000214_7870">
      »Wein' nicht,« sagte es, »mit mir wird's schon recht werden.«
     </p>
-    <p xml:id="eco_de_0000144_7880">
+    <p xml:id="eco_de_0000214_7880">
      Frau Rauchfuß sah in ein Paar entschlossene, ernste Augen.
     </p>
-    <p xml:id="eco_de_0000144_7890">
+    <p xml:id="eco_de_0000214_7890">
      »Leg' dein Köpfchen wieder auf meine Schulter und sei ganz ruhig,« sagte das Kind.
     </p>
-    <p xml:id="eco_de_0000144_7900">
+    <p xml:id="eco_de_0000214_7900">
      Der Frau wurde es wunderlich ums Herz. Sie fühlte einen kleinen, herrlichen Menschen neben sich stehen, der ihr Trost brachte.
     </p>
-    <p xml:id="eco_de_0000144_7910">
+    <p xml:id="eco_de_0000214_7910">
      »Wenn du stirbst,« fragte das Kind ernst, »wirst du dann in einem Sarg fortgetragen und in die Erde gelegt werden und mit Erde bedeckt werden?«
     </p>
-    <p xml:id="eco_de_0000144_7920">
+    <p xml:id="eco_de_0000214_7920">
      »Ja,« sagte die Frau.
     </p>
-    <p xml:id="eco_de_0000144_7930">
+    <p xml:id="eco_de_0000214_7930">
      »Kannst du nicht wiederkommen?«
     </p>
-    <p xml:id="eco_de_0000144_7940">
+    <p xml:id="eco_de_0000214_7940">
      »Nein. – Ich bin dann bei Gott.«
     </p>
-    <p xml:id="eco_de_0000144_7950">
+    <p xml:id="eco_de_0000214_7950">
      »Ist Gott gut?« fragte das Kind.
     </p>
-    <p xml:id="eco_de_0000144_7960">
+    <p xml:id="eco_de_0000214_7960">
      »Ja, er ist gut.«
     </p>
-    <p xml:id="eco_de_0000144_7970">
+    <p xml:id="eco_de_0000214_7970">
      »Gut?« sagte es nachdenklich.
     </p>
-    <p xml:id="eco_de_0000144_7980">
+    <p xml:id="eco_de_0000214_7980">
      Die Frau sah mit Staunen auf ihr Kind.
     </p>
-    <p xml:id="eco_de_0000144_7990">
+    <p xml:id="eco_de_0000214_7990">
      »Andere Mütter sagen's ihren Kindern nicht, wenn sie bald sterben müssen, aber ich mußte das tun – du mußt es wissen.«
     </p>
-    <p xml:id="eco_de_0000144_8000">
+    <p xml:id="eco_de_0000214_8000">
      »Is' schon recht,« antwortete das Kind, »sag' mir nur alles. Alles, was ich daheim tun muß, wenn du gestorben bist. Auf den Vater will ich schon schauen – und wann stirbst du?«
     </p>
-    <p xml:id="eco_de_0000144_8010">
+    <p xml:id="eco_de_0000214_8010">
      »Das weiß ich noch nicht.«
     </p>
-    <p xml:id="eco_de_0000144_8020">
+    <p xml:id="eco_de_0000214_8020">
      »Also« – sagte das Mädchen.
     </p>
-    <p xml:id="eco_de_0000144_8030">
+    <p xml:id="eco_de_0000214_8030">
      Sie saßen nun beide still auf dem Mäuerchen, auf dem in grauer Zeit das Bildnis der schmerzhaften Mutter Gottes gestanden hatte. Das Kind weinte nicht, sondern sah ernst und fest vor sich hin.
     </p>
-    <p xml:id="eco_de_0000144_8040">
+    <p xml:id="eco_de_0000214_8040">
      Auch die Frau weinte nicht mehr. Sie hatte einen Trost ins Herz bekommen und blickte befremdet auf das ernste, starke Geschöpf, das so fest vor sich hin sah.
     </p>
-    <p xml:id="eco_de_0000144_8050">
+    <p xml:id="eco_de_0000214_8050">
      Von diesem Tag an aber war sie nicht mehr allein und nicht mehr ungetröstet. – –
     </p>
-    <p xml:id="eco_de_0000144_8060">
+    <p xml:id="eco_de_0000214_8060">
      Und als es nach Jahresfrist wirklich zum Sterben kam und sie die Hand der elfjährigen Beate in der ihren hielt, wußte sie: das Kind wird sich und andern helfen. Sie empfahl sie Gott an und niemand sonst auf Erden. Sie fühlte auch in den letzten, harten Augenblicken den herrlichen, kleinen Menschen neben sich, der sie mit seiner Kraft und seinem Schweigen tröstete.
     </p>
-    <p xml:id="eco_de_0000144_8070">
+    <p xml:id="eco_de_0000214_8070">
      Und nun war Ritter Rauchfuß mit seinem »Badewännchen« allein.
     </p>
-    <p xml:id="eco_de_0000144_8080">
+    <p xml:id="eco_de_0000214_8080">
      Die Frau war ihm oft unbequem gewesen. Er hatte sich unter einer Frau etwas ganz anderes vorgestellt, und jetzt ging es ihm mit seinem »Badewännchen« nicht viel besser. Er dachte ein nettes Püppchen zum Spielen an ihr zu finden und spürte statt dessen, daß eine kleine Respektsperson neben ihm aufwuchs, eine Aufpasserin.
     </p>
-    <p xml:id="eco_de_0000144_8090">
+    <p xml:id="eco_de_0000214_8090">
      Er fuhr mit ebenso schlechtem Gewissen zur Stadt wie früher und schimpfte in seinen roten Bart hinein auf das Weiberzeug, das sich mausig machte, dem man eins versetzen soll, das sich zum »Teifel« packen soll!
     </p>
-    <p xml:id="eco_de_0000144_8100">
+    <p xml:id="eco_de_0000214_8100">
      Frau Rauchfuß hatte dafür gesorgt, daß eine tüchtige Mamsell und ein Verwalter aufs Gut kamen, damit Badewännchens Erbe in guter Verfassung blieb, trotz des fidelen Herrn Vaters. Zwischen all dieser Bravheit fühlte Herr Rauchfuß sich nicht behaglich. Er trank wie früher, und es brauchte auch nicht gerade der »Elefant« zu sein, wo er seinen Kummer hinunterspülte und seine schlechte Laune. Jede Kneipe war recht, auch hinter dem Ettersberg. Er nahm es nicht mehr so genau. Ein reputierlicher, forscher Herr aber blieb er nach wie vor, der sich am Wirtshaustisch gut ausnahm, und dessen Stolz es noch immer war, daß er auch beim Soundsovielten noch aufrecht gehen und menschlich sprechen konnte.
     </p>
-    <p xml:id="eco_de_0000144_8110">
+    <p xml:id="eco_de_0000214_8110">
      Als Badewännchen älter wurde, fuhr sie jeden Morgen um fünf Uhr mit dem Milchwagen in die Stadt zur Schule, Winter und Sommer, und stieg im Entenfang bei Madame Kummerfelden ab, die das Kind bei sich behielt, bis die Schule anging, dann speiste sie mit ihr zusammen zu Mittag, hatte mit den anderen Mädchen die berühmten, köstlichen Nähstunden bei der lieben, munteren Madame und fuhr dann mit dem Wagen, der die Abendmilch gebracht hatte, wieder heim.
     </p>
-    <p xml:id="eco_de_0000144_8120">
+    <p xml:id="eco_de_0000214_8120">
      Die gute Kummerfelden hatte Gefallen an dem Mädchen gefunden, aber auch für Rauchfuß, den Vater, hatte die alte Frau viel übrig; wenn sie in einem ihrer geblümten Kleider und der Haube, die sie ihrem jugendlichen Lebensmute übergestülpt hatte, so recht wohlhäbig und behaglich Sonntag nachmittags ihren Kaffee im Häuschen am Entenfang trank, war es ihr gar nicht fatal, wenn der alte Sünder ein Stündchen bei ihr Einkehr hielt. Er bekam seine zwei, drei Schnäpschen, aber beileibe nicht mehr, den besten Schnupftabak, den sich nur eine Nase wünschen konnte, und einen doppelt starken Kaffee, den auch eine so ausgepichte Kehle spüren mußte.
     </p>
-    <p xml:id="eco_de_0000144_8130">
+    <p xml:id="eco_de_0000214_8130">
      »So ä bißchen ä Mann ist 'ne goldene Handhabe,« sagte sie, »und gar der Rauchfuß mit seinem roten Bart und seiner Hünengestalt und seinem Schritt und Tritt, da spürt unsereins doch noch, daß es Mannsbilder auf der Welt gibt, was man bei der ewigen Nähstunde mit all den Lausmädchens balde vergessen hätte.«
     </p>
-    <p xml:id="eco_de_0000144_8140">
+    <p xml:id="eco_de_0000214_8140">
      Und gerade so ein alter Sünder war ihr recht.
     </p>
-    <p xml:id="eco_de_0000144_8150">
+    <p xml:id="eco_de_0000214_8150">
      »Ja,« sagte sie einmal zu ihrem Freund, »wenn der liebe Gott ein Weib wäre, was so ganz unmöglich nicht ist, haben's die Mannsbilder einmal drüben nicht schlecht, denn dann werden die ärgsten Sündenböcke vortrefflich aufgenommen, wie auch hier auf Erden schon, wo ein Mannsbild jedwede Moral sich sparen kann, und wird doch geliebt und begehrt, daß es eine Art hat.«
     </p>
-    <p xml:id="eco_de_0000144_8160">
+    <p xml:id="eco_de_0000214_8160">
      Durch solche Reden hatte die kluge Frau beim Rittmeister einen Stein im Brett und konnte sich dafür so manches herausnehmen.
     </p>
-    <p xml:id="eco_de_0000144_8170">
+    <p xml:id="eco_de_0000214_8170">
      Oft schimpfte sie ihn herunter wie einen Schulbuben; das nahm er dann auch freundlich hin.
     </p>
-    <p xml:id="eco_de_0000144_8180">
+    <p xml:id="eco_de_0000214_8180">
      »Nur bei einem Mannsbild nie gradaus. Ordentlich Honig ums Maul gestrichen, und während sie schlecken, dann kommt das Rechte, das, was sie sollen. Das muß es sein.« Das sagte die Alte oft.
     </p>
-    <p xml:id="eco_de_0000144_8190">
+    <p xml:id="eco_de_0000214_8190">
      Und so strich sie derb und lustig unverschämt, wie so manches kluge Weiblein, und hatte dafür einen fügsamen Freund.
     </p>
-    <p xml:id="eco_de_0000144_8200">
+    <p xml:id="eco_de_0000214_8200">
      Der Rittmeister war ganz vernarrt in Badewännchens Schönheit.
     </p>
-    <p xml:id="eco_de_0000144_8210">
+    <p xml:id="eco_de_0000214_8210">
      So saßen die beiden Alten eines Sonntags im Häuschen am Entenfang bei der alten Schauspielerin, jetzt Nählehrerin, beieinander. »Die Tochter vom Rauchfuß ist nicht Übel? – was, Kummerfelden? Solche feste Arme – und wie sie geht! – Ein ganzer Kerl, und dazu der rotblonde Schopf, und die verdammten Augen! He, Kummerfelden, das hab' ich gut gemacht! – Was? – Schaut Euch doch all die Nachbrut an! Saht Ihr da so etwas? – –«
     </p>
-    <p xml:id="eco_de_0000144_8220">
+    <p xml:id="eco_de_0000214_8220">
      »No, no,« meinte die Kummerfelden, »nur nicht so üppig, Monsieur. Sie ist doch bei weitem mehr die Tochter ihrer braven Mutter.«
     </p>
-    <p xml:id="eco_de_0000144_8230">
+    <p xml:id="eco_de_0000214_8230">
      »I was, brav!« sagte der Rittmeister. »– Teifel auch, beim Weib kommt's auf die Schönheit an. – Basta.«
     </p>
-    <p xml:id="eco_de_0000144_8240">
+    <p xml:id="eco_de_0000214_8240">
      »Sie Narr,« meinte die Kummerfelden. »Und was hat denn aber Ihr Gut so beieinander gehalten? Hat das die Schönheit Ihrer Frau getan oder die Tüchtigkeit?«
     </p>
-    <p xml:id="eco_de_0000144_8250">
+    <p xml:id="eco_de_0000214_8250">
      »Ah, paperla – paperla, mit einer Nebensache läßt sich auch was machen. Aber die Hauptsache! Auf den Knien hätte sie mich bitten können, ich hätte Frau Rauchfuß nie geheiratet – wenn sie nicht so'n netter Käfer gewesen war'.«
     </p>
-    <p xml:id="eco_de_0000144_8260">
+    <p xml:id="eco_de_0000214_8260">
      »Gott sei euch Mannsbildern gnädig!« meinte die Kummerfelden und rührte den Zucker in ihrem Kaffee um. »Ihr nehmt, die euch gefällt, und nennt sie schön, solange ihr sie wollt. Was hat Eure Frau für ein Leben bei Euch geführt, einsam und verlassen, wie neben einem Holzklotz.«
     </p>
-    <p xml:id="eco_de_0000144_8270">
+    <p xml:id="eco_de_0000214_8270">
      »Kummerfelden – Donnerwetter, was nimmt Sie sich heraus!«
     </p>
-    <p xml:id="eco_de_0000144_8280">
+    <p xml:id="eco_de_0000214_8280">
      »Weil's wahr ist,« sagte die Kummerfelden ärgerlich. »Und ein Schaukelpferd könnte auch kein schlechterer Vater sein, wie Ihr gegen das gute Kind seid. Was ist denn das, nachts zwei Uhr angetrunken nach Hause zu kommen und nicht an das arme Geschöpf zu denken, was Euch halb wachend erwartet und Euch hilft, ins Bett zu kommen, alter Saufaus! Um zwei Uhr laßt Ihr Euch noch 'nen Kaffee von dem guten Geschöpf machen. Und das nehmt Ihr so gedankenlos und töricht hin. Und alle Nasen lang kommt's vor. Pfui, Rittmeister, ich verlange gewiß von keinem Mann, daß er, was Moral und Saufen betrifft, anständig ist. Aber auch für ein Mannsbild gibt's Grenzen, – und die überschreitet Ihr, Verehrtester.«
     </p>
-    <p xml:id="eco_de_0000144_8290">
+    <p xml:id="eco_de_0000214_8290">
      Die Kummerfelden war heute besonders erbost über ihren alten Freund, denn es war ihr gerade manches zu Ohren gekommen. Aber sie schenkte doch ihrem Sonntagsgast die dritte Tasse starken Kaffees ein und bediente ihn so aufmerksam, als wäre er der heilige Nikolaus.
     </p>
-    <p xml:id="eco_de_0000144_8300">
+    <p xml:id="eco_de_0000214_8300">
      »Und noch eins,« sagte die Kummerfelden, »glaubt Ihr, daß das gute Kind ein Wort darüber redet, wie Ihr's treibt? Nicht eine Silbe. Zerreißen könnte man sie und brächte nichts aus ihr heraus, was Euch nicht zur Ehre gereichte.«
     </p>
-    <p xml:id="eco_de_0000144_8310">
+    <p xml:id="eco_de_0000214_8310">
      »Soldatenkind – verdammtes!« sagte der Rittmeister und schlug mit der Faust auf den Tisch. »Das hat sie von mir, der Racker!«
     </p>
-    <p xml:id="eco_de_0000144_8320">
+    <p xml:id="eco_de_0000214_8320">
      Die Kummerfelden aber faßte sich mit beiden geschäftigen Händen an die große Haube, als müßte sie diese gegen Unerhörtes schützen.
     </p>
-    <p xml:id="eco_de_0000144_8330">
+    <p xml:id="eco_de_0000214_8330">
      »Gott sei mir gnädig,« sagte sie, »so was ist unerschütterlich.«
     </p>
-    <p xml:id="eco_de_0000144_8340">
+    <p xml:id="eco_de_0000214_8340">
      Als Rittmeister Rauchfußens Mädchen ihr siebzehntes Jahr erreicht hatte, begab es sich, daß der Alte in einen Liebeshandel geriet. An den Sonntagen bei der Kummerfelden hatte sich in dieser Zeit gar oft eine recht saubere, kleine Witwe eingefunden, die der Kummerfelden allerliebst um den Bart ging. Sie war eine frühere Schülerin der alten Nählehrerin und war nach dem Tode des Mannes in armselige Verhältnisse geraten. Mit der Kummerfelden beriet sie sich sittsam darüber, daß sie sich als Krankenpflegerin wollte in Weimar niederlassen, und machte das so rührend und allerliebst anschaulich, daß dem Rittmeister, der bei diesen Beratungen auch mal zugegen war, ganz warm ums Herz wurde. Dazu hatte das Weibchen ein allerliebstes Herzgesicht, breite Stirn und spitzes Kinn und ein paar braune, lebenslustige, runde Augen.
     </p>
-    <p xml:id="eco_de_0000144_8350">
+    <p xml:id="eco_de_0000214_8350">
      »So eine Krankenpflegerin lass' ich mir schon gefallen, warum nicht,« sagte der Rittmeister, »so ein munteres Weibchen, da sieht die ganze Geschichte so schlimm nicht aus. Spaßhaft so 'was!«
     </p>
-    <p xml:id="eco_de_0000144_8360">
+    <p xml:id="eco_de_0000214_8360">
      »Schäm' Er sich, alter Narr,« sagte die Kummerfelden ärgerlich.
     </p>
-    <p xml:id="eco_de_0000144_8370">
+    <p xml:id="eco_de_0000214_8370">
      »I was,« meinte der Rittmeister, »Kummerfelden, Sie sind eine alte, majestätische Fregatte mit Ihrer Haube. So ein junges flottes Fahrzeug wie unsere Marianne, das fährt in andere Wasser als so ein altes Tugendschiff. Nicht wahr, Frau Marianne?«
     </p>
-    <p xml:id="eco_de_0000144_8380">
+    <p xml:id="eco_de_0000214_8380">
      »Bitt' mir's aus, Herr Rittmeister,« schmollte das kleine Weib. »Meint Ihr, es ist mir nicht Ernst?« Und das kleine Weibchen breitete ihre Tugenden und ihr heiliges Vorhaben wieder vor der alten, guten Frau und Herrn Rauchfuß aus.
     </p>
-    <p xml:id="eco_de_0000144_8390">
+    <p xml:id="eco_de_0000214_8390">
      »Teufelsweibchen!« brummte der Rittmeister in den roten Bart.
     </p>
-    <p xml:id="eco_de_0000144_8400">
+    <p xml:id="eco_de_0000214_8400">
      »Jawohl,« sagte die kleine, zierliche Frau und machte eine allerliebste Bewegung mit ihrem Herzköpfchen, um das sie ein schneeweißes, dreieckiges Tüchlein gebunden hatte. So ein bißchen nonnenhaft und sauber wollte sie aussehen. »Jawohl,« sagte sie, »Ihr kommt mir recht! Teufelsweibchen! Ihr werdet schon das Teufelsweibchen kennen lernen, wenn Ihr mich zur Pflege hinaufkommen lasset, wenn's den Herrn Rittmeister 'mal hat. Die Küche würde ich auch gleich mit übernehmen. Wer weiß denn so einem Kranken so recht bekömmlich aufzutischen, daß ihm die Lebensgeister wiederkommen, wenn er nur so ein Süppchen riecht. Und eins sag' ich: Bei mir kann sich ein Kranker den Doktor sparen. Von meiner Mutter selig weiß ich so viel – allerhand Wundermittel, wann eins die Gicht hat oder 's Zipperlein – da stehen die Doktors und haben 's Nachsehen.«
     </p>
-    <p xml:id="eco_de_0000144_8410">
+    <p xml:id="eco_de_0000214_8410">
      »Is' aber nicht!« sagte der Rittmeister.
     </p>
-    <p xml:id="eco_de_0000144_8420">
+    <p xml:id="eco_de_0000214_8420">
      »Nu, desto besser,« meinte das Weibchen. »Nee, nee, gesucht würde ich schon. Wer ist denn hier? So 'n paar alte Karreiten, die bei jeder Bewegung knarren, und Ihre Freundin, die Rabenmutter, Frau Kummerfelden, die mit ihren groben Pratzen 'was Feines gleich totdrückt.«
     </p>
-    <p xml:id="eco_de_0000144_8430">
+    <p xml:id="eco_de_0000214_8430">
      »Nein, nein,« sagte die Kummerfelden, »an die Rabenmutter rühren Sie nicht, das ist eine Seele von einem Menschen.«
     </p>
-    <p xml:id="eco_de_0000144_8440">
+    <p xml:id="eco_de_0000214_8440">
      »Nur ist sie zu viel Leib dabei,« sagte die kleine Witwe und drehte ihr zierliches Figürchen.
     </p>
-    <p xml:id="eco_de_0000144_8450">
+    <p xml:id="eco_de_0000214_8450">
      »Ja,« sagte die Kummerfelden, »Recht muß Recht bleiben. Die Rabenmutter ist schon reichlich massiv, freilich hat sie mich vorigen Winter, als in mir so allerhand lungte und loderte, wie ein Kind aus dem Bette gehoben und wieder eingelegt; aber geprustet hat sie dabei wie der heilige Christophorus, was nicht jedermanns Sache ist.«
     </p>
-    <p xml:id="eco_de_0000144_8460">
+    <p xml:id="eco_de_0000214_8460">
      »Nee, nee, nee,« meinte die kleine Witwe, »geräuschlos muß eins sein können.«
     </p>
-    <p xml:id="eco_de_0000144_8470">
+    <p xml:id="eco_de_0000214_8470">
      Als das niedliche Weib eines Tages sagte: »Jetzt muß ich aber heim; meine Herren warten auf mich; dem einen muß ich sein Bierchen noch holen!« – da fragte der Rittmeister ganz verblüfft: »Herren? Was hat Sie denn für Herren?«
     </p>
-    <p xml:id="eco_de_0000144_8480">
+    <p xml:id="eco_de_0000214_8480">
      »In Kost und Logis,« sagte das Weibchen, und das muntere Herzgesicht mit seinen runden, braunen Augen schaute so ein wenig herausfordernd auf den alten Soldaten.
     </p>
-    <p xml:id="eco_de_0000144_8490">
+    <p xml:id="eco_de_0000214_8490">
      »Sapperment!« sagte der.
     </p>
-    <p xml:id="eco_de_0000144_8500">
+    <p xml:id="eco_de_0000214_8500">
      »Na, was hat Er denn da?« meinte die Kummerfelden. »Gottlob, daß ihr der liebe Gott so ein paar verständige, rechtliche Männer ins Quartier geschickt hat, denn wovon sollte die arme Haut wohl leben?«
     </p>
-    <p xml:id="eco_de_0000144_8510">
+    <p xml:id="eco_de_0000214_8510">
      Der Rittmeister lachte recht ungefüg.
     </p>
-    <p xml:id="eco_de_0000144_8520">
+    <p xml:id="eco_de_0000214_8520">
      Als das Weibchen gegangen war, stand er schwerfällig vom Kaffeetisch auf und ging im Zimmer auf und nieder. »Das mit den Kostgängern paßt mir ganz und gar nicht,« sagte er ärgerlich.
     </p>
-    <p xml:id="eco_de_0000144_8530">
+    <p xml:id="eco_de_0000214_8530">
      »Schaut den an,« lachte die Kummerfelden. »Rittmeister, da brauchen Sie sich keine Sorgen zu machen; die ist klug, daß Ihr für ihrer Klugheit Nadelöhr keinen so feinen Faden habt.«
     </p>
-    <p xml:id="eco_de_0000144_8540">
+    <p xml:id="eco_de_0000214_8540">
      Von da ab aber fehlte weder der Rittmeister noch das feine Weibchen zur Kaffeestunde am Sonntagnachmittag bei der Kummerfelden, bis es der Alten zu dumm wurde.
     </p>
-    <p xml:id="eco_de_0000144_8550">
+    <p xml:id="eco_de_0000214_8550">
      Es währte lange, bis die Gute zu merken begann, daß der Rittmeister und das junge Weibchen auf Freiersfüßen gingen.
     </p>
-    <p xml:id="eco_de_0000144_8560">
+    <p xml:id="eco_de_0000214_8560">
      ›Herr Gott,« dachte sie, ›das wolltest du mir gewähren, daß meine Augen nie den Mann sehen müssen, der keine Frau bekommt, den wirklich keine nähme – Amen.«
     </p>
-    <p xml:id="eco_de_0000144_8570">
+    <p xml:id="eco_de_0000214_8570">
      Als die Kummerfelden endlich klug geworden war und gesehen hatte, wie der Hase lief, begann sie an Sonntagnachmittagen Landpartien zu machen, nahm ihren Strickbeutel, setzte den großen Hut über die große Haube, zog ein lieblich geblümtes Kleid an und schloß die Tür des Entenfanges hinter sich ab.
     </p>
-    <p xml:id="eco_de_0000144_8580">
+    <p xml:id="eco_de_0000214_8580">
      Dann zog sie hinaus in Gottes freie Natur, kaufte sich unterwegs beim Bäcker noch ein paar Maulschellen, um etwa in Rödchen, Tröbsdorf oder Süßenborn etwas zu haben, was sie in den Kaffee stippen konnte.
     </p>
-    <p xml:id="eco_de_0000144_8590">
+    <p xml:id="eco_de_0000214_8590">
      »Nee,« sagte sie bei sich, »jetzt haben wir Badewännchen endlich so weit, jetzt braucht sie keine Stiefmutter mehr, ist überhaupt ganz unnotwendig, und gar die kleine Frau Marianne. Alles was recht ist, aber ich gebe keinen Sechser dafür, daß ihr Herz auch nur so groß ist, wie das Herz einer Suppenhenne. Ich sehe nicht ein, weshalb wir der für eine Sinekure auf dem Ettersberg sorgen müssen.«
     </p>
-    <p xml:id="eco_de_0000144_8600">
+    <p xml:id="eco_de_0000214_8600">
      Als aber der Rittmeister ein paar Sonntage lang die verschlossene Tür fand, ergrimmte er gewaltig auf die Kummerfelden. »So 'n altes Weib,« schimpfte er vor ihrer Tür, »stiehlt Gott die Tage, und wenn's mal zu was zu gebrauchen wäre, macht sich's davon.«
     </p>
-    <p xml:id="eco_de_0000144_8610">
+    <p xml:id="eco_de_0000214_8610">
      Bisher war dem Rittmeister seine Liebe ganz leicht und behaglich zu tragen gewesen, eine glückliche, glatte Liebe. Aber nun begann sie in seinen Knochen wie sein Zipperlein zu reißen. ›Man wird alt – man wird alt,« dachte er bei sich und mußte seine Kräfte im »Elefanten« auffrischen, seine Sehnsucht betäuben, sein Unbehagen tatsächlich ersäufen, und doch gelang's ihm nicht. Eine gewaltige Unruhe trieb ihn umher. Des Tags wohl zehnmal spazierte er mit gravitätischen Schritten durch die kleine Stadt und hätte gewünscht, sie wäre zehnmal so groß. Endlich hatte er den Mut gefaßt, bei seiner Angebeteten einen Besuch nach allen Regeln zu machen, wurde aber von ihr selbst schnöde abgewiesen. ›Ob er denn glaube, daß sie Herrenbesuche empfinge?« Das verdutzte ihn. ›Wenn sie das ganze Haus voll Mannsbilder in Kost und Logis hat!« dachte er.
     </p>
-    <p xml:id="eco_de_0000144_8620">
+    <p xml:id="eco_de_0000214_8620">
      Sein Erstaunen mochte dem alten Soldaten so deutlich auf dem Gesicht zu lesen gewesen sein, daß das hübsche Weibchen ihn völlig begriff und freundlich sagte: »Mein lieber Herr Rittmeister, das sehen die Leute ein, daß eine arme Witwe ihren Unterhalt haben muß; aber wenn ich einen jeden, dem's gefiele, bei mir einlassen wollte, würd' ich nicht übel ins Gerede kommen. Also nichts für ungut, Herr Rittmeister.« Dabei sah sie so liebreizend aus, das Herzgesicht hatte einen Anflug süßer Röte, denn es war ihr in der Tat nicht recht, daß ihr Verehrer hier vor aller Augen vor ihrer Haustür stand, im kleinen Gärtchen. »Aber,« sagte sie und schaute sittsam nieder, »das möchte wohl gehen, daß ich 'mal 'raufspaziert käme und Ihrem Töchterchen eine Visite machen täte.«
     </p>
-    <p xml:id="eco_de_0000144_8630">
+    <p xml:id="eco_de_0000214_8630">
      »Dem Badewännchen?« lachte er erstaunt.
     </p>
-    <p xml:id="eco_de_0000144_8640">
+    <p xml:id="eco_de_0000214_8640">
      »Also Sonntag, wenn's Badewännchen daheim ist,« sagte der Rittmeister pfiffig und machte einen Bückling, wie er ihn seit Jahrzehnten nicht nötig gehabt.
     </p>
-    <p xml:id="eco_de_0000144_8650">
+    <p xml:id="eco_de_0000214_8650">
      Ihr kluges Betragen bewies ihm, daß sie ihn nicht ungern sah. Er war daher sehr gut gelaunt.
     </p>
-    <p xml:id="eco_de_0000144_8660">
+    <p xml:id="eco_de_0000214_8660">
      An diesem Abend hatte Badewännchen große Not mit Herrn Rauchfuß. Er stieg bedenklich fußunsicher aus dem Kütschchen. Bisher war er immer stattlich durch den Hof geschritten, unnatürlich gerade, den Schnauzbart in die Luft gestreckt, die Hand auf dem Rücken, wie ein Mann, der jeden Blick erträgt: Na, schaut mich an!
     </p>
-    <p xml:id="eco_de_0000144_8670">
+    <p xml:id="eco_de_0000214_8670">
      Das Unglück war erst immer daheim angegangen, da war er in sich zusammengefallen und hatte Badewännchen viel Müh' und Angst gemacht, hatte bös geschimpft und wohl auch geschlagen und sie dann wieder über alle Maßen gelobt und sie dabei mit gläsernen Augen angestarrt, so daß das arme Kind aus der Bangigkeit nicht herauskam.
     </p>
-    <p xml:id="eco_de_0000144_8680">
+    <p xml:id="eco_de_0000214_8680">
      Heut' aber, da war er ganz sonderbar, wie noch nie.
     </p>
-    <p xml:id="eco_de_0000144_8690">
+    <p xml:id="eco_de_0000214_8690">
      Da saß er in seinem Lehnstuhl und machte sich mit etwas zu schaffen, was nicht da war. »Geh',« sagte er, »oder meinetwegen bleib' da!« Und da strich er der Katze, die nicht da war, über den Rücken.
     </p>
-    <p xml:id="eco_de_0000144_8700">
+    <p xml:id="eco_de_0000214_8700">
      »Vater,« sagte die Kleine, »was hast du denn? Was spaßt du denn? Sie ist doch gar nicht da.«
     </p>
-    <p xml:id="eco_de_0000144_8710">
+    <p xml:id="eco_de_0000214_8710">
      »Gans,« sagte Herr Rauchfuß, »hast du in den Augen ein Loch, daß die Katze dir durchfällt?«
     </p>
-    <p xml:id="eco_de_0000144_8720">
+    <p xml:id="eco_de_0000214_8720">
      »No, was hat sie denn nur,« fuhr Herr Rauchfuß auf und machte sich mit der unsichtbaren Katze zu tun. »Ja! – Was! – Schnappen! – Seit wann denn? – Wie 'n Hund! – Die Bestie.« Sein Gesicht wurde dunkelrot. Die Zornader schwoll. Er gab dem Tiere einen Tritt. »So, jetzt hat sie genug! So ist noch kein solch Vieh an die Wand gekeilt worden.«
     </p>
-    <p xml:id="eco_de_0000144_8730">
+    <p xml:id="eco_de_0000214_8730">
      Er setzte sich befriedigt nieder, schwer aufatmend. Krank sah er aus. Jetzt wird er ganz fahl, blauschwärzlich unter den Augen, der Blick abwesend. Das arme Kind wollte die Mamsell rufen, aber es konnte sich nicht vom Platz rühren vor Angst und fing bitterlich an zu weinen. Das brachte Herrn Rauchfuß auf: »Da, siehst du's etwa wieder nicht?« schrie er wütend. »Sperr' die Augen auf!« Er schaute starr vor sich. »Hat sie sich doch hereingemacht! So ein Vieh hat keine Ehre im Leib. Fährst du ab!« Damit stieß er mit dem Fuß nach ihr.
     </p>
-    <p xml:id="eco_de_0000144_8740">
+    <p xml:id="eco_de_0000214_8740">
      Jetzt mit einem Male kam weiche Stimmung über ihn. »Badewännchen, siehst 'n,« sagte er matt, »du sollst 'n gutes Kind sein, was meinst du denn, was ich mich mit dir plagen muß! So 'n mutterloses Kind aufziehen ist keine Kleinigkeit für'n alten Sünder. Geh', brau' mir 'n Grog, weißt, 'n so 'n feinen, so 'n höllischen, – das wird mir gut tun.«
     </p>
-    <p xml:id="eco_de_0000144_8750">
+    <p xml:id="eco_de_0000214_8750">
      Derart wunderliche Zustände stellten sich jetzt öfters ein. Zwischendurch waren ruhige Tage, an denen sich Herr Rauchfuß nicht besonders wohl zu fühlen schien. Er aß oft tagsüber keinen Bissen und war mißlaunig und matt.
     </p>
-    <p xml:id="eco_de_0000144_8760">
+    <p xml:id="eco_de_0000214_8760">
      An einem schönen Sommernachmittag kam durch wogende Felder Marianne, die junge Witwe, zum Ettersberg heraufgewandelt und fragte nach Mamsell Beate Rauchfuß. Die traf sie im Garten an. Da lag das Kind auf der langen Wiese, die zur Bleiche diente, im Heu und schlief und erwachte nicht, als die Fremde sich ihr näherte.
     </p>
-    <p xml:id="eco_de_0000144_8770">
+    <p xml:id="eco_de_0000214_8770">
      ›Drollig,« dachte die junge Witwe, ›daß sie da liegt und schläft. Was treibt das Mädchen überhaupt den ganzen Tag?« Sie sah das tiefrote Haar, das im starken Zopf um den Kopf geschlungen war, das zarte Gesicht, die feste, kleine Nase, und einen Mund, der ganz aus Kraft und Weh gebildet zu sein schien, die junge Gestalt im Rosagewändchen und ein Paar runde, kindliche Arme; braune Hände, die den Blick auf sich zogen. Die eine zur Faust geballt, sagte: ›Was ich halte, das halt' ich. Was ich will, das will ich.«
     </p>
-    <p xml:id="eco_de_0000144_8780">
+    <p xml:id="eco_de_0000214_8780">
      Die junge Witwe denkt bei sich: ›Das schöne Gut wär' recht, und der Alte auch, weshalb nicht; aber die Junge! – Ach, daß so ein armes Weibchen sich gar so viel plagen muß, um irgendwo unterzuschlüpfen, daß alle Bravheit, Schlauheit und Hübschheit nichts nutzt: Wie man's auch anfängt, schwer bleibt's alleweile.«
     </p>
-    <p xml:id="eco_de_0000144_8790">
+    <p xml:id="eco_de_0000214_8790">
      Es gingen ihr ihre Kostherren durch den Sinn und so manche schöne Möglichkeit, die ihr entschlüpft war.
     </p>
-    <p xml:id="eco_de_0000144_8800">
+    <p xml:id="eco_de_0000214_8800">
      Das junge Geschöpf wachte auf, beunruhigt von den Blicken der Fremden, und sah sie erstaunt und erschreckt an.
     </p>
-    <p xml:id="eco_de_0000144_8810">
+    <p xml:id="eco_de_0000214_8810">
      »Ich kam herauf, um Sie und den Herrn Vater hier oben aufzusuchen,« sagte Frau Marianne etwas beklommen, denn der forschende, fremde Blick des Mädchens zeigte ihr, daß Mamsell Beate von ihr nichts wußte.
     </p>
-    <p xml:id="eco_de_0000144_8820">
+    <p xml:id="eco_de_0000214_8820">
      »Der Herr Vater«, fuhr das Weibchen fort, »hat mich aufgefordert, einmal nach Ihnen zu schauen.«
     </p>
-    <p xml:id="eco_de_0000144_8830">
+    <p xml:id="eco_de_0000214_8830">
      ›Der Vater?« dachte Beate langsam.
     </p>
-    <p xml:id="eco_de_0000144_8840">
+    <p xml:id="eco_de_0000214_8840">
      »Wie geht's dem Herrn Vater?«
     </p>
-    <p xml:id="eco_de_0000144_8850">
+    <p xml:id="eco_de_0000214_8850">
      Hart und kurz sagte das Kind: »Gut.«
     </p>
-    <p xml:id="eco_de_0000144_8860">
+    <p xml:id="eco_de_0000214_8860">
      »Ja, was für ein lieber, munterer Herr er ist.«
     </p>
-    <p xml:id="eco_de_0000144_8870">
+    <p xml:id="eco_de_0000214_8870">
      Das junge Ding schwieg und schaute ernst, mit schwerem Blick vor sich hin. Sie wußte nicht, was sie mit der freundlichen, zierlichen Person anfangen sollte.
     </p>
-    <p xml:id="eco_de_0000144_8880">
+    <p xml:id="eco_de_0000214_8880">
      Die süße Tölpelhaftigkeit der ersten Jugend lag weich und schwer über ihr. Sie war nicht gewöhnt, mit fremden Leuten zu reden, und der wundervolle, tiefe Sommerschlaf befing sie noch.
     </p>
-    <p xml:id="eco_de_0000144_8890">
+    <p xml:id="eco_de_0000214_8890">
      »Wie schön haben Sie's hier!« sagte das Weibchen, um endlich doch einen Widerklang ihrer Liebenswürdigkeit zu finden.
     </p>
-    <p xml:id="eco_de_0000144_8900">
+    <p xml:id="eco_de_0000214_8900">
      Das Mädchen nickte leicht.
     </p>
-    <p xml:id="eco_de_0000144_8910">
+    <p xml:id="eco_de_0000214_8910">
      »Ist's wahr, daß Ihr Herr Vater täglich im Sommer eine Rose vor dem Frühstück verspeist, damit er so frisch und munter bleibt, wie er ist?« fragte das Weibchen wieder und lächelte.
     </p>
-    <p xml:id="eco_de_0000144_8920">
+    <p xml:id="eco_de_0000214_8920">
      »Eine Rose?« Das Mädchen schreckte wie aus Gedanken versunken auf. »Ja, er hat einmal so etwas gesagt, dünkt mich, daß er's früher getan hat. Hat er's Ihnen auch gesagt?«
     </p>
-    <p xml:id="eco_de_0000144_8930">
+    <p xml:id="eco_de_0000214_8930">
      »Ja wohl,« meinte die Witwe, »und es muß kein übles Mittel sein. Wenn man ihn so stattlich dahergehen sieht, wie noch mal 'n Kavalier, da glaubt man's schon.« »Badewännchen!« rief eine gewaltige Stimme vom Hause her. »Wo seid Ihr denn?«
     </p>
-    <p xml:id="eco_de_0000144_8940">
+    <p xml:id="eco_de_0000214_8940">
      Und als Badewännchen aufschaute, sah sie ihren Vater gar stattlich daherkommen. Er mußte fürwahr viele Rosen soeben gegessen haben, denn er war wie verwandelt. So hatte sie ihn ihr Lebtag nicht gesehen. War er's denn wirklich? Heut so grau und mißgelaunt und voller Ekel bei Tisch, und nun?
     </p>
-    <p xml:id="eco_de_0000144_8950">
+    <p xml:id="eco_de_0000214_8950">
      Der rote Bart glänzte, die Augen leuchteten, und er ging wie auf Federn.
     </p>
-    <p xml:id="eco_de_0000144_8960">
+    <p xml:id="eco_de_0000214_8960">
      Badewännchen riß die Augen auf.
     </p>
-    <p xml:id="eco_de_0000144_8970">
+    <p xml:id="eco_de_0000214_8970">
      »Bravo, Frau Marianne!« rief Herr Rauchfuß, »daß Sie den weiten, sonnigen Weg gemacht haben, um meiner armen Kleinen ein wenig Gesellschaft zu leisten, das lob' ich mir.«
     </p>
-    <p xml:id="eco_de_0000144_8980">
+    <p xml:id="eco_de_0000214_8980">
      Die junge Beate schaute ängstlich auf Vater und Gast; was fiel ihm ein, ihr für Gesellschaft zu sorgen?
     </p>
-    <p xml:id="eco_de_0000144_8990">
+    <p xml:id="eco_de_0000214_8990">
      Sie war hier oben an Einsamkeit gewöhnt. Gewünscht hatte sie sich oft die Kirstensmädchen mit ihren Freundinnen, die sie bei der Kummerfelden und hin und wieder bei Sperbers traf, die wären auch zu ihr heraufgekommen; aber dann hatte sie gedacht: ›Wenn die den Vater sehen würden, wie sie ihn oft sah« – und alle Lust war ihr vergangen.
     </p>
-    <p xml:id="eco_de_0000144_9000">
+    <p xml:id="eco_de_0000214_9000">
      Aber Beatens Einsamkeit war eine wundervoll kräftige Einsamkeit gewesen. Wie ein kleines Tier hatte sie im vollaubigen Garten gelebt, hatte unter den Bäumen oder in voller Sonne geschlafen, hatte gegraben, gepflanzt und war in Feld und Wald umhergestrichen, ohne daß irgend jemand nach ihr gefragt hätte.
     </p>
-    <p xml:id="eco_de_0000144_9010">
+    <p xml:id="eco_de_0000214_9010">
      Wo es zu arbeiten gab, hatte sie tüchtig mit Hand angelegt, beim Säen und Ernten, im Stall und in der Milchkammer, im Obst- und Gemüsegarten.
     </p>
-    <p xml:id="eco_de_0000144_9020">
+    <p xml:id="eco_de_0000214_9020">
      Knechte und Mägde hatten vor ihr Respekt und sagten: ›Wie sie nur alles angreift, verständig wie ein Großes!«
     </p>
-    <p xml:id="eco_de_0000144_9030">
+    <p xml:id="eco_de_0000214_9030">
      Und im Winter in der Gesindestube, da vermißte sie auch kaum ihresgleichen, da gab es zu hören und so manches zu erlauschen, da wurden die Dinge beim rechten Namen genannt, da erstand ihr eine hahnebüchene Welt, in der auch die Geister und Gespenster handgreiflicher Natur waren.
     </p>
-    <p xml:id="eco_de_0000144_9040">
+    <p xml:id="eco_de_0000214_9040">
      In der Gesindestube wehte eine ganz gehörig scharfe Luft, was Witze und dumme Geschichten betraf, und wie ein Kind aus dem Volke wußte sie früh über Liebe Bescheid; aber ohne Sehnsucht.
     </p>
-    <p xml:id="eco_de_0000144_9050">
+    <p xml:id="eco_de_0000214_9050">
      Es war da nichts Rätselhaftes, Geheimnisvolles, nichts allzu Anziehendes; aber es war etwas, was sein mußte, wie Säen und Ernten, wie Tod und Leben.
     </p>
-    <p xml:id="eco_de_0000144_9060">
+    <p xml:id="eco_de_0000214_9060">
      Ihr waren über die Dinge dieser Erde keine Schleier gebreitet, auch über den Tod nicht. Alles war, wie es war, und mußte hingenommen werden.
     </p>
-    <p xml:id="eco_de_0000144_9070">
+    <p xml:id="eco_de_0000214_9070">
      Und so kam ihr das Wesen zwischen Vater und Gast sofort sonderbar vor.
     </p>
-    <p xml:id="eco_de_0000144_9080">
+    <p xml:id="eco_de_0000214_9080">
      Sie hatten in der Gesindestube sie schon manchesmal damit geneckt und gehänselt, daß der Vater einmal mit einer Stiefmutter ihr kommen könnte.
     </p>
-    <p xml:id="eco_de_0000144_9090">
+    <p xml:id="eco_de_0000214_9090">
      Und jetzt dachte sie: ›Sollte dies sein?«
     </p>
-    <p xml:id="eco_de_0000144_9100">
+    <p xml:id="eco_de_0000214_9100">
      Sie fand sie sehr hübsch; die Zierlichkeit, ihr angenehmes Lächeln, die dunklen, wohl frisierten Löckchen, alles bezauberte sie. Ja, es erschien ihr, als wäre das Weibchen ein Wunder gegen ihre eigene Tölpelhaftigkeit.
     </p>
-    <p xml:id="eco_de_0000144_9110">
+    <p xml:id="eco_de_0000214_9110">
      Es war ein recht froher Nachmittag droben im alten Gutshaus. Solch ein helles Frauenlachen hatte da oben in langen Jahren nicht geklungen.
     </p>
-    <p xml:id="eco_de_0000144_9120">
+    <p xml:id="eco_de_0000214_9120">
      Die Mamsell kochte einen vorzüglichen Kaffee, breitete im Garten unter der alten Linde, unter der Frau Rauchfuß einst wie ein schon abgeschiedener Geist ihr Kind hatte tanzen sehen, ein weißes Tuch über den Tisch und trug frisch gebackene Kräpfel auf.
     </p>
-    <p xml:id="eco_de_0000144_9130">
+    <p xml:id="eco_de_0000214_9130">
      Die junge Beate schnitt Blumen und stellte einen Strauß auf den Tisch. Frau Marianne ertrank fast in eigener Liebenswürdigkeit, und der Rittmeister war wie das Gespenst seiner eigenen Jugend.
     </p>
-    <p xml:id="eco_de_0000144_9140">
+    <p xml:id="eco_de_0000214_9140">
      Beate saß ganz still und schaute und verglich den einen schönen Sommertag mit all den Sommer-, Winter-, Frühlings- und Herbsttagen, die sie kannte, und sie ballte die festen, kleinen Hände zu Fäusten, um die Tränen zu besiegen, und starrte auf ihren Vater, von dem aus so viel Leid ihr Lebtag ausgegangen war, und dachte an die Freudlosigkeit ihrer Mutter.
     </p>
-    <p xml:id="eco_de_0000144_9150">
+    <p xml:id="eco_de_0000214_9150">
      ›Nein,« dachte die junge Beate: ›Sie soll nicht zu uns heraufkommen, leid tät' sie mir. Um mich ist's nicht schade, ich weiß schon alles.«
     </p>
-    <p xml:id="eco_de_0000144_9160">
+    <p xml:id="eco_de_0000214_9160">
      Als die hübsche Witwe im Kütschchen wieder heimfuhr, küßte der Rittmeister ihr gar zärtlich und zuversichtlich die Hand.
     </p>
-    <p xml:id="eco_de_0000144_9170">
+    <p xml:id="eco_de_0000214_9170">
      So fuhr Frau Marianne siegesstolz davon. Den hatte sie jetzt, den Alten!
     </p>
-    <p xml:id="eco_de_0000144_9180">
+    <p xml:id="eco_de_0000214_9180">
      Und wie das Kütschchen gut rollte!
     </p>
-    <p xml:id="eco_de_0000144_9190">
+    <p xml:id="eco_de_0000214_9190">
      Es war dasselbe Kütschchen, in dem Frau Rauchfuß, an die Lederkissen geschmiegt, ihre todestraurige Fahrt nach Hause gemacht hatte.
     </p>
-    <p xml:id="eco_de_0000144_9200">
+    <p xml:id="eco_de_0000214_9200">
      Frau Marianne war gar übermütig gestimmt, abgetan waren die Kostgänger.
     </p>
-    <p xml:id="eco_de_0000144_9210">
+    <p xml:id="eco_de_0000214_9210">
      Als sie ihrem Häuschen zurollte – es war schon etwas spät –, dachte sie: ›Herr Leinhose hätte sein Bierchen schon längst haben sollen und Herr Oehmchen seine Bratwurst! Ach was! Mögen sie einmal warten!«
     </p>
-    <p xml:id="eco_de_0000144_9220">
+    <p xml:id="eco_de_0000214_9220">
      Die beiden saßen schon in der Wohnstube, als sie eintrat, und schienen etwas mißgestimmt zu sein. Der eine zog seine Uhr und schaute darauf, wie ein ungehaltener Gläubiger auf seinen Schuldschein. »Spät, spät sind wir daran,« sagte er bedächtig.
     </p>
-    <p xml:id="eco_de_0000144_9230">
+    <p xml:id="eco_de_0000214_9230">
      Die kleine Witwe lachte etwas leichtfertig. Der Hunger ihrer Kostgänger ließ sie sehr kühl, dieser Kostgänger, die ihr so sehr am Herzen gelegen und deren Wohlergehen ihre größte Sorge gewesen war; denn keinem ledigen Mann geht es besser, als wenn ihn ein Frauchen, das auf Freiersfüßen geht, versorgt.
     </p>
-    <p xml:id="eco_de_0000144_9240">
+    <p xml:id="eco_de_0000214_9240">
      Die beiden Kostgänger nahmen schon seit Jahr und Tag der kleinen Witwe Fürsorge hin, und jeder von ihnen stand so mit ihr, daß sie die Wahl zwischen ihnen beiden zu haben glaubte. Der eine wartete auf eine Gehaltsverbesserung, die jeden Tag vor sich gehen konnte, und der andere hatte einen kleinen, netten Prozeß wegen einer Erbschaft und konnte jeden Tag Herr von einigen tausend Reichstalern werden, mit denen sich allerhand anfangen ließ.
     </p>
-    <p xml:id="eco_de_0000144_9250">
+    <p xml:id="eco_de_0000214_9250">
      Sie waren beide zwei Herren mit den schönsten Möglichkeiten, und eine kleine heiratslustige Witwe konnte schon ein übriges an Beköstigung und Aufwartung für sie tun. Sie standen auch beide im guten Alter, nicht zu alt und nicht zu jung.
     </p>
-    <p xml:id="eco_de_0000144_9260">
+    <p xml:id="eco_de_0000214_9260">
      Wirklich ganz erstaunt blickten sie heute auf ihre kleine Freßmadame, die sich durch ihr Mißvergnügen gar nicht beirren ließ, sondern Hut und Longschal bedächtig in das lavendelduftende Kommodenfach legte.– Was sie nur hatte?
     </p>
-    <p xml:id="eco_de_0000144_9270">
+    <p xml:id="eco_de_0000214_9270">
      Sie warteten und warteten. Die Witib trödelte geradezu mit dem Essen. Und als es endlich kam, wurde es durchaus nicht so liebevoll wie sonst vor jeden hingesetzt, sondern recht gleichmütig. Die Wurst war auch nicht so knusperig wie sonst.
     </p>
-    <p xml:id="eco_de_0000144_9280">
+    <p xml:id="eco_de_0000214_9280">
      Die junge Frau nahm Platz am Fenster und spann.
     </p>
-    <p xml:id="eco_de_0000144_9290">
+    <p xml:id="eco_de_0000214_9290">
      Jetzt wäre die Zeit gewesen, zu der sie allabendlich miteinander den Küchenzettel für den nächsten Tag zu machen gewohnt waren. Friedlich hatten sie zu dieser Speisestunde einen weiteren Genuß, kraft ihrer Phantasie und schöpferischen Gaben, sich vor die frohen Seelen gestellt. Das blieb heute auch aus.
     </p>
-    <p xml:id="eco_de_0000144_9300">
+    <p xml:id="eco_de_0000214_9300">
      Sie spann und lächelte träumerisch vor sich hin, und die beiden schmausenden Kostgänger waren für sie gar nicht vorhanden.
     </p>
-    <p xml:id="eco_de_0000144_9310">
+    <p xml:id="eco_de_0000214_9310">
      Sie wirtschaftete oben auf dem schönen Gut, wandelte im Geist durch Stall und Küche, rückte im Wohnzimmer allerhand nach ihrem Geschmack und fühlte sich so recht an ihrem Platz.
     </p>
-    <p xml:id="eco_de_0000144_9320">
+    <p xml:id="eco_de_0000214_9320">
      Da schellte es unten an der Haustür auf eine heftige; sonderbare Weise.
     </p>
-    <p xml:id="eco_de_0000144_9330">
+    <p xml:id="eco_de_0000214_9330">
      Als die kleine Witwe die Treppe wieder heraufgestiegen kam, hörten die Kostgänger zögernde Schritte hinter ihr drein kommen.
     </p>
-    <p xml:id="eco_de_0000144_9340">
+    <p xml:id="eco_de_0000214_9340">
      Ganz erregt trat die Frau ein, und ihr folgte etwas, worauf die beiden Kostgänger nicht gefaßt waren, ein rothaariges, kindliches Mädchen. Sie trug ein Schaltuch über dem Kopf, welches das Haar halb verdeckte. Es quoll aber in Ringeln und verwirrten Strähnen daraus hervor.
     </p>
-    <p xml:id="eco_de_0000144_9350">
+    <p xml:id="eco_de_0000214_9350">
      Die biegsame, mittelgroße Gestalt, das weiche, rosige Gesicht, die scharfgeschwungenen, dunklen Augenbrauen, all das machte die Erscheinung, die stumm an der Tür stand, so märchenhaft und wunderlich, daß Herrn Oehmchen und Herrn Leinhose der Bissen im Munde steckenblieb. Sie wagten nicht mehr zu kauen. Das schöne Geschöpf aber rührte sich nicht und starrte auf die beiden Mannsbilder und schien sich gar nicht fassen zu können.
     </p>
-    <p xml:id="eco_de_0000144_9360">
+    <p xml:id="eco_de_0000214_9360">
      »Nun, Mamsell Rauchfuß,« sagte das Weibchen mit dem Herzgesicht, »was verschafft mir denn das Vergnügen?«
     </p>
-    <p xml:id="eco_de_0000144_9370">
+    <p xml:id="eco_de_0000214_9370">
      Das wunderliche Geschöpf aber antwortete noch immer nicht, sondern schaute nur. Man sah, sie kämpfte in sich mit etwas, was sie sagen wollte und nicht konnte.
     </p>
-    <p xml:id="eco_de_0000144_9380">
+    <p xml:id="eco_de_0000214_9380">
      »Ei, so setzen Sie sich doch, Mamsell,« sagte der Herr Leinhose, und rückte ihr einen Stuhl an den Tisch.
     </p>
-    <p xml:id="eco_de_0000144_9390">
+    <p xml:id="eco_de_0000214_9390">
      »Ja, um Himmels willen, ist denn etwas geschehen?« fragte das arme Weibchen kleinlaut.
     </p>
-    <p xml:id="eco_de_0000144_9400">
+    <p xml:id="eco_de_0000214_9400">
      Da nahm das seltsame Geschöpf Platz auf dem Stuhl, verbarg den Kopf in den Armen, die sie breit auf den Tisch legte, und begann zu schluchzen.
     </p>
-    <p xml:id="eco_de_0000144_9410">
+    <p xml:id="eco_de_0000214_9410">
      Die Witwe legte ihre Hand beruhigend ihr auf die Schulter.
     </p>
-    <p xml:id="eco_de_0000144_9420">
+    <p xml:id="eco_de_0000214_9420">
      »Ach, heiraten Sie meinen Vater doch nicht,« klang es leidenschaftlich und doch so weich frühlingshaft zwischen dem Schluchzen hindurch. »Zu schad' wär's um Sie.«
     </p>
-    <p xml:id="eco_de_0000144_9430">
+    <p xml:id="eco_de_0000214_9430">
      Das Mädchen war ganz in Tränen aufgelöst.
     </p>
-    <p xml:id="eco_de_0000144_9440">
+    <p xml:id="eco_de_0000214_9440">
      »Aber, wer denkt denn daran!« sagte die kleine Witwe ärgerlich.
     </p>
-    <p xml:id="eco_de_0000144_9450">
+    <p xml:id="eco_de_0000214_9450">
      »Doch! doch! Sie – und auch der Vater, ganz gewiß. Tun Sie's um Gottes willen nicht. Sie wissen nicht, wie traurig es oben bei uns ist!«
     </p>
-    <p xml:id="eco_de_0000144_9460">
+    <p xml:id="eco_de_0000214_9460">
      Das Schluchzen war so wild und ungezügelt, als hätte das arme Kind es jahrelang eingedämmt, und nun tobte es wie ein Frühlingswasser. »In solcher Angst bin ich von oben herabgelaufen; ich mußte es Ihnen sagen. So eine Sünde wäre es gewesen, hätte ich's nicht getan. Wenn Sie wüßten, wie traurig meine arme Mutter immer war und wie traurig – traurig sie gestorben ist!«
     </p>
-    <p xml:id="eco_de_0000144_9470">
+    <p xml:id="eco_de_0000214_9470">
      Das gute, arme Kind, das es in seiner Herzensangst so treu und ehrlich meinte und der Witwe soeben einen gar schlimmen Streich spielte, hatte noch immer das mit der roten Haarkrone geschmückte Haupt auf die Arme gepreßt.
     </p>
-    <p xml:id="eco_de_0000144_9480">
+    <p xml:id="eco_de_0000214_9480">
      Sie sah nicht, wie die beiden Kostgänger belustigte Blicke auf ihre kleine Freßmadame warfen, und wie deren Herzgesicht erbleichte und wie darüber hin ein Weh zog, vergebliche Mühe, vergebliches Hoffen.
     </p>
-    <p xml:id="eco_de_0000144_9490">
+    <p xml:id="eco_de_0000214_9490">
      Einsam weinte das junge, schöne Menschenwesen unter diesen dreien, die alle ihre eigene Verwirrung hatten.
     </p>
-    <p xml:id="eco_de_0000144_9500">
+    <p xml:id="eco_de_0000214_9500">
      »Schau – schau,« sagte Herr Oehmchen endlich, »unsere teure Frau Marianne.« Seine Stimme klang etwas giftig. Gott weiß, ob er je Gebrauch von der Güte und Bereitwilligkeit seiner Wohltäterin gemacht hätte; aber er wollte der Teil sein, der wählte und verwarf, nicht sie.
     </p>
-    <p xml:id="eco_de_0000144_9510">
+    <p xml:id="eco_de_0000214_9510">
      Er war der Gekränkte.
     </p>
-    <p xml:id="eco_de_0000144_9520">
+    <p xml:id="eco_de_0000214_9520">
      Nicht anders betrug sich Herrn Leinhose; auch der fühlte sich als der Herr der Schöpfung genasführt und machte sich durch einige geschmerzte unartige Bemerkungen Luft. Die kleine Witwe aber war rat- und wehrlos gegen diese beiden in Ungerechtigkeit geharnischten Mannsbilder.
     </p>
-    <p xml:id="eco_de_0000144_9530">
+    <p xml:id="eco_de_0000214_9530">
      Das Bild der vier Puppen, die das Schicksal am Draht hatte, bekam jetzt einen Ruck, der die ganze Lage der Dinge veränderte.
     </p>
-    <p xml:id="eco_de_0000144_9540">
+    <p xml:id="eco_de_0000214_9540">
      Die Augen der Kostgänger richteten sich jetzt nicht zürnend und giftig in gekränkter Männerwürde auf die hübsche Witwe, sondern wohlgefällig und zutunlich auf das weinende Mädchen, das jetzt Freunde bekam auf Kosten eines andern, wie das so oft geschieht. Der eine verliert, wodurch notwendig ein zweiter gewinnen muß.
     </p>
-    <p xml:id="eco_de_0000144_9550">
+    <p xml:id="eco_de_0000214_9550">
      »Nun, jetzt bitte ich Sie, schaut niemand von uns allen darauf, daß Mamsell Rauchfuß sich beruhigt!«
     </p>
-    <p xml:id="eco_de_0000144_9560">
+    <p xml:id="eco_de_0000214_9560">
      Damit schob Herr Leinhose zur Tür hinaus und kam mit einem Glase frischen Wassers wieder herein: »Hier Mamsell,« sagte er sanft wie eine Kindermuhme, »trinken Sie ein Schlückchen!«
     </p>
-    <p xml:id="eco_de_0000144_9570">
+    <p xml:id="eco_de_0000214_9570">
      Frau Marianne sah ganz erstaunt auf. Solch ein Laut war hier noch nie erklungen! Die Herren waren ununterbrochen von ihr gut bedient worden, in allzu großem Eifer, von ihr! und hatten gar keine Gelegenheit gehabt, sich ihr gegenüber zu revanchieren.
     </p>
-    <p xml:id="eco_de_0000144_9580">
+    <p xml:id="eco_de_0000214_9580">
      Wenn das Männchen aber wirbt, sieht es das Weibchen gern hilfsbedürftig, so sehr sich dieses Wohlgefallen an Hilfsbedürftigkeit auch später ändert.
     </p>
-    <p xml:id="eco_de_0000144_9590">
+    <p xml:id="eco_de_0000214_9590">
      O weh, dachte die hübsche Witwe, da haben wir's.
     </p>
-    <p xml:id="eco_de_0000144_9600">
+    <p xml:id="eco_de_0000214_9600">
      Sie mußte zuschauen, wie die beiden sich überboten, dem jungen Geschöpf zu dienen.
     </p>
-    <p xml:id="eco_de_0000144_9610">
+    <p xml:id="eco_de_0000214_9610">
      Die Stimmen ihrer Kostgänger wurden zarter und zarter, ganz hingerissen.
     </p>
-    <p xml:id="eco_de_0000144_9620">
+    <p xml:id="eco_de_0000214_9620">
      Dem einsamen jungen Geschöpf aber taten diese gütigen Stimmen wohl, es begann sich zu beruhigen, schaute auf.
     </p>
-    <p xml:id="eco_de_0000144_9630">
+    <p xml:id="eco_de_0000214_9630">
      Das rosige, vom Weinen etwas verschwollene Gesicht unter dem Schopf roten Haares begeisterte die Kostgänger ganz augenscheinlich. Ihre Seelen gossen wahrhaft Güte und Liebenswürdigkeit aus, und Frau Marianne durfte nicht allzusehr von den beiden abstechen, um sich nicht lächerlich zu machen, und war daher gezwungen, einigermaßen mütterlich zärtlich gegen den Störenfried zu sein.
     </p>
-    <p xml:id="eco_de_0000144_9640">
+    <p xml:id="eco_de_0000214_9640">
      Sie hatte nun erfahren, die Aermste, daß Liebe sich nicht bürgerlich gesittet und wohlberechtigt einfangen läßt.
     </p>
-    <p xml:id="eco_de_0000144_9650">
+    <p xml:id="eco_de_0000214_9650">
      So mußte sie's ertragen, daß ihre beiden wohlgenährten Kostgänger, die so viel Mühe und Gewissenhaftigkeit geschluckt hatten, den kleinen Balg im Dunkeln wieder hinauf auf den Ettersberg brachten. Sie mußte es auch über sich ergehen lassen, daß das dumme Mädel in leidenschaftlicher Besorgnis noch einmal die Arme um sie schlang und sagte: »Traurig und unglücklich würden Sie werden, und Sie sind so schön und lieb. O, könnte ich werden wie Sie!«
     </p>
-    <p xml:id="eco_de_0000144_9660">
+    <p xml:id="eco_de_0000214_9660">
      Kaum nötig wäre es gewesen, daß die junge Beate dem armen Frauenzimmer, der Witwe, so großen Verdruß ins Haus gebracht hatte, denn Rittmeister Rauchfuß wurde bald darauf hinfällig und ganz gebrechlich.
     </p>
-    <p xml:id="eco_de_0000144_9670">
+    <p xml:id="eco_de_0000214_9670">
      Die böse Krankheit packte ihn, die so manchem prächtigen Herrn, der sein Lebtag stramm und freimütig getrunken hatte, das Lebenslicht unter Qualen und Nöten fein langsam verlöschen läßt.
     </p>
-    <p xml:id="eco_de_0000144_9680">
+    <p xml:id="eco_de_0000214_9680">
      Rittmeister Rauchfuß begann in gar wunderlichen peinlichen Vorstellungen zu leben. Dinge sah er, die andere nicht sahen, und da die Mehrzahl hier auf Erden recht behält und die Ausnahmen unrecht, mußte Herr Rauchfuß es sich gefallen lassen, hin und wieder nach Jena zu fahren, zu einem Arzt, der in seinem Hause so sonderbare Herren freundlich aufnahm, bis sich gewisse Irrtümer und Torheiten fürs erste gelegt hatten.
     </p>
-    <p xml:id="eco_de_0000144_9690">
+    <p xml:id="eco_de_0000214_9690">
      Die erträglicheren Zeiten brachte er auf dem Ottersberg, im alten Heim, wieder zu, und dort erwischte ihn auch sein letztes Stündlein.
     </p>
-    <p xml:id="eco_de_0000144_9700">
+    <p xml:id="eco_de_0000214_9700">
      Sperbers waren gekommen und auch die alte Kummerfelden, als sie hörten, Herr Rauchfuß hätte vor, abzuscheiden: sie wollten dem Alten, der sein Leben so torheitsvoll und unbekümmert hingebracht hatte wie die meisten Menschen, in der letzten Stunde nahe sein, seinetwegen und Badewännchens wegen.
     </p>
-    <p xml:id="eco_de_0000144_9710">
+    <p xml:id="eco_de_0000214_9710">
      Und so saßen sie im Nebenzimmer, als Herr Rauchfuß sich unter großen Qualen zur langen Reise anschickte. Sie saßen und tranken Kaffee, den die Mamsell immer neu braute, und aßen Schinkenbrot.
     </p>
-    <p xml:id="eco_de_0000144_9720">
+    <p xml:id="eco_de_0000214_9720">
      Der Arzt blieb auch in dieser Nacht oben auf dem Ettersberg und plauderte mit den drei Alten.
     </p>
-    <p xml:id="eco_de_0000144_9730">
+    <p xml:id="eco_de_0000214_9730">
      Badewännchen hielt am Lager ihres Vaters aus wie ein braver Soldat. Es war ein böses Sterben, und das gute Kind sah in die Schrecken des Lebens hinein wie in eine Feuersbrunst.
     </p>
-    <p xml:id="eco_de_0000144_9740">
+    <p xml:id="eco_de_0000214_9740">
      Sie selbst hatte so etwas Lebensvolles, Sonniges, daß es war, als stände das Leben selbst am Totenbette.
     </p>
-    <p xml:id="eco_de_0000144_9750">
+    <p xml:id="eco_de_0000214_9750">
      »Du Rackersmädchen, du!« sagte Herr Rauchfuß ärgerlich. »Wart' nur! – Siehste, wie's geht? – Soldatenkind! – Soldatenkind!«
     </p>
-    <p xml:id="eco_de_0000144_9760">
+    <p xml:id="eco_de_0000214_9760">
      Als er in der Nacht eine Weile still und teilnahmlos gelegen hatte, sagte er mit erloschener Stimme: »Sperber soll kommen.«
     </p>
-    <p xml:id="eco_de_0000144_9770">
+    <p xml:id="eco_de_0000214_9770">
      Und als der alte Nachbar kam, griff er nach dessen Hand und hielt sich daran in großer Bangigkeit, da war aber nichts mehr zu machen.
     </p>
-    <p xml:id="eco_de_0000144_9780">
+    <p xml:id="eco_de_0000214_9780">
      Er wollte noch sprechen, und schwer rang es sich heraus: »Sehr hoch – wohl – geboren höchst unwohl gestorben – alter Freund – alter Freund!«
     </p>
-    <p xml:id="eco_de_0000144_9790">
+    <p xml:id="eco_de_0000214_9790">
      »No, no,« sagte gutmütig beschwichtigend Nachbar Sperber, »das machen mir dir alle nach. Alle nach. Ach, du mein Gott.« So hielt er des alten Sünders Hand, mit dem er so manches Bésigue gespielt und so manchen guten Trunk getan hatte, während dessen arme, törichte Seele in Todesängsten über die Schwelle vom Ich zum Nichtich glitt.
     </p>
-    <p xml:id="eco_de_0000144_9800">
+    <p xml:id="eco_de_0000214_9800">
      Der Sommer nach des Vaters Tod ließ das Mädchen wundervoll erblühen. Das war ein Sommer! Keine Regenzeiten. Hin und wieder ein mächtiges Gewitter, das den alten Ettersberg überbrauste; Nachtregen und taufrische, tropfende, sonnenstrahlende Morgen. Ein Sommer, wie man ihn nur träumen konnte.
     </p>
-    <p xml:id="eco_de_0000144_9810">
+    <p xml:id="eco_de_0000214_9810">
      Von Badewännchen war der Lebensdruck abgefallen; sie kam ins Blühen und Leuchten.
     </p>
-    <p xml:id="eco_de_0000144_9820">
+    <p xml:id="eco_de_0000214_9820">
      »Eine Kopfverdreherin haben wir da oben,« meinte der alte Sperber. »Gott mag wissen, was die da oben anrichtet! Wenn das Mädel nur die verdammt roten Haare nicht hätte; aber so läuft sie wie eine Fackel umher, und jeder schaut und rennt ihr nach, bis zum Knecht hinab.
     </p>
-    <p xml:id="eco_de_0000144_9830">
+    <p xml:id="eco_de_0000214_9830">
      Sie lebte wie eine Königin da oben, trotzdem die beiden Sperbers brummten und schimpften, daß sie tat, was sie wollte und in ihrem Elternhause blieb, statt zu ihnen herüberzuziehen und das Gut zu verpachten.
     </p>
-    <p xml:id="eco_de_0000144_9840">
+    <p xml:id="eco_de_0000214_9840">
      Seit jenem Abend bei der jungen Witwe, als die trockenen Stimmen der Kostgänger sich zu Kindermuhmenzärtlichkeit und Besorgtheit verwandelten und schließlich zu Tönen kamen, die sie sich selbst kaum zugetraut hatten, wußte sie, daß sie schön war und Macht über die Menschen hatte.
     </p>
-    <p xml:id="eco_de_0000144_9850">
+    <p xml:id="eco_de_0000214_9850">
      An jenem Abend, als die beiden Kostgänger sie bis an das Haustor gebracht, hatte das einsame junge Mädchen in tiefer Nacht ihr Schlafkammerfenster geöffnet und in die große Dunkelheit und Stille hinausgeschaut. Ihr Herz schlug damals zum Zerspringen, das edle Blut durchglühte ihr die Haut.
     </p>
-    <p xml:id="eco_de_0000144_9860">
+    <p xml:id="eco_de_0000214_9860">
      Ein Wunder war geschehen! Trunken wurden die Menschen an ihr, trunken vor Freude.
     </p>
-    <p xml:id="eco_de_0000144_9870">
+    <p xml:id="eco_de_0000214_9870">
      Sie dankte Gott und preßte die gefalteten Hände an die Brust und war voll Seligkeit und Staunen. Sie konnte sich von der Stille nicht losreißen, die sie ganz mit ihrer eigenen Herrlichkeit erfüllte.
     </p>
-    <p xml:id="eco_de_0000144_9880">
+    <p xml:id="eco_de_0000214_9880">
      Daß die zwei Kostgänger der armen Frau Marianne im Grund zwei recht elende Wichte waren, tat nichts zur Sache. Sie hatte sie trunken vor Freude werden sehen.
     </p>
-    <p xml:id="eco_de_0000144_9890">
+    <p xml:id="eco_de_0000214_9890">
      Das bewegte sie tagelang, das heiligte sie vor sich selbst. Da, in diesem köstlichen Sommer, in dem aller Lebensdruck von ihr abgefallen war, wuchs und verschönte sie sich durch eigene Seligkeit.
     </p>
-    <p xml:id="eco_de_0000144_9900">
+    <p xml:id="eco_de_0000214_9900">
      Als Kind hatte sie Blumen um ihrer Schönheit willen beneidet, und nun war sie selbst schön. Sie bekam etwas Sicheres, Frohes.
     </p>
-    <p xml:id="eco_de_0000144_9910">
+    <p xml:id="eco_de_0000214_9910">
      Es war so gesund für sie, daß sie nun um ihre Schönheit wußte, den Tod kannte sie, völlige Einsamkeit und das Ertragenmüssen. Fuchs und Rotkopf hatte man sie in ihrer Kindheit gerufen. Von nun an bemerkte sie, daß ein jeder ihr nachsah, daß man stehenblieb, wenn sie vorüberging.
     </p>
-    <p xml:id="eco_de_0000144_9920">
+    <p xml:id="eco_de_0000214_9920">
      Und immer wieder kam diese große Freude, rann durch ihre Adern und stärkte sie.
     </p>
-    <p xml:id="eco_de_0000144_9930">
+    <p xml:id="eco_de_0000214_9930">
      Während dieses Sommers war sie tapfer bei der Arbeit. Sie wollte den alten Sperberleuten beweisen, daß sie eine gute Hausfrau und Gutsherrin sei. Trotzdem die Verantwortung auf dem Verwalter und der Mamsell lag, ließ sie sich das Heft nicht aus den Händen nehmen. Sie mußte von allem, was geschehen sollte, erfahren und ihre Einwilligung geben.
     </p>
-    <p xml:id="eco_de_0000144_9940">
+    <p xml:id="eco_de_0000214_9940">
      »Ein Rackersmädchen!« sagte der alte Sperber. Sie war viel drüben, holte sich dort Rat ein und traf mit jenen Mädchen und deren Kameraden zusammen, nach denen lange schon ihr Sinnen und Trachten stand.
     </p>
-    <p xml:id="eco_de_0000144_9950">
+    <p xml:id="eco_de_0000214_9950">
      Jetzt, da sie allein war, hielt kein Bedenken sie mehr von ihnen fern.
     </p>
-    <p xml:id="eco_de_0000144_9960">
+    <p xml:id="eco_de_0000214_9960">
      Das waren die beiden Töchter des Rats Kirsten aus der Wünschengasse unten in Weimar, die mit ihren Freunden Bundang, Ernst von Schiller und Horny hinauf zu den alten Sperbers kamen und dort wahre Freudenfeste feierten.
     </p>
-    <p xml:id="eco_de_0000144_9970">
+    <p xml:id="eco_de_0000214_9970">
      Sie standen den Sperbers sehr nahe, denn sie verstanden lustig und liebenswürdig zu sein und waren voller kindlicher Keckheit und Jugendüberschwall, daß den beiden Alten das Herz lachte.
     </p>
-    <p xml:id="eco_de_0000144_9980">
+    <p xml:id="eco_de_0000214_9980">
      Die junge Beate hatte es nie verstanden, die beiden guten Menschen so lächeln und lachen zu machen. Das tat ihr leid. Es lag etwas Schweres über ihr von Kindheit an. Sie war nie so recht sorglos gewesen.
     </p>
-    <p xml:id="eco_de_0000144_9990">
+    <p xml:id="eco_de_0000214_9990">
      Für sie waren aber die beiden Mädchen Röse und Marie etwas ganz Wundervolles. Nun, da sie wußte, daß sie selbst schön war, näherte sie sich ihnen wie ihresgleichen und wurde freudig aufgenommen.
     </p>
-    <p xml:id="eco_de_0000144_10000">
+    <p xml:id="eco_de_0000214_10000">
      Das Mädchen auf dem Ettersberg, das immer Reißaus genommen hatte, wenn sie sie zufällig bei Sperbers trafen, hatte längst ihr Verlangen erregt, besonders da ihre drei Freunde sehr viel von ihr hielten.
     </p>
-    <p xml:id="eco_de_0000144_10010">
+    <p xml:id="eco_de_0000214_10010">
      »Wegen ihres roten Haarschopfes mögt ihr sie wohl?« fragten die Mädchen ihre Freunde.
     </p>
-    <p xml:id="eco_de_0000144_10020">
+    <p xml:id="eco_de_0000214_10020">
      »Sie hat etwas Königliches,« sagte Horny. »Ich habe sie einmal belauscht, wie sie im Herbst vor zwei Jahren auf einem Acker, abends, als Knechte und Mägde gegangen waren, sich ganz einsam ein Kartoffelfeuerchen anzündete. Ich habe gesehen, wie sie das dürre Kraut geschleppt brachte, wie sie Feuer schlug und wie sie die Kartoffeln in die heiße Asche legte und dann zusammengekauert saß und in die Glut sah, so einsam und voller Gedanken. Ich war im Wald verborgen und mußte mir die Hände vor den Mund pressen, daß ich nicht jubelte über ihre Einsamkeit, und daß sie sich so ganz allein ein Feuerchen angebrannt hatte, und daß es ihr so behaglich in dieser Herbststille war. Dann hat sie von den Kartoffeln gegessen, so ganz einfach, wie ein junges verlassenes Tier, und ihr mögt mir's glauben, da liefen mir Tränen über das Gesicht. Die Felder und was ich ringsumher sah, war alles so weit und groß und grau und kühl. Ihr Feuerchen und sie selbst erschien mir in dem grauen Nebel nur wie ein winziger, lebendiger Punkt. Ich wußte ja auch, daß sie keine Mutter hatte. Dann sah ich sie so still und ernst den Weg entlang gehen, ihrem Hause zu. Nie werd' ich das vergessen.«
     </p>
-    <p xml:id="eco_de_0000144_10030">
+    <p xml:id="eco_de_0000214_10030">
      Die beiden Mädchen sahen sich ganz betroffen an. Sie gingen, als Horny ihnen sein verschwiegenes Erlebnis erzählte, abends auf dem Sperberschen Gutshof auf und nieder.
     </p>
-    <p xml:id="eco_de_0000144_10040">
+    <p xml:id="eco_de_0000214_10040">
      »Weshalb hat er uns das noch nie erzählt?« fragte Röse, bekam aber keine Antwort.
     </p>
-    <p xml:id="eco_de_0000144_10050">
+    <p xml:id="eco_de_0000214_10050">
      Röse und Marie hatten für alles, was Horny ihnen erzählte, viel übrig.
     </p>
-    <p xml:id="eco_de_0000144_10060">
+    <p xml:id="eco_de_0000214_10060">
      »Als wenn man sie hocken sieht,« sagte Röse.
     </p>
-    <p xml:id="eco_de_0000144_10070">
+    <p xml:id="eco_de_0000214_10070">
      »Und daß sie Badewännchen heißt,« meinte Marie. »Die Sperbers wollen auch, daß wir uns um sie bekümmern,« fuhr Röse fort, »und jetzt läßt sich auch etwas mit ihr anfangen. Sie ist so scheu nicht mehr, und man kann ganz vernünftig mit ihr reden. Ihr ist auch zuwider, was uns zuwider ist. Am liebsten rennt sie draußen herum und arbeitet ordentlich. Herr Gott, wie sie's gut hat!«
     </p>
-    <p xml:id="eco_de_0000144_10080">
+    <p xml:id="eco_de_0000214_10080">
      »Na, hör' mal,« sagte Marie, »so allein!«
     </p>
-    <p xml:id="eco_de_0000144_10090">
+    <p xml:id="eco_de_0000214_10090">
      »Ja,« sagte Horny wieder, »sie hat etwas von einer Königin. Sie tut, was sie will, und denkt, wie sie will. Sie lebt ein Leben für sich.«
     </p>
-    <p xml:id="eco_de_0000144_10100">
+    <p xml:id="eco_de_0000214_10100">
      »Als wenn das die Königinnen täten,« meinte Röse.
     </p>
-    <p xml:id="eco_de_0000144_10110">
+    <p xml:id="eco_de_0000214_10110">
      »Die Königinnen, die ich meine,« antwortete Horny, »die können in der Wünschengasse wohnen oder auf dem Ettersberg.«
     </p>
-    <p xml:id="eco_de_0000144_10120">
+    <p xml:id="eco_de_0000214_10120">
      »Solche Königinnen!« lachte Marie.
     </p>
-    <p xml:id="eco_de_0000144_10130">
+    <p xml:id="eco_de_0000214_10130">
      »Das einzig sind die Wahren! Jung müssen sie sein, ohne Tadel – und frei und froh und jedem gerade und stolz in die Augen sehen.«
     </p>
-    <p xml:id="eco_de_0000144_10140">
+    <p xml:id="eco_de_0000214_10140">
      Das entzückte beide, Röse und Marie.
     </p>
-    <p xml:id="eco_de_0000144_10150">
+    <p xml:id="eco_de_0000214_10150">
      »Wir sind drei Königinnen!« riefen sie Ernst Schiller und Budang entgegen. »Kommt, wir wollen zur dritten gehen!«
     </p>
-    <p xml:id="eco_de_0000144_10160">
+    <p xml:id="eco_de_0000214_10160">
      Und sie machten sich alle auf und gingen einen schmalen Weg über ein paar Wiesen und Felder, an einer Sandgrube hin, zum Rauchfußschen Hof, und fanden die junge Herrin im Garten unter der Linde sitzen, ihr Abendbrot verzehrend.
     </p>
-    <p xml:id="eco_de_0000144_10170">
+    <p xml:id="eco_de_0000214_10170">
      Auf dem weiß gedeckten Tisch stand ein Schüsselchen Sauermilch, aus dem sie löffelte, und ein Laib frisches Brot lag dabei, und ein Teller goldgelber Butter leuchtete auf dem weißen Tuch.
     </p>
-    <p xml:id="eco_de_0000144_10180">
+    <p xml:id="eco_de_0000214_10180">
      »Herrlich,« sagte Röse, »wie sie zu Abend ißt.«
     </p>
-    <p xml:id="eco_de_0000144_10190">
+    <p xml:id="eco_de_0000214_10190">
      Sie wurden alle eingeladen mitzuessen, und bald saß jedes vor solch einem Schüsselchen Sauermilch und schnitt Brot und strich Butter. Im stillen dachten sie: ›Da wird die liebe Frau Sperber mit dem Essen auf uns warten.« Aber sie sahen alle das gute, freundliche Gesicht vor sich, von dem sie nicht glaubten, daß es ihnen ihre Freude mißgönnen würde, und dann dachten sie: ›Wer weiß, vielleicht essen wir, wenn wir nach Hause kommen, was sie für uns hat, auch noch.«
     </p>
-    <p xml:id="eco_de_0000144_10200">
+    <p xml:id="eco_de_0000214_10200">
      Als sie abgetafelt hatten, war es ganz selbstverständlich, daß sie zu tanzen begannen unter der blühenden Linde. Da wurde gar nicht weiter darüber geredet.
     </p>
-    <p xml:id="eco_de_0000144_10210">
+    <p xml:id="eco_de_0000214_10210">
      »Also los!« sagte Röse. Die Pärchen fanden sich: den Takt singend und brummend, wiegten sie sich auf dem festgetretenen Kiesboden. Badewännchen rannte ins Haus, als die Dunkelheit hereinbrach, und holte eine Stallaterne, denn unter der dicken Linde dunkelte es bereits, als der Garten noch in Dämmerung lag. Dann kamen die Glühwürmchen und schwirrten durch die duftenden Zweige. Das junge Menschenvolk faßte sich bei den Händen und tanzte Ringelreihen um den alten, düsteren Stamm, bald links herum, bald rechts herum, und fand kein Ende damit.
     </p>
-    <p xml:id="eco_de_0000144_10220">
+    <p xml:id="eco_de_0000214_10220">
      Sie waren alle von seligster Harmonie zueinander hingezogen. Der stille, stille Garten um sie her, der duftende, schützende Baum und die leuchtende Stallaterne, in deren Strahlenkegel junge Herrlichkeit auftauchte.
     </p>
-    <p xml:id="eco_de_0000144_10230">
+    <p xml:id="eco_de_0000214_10230">
      Sie sprachen kaum und lachten kaum. Es war so eine große, große, heilige Wonne, die alle durchdrang. Das einsame Mädchen, das die glücklichen Jugendfreunde mit in ihren frohen Reigen gezogen hatten, war von überirdischer Wonne durchdrungen.
     </p>
-    <p xml:id="eco_de_0000144_10240">
+    <p xml:id="eco_de_0000214_10240">
      Das war ihr erster Tanz, dieser schweigende, selige Ringeltanz. Links herum, rechts herum, solange es zu ertragen war.
     </p>
-    <p xml:id="eco_de_0000144_10250">
+    <p xml:id="eco_de_0000214_10250">
      Es war ein Tanz zum Lobe Gottes, der Schönheit auf Erden und der wundervollen Jugend. Da wurden sie freilich nicht müde, und alle wußten, daß sie einander liebten von Kindheit an.
     </p>
-    <p xml:id="eco_de_0000144_10260">
+    <p xml:id="eco_de_0000214_10260">
      »Schön ist's,« sagte Röse.
     </p>
-    <p xml:id="eco_de_0000144_10270">
+    <p xml:id="eco_de_0000214_10270">
      Herr und Frau Sperber waren heraufgestiegen, um nach ihren Flüchtlingen zu sehen, und standen ganz ehrerbietig in der Ferne und sahen dem heiligen Tanz zu. Die Kummerfelden, die vom Samstag zum Sonntag im Sommer hin und wieder auch Logiergast war, denn Sperbers Gastfreundschaft war unergründlich, war mit ihnen gekommen.
     </p>
-    <p xml:id="eco_de_0000144_10280">
+    <p xml:id="eco_de_0000214_10280">
      Die drei Alten rührten sich nicht.
     </p>
-    <p xml:id="eco_de_0000144_10290">
+    <p xml:id="eco_de_0000214_10290">
      »Ja – ja!« sagte der gute Sperber, und hätte er eine Rede über alles Weh und alle Freude dieser geheimnisvollen Erde gehalten, sie hätte nicht tiefer und verständiger ausfallen können.
     </p>
-    <p xml:id="eco_de_0000144_10300">
+    <p xml:id="eco_de_0000214_10300">
      Die alte Kummerfelden meinte: »Du lieber, braver Sperber, da möchte ich dir die Hand dafür drücken, denn recht hast du,« und nun sagte sie selbst auch: »Ja – ja!« Aber das ging Frau Sperber durch Mark und Bein, denn die Kummerfelden war nicht umsonst eine hochberühmte Schauspielerin gewesen.
     </p>
-    <p xml:id="eco_de_0000144_10310">
+    <p xml:id="eco_de_0000214_10310">
      »So mach' einem doch das Herz nicht schwer, dumme Suse,« sagte sie zu ihrer guten Freundin, »du mußt auch immer in den Dingen herumrühren.«
     </p>
-    <p xml:id="eco_de_0000144_10320">
+    <p xml:id="eco_de_0000214_10320">
      Aber«, sagte Herr Sperber, »fort gehen tut es so nicht, das könnte lustig da oben werden – Badewännchen muß heiraten.«
     </p>
-    <p xml:id="eco_de_0000144_10330">
+    <p xml:id="eco_de_0000214_10330">
      »Heiraten!« sagte die Kummerfelden. »So eine Schönheit. Ewig schade wär's um sie.«
     </p>
-    <p xml:id="eco_de_0000144_10340">
+    <p xml:id="eco_de_0000214_10340">
      »No, was denken Sie denn mit ihr zu machen?« fragte Herr Sperber. »Schließlich sind Frauenzimmer doch nur zum Heiraten da.«
     </p>
-    <p xml:id="eco_de_0000144_10350">
+    <p xml:id="eco_de_0000214_10350">
      »Ja, Gott sei's geklagt.«
     </p>
-    <p xml:id="eco_de_0000144_10360">
+    <p xml:id="eco_de_0000214_10360">
      »Gerade die Tochter des alten Rauchfuß muß früh heiraten, sonst erleben wir was. Das ist ein Teufelsmägen; der Pfarrer sagt's auch, er hat einen Freier für sie.«
     </p>
-    <p xml:id="eco_de_0000144_10370">
+    <p xml:id="eco_de_0000214_10370">
      »I, warum nicht gar, der Pfarrer, der wird was Rechtes haben,« rief die Kummerfelden.
     </p>
-    <p xml:id="eco_de_0000144_10380">
+    <p xml:id="eco_de_0000214_10380">
      »Und unser Neffe?« fragte Frau Sperber. »Für den wären Mädchen und Gut wie geschaffen, und wir hätten ihn dann in unserer Nähe.«
     </p>
-    <p xml:id="eco_de_0000144_10390">
+    <p xml:id="eco_de_0000214_10390">
      »Natürlich,« sagte die Kummerfelden, »das wäre dann ja in schönster Ordnung.«
     </p>
-    <p xml:id="eco_de_0000144_10400">
+    <p xml:id="eco_de_0000214_10400">
      Währenddem tanzten die Jungen unter dem Baum und achteten nicht auf die Alten, die nicht mehr wissen, was reine Freude ist, und mit ihren verständigen, häßlichen Lebenserfahrungen das reine, junge, menschliche Glück antasten und beschmutzen, so gut sie es auch meinen. Ohne zu wissen, daß die alten Augen voll Wehmut und Vernunft auf ihnen geruht hatten, tanzten die jungen Glücklichen schweigsam und selig weiter.
     </p>
-    <p xml:id="eco_de_0000144_10410">
+    <p xml:id="eco_de_0000214_10410">
      Als sie sich damit genug getan, gingen sie in den nächtlichen Wald und sangen und sahen den Glühwürmchen zu und sprachen, wie nur ganz junge Freunde und Freundinnen reden, die noch Scheu tragen, von Liebe zu sprechen.
     </p>
-    <p xml:id="eco_de_0000144_10420">
+    <p xml:id="eco_de_0000214_10420">
      Spät wurde es.
     </p>
-    <p xml:id="eco_de_0000144_10430">
+    <p xml:id="eco_de_0000214_10430">
      »Mich dürstet,« sagte Röse, »und nun können wir doch nicht mehr bei Sperbers nach unserem Nachtessen fragen und müssen froh sein, wenn wir ohne Zankerei hereinkommen.«
     </p>
-    <p xml:id="eco_de_0000144_10440">
+    <p xml:id="eco_de_0000214_10440">
      Beate meinte: »Wir gehen in den Kuhstall und trinken frische Milch.«
     </p>
-    <p xml:id="eco_de_0000144_10450">
+    <p xml:id="eco_de_0000214_10450">
      Da waren alle dabei.
     </p>
-    <p xml:id="eco_de_0000144_10460">
+    <p xml:id="eco_de_0000214_10460">
      »Aber still muß man sein, die Knechte schlafen ganz nebenan.«
     </p>
-    <p xml:id="eco_de_0000144_10470">
+    <p xml:id="eco_de_0000214_10470">
      So schlichen sie miteinander zum Kuhstall. Beate Rauchfuß trug die Laterne. Der Hof lag still und dunkel, der mächtige Misthaufen dunstete herb und schwer. Das schöne Geschöpf öffnete die alte, verschabte Stalltür, und sie traten ein. Der warme Dunst schlug ihnen entgegen. In einer Mauernische brannte ein Oellämpchen und warf auf einen weißen Kuhrücken ihren gelben Schein.
     </p>
-    <p xml:id="eco_de_0000144_10480">
+    <p xml:id="eco_de_0000214_10480">
      Beate meinte: »Es wird schon ein wenig hell. Die Magd wird bald zum Melken kommen.« Sie beleuchtete mit ihrer Laterne ein Gestell, auf dem allerlei hellgescheuerte Kübel und Näpfe standen, und nahm ein schneeweißes Holzkübelchen.
     </p>
-    <p xml:id="eco_de_0000144_10490">
+    <p xml:id="eco_de_0000214_10490">
      Aus den Schwalbennestern, die am dunkeln Gebälk klebten, klang das Piepen und Zirpen der jungen Vögel. Süße, süße Tönchen in dem warmen Dunst. Der kleine Brunnen im Stall plätscherte in seinem Trog.
     </p>
-    <p xml:id="eco_de_0000144_10500">
+    <p xml:id="eco_de_0000214_10500">
      Beate nahm den Melkkübel der Magd, streichelte und klopfte eine schöne, weiß-braun gescheckte Kuh und molk dann in ihr Kübelchen. An dem mächtigen Kuhleib lag der frohe Kopf des Mädchens. Horny hielt die Laterne. Sie molk ihr Kübelchen schäumend voll. Die Kuh brummte über die sonderbare, allzu frühe Störung.
     </p>
-    <p xml:id="eco_de_0000144_10510">
+    <p xml:id="eco_de_0000214_10510">
      »Das ist eine Milch!« sagte die junge Gutsherrin. »Und nun trinkt alle einmal.« Sodann reichte sie ihren Kübel, und sie tranken in langen, langen Zügen.
     </p>
-    <p xml:id="eco_de_0000144_10520">
+    <p xml:id="eco_de_0000214_10520">
      »Eine Königin ist sie,« sagte Horny wieder zu Röse. »Wie herrlich das alles ist! Prachtvoll ist solch ein weißes, duftendes Milchmeer, das vor den Augen schwankt und einen ganz durchströmt mit Kraft und Wärme.«
     </p>
-    <p xml:id="eco_de_0000144_10530">
+    <p xml:id="eco_de_0000214_10530">
      »Nicht wahr, nun seid ihr alle satt?« fragte Beate stolz und glücklich.
     </p>
-    <p xml:id="eco_de_0000144_10540">
+    <p xml:id="eco_de_0000214_10540">
      Sie sagten sich Lebewohl und brachten ihre junge Wirtin noch bis an die Tür des einsamen Wohnhauses.
     </p>
-    <p xml:id="eco_de_0000144_10550">
+    <p xml:id="eco_de_0000214_10550">
      Die drei Alten aber hatten den Entschluß, oben im Rauchfußschen Hofe Ordnung zu schaffen, sehr energisch gefaßt. Badewännchen durfte sich nicht selbst überlassen bleiben. Nein, so was geht nicht! – »So ein Mägen allein im Hause!« meinten die beiden Sperbers ganz gedankenvoll, und so kam es, daß sie ihren Neffen zu sich aufs Gut kommen ließen.
     </p>
-    <p xml:id="eco_de_0000144_10560">
+    <p xml:id="eco_de_0000214_10560">
      Das war ein guter, frischer Mensch. Alle Nachbarn im ganzen Umkreise vom Ettersberg und hinter dem Ettersberg, in Weimar und um Weimar dachten wie die alten Sperbers: »Das geht nicht, daß das kleine, dumme Frauenzimmer mit ihrem Hofe allein bleibt.«
     </p>
-    <p xml:id="eco_de_0000144_10570">
+    <p xml:id="eco_de_0000214_10570">
      Ein jeder dachte an einen Neffen, Bruder, Sohn oder sonst einen Anverwandten, den er auf das seltene Wild hetzen wollte, während das junge Mädchen in vollen Zügen ihre Freiheit und Jugend genoß.
     </p>
-    <p xml:id="eco_de_0000144_10580">
+    <p xml:id="eco_de_0000214_10580">
      Sie lebte trotz alledem recht ruhig und ehrbar, wußte sich trotz Verwalter und Mamsell bei ihren Leuten in Respekt zu setzen und war durchaus tüchtig und fleißig.
     </p>
-    <p xml:id="eco_de_0000144_10590">
+    <p xml:id="eco_de_0000214_10590">
      Da brach es los, was die Alten in ihrem Uebereifer herbeigeseufzt hatten, – die Freier kamen.
     </p>
-    <p xml:id="eco_de_0000144_10600">
+    <p xml:id="eco_de_0000214_10600">
      Der schöne Jugendfriede der drei Königinnen mit ihren guten Freunden wurde gestört. Solch neue, wundervolle Jugend muß sich erst auf sich selbst besinnen, ehe sie zum Verlangen und Begehren wird. Die drei vernünftigen Alten hätten ruhig die drei Königinnen ihren herrlichen Reigen weitertanzen lassen sollen. Zuerst rechts herum, dann links herum, solange es zu ertragen war. Solch ein Reigen wird nicht wieder getanzt – nie im Leben.
     </p>
-    <p xml:id="eco_de_0000144_10610">
+    <p xml:id="eco_de_0000214_10610">
      Die ersten Freier, die sich meldeten, waren die beiden Kostgänger der hübschen, kleinen Witwe mit dem Herzgesicht, Herr Oehmchen und Herr Leinhose. Sie machten bei Sperbers Besuch, und nicht etwa zusammen. Keiner wußte von dem andern.
     </p>
-    <p xml:id="eco_de_0000144_10620">
+    <p xml:id="eco_de_0000214_10620">
      Hinauf auf das Rauchfußsche Gut hatten sie sich nicht gewagt, denn die Sache sollte in allerschönster Ordnung vor sich gehen.
     </p>
-    <p xml:id="eco_de_0000144_10630">
+    <p xml:id="eco_de_0000214_10630">
      ›Halloh!« dachte Herr Sperber. ›Jetzt wird's schon ernst, wenn die abgestandenen Ehrenmänner sich auf den Weg machen.« Herr Sperber wollte demnach nicht allzu hoch hinaus mit seinem Schützling. ›So ein ganz schlichter Mann, das ist der beste für so ein Frauenzimmer,« meinte er, ›da gibt's keine Geschichten wie mit Herrn Rauchfuß; so einer hat der Welt nichts Besonderes zu zeigen, keinen roten Bart, keine Hünengestalt, nicht Mucken im Kopf, nicht Herz und nicht Geist – so einer wie die meisten, der hält Ruh' gottlob.«
     </p>
-    <p xml:id="eco_de_0000144_10640">
+    <p xml:id="eco_de_0000214_10640">
      Herr Sperber nahm die Herren recht freundlich auf. Der Neffe natürlich würde sie ausstechen, das war ihre Sache. Er selbst, Herr Sperber, hatte nur freundlich und gerecht zu sein.
     </p>
-    <p xml:id="eco_de_0000144_10650">
+    <p xml:id="eco_de_0000214_10650">
      Beate, die zu dem Neffen und den beiden Kostgängern eines Abends zu ihren Vormundsleuten geladen wurde, genoß das Staunen, das Hingerissensein der drei Mannsbilder wie ganz vortreffliches Konfekt und ließ es sich schmecken. Es war ein wundervolles Konfekt, nein, es war ein süßer Duft, den sie einatmete.
     </p>
-    <p xml:id="eco_de_0000144_10660">
+    <p xml:id="eco_de_0000214_10660">
      ›Die Menschen werden trunken von mir,« dachte sie wieder und wurde übermütig und glückselig.
     </p>
-    <p xml:id="eco_de_0000144_10670">
+    <p xml:id="eco_de_0000214_10670">
      Trotzdem die Kostgänger und der Neffe ganz gehörig langweilig in ihrer großen Verliebtheit waren und ungeschickt dazu, langweilte sie sich nicht, fühlte nur sich selbst und den Opferduft, der zu ihr aufstieg und sie kräftigte. Die drei Mannsbilder waren ihr gleichgültig, waren nur die Pfannen, in denen Weihrauch brannte.
     </p>
-    <p xml:id="eco_de_0000144_10680">
+    <p xml:id="eco_de_0000214_10680">
      Nach solch einem Abend war sie stark und froh wie eine junge Göttin, arbeitete am andern Tag unverdrossen, setzte sich in Respekt bei ihren Leuten und fühlte sich wohl.
     </p>
-    <p xml:id="eco_de_0000144_10690">
+    <p xml:id="eco_de_0000214_10690">
      Samstag abends wanderten die Kirstensmädchen mit ihren Freunden herauf; aber es währte nicht lange, da kam dieser und jener mit, der sich unterwegs angeschlängelt hatte und den sie nicht los hatten werden können. Darüber waren Röse und Marie sehr mißmutig. »So einer stört,« sagten sie, »wir wollen unter uns sein.« Beate Rauchfuß aber meinte: »Laßt ihn, er ist ja ganz gleichgültig.«
     </p>
-    <p xml:id="eco_de_0000144_10700">
+    <p xml:id="eco_de_0000214_10700">
      »Natürlich rennen sie jetzt alle 'rauf zu dir, weil sie denken, da ist was zu holen,« sagte Röse. »Sag's ihnen doch, daß du nichts von ihnen wissen willst. Was brauchst du die, du hast ja uns!«
     </p>
-    <p xml:id="eco_de_0000144_10710">
+    <p xml:id="eco_de_0000214_10710">
      Den alten Sperbers wurden die Besuche der jungen Leute auf ihrem Gute bald zuviel, und besonders der Neffe wollte nichts mehr davon wissen; deshalb beschlossen sie, die alte Freundin der Kummerfelden, die Rabenmutter, Beaten als Ehrenwache beizugeben. Die war Schutz genug, zehn Freier in Respekt zu halten und war zu allem anstellig, bei Kranken und Toten zu wachen, weshalb nicht einmal bei der Schönheit eines jungen Frauenzimmers?
     </p>
-    <p xml:id="eco_de_0000144_10720">
+    <p xml:id="eco_de_0000214_10720">
      Sie war die Witwe des Zinngießers Lange, hatte ihre Kinder alle verheiratet und stand hilfsbereit ihren Freunden und Bekannten zu Diensten; auch zu Gelegenheitsgedichten war sie immer zu haben, denn unter dem großen Christophorusmantel, den sie winters wie sommers trug, schlug ein gar empfindsames Herz, und in dem starken, großen Körper wohnte auch eine stattliche Seele. Auf den Ettersberg als Badewännchens Ehrenwächterin kam sie gar zu gern; es war Winters Anfang, als man sie rief.
     </p>
-    <p xml:id="eco_de_0000144_10730">
+    <p xml:id="eco_de_0000214_10730">
      So etwas hatte sie sich lange gewünscht. Da droben auf dem prächtigen Gutshof, da sollte es ihr wohl gefallen. Wenn Schnee lag, hätte sie es von da auch nicht weit zu ihren Schützlingen, den Raben, die sie auf den verschneiten Feldern zu füttern pflegte. Die Rabenmutter zog anfangs November auf dem Rauchfußschen Gut ein.
     </p>
-    <p xml:id="eco_de_0000144_10740">
+    <p xml:id="eco_de_0000214_10740">
      »Im Frühjahr ist Hochzeit,« hatte ihr der alte Sperber gesagt.
     </p>
-    <p xml:id="eco_de_0000144_10750">
+    <p xml:id="eco_de_0000214_10750">
      »Weshalb muß nun dies Mädchen, das alle Ursache hätte, fein bescheiden und unauffällig ihren Gatten zu wählen, solch ein brennendes Strohdach sein? – Und Freude hat der Racker daran; wie ein Trinker den Wein, liebt sie die Verliebtheit all dieser Esel. So suchst du die Sünden der Väter heim an den Kindern bis in das dritte und vierte Glied.« Der alte Sperber sah sehr schwarz, war sehr ärgerlich über Herrn Rauchfußens Badewännchen.
     </p>
-    <p xml:id="eco_de_0000144_10760">
+    <p xml:id="eco_de_0000214_10760">
      »Was du für Geschichten machst!« sagte er zu ihr. »Den ersten besten nimmt ein Mädchen unten in der Stadt, und du läßt alles, was Beine hat, den langen Weg heraufrennen. Weißt du, das ist unverschämt von dir. Ein Frauenzimmer soll bescheiden sein.«
     </p>
-    <p xml:id="eco_de_0000144_10770">
+    <p xml:id="eco_de_0000214_10770">
      Da lachte das Mädchen übermütig. Ihr Herz war so frei und leicht überströmend von Erdenwonne.
     </p>
-    <p xml:id="eco_de_0000144_10780">
+    <p xml:id="eco_de_0000214_10780">
      Was auch gesagt wurde, sie hörte nur halb. Sie war ganz in sich selbst verpuppt.
     </p>
-    <p xml:id="eco_de_0000144_10790">
+    <p xml:id="eco_de_0000214_10790">
      Ihre Seele, rund wie eine Kugel, hatte keine Ecke, keinen Riß, an dem die Sorge sich hätte einhaken, oder in den sie hätte eindringen können, eine schöne Kristallkugel, von Licht überschienen und durchleuchtet.
     </p>
-    <p xml:id="eco_de_0000144_10800">
+    <p xml:id="eco_de_0000214_10800">
      Wundervoll ist das Nichthören auf Vernunft und Weisheit, das ganz Ichsein der ersten Jugend, das Halbhören auf alles. Wie ein fernes Rauschen und Lärmen und Läuten tönt das Treiben der Welt in die unstörbare Wonne solcher in sich versunkener Schönheit und Jugend hinein.
     </p>
-    <p xml:id="eco_de_0000144_10810">
+    <p xml:id="eco_de_0000214_10810">
      Uebrigens kamen ganz reputierliche Herren den langen Weg dahergewandelt. Unermüdlich waren Herr Leinhose und Herr Oehmchen.
     </p>
-    <p xml:id="eco_de_0000144_10820">
+    <p xml:id="eco_de_0000214_10820">
      Zu ihnen gesellte sich oft die junge Witwe mit dem Herzgesicht, in kluger Erwägung, daß das gefährliche Mädchen im schlimmsten Falle nur einen ihrer wohlgenährten Kostgänger nehmen könnte, so blieb sie freundlich gegen beide.
     </p>
-    <p xml:id="eco_de_0000144_10830">
+    <p xml:id="eco_de_0000214_10830">
      Außer diesen beiden machte sich gar oft der Hofmann auf den Weg, der in der Umgebung von Weimar ein ziemlich verschuldetes Gütchen besaß, aber außerdem tadellose Manieren, einen außergewöhnlich kleinen Kopf und aristokratische Hände. Er schaute auf eine stattliche Reihe von Ahnen, die alle an seinem Besitztum und seiner Persönlichkeit geknabbert hatten; denn von beiden war wenig mehr da, und es schien durchaus vernünftig, daß er sich um eine Vervollständigung umsah.
     </p>
-    <p xml:id="eco_de_0000144_10840">
+    <p xml:id="eco_de_0000214_10840">
      Er war allen über an Formen und imponierte daher. Sie hielten ihn für gefährlich und waren froh, wenn er bei irgendeiner festlichen Gelegenheit, einer Schlittenfahrt oder einer Redoute im Stadthause ausbleiben mußte, denn er ging zu Hof, und daher arrangierten die Freier ihre Feste gern an Tagen, an denen er fern bleiben mußte.
     </p>
-    <p xml:id="eco_de_0000144_10850">
+    <p xml:id="eco_de_0000214_10850">
      Tanzkränzchen, Liederabende, Spinnstuben, Redouten gab's diesen Winter in Weimar in Hülle und Fülle, und die schöne Rauchfuß wurde in alles mit hineingezogen; bald machte der eine sich liebenswürdig, bald der andere. Ritter hatte sie genug, alle gangbaren Kaufmannssöhne des Städtchens, junge Herren vom Gericht, was sich nur irgendwie zum Bürgerstande zählte und darunter – und darüber hinaus. Es jagte, wer da irgend jagen konnte.
     </p>
-    <p xml:id="eco_de_0000144_10860">
+    <p xml:id="eco_de_0000214_10860">
      Sie liebte den Tanz. Ja, tanzen schien ihr das Herrlichste auf Erden zu sein, sich ganz zu vergessen, ja, sich ganz aufzulösen in Musik und Bewegung. – Sie unterschied ihre Freier nur nach ihrem Tanzvermögen; in ihren geistigen Kapazitäten, die bei keinem bemerkenswert waren, verwechselte sie diese untereinander und war selbst ganz ohne Jagd- und Beutelust, einfach zufrieden und selig in sich.
     </p>
-    <p xml:id="eco_de_0000144_10870">
+    <p xml:id="eco_de_0000214_10870">
      So ging die Zeit hin.
     </p>
-    <p xml:id="eco_de_0000144_10880">
+    <p xml:id="eco_de_0000214_10880">
      Die Ungeduld der Braven hätte ihr wie eine Flut zum Lippenrand steigen müssen, sie bedrängend und ängstigend, oder etwa, als ständen vor ihrer Tür eine Reihe Gläubiger, sie aber säße in ihrem Stübchen in allem Frieden und ließe sie, so ungestüm sie wollten, klopfen und läuten.
     </p>
-    <p xml:id="eco_de_0000144_10890">
+    <p xml:id="eco_de_0000214_10890">
      Sie spürte die Ungeduld der Glücksritter gar nicht. Sie waren ihr so fremd, so fern. –
     </p>
-    <p xml:id="eco_de_0000144_10900">
+    <p xml:id="eco_de_0000214_10900">
      Einen dieser fremden Leute sich ins Haus nehmen, ihn immer haben und sehen müssen, schien ihr so abgeschmackt und unmöglich, daß sie der Gedanke nicht einmal beunruhigte; aber sie träumte von Wundern, von einem, den sie lieben wollte. Sie fühlte etwas so Starkes, Großes und Gutes in sich und empfand dabei ihre Unwissenheit und Enge. Die Sehnsucht nach dem Unbefangenen war zugleich eine brennende Sehnsucht nach Weite, ein Entfliehenwollen aus der Enge, ein Wachsenwollen. Niemand hatte ihr bisher das Brot des Lebens geboten. Sie hungerte. Ihre Schönheit barg etwas noch Schlafendes, etwas Starkes, das sich regen wollte in dieser Welt und über diese hinaus; aber niemand nährte dies Wundervolle. Die Speise, die sie ihr boten, war keine königliche, keine seelenstärkende Speise, es war Alltagsfutter, an dem sie verkümmern mußte.
     </p>
-    <p xml:id="eco_de_0000144_10910">
+    <p xml:id="eco_de_0000214_10910">
      Ja, sie träumte lang unter all' ihren Freiern vom Erwachen, gegen das das Leben, welches die andern in ihr weckten, tiefer, dumpfer Schlaf war.
     </p>
-    <p xml:id="eco_de_0000144_10920">
+    <p xml:id="eco_de_0000214_10920">
      Die Rabenmutter hatte ihre Freude daran, daß die Festung, die sie behüten sollte, sich nicht ergab, denn so konnte sich das behagliche Leben oben auf dem Rauchfußschen Gute noch eine Weile für sie ausdehnen.
     </p>
-    <p xml:id="eco_de_0000144_10930">
+    <p xml:id="eco_de_0000214_10930">
      Sonntag abends oder nachmittags hatten sie meist Besuch, da kamen die Freier, die Kirstensmädchen mit ihren Freunden und die hübsche, junge Witwe, und oft fand sich auch die brave Kummerfelden ein. Die hatte ihre Freude an dem unvernünftigen Geplauder der verliebten Junggesellen.
     </p>
-    <p xml:id="eco_de_0000144_10940">
+    <p xml:id="eco_de_0000214_10940">
      »Ganz des Kuckucks ist das Mannsvolk, wenn es verliebt ist,« sagte sie einmal zur Rabenmutter; »der Vogel singt seiner Liebsten die schönsten Lieder und reizendsten Redensarten, die er ersinnen kann; aber unsere Mannsbilder, mit Ausnahme weniger, die es gleich drucken lassen, reden doch einen ganz jämmerlichen Brei daher. Die Haare stehen mir unter der Haube auf, wenn ich denke, akkurat so taten sie's auch zu meiner Zeit und nicht einmal gar so übel hab' ich's gefunden. Mannsbilder sind nun mal nur gescheit, wenn's durchaus sein muß, soweit's gezahlt wird. Greulich schwer muß es ihnen fallen.«
     </p>
-    <p xml:id="eco_de_0000144_10950">
+    <p xml:id="eco_de_0000214_10950">
      »Ja,« meinte die Rabenmutter, »gerad' als ob sie meinen, daß so ein frisches Mägen nur durch ausbündige Blödheit zu kirren wäre – das Mägen lacht freilich dazu – aber das sag' ich dir, sie ist eine ausgesucht kalte Hundeschnauze.«
     </p>
-    <p xml:id="eco_de_0000144_10960">
+    <p xml:id="eco_de_0000214_10960">
      »Recht hat sie,« meinte die Kummerfelden.
     </p>
-    <p xml:id="eco_de_0000144_10970">
+    <p xml:id="eco_de_0000214_10970">
      Es ist eine kühle Sache um das Plaudern von so zwei Alten. In Frühlings-Abenddämmerung saßen sie im großen Wohnzimmer am Fenster. Die Jugend spielte Pfänderspiele. Im Nebenzimmer wurde der Tisch zum Abendessen gedeckt.
     </p>
-    <p xml:id="eco_de_0000144_10980">
+    <p xml:id="eco_de_0000214_10980">
      Sie hatten schon muntere Sonntagnachmittage und Abende oben bei der Vielumworbenen verlebt, harmlose, köstliche Stunden, in denen jeder einzelne vergaß, weshalb er eigentlich hier heraufgelaufen und sich nur vergnügte, wie die anderen sich vergnügten.
     </p>
-    <p xml:id="eco_de_0000144_10990">
+    <p xml:id="eco_de_0000214_10990">
      Heut' aber lag etwas wie Frühjahrsmüdigkeit in der Luft. Draußen regnete es kalt und gleichmäßig, trotz des junges Laubes.
     </p>
-    <p xml:id="eco_de_0000144_11000">
+    <p xml:id="eco_de_0000214_11000">
      Die Hühner saßen in ihrem Stall und glucksten in Sonntagnachmittags-Griesgrämigkeit. Knechten und Mägden hatte der trübselige Regen die Sonntags-Unternehmungen verdorben.
     </p>
-    <p xml:id="eco_de_0000144_11010">
+    <p xml:id="eco_de_0000214_11010">
      Schritte schlürften über den Hof, denen man Unbefriedigtsein und Langeweile anhörte. Die Tropfen klatschten gegen die Scheiben, oder wenn der Wind sich gelegt hatte, rieselte es sachte und grau hernieder.
     </p>
-    <p xml:id="eco_de_0000144_11020">
+    <p xml:id="eco_de_0000214_11020">
      Das kleine Weimar mit all seinen berühmten Leuten lag auch vernebelt und langweilig unten am Fuße des langgestreckten Ettersberges, sah aus wie jedes andere trübselige Landstädtchen im Regen – trostlos und öde.
     </p>
-    <p xml:id="eco_de_0000144_11030">
+    <p xml:id="eco_de_0000214_11030">
      Aus der großen Einsamkeit und Frühlingsnässe klang hin und wieder süßer Amselschlag, sehnsuchtsvoll nach Sonne.
     </p>
-    <p xml:id="eco_de_0000144_11040">
+    <p xml:id="eco_de_0000214_11040">
      Die Kirstensmädchen mitsamt ihren Kameraden waren heute trotz Sturm und Schmutz und Regen heraufgetappt, weil sie gehofft hatten, heute würden die verliebten Junggesellen, sie sagten »Esel«, einmal daheim bleiben.
     </p>
-    <p xml:id="eco_de_0000144_11050">
+    <p xml:id="eco_de_0000214_11050">
      Jedem war es so ergangen. Jeder einzelne hatte gehofft, den andern nicht zu finden und einmal seine Person allein zur Geltung zu bringen, und alle waren sie enttäuscht.
     </p>
-    <p xml:id="eco_de_0000144_11060">
+    <p xml:id="eco_de_0000214_11060">
      Die Vielumworbene war auch nichts weniger als gut aufgelegt. Mißmut hatte sie erfaßt, als all die nassen, gleichgültigen Gestalten sich draußen mit viel Lärm und Geschnauf ihrer tropfenden Hüllen entledigten.
     </p>
-    <p xml:id="eco_de_0000144_11070">
+    <p xml:id="eco_de_0000214_11070">
      Die Stallmagd mußte ihnen die Stiefel reinigen oder, falls sie ein anderes Paar zum Wechseln mit herausgebracht hatten, die nassen abnehmen, um sie am Ofen zu trocknen.
     </p>
-    <p xml:id="eco_de_0000144_11080">
+    <p xml:id="eco_de_0000214_11080">
      Jeder fand sich mit mehr Lärm und Aufruhr ein, als es ihm zukam. Dem jungen Mädchen erschienen sie alle wie polternde Ehemänner. Auch sie wäre heute gar zu gern mit den Kirstensmädchen und den Kameraden allein geblieben.
     </p>
-    <p xml:id="eco_de_0000144_11090">
+    <p xml:id="eco_de_0000214_11090">
      Heute bedrückten sie die fremden Mannsbilder, von denen jeder sich mit dem Gedanken trug, hier oben heimisch zu werden, Herr von allem.
     </p>
-    <p xml:id="eco_de_0000144_11100">
+    <p xml:id="eco_de_0000214_11100">
      Unverschämt erschienen sie ihr. Eine schwere Traurigkeit überkam sie. Sie dachte der Ehe ihrer Mutter, an das arbeitsvolle Leben der stillen Frau, an ihre Einsamkeit, an die Gleichgültigkeit, die sie zu ertragen hatte, an die heißen, schmerzvollen Umarmungen, die sie für ihr Kind hatte.
     </p>
-    <p xml:id="eco_de_0000144_11110">
+    <p xml:id="eco_de_0000214_11110">
      »Eine nette Geschichte!« Das junge Mädchen wurde voll Trotz und Zorn. »Hat einer von allen, die hier heraufkommen, mir auch nur etwas gegeben, was ich nicht schon wußte und kannte? Langweilig sind sie. Hab' ich erst einmal einen von ihnen, so sieht er nicht mehr, daß ich schön bin. Was bleibt dann übrig?«
     </p>
-    <p xml:id="eco_de_0000144_11120">
+    <p xml:id="eco_de_0000214_11120">
      Sie spielten Pfänderspiele, die unruhigen, unbefriedigten Gedanken aller lagen drückend im geschlossenen Raum. Auch beim Abendessen ging es nicht so munter her wie früher.
     </p>
-    <p xml:id="eco_de_0000144_11130">
+    <p xml:id="eco_de_0000214_11130">
      Die Wirtin war schweigsam und strahlte nicht wie sonst im Bewußtsein ihrer Kraft und Schönheit.
     </p>
-    <p xml:id="eco_de_0000144_11140">
+    <p xml:id="eco_de_0000214_11140">
      Zum ersten Male seit ihrem Erwachen zu Sorglosigkeit, erster Jugend war heute die Kristallkugel, der ihre Seele glich, fleckig und trübe. Sie schwebte nicht mehr wie im Sonnenlichte, ganz durchleuchtet.
     </p>
-    <p xml:id="eco_de_0000144_11150">
+    <p xml:id="eco_de_0000214_11150">
      Um neun Uhr, als der Regen in Strömen goß und eben beratschlagt wurde, daß die Kirstensmädchen bei Badewännchen nächtigen sollten, die drei Kameraden und die Kummerfelden bei Sperbers, und die Freier sich nach und nach an den Gedanken gewöhnen mußten, bald in Wind und Wetter aufzubrechen, wurde draußen am Hoftor heftig geschellt.
     </p>
-    <p xml:id="eco_de_0000144_11160">
+    <p xml:id="eco_de_0000214_11160">
      »Um Gottes willen!« rief die Rabenmutter.
     </p>
-    <p xml:id="eco_de_0000144_11170">
+    <p xml:id="eco_de_0000214_11170">
      Alle saßen stumm; sie waren vollzählig beieinander. »Vielleicht doch noch einer von Sperbers,« meinte Röse zweifelhaft.
     </p>
-    <p xml:id="eco_de_0000144_11180">
+    <p xml:id="eco_de_0000214_11180">
      »Bewahre!« sagte Beate.
     </p>
-    <p xml:id="eco_de_0000144_11190">
+    <p xml:id="eco_de_0000214_11190">
      Sie dachte: ›Es ist kein Leben, wenn ich einen von diesen heirate. Es würde eine trostlose Geschichte.« Und sie spürte wieder die Kraft ihrer sehnsüchtigen, hungrigen jungen Seele, die wachsen wollte und der niemand Nahrung gab.
     </p>
-    <p xml:id="eco_de_0000144_11200">
+    <p xml:id="eco_de_0000214_11200">
      Ganz versunken war sie in dem neuen, fremden Weh, da kam die Stallmagd außer Atem herauf und sagte: »Einen fremden Menschen hab' ich hereingelassen. Er bittet, hier das fürchterliche Wetter abwarten zu dürfen. Er kommt von über Land,« sagt er.
     </p>
-    <p xml:id="eco_de_0000144_11210">
+    <p xml:id="eco_de_0000214_11210">
      »Ja,« sagte die Rabenmutter, »ist's denn ein ordentlicher Mensch?«
     </p>
-    <p xml:id="eco_de_0000144_11220">
+    <p xml:id="eco_de_0000214_11220">
      »Freilich!« Voll Eifer schlug die Stallmagd sich' auf die Schenkel. »Er gehört schon zu den Herrensleuten, wenn er auch jetzt recht durchnäßt ist.«
     </p>
-    <p xml:id="eco_de_0000144_11230">
+    <p xml:id="eco_de_0000214_11230">
      Alle lachten hell auf. Das plötzliche Lachen fuhr so unvermutet wie ein Schwarm Vögel in die Höhe, den ein Spaziergänger auf einem stillen Stoppelfelde aufgescheucht hat.
     </p>
-    <p xml:id="eco_de_0000144_11240">
+    <p xml:id="eco_de_0000214_11240">
      Mitten im Lachen sagte Beate zur Magd: »Führ' ihn herein und hilf ihm doch.«
     </p>
-    <p xml:id="eco_de_0000144_11250">
+    <p xml:id="eco_de_0000214_11250">
      Die Rabenmutter erhob sich auch und sagte: »Den wollen wir einmal in Augenschein nehmen; hat er seinen Namen nicht gesagt?«
     </p>
-    <p xml:id="eco_de_0000144_11260">
+    <p xml:id="eco_de_0000214_11260">
      »Kupferstecher Kosch hat er dreimal gesagt – und wie!« antwortete die derbe Magd und grinste. »Was er dann aber noch gesagt hat! – Aus Eiweiß wäre er, hat er gesagt, und aus Asche, oder, ich weiß nich', aus noch allerlei.« Die Magd rieb sich die Arme und grinste – grinste. »Das sollt' ich der Herrschaft ausrichten, hat er gesagt. Grad so, hat er gesagt, wär' er gebraut und gebacken wie die oben auch.«
     </p>
-    <p xml:id="eco_de_0000144_11270">
+    <p xml:id="eco_de_0000214_11270">
      Der Hofmann sprang auf und rief: »Der darf nicht herein, das ist ein Verrückter! Das ist eine Unmöglichkeit, liebe Mamsell Rauchfuß.«
     </p>
-    <p xml:id="eco_de_0000144_11280">
+    <p xml:id="eco_de_0000214_11280">
      Beate Rauchfuß lächelte.
     </p>
-    <p xml:id="eco_de_0000144_11290">
+    <p xml:id="eco_de_0000214_11290">
      »Wenn er gerade so gebacken und gebraut ist wie wir alle hier, weshalb dann nicht?«
     </p>
-    <p xml:id="eco_de_0000144_11300">
+    <p xml:id="eco_de_0000214_11300">
      »Weil das albern ist,« sagte der Sperbersche Neffe.
     </p>
-    <p xml:id="eco_de_0000144_11310">
+    <p xml:id="eco_de_0000214_11310">
      »Albern?« fragte die Vielumworbene lachend. »Sind wir denn auch aus Eiweiß?«
     </p>
-    <p xml:id="eco_de_0000144_11320">
+    <p xml:id="eco_de_0000214_11320">
      »Aber liebe Mamsell,« sagte Herr von Mengersen, »das sind doch Dinge…«
     </p>
-    <p xml:id="eco_de_0000144_11330">
+    <p xml:id="eco_de_0000214_11330">
      »Er hat noch ganz andere Sachen dahergered't!« Die Magd lachte.
     </p>
-    <p xml:id="eco_de_0000144_11340">
+    <p xml:id="eco_de_0000214_11340">
      »Schweigen Sie!« fuhr der Hofmann sie an.
     </p>
-    <p xml:id="eco_de_0000144_11350">
+    <p xml:id="eco_de_0000214_11350">
      »Nä – nä,« meinte die Magd. »Ich sag' nischt, das war auch nur für unsereins.«
     </p>
-    <p xml:id="eco_de_0000144_11360">
+    <p xml:id="eco_de_0000214_11360">
      »Gehen Sie!« schrie der Hofmann und hielt seine zarten, langen Hände wie schützend ausgestreckt. – »Bedenken Sie, daß hier junge Mamsells im Zimmer sind.«
     </p>
-    <p xml:id="eco_de_0000144_11370">
+    <p xml:id="eco_de_0000214_11370">
      »Geh 'naus, dummes Mensch,« brummte der Sperbersche Neffe, »pack' dich!«
     </p>
-    <p xml:id="eco_de_0000144_11380">
+    <p xml:id="eco_de_0000214_11380">
      Grinsend machte sich die Magd davon. Beate lachte.
     </p>
-    <p xml:id="eco_de_0000144_11390">
+    <p xml:id="eco_de_0000214_11390">
      Es war wie frische Luft ins Zimmer gekommen. Sie atmete tief auf. Wieviel lustiger und gescheiter waren die Knechte und Mägde untereinander als ihre Freier. Was hatte sie da schon gehört! Die machten nicht viel Federlesens und sagten, was sie dachten.
     </p>
-    <p xml:id="eco_de_0000144_11400">
+    <p xml:id="eco_de_0000214_11400">
      Jetzt kam die Rabenmutter herein. »Ein ganz reputierlicher Mensch,« sagte sie aufgeregt, »nee, wirklich.«
     </p>
-    <p xml:id="eco_de_0000144_11410">
+    <p xml:id="eco_de_0000214_11410">
      »Kommt er denn 'rein?« riefen die Kirstensmädchen.
     </p>
-    <p xml:id="eco_de_0000144_11420">
+    <p xml:id="eco_de_0000214_11420">
      Und da kam er schon, machte vor der Tür einen tiefen Bückling, daß der Haarschopf ihm über die Stirn fiel.
     </p>
-    <p xml:id="eco_de_0000144_11430">
+    <p xml:id="eco_de_0000214_11430">
      Er stand recht bescheiden da, fast ein wenig ärmlich, hager und nicht besonders gepflegt; als er seinen Kopf wieder erhob, blickte ein fahles, unregelmäßiges Gesicht mit scharfen, grauen Augen auf die Gesellschaft. Der Mund groß und gescheit, von einem etwas borstigen, farblosen Schnurrbärtchen wenig verdeckt.
     </p>
-    <p xml:id="eco_de_0000144_11440">
+    <p xml:id="eco_de_0000214_11440">
      Er nahm auf eine gute Art Platz am Tisch. Ein Gesellschaftsmensch war er nicht; aber er mochte den Entschluß gefaßt haben, sich nicht verblüffen zu lassen. Die ganze Person schien von einem gleichmäßigen Willen durchdrungen.
     </p>
-    <p xml:id="eco_de_0000144_11450">
+    <p xml:id="eco_de_0000214_11450">
      Er machte nicht den Eindruck, als hätte das schlimme Wetter ihn irgendwie stark mitgenommen. Er war aus dem Unwetter aufgetaucht, etwa wie ein Hecht aus den Fluten, in grauer, unauffälliger Montur.
     </p>
-    <p xml:id="eco_de_0000144_11460">
+    <p xml:id="eco_de_0000214_11460">
      Die andern sahen gegen ihn alle angezogen aus, überzogen mit fremden Stoffen und Lappen. Die drei Königinnen ausgenommen, deren Jugend und Schönheit die Kleider kräftig und lebendig durchdrangen.
     </p>
-    <p xml:id="eco_de_0000144_11470">
+    <p xml:id="eco_de_0000214_11470">
      Er saß neben der Vielumworbenen.
     </p>
-    <p xml:id="eco_de_0000144_11480">
+    <p xml:id="eco_de_0000214_11480">
      Große Stille.
     </p>
-    <p xml:id="eco_de_0000144_11490">
+    <p xml:id="eco_de_0000214_11490">
      »Herr Kupferstecher,« sagte die Rabenmutter, »bitte sich zu, bedienen.«
     </p>
-    <p xml:id="eco_de_0000144_11500">
+    <p xml:id="eco_de_0000214_11500">
      »Herr Kupferstecher?« fragte der Fremde mit sonderbarer Betonung. »Weshalb nicht zum Beispiel Herr Spazierläufer – Herr Allesfresser – Herr Säufer oder Herr Schläfer? Oder – no, wollen wir's genug sein lassen.« Er fragte sehr gleichmütig.
     </p>
-    <p xml:id="eco_de_0000144_11510">
+    <p xml:id="eco_de_0000214_11510">
      »No aber,« sagte die Rabenmutter.
     </p>
-    <p xml:id="eco_de_0000144_11520">
+    <p xml:id="eco_de_0000214_11520">
      »Ja freilich,« meinte der Fremde.
     </p>
-    <p xml:id="eco_de_0000144_11530">
+    <p xml:id="eco_de_0000214_11530">
      »Woher wissen Sie, daß ich mehr und lieber Kupfer steche, als etwa schlafe und fresse? Verzeihen Sie, also – esse…«
     </p>
-    <p xml:id="eco_de_0000144_11540">
+    <p xml:id="eco_de_0000214_11540">
      »Ja,« sagte die Rabenmutter, »ich meine doch, daß man einen Menschen nach seiner reputierlichsten Beschäftigung tituliert.«
     </p>
-    <p xml:id="eco_de_0000144_11550">
+    <p xml:id="eco_de_0000214_11550">
      »Reputierlich? Ich finde zum Beispiel reputierlich, wenn einer im heißen Sommer vor einem Mauseloch im Feld auf dem Bauch liegt und schaut, was die kleine, graue Madame so tagsüber daheim treibt. – Da kommt er der Weltseele näher, als wenn er in Kupfer sticht, was irgendein Esel sich zurecht geschmiert hat. Ja – ja – unsere reputierlichen Beschäftigungen!«
     </p>
-    <p xml:id="eco_de_0000144_11560">
+    <p xml:id="eco_de_0000214_11560">
      »No aber,« sagte die Rabenmutter wieder recht verblüfft und schaute sich um nach den übrigen Gesichtern. – Da sah sie ein lustiges Leuchten in den Augen der alten Kummerfelden. Die Kirstensmädchen blickten sehr schelmisch, weil sie ein köstliches Lachen eingefangen hatten und mit diesem zappeligen Ding nicht recht fertig wurden.
     </p>
-    <p xml:id="eco_de_0000144_11570">
+    <p xml:id="eco_de_0000214_11570">
      Die jungen Kameraden schauten mit Interesse auf den, der wie ein Hecht aus der Flut aufgetaucht war. Die Freier sahen äußerst unduldsam aus. Die Augen der Vielumworbenen hingen verlangend an dem Fremden, als schnitte er Lebensbrot auf. Freilich hartrindig schien es zu sein und brüchig. Aber es war da etwas wie nach Nahrung Duftendes.
     </p>
-    <p xml:id="eco_de_0000144_11580">
+    <p xml:id="eco_de_0000214_11580">
      Sonderbar war ihm die Nase gewachsen.
     </p>
-    <p xml:id="eco_de_0000144_11590">
+    <p xml:id="eco_de_0000214_11590">
      Die Nase stand gewissermaßen vereinsamt da im Gesicht mit ihren Buchten und Knorpeln. Eigentlich eine ganz anständige Nase, wenn man an ihre Schönheit nicht zuviel Anforderungen stellte. Sie hatte sich aus ihrer übrigen Gesellschaft herausgerungen. Diese Nase schien mit dem Wesen des Fremden große Ähnlichkeit und Sympathien zu haben. Etwas Ringendes hatte seine Art, sich auszudrücken, auch seine Haltung, jede Bewegung.
     </p>
-    <p xml:id="eco_de_0000144_11600">
+    <p xml:id="eco_de_0000214_11600">
      »Darf man fragen,« begann die kleine Madame Kummerfelden in ihrem freundlich geblümten Kleid und aus der großen Haube heraus, »wo der Herr hergekommen, und wohin der Weg führt?«
     </p>
-    <p xml:id="eco_de_0000144_11610">
+    <p xml:id="eco_de_0000214_11610">
      »Ich wollte mir 'mal euren alten Herrn anschauen da unten in der Stadt.«
     </p>
-    <p xml:id="eco_de_0000144_11620">
+    <p xml:id="eco_de_0000214_11620">
      »Den Herzog?«
     </p>
-    <p xml:id="eco_de_0000144_11630">
+    <p xml:id="eco_de_0000214_11630">
      »Nee.«
     </p>
-    <p xml:id="eco_de_0000144_11640">
+    <p xml:id="eco_de_0000214_11640">
      »Seine Exzellenz?« fragte die Kummerfelden in einer Art höfischen Tones, den sie gern hervorholte. Sie verstand sich darauf, mit vornehmen und von vornehmen Leuten zu sprechen.
     </p>
-    <p xml:id="eco_de_0000144_11650">
+    <p xml:id="eco_de_0000214_11650">
      »Seine Exzellenz,« sagte er borstig. »Damit ist alles gesagt. Nun haben Sie's mir gründlich verdorben. Jetzt könnt' ich am einfachsten wieder umkehren. Ich komme aus der Harzgegend, aus einem der vielen unbekannten Nester dieser Erde und wollte, da ich mein Lebtag unter Tieren, was man so Menschen nennt, lebte, einmal den seh'n, der da sagte: ›Der Menschheit ganzer Jammer faßt mich an« – und noch einiges mehr. Ich wußt's ja, aber nun hör' ich's. – Seine Exzellenz! – Wunderlich. – Und wie Sie das schön sagten, Verehrteste. – Man sieht ihn steifrückig vor sich. – Und ich wollte hingehen und ihn bei der Hand fassen und sagen: ›Herr Gott, ich danke dir, daß du auch 'mal was Vernünftiges schufst, damit man an dich doch mit gutem Gewissen glauben kann – denn deine Ebenbilder hier auf Erden! Alle Achtung vor dir – aber hör' mal…!«
     </p>
-    <p xml:id="eco_de_0000144_11660">
+    <p xml:id="eco_de_0000214_11660">
      Was ich will, dazu paßt kein Bückling und kein Wartezimmer. Nackt sollte er gehen, eure Exzellenz, unter hohen, mächtigen Bäumen, auf glattem, feierlichem Grund.«
     </p>
-    <p xml:id="eco_de_0000144_11670">
+    <p xml:id="eco_de_0000214_11670">
      »Verehrtester,« sagte der Hofmann gemessen, »Sie scheinen sich von Seiner Exzellenz die eigentümlichsten Begriffe zu machen. Bei ihm Audienz zu erhalten, ist nicht allzu leicht.«
     </p>
-    <p xml:id="eco_de_0000144_11680">
+    <p xml:id="eco_de_0000214_11680">
      »Will auch gar nicht,« sagte der Kupferstecher borstig. »Bei mir daheim, in meiner Einsamkeit, ist er ein wundervoller Freund, den man liebt, heiß – wie nur ein einsamer Mensch einen wundervollen Freund zu lieben versteht. Nee, nee, behaltet eure Exzellenz.«
     </p>
-    <p xml:id="eco_de_0000144_11690">
+    <p xml:id="eco_de_0000214_11690">
      Ernst von Schiller, der Freund der Kirstensmädchen, sagte bescheiden, aber begeistert: »Er scheint durch alle menschlichen Verhältnisse hindurch. Er ist stärker als alles. Als Sohn wohlhabender Eltern aufgewachsen in einer großen Stadt, Jurist geworden, dann im engen Weimar zu Amt und Würden gekommen, Hofmann geworden und immer in gutem Behagen, – gibt's einen schlimmeren Weg für ein Genie? Und er blieb klar und scharf und tief und voller Güte, wurde nie stumpf und dumpf.«
     </p>
-    <p xml:id="eco_de_0000144_11700">
+    <p xml:id="eco_de_0000214_11700">
      »Jawohl,« sagte der Kupferstecher heftig. »Wer sagt denn das? Haben Sie ihn inmitten unter den Elenden sitzen geseh'n? Haben Sie ihn ringen seh'n, ringen mit den Mächten des Lebens – aus der Dunkelheit sich heraufringen seh'n?
     </p>
-    <p xml:id="eco_de_0000144_11710">
+    <p xml:id="eco_de_0000214_11710">
      Kennen Sie denn diese ungeheuren Gewalten, die Menschen das Denken herauspressen, wie die Kelter den Wein aus den Trauben?
     </p>
-    <p xml:id="eco_de_0000144_11720">
+    <p xml:id="eco_de_0000214_11720">
      Ein Jahr ohne Geld, ein einziges Jahr ohne Geld – ohne Anhang: eure Exzellenz wäre lebendig geworden wie Gott – nie hättet ihr solch ein Wunder auf Erden gehabt – die Welt erlöst hätte er, wäre er durchglüht worden bis aufs Mark, hätte er unter den Elenden gesessen, unter denen, welche die Welt von der Schattenseite sehen. Eine kurze Zeit da stehen, wo die stehen, welche die Arme nach ihren Ebenbildern um Hilfe ausstrecken, ein paar Wanderungen durch Städte und Dörfer, dem Winter entgegen, ohne zu wissen, wo der Balg Wärme und Futter bekommt, und ein paar gute Kameraden unter denen, vor denen der Ehrenmann ausspuckt.
     </p>
-    <p xml:id="eco_de_0000144_11730">
+    <p xml:id="eco_de_0000214_11730">
      Meine Hand leg' ich ins Feuer, heut' nacht noch könnte ich an seine Tür klopfen und rufen: ›Mach' auf, Bruder! Einer kommt, der dich liebt. Er kommt aus der Welt, aus der du deine Kraft holtest, deine Einsicht, deine Größe, deine große Güte. Mach' auf,« wie es im Hohen Liede heißt: Wie soll ich meine Füße … und so weiter, und so weiter, hätte er nicht gesagt. Zu Seiner Exzellenz werde ich, wenn's Glück gut ist, nicht einmal vorgelassen. Auch gut!«
     </p>
-    <p xml:id="eco_de_0000144_11740">
+    <p xml:id="eco_de_0000214_11740">
      Der Hofmann sagte: »Lieber Herr, wo käme Seine Exzellenz denn hin, wenn er jeden Durchreisenden empfangen wollte? Bedenken Sie.«
     </p>
-    <p xml:id="eco_de_0000144_11750">
+    <p xml:id="eco_de_0000214_11750">
      »Bin nicht jeder Durchreisende!« brummte der Kupferstecher und schaute auf den Tisch vor sich hin, als schaute er da die bewegendsten Dinge. Kann sein, daß er sich selbst so sah, sein Wesen, seine Vergangenheit, all die ihm vertrauten Sachen und Begebnisse, die niemand etwas angingen.
     </p>
-    <p xml:id="eco_de_0000144_11760">
+    <p xml:id="eco_de_0000214_11760">
      Herrn Rauchfußens Tochter fühlte etwas, als wäre ein ihr Zugehöriger endlich zurückgekehrt. Nicht gewundert hätte sie sich, wenn der Zugelaufene gesagt hätte: Nun, wie steht's? Habe ich mich verändert in der langen Zeit? Ich hoffe, du verstehst mich noch wie sonst?
     </p>
-    <p xml:id="eco_de_0000144_11770">
+    <p xml:id="eco_de_0000214_11770">
      Sie sprach kein Wort, so gut wie kein Wort. Sie hätte ihm denn gleich ihr ganzes Herz ausschütten müssen.
     </p>
-    <p xml:id="eco_de_0000144_11780">
+    <p xml:id="eco_de_0000214_11780">
      Das war ein lebendiger Mensch. – – Sie wußte das ganz genau. Alle, die sie kannte, waren noch nie, so schien es ihr, so lebendig gewesen. Eingelullt von den Gewohnheiten waren sie alle.
     </p>
-    <p xml:id="eco_de_0000144_11790">
+    <p xml:id="eco_de_0000214_11790">
      Ihr Vater? Da ahnte sie so etwas, als hätte der lebendig sein können, wenn er gewollt hätte – aber es hatte ihm wohl nicht gepaßt, – und er hatte getrunken, um sich zu betäuben.
     </p>
-    <p xml:id="eco_de_0000144_11800">
+    <p xml:id="eco_de_0000214_11800">
      Von ihm hatte sie wohl die Sehnsucht, selbst lebendig zu sein und unter Lebendigen zu leben.
     </p>
-    <p xml:id="eco_de_0000144_11810">
+    <p xml:id="eco_de_0000214_11810">
      Sie konnte die Blicke nicht von dem wachen Gesicht wenden und fühlte einen Strom von Kraft und Leben von ihm zu ihr strömen.
     </p>
-    <p xml:id="eco_de_0000144_11820">
+    <p xml:id="eco_de_0000214_11820">
      Er beachtete sie kaum und sprach und stritt in seiner abgerissenen, ringenden Art weiter mit den Freiern, die ihn für ein verrücktes Tier hielten.
     </p>
-    <p xml:id="eco_de_0000144_11830">
+    <p xml:id="eco_de_0000214_11830">
      Als alles aufbrach, sagte sie zur Rabenmutter laut und fest, daß alle es hörten. »Herr Kosch bleibt hier. Jetzt ist's zu spät für ihn, unten in Weimar noch in ein Gasthaus zu gehen. Lassen Sie ihm das Fremdenstübchen richten.«
     </p>
-    <p xml:id="eco_de_0000144_11840">
+    <p xml:id="eco_de_0000214_11840">
      Diese Worte rangen auch ihr sich aus der Seele. Sie waren zentnerschwer zu sprechen.
     </p>
-    <p xml:id="eco_de_0000144_11850">
+    <p xml:id="eco_de_0000214_11850">
      Sie wollte ihn nicht hergeben.
     </p>
-    <p xml:id="eco_de_0000144_11860">
+    <p xml:id="eco_de_0000214_11860">
      Und er blieb.
     </p>
-    <p xml:id="eco_de_0000144_11870">
+    <p xml:id="eco_de_0000214_11870">
      Und als alle gegangen waren, kamen ein paar kurze Augenblicke, in denen sie mit ihm im Wohnzimmer allein zurückblieb.
     </p>
-    <p xml:id="eco_de_0000144_11880">
+    <p xml:id="eco_de_0000214_11880">
      Er stand mit dem Rücken gegen das Fenster und schaute über das Zimmer hin.
     </p>
-    <p xml:id="eco_de_0000144_11890">
+    <p xml:id="eco_de_0000214_11890">
      »Was werden die Monsieurs zum Beispiel sagen, daß Sie mich Zufallsmann hier behielten – und was denken Sie denn darüber?«
     </p>
-    <p xml:id="eco_de_0000144_11900">
+    <p xml:id="eco_de_0000214_11900">
      »Ich,« sagte sie, »ich denke, daß es zu spät für Sie ist, noch in Weimar Unterkommen zu finden.«
     </p>
-    <p xml:id="eco_de_0000144_11910">
+    <p xml:id="eco_de_0000214_11910">
      »Na,« meinte er, »eine Prinzessin auf der Erbse bin ich nicht. Ich wäre in jede Spelunke, die sich mir aufgetan hätte, auch gekrochen.«
     </p>
-    <p xml:id="eco_de_0000144_11920">
+    <p xml:id="eco_de_0000214_11920">
      Sie sah ihn schweigend an und errötete stark.
     </p>
-    <p xml:id="eco_de_0000144_11930">
+    <p xml:id="eco_de_0000214_11930">
      Es lag etwas Lustig-Spöttisches in seinem Blick, der scharf auf sie gerichtet war. »Weiberchen! – Weiberchen!« sagte er leichthin.
     </p>
-    <p xml:id="eco_de_0000144_11940">
+    <p xml:id="eco_de_0000214_11940">
      Da war es ihr, als wenn sie etwas an der Kehle packte und würgte. Das ist ein Mensch, der viel herumgekommen ist. Sie dachte an die Weibergeschichte der Knechte, die sie sich in der Gesindestube erzählten.
     </p>
-    <p xml:id="eco_de_0000144_11950">
+    <p xml:id="eco_de_0000214_11950">
      ›Was er von mir denkt?« Tränen stiegen ihr heiß in die Augen. Sie trat einen Schritt vor, wollte sprechen, fand kein Wort. »Ich weiß« … sagte sie und kam nicht weiter.
     </p>
-    <p xml:id="eco_de_0000144_11960">
+    <p xml:id="eco_de_0000214_11960">
      »Na, was wissen Sie, schönes Kind? Was weiß so ein schönes Kind?«
     </p>
-    <p xml:id="eco_de_0000144_11970">
+    <p xml:id="eco_de_0000214_11970">
      Sie wurde bleich.
     </p>
-    <p xml:id="eco_de_0000144_11980">
+    <p xml:id="eco_de_0000214_11980">
      »Sprechen Sie doch mit mir, wie Sie mit den jungen Männern sprachen! Sprechen Sie doch wie mit einem Menschen mit mir.« Es lag etwas Flehendes in der Stimme und etwas Ungeschicktes.
     </p>
-    <p xml:id="eco_de_0000144_11990">
+    <p xml:id="eco_de_0000214_11990">
      Ueberhastend sprach sie jetzt wie jemand, der vieles sagen möchte und alles in ein paar Worte preßt, deren Bedeutung der andere nicht versteht. »Sie sollen mir die Hand geben, ganz einfach sagen: Es ist freundlich, daß Sie mich hier behalten.«
     </p>
-    <p xml:id="eco_de_0000144_12000">
+    <p xml:id="eco_de_0000214_12000">
      »Sonderbares Hühnchen,« sagte der Fremde, kühl lächelnd, wie zu sich selbst. »Was?«
     </p>
-    <p xml:id="eco_de_0000144_12010">
+    <p xml:id="eco_de_0000214_12010">
      Seine Augen bekamen etwas Unverschämtes.
     </p>
-    <p xml:id="eco_de_0000144_12020">
+    <p xml:id="eco_de_0000214_12020">
      Das Mädchen fragte in tiefer Erregung: »Ist Ihnen nie eine gute, einfache Frau begegnet oder ein Mädchen?«
     </p>
-    <p xml:id="eco_de_0000144_12030">
+    <p xml:id="eco_de_0000214_12030">
      Er unterbrach sie. »An Güte fehlte es selten genug, schönste Mamsell.«
     </p>
-    <p xml:id="eco_de_0000144_12040">
+    <p xml:id="eco_de_0000214_12040">
      »Nein,« sagte sie jetzt ruhig, »eine Frau, die sagte: Sprechen Sie doch mit mir wie mit einem Menschen, erzählen Sie mir, was Sie wissen und was Sie denken, mich verlangt nach etwas, wovon meine Seele leben könnte?«
     </p>
-    <p xml:id="eco_de_0000144_12050">
+    <p xml:id="eco_de_0000214_12050">
      »Nein,« sagte er, »so eine ist mir nie vorgekommen. Wenn ich je zu einer sprach wie zu einem Menschen, hat sie zu gähnen angefangen.«
     </p>
-    <p xml:id="eco_de_0000144_12060">
+    <p xml:id="eco_de_0000214_12060">
      »Wirklich?« sagte das Mädchen traurig. »Oder ist es Ihnen zwei- oder dreimal so begegnet, wie Sie sagen – und dann haben Sie die anderen eingeschüchtert?«
     </p>
-    <p xml:id="eco_de_0000144_12070">
+    <p xml:id="eco_de_0000214_12070">
      »Kann auch sein. Es kommt überhaupt nicht viel dabei heraus.«
     </p>
-    <p xml:id="eco_de_0000144_12080">
+    <p xml:id="eco_de_0000214_12080">
      »Weshalb nicht?« fragte sie erregt.
     </p>
-    <p xml:id="eco_de_0000144_12090">
+    <p xml:id="eco_de_0000214_12090">
      »Höchstens 'ne dumme Liebesgeschichte, Mamsell – die alte, dumme Geschichte.«
     </p>
-    <p xml:id="eco_de_0000144_12100">
+    <p xml:id="eco_de_0000214_12100">
      »Traurig ist das,« sagte das Mädchen. »Gott sieht in mein Herz,« fuhr sie auf eine schlichte Weise fort zu sprechen. »Ja, ich habe Sie hier bei uns behalten wollen, weil mir war, als könnten Sie mir Lebendiges sagen. Ich wollte Ihnen zuhören. Nun sind Sie ein ganz anderer. Glauben Sie denn, die Mannsbilder, die Sie hier sahen, sind klüger als ich? Glauben Sie, auch nur einer verstand, was Sie sagten? Ich sah auf ihren Gesichtern, daß sie Sie für halb verrückt hielten. Schlafen Sie wohl! sagte sie ruhig, indem sie sich von ihm abwendete und zur Tür hinausging.
     </p>
-    <p xml:id="eco_de_0000144_12110">
+    <p xml:id="eco_de_0000214_12110">
      Er dachte: ›Ei verflucht! Ein schöngeistiges Huhn. Schön ist die Person! Wollen einmal seh'n. Zwei Stunden im Umkreis von Seiner Exzellenz treibt schon das Unkraut wunderliche Blüten.«
     </p>
-    <p xml:id="eco_de_0000144_12120">
+    <p xml:id="eco_de_0000214_12120">
      Als er von der Rabenmutter in sein Stübchen geleitet worden war, fand er, als er vor dem schneeweißen Bett stand, daß er sich in gar kein übles Abenteuer begeben hatte. Der große Gutshof, das weitläufige Haus, das schöne Mädchen, das er, umgeben von Freiern und Freundinnen, angetroffen hatte, und ihre Verliebtheit, die sie so drollig maskierte.
     </p>
-    <p xml:id="eco_de_0000144_12130">
+    <p xml:id="eco_de_0000214_12130">
      Sie war ihm beim ersten Blick als ungewöhnlich schön aufgefallen, und er hatte gedacht: »Da sitzt sie und wählt von all den höflichen Herren sich den höflichsten, reichsten und dümmsten aus! Daß die Wahl auf ihn fallen könnte, wäre ihm nicht im Traum gekommen. So war sie ihm der Beachtung nicht wert gewesen.
     </p>
-    <p xml:id="eco_de_0000144_12140">
+    <p xml:id="eco_de_0000214_12140">
      Aus kleinen Verhältnissen hatte er sich so weit heraufgearbeitet, daß er das Leben eines sonderbaren Kauzes führen konnte. Er hatte sich auf das äußerste Maß einer bescheidenen Lebensführung selbst beschränkt, kannte keinen Luxus als den, so zu denken und zu handeln, wie es ihm gefiel, und von Zeit zu Zeit einen guten Schluck zu tun; den liebte er und hielt ihn eines deutschen Mannes würdig. Die ganze Art seiner Beanlagung war auf eine solche Kraftzufuhr von außen gewissermaßen angewiesen. Seine Leidenschaftlichkeit, sich in Dinge dieser Welt einzuwühlen, war so groß, daß auf diese Leidenschaftlichkeiten eben solche Ermattungen folgten, die gehoben werden mußten.
     </p>
-    <p xml:id="eco_de_0000144_12150">
+    <p xml:id="eco_de_0000214_12150">
      Das Weib spielte in seinem Leben eine kleine, fast komische, etwas erbärmliche Rolle. Mitleidig sah er auf dieses, wie auf ein höchst unvollkommenes, kränkliches Wesen herab.
     </p>
-    <p xml:id="eco_de_0000144_12160">
+    <p xml:id="eco_de_0000214_12160">
      In seinen Liebschaften war er nicht wählerisch gewesen.
     </p>
-    <p xml:id="eco_de_0000144_12170">
+    <p xml:id="eco_de_0000214_12170">
      Seine Mutter war ein bedrücktes Weibchen, das ihn nie verstanden hatte; die Schwester spießbürgerlich. So hielt er von den Frauen nicht viel.
     </p>
-    <p xml:id="eco_de_0000144_12180">
+    <p xml:id="eco_de_0000214_12180">
      Er erachtete zum Beispiel auch die Pferde für besonders dumme Tiere und konnte in größten Zorn geraten, wenn ein Pferdeliebhaber ihm das Gegenteil zu beweisen anhub.
     </p>
-    <p xml:id="eco_de_0000144_12190">
+    <p xml:id="eco_de_0000214_12190">
      Ueberhaupt saßen seine Ansichten wie mit Widerhaken in ihm fest, und er konnte ein sehr empfindlicher Herr werden, wenn man daran rüttelte. ›Das ist sonderbar genug, daß ich mich hier in diesem Nest, das ich durch Regen, Sturm und Nebel kaum noch sah, in eine Liebesgeschichte eingesponnen habe.«
     </p>
-    <p xml:id="eco_de_0000144_12200">
+    <p xml:id="eco_de_0000214_12200">
      Damit legte er sich aufs Ohr.
     </p>
-    <p xml:id="eco_de_0000144_12210">
+    <p xml:id="eco_de_0000214_12210">
      ›Schade, daß das schöne Ding Schrullen hat – was ihr wohl fehlt. Sie sieht sonst ganz gesund aus.«
     </p>
-    <p xml:id="eco_de_0000144_12220">
+    <p xml:id="eco_de_0000214_12220">
      Am anderen Morgen war lachendes Frühlingswetter. Es hatte sich endlich ausgetobt.
     </p>
-    <p xml:id="eco_de_0000144_12230">
+    <p xml:id="eco_de_0000214_12230">
      Die Kirstensmädchen waren in aller Herrgottsfrühe schon mit den Kameraden zur Stadt hinuntergezogen, hatten aber versprochen, so bald als möglich wieder heraufzukommen. Beate hatte mit ihnen zusammen gefrühstückt und ging nun im Garten umher, sah aber die junge Frühlingspracht kaum.
     </p>
-    <p xml:id="eco_de_0000144_12240">
+    <p xml:id="eco_de_0000214_12240">
      Der Gast im Fremdenstübchen ließ ihr das Herz schlagen. Ja, sie hätte es nicht tun sollen.
     </p>
-    <p xml:id="eco_de_0000144_12250">
+    <p xml:id="eco_de_0000214_12250">
      Sie hätte nicht sich das Herz fassen sollen, zu sagen: ›Herr Kosch bleibt hier.«
     </p>
-    <p xml:id="eco_de_0000144_12260">
+    <p xml:id="eco_de_0000214_12260">
      Herr Kosch wanderte zur selben Zeit durch Hof und Ställe und kam auch in den Garten, sah seine junge Wirtin wandeln und dachte: ›Wollen wir mal 'ne Ausnahme machen und sehen, wann sie mit Gähnen anhebt. Schließlich verlohnt sich's der Mühe.«
     </p>
-    <p xml:id="eco_de_0000144_12270">
+    <p xml:id="eco_de_0000214_12270">
      So kam es, daß er mit ihr redete wie mit seinesgleichen, sagen wir, wie etwa mit seinen Kameraden abends am Stammtisch, mit denen er nie weiter als bis dahin gekommen war, daß sie ihn für einen närrischen, nicht ungefährlichen Kerl hielten; nicht ungefährlich aus den verschiedensten Gründen, erstens, weil sie ihn nicht verstanden, und dann, – er neigte aus diesem Grunde leicht zum Jähzorn.
     </p>
-    <p xml:id="eco_de_0000144_12280">
+    <p xml:id="eco_de_0000214_12280">
      Jetzt nahm er also seiner jungen Wirtin die große Bangigkeit vom Herzen, die er ihr gestern durch sein spöttisches und mißachtendes Wesen verschuldet hatte.
     </p>
-    <p xml:id="eco_de_0000144_12290">
+    <p xml:id="eco_de_0000214_12290">
      Er ließ sich gehen, sprach, wie es seine Art war, und gab den spöttischen und spielerischen Ton auf, den er für die Weiber bereithielt.
     </p>
-    <p xml:id="eco_de_0000144_12300">
+    <p xml:id="eco_de_0000214_12300">
      Sie hörte ihm still zu, wovon er auch sprach. Seine Sprünge ermüdeten sie nicht. Sie gähnte zu seinem Erstaunen nicht.
     </p>
-    <p xml:id="eco_de_0000144_12310">
+    <p xml:id="eco_de_0000214_12310">
      ›Die Liebe muß groß sein,« dachte er.
     </p>
-    <p xml:id="eco_de_0000144_12320">
+    <p xml:id="eco_de_0000214_12320">
      »Mir gefällt, daß Ihr Garten eine Wildnis ist,« sagte er unter anderm. »Nichts Verschnittenes, keine Quadrate, keine Kreise und geometrischen Figuren, so daß man auf den ersten Blick sieht, daß man es mit Menschen auf unterster Stufe zu tun hat. Die Freude am Kreis, am Viereck ist ein böses Zeichen. Wer möchte schließlich mit Höhlenmenschen verkehren! – Nein, ein sehr anständiger Garten, der nichts verrät.«
     </p>
-    <p xml:id="eco_de_0000144_12330">
+    <p xml:id="eco_de_0000214_12330">
      »Ich weiß aber,« sagte Beate, »daß Menschen hier gelebt haben, die nicht viel Lebensfreude hatten – wäre meine Mutter glücklicher gewesen, glaube ich wohl, daß sie ein paar Tulpenbeete angelegt haben würde, rund oder lang, wie es ihr gefallen hätte.«
     </p>
-    <p xml:id="eco_de_0000144_12340">
+    <p xml:id="eco_de_0000214_12340">
      »Ja, ja,« sagt der Kupferstecher, »man muß es den Menschen gönnen, daß sie sich auf ihre Weise vergnügen – aber greulich bleibt's.
     </p>
-    <p xml:id="eco_de_0000144_12350">
+    <p xml:id="eco_de_0000214_12350">
      Denken Sie sich, ein so armer Kerl will Herrliches schaffen in der Freude seines Herzens und kratzt wie ein Huhn sich ein Beet in den Sand, länglich, mondlich, und ist stolz und froh.
     </p>
-    <p xml:id="eco_de_0000144_12360">
+    <p xml:id="eco_de_0000214_12360">
      Und so ist das ganze Leben. Alles eine Armseligkeit. Das Fressen – und das Fressen erjagen verstehen die meisten nicht übel – aber außerdem kratzen wir alle im Sand.
     </p>
-    <p xml:id="eco_de_0000144_12370">
+    <p xml:id="eco_de_0000214_12370">
      Haben Sie zum Beispiel schon einmal etwas gedacht, meine schöne Mamsell? Ich meine nicht, ob heut' schön Wetter wird oder ob ich den Müller nehmen soll oder den Meier – oder ob mir das blaue Kleid besser steht als das rote – oder ob's eine ewige Seligkeit gibt oder nicht.
     </p>
-    <p xml:id="eco_de_0000144_12380">
+    <p xml:id="eco_de_0000214_12380">
      Ich meine, ist Ihnen über etwas, entgegen allen anderen, ein Licht aufgegangen? Und haben Sie über dies aufgegangene Licht solch unbändige Freude gehabt, daß Sie einen Kriegstanz mit Geheul und Gejohl hätten aufführen können? He?«
     </p>
-    <p xml:id="eco_de_0000144_12390">
+    <p xml:id="eco_de_0000214_12390">
      »Nein, Herr Kosch, solch' eine Freude hab' ich nie gehabt,« sagte das Mädchen.
     </p>
-    <p xml:id="eco_de_0000144_12400">
+    <p xml:id="eco_de_0000214_12400">
      »Sehen Sie, Mamsell,« lachte er auf, »und da wollen Sie mitreden!«
     </p>
-    <p xml:id="eco_de_0000144_12410">
+    <p xml:id="eco_de_0000214_12410">
      »Sind die Taten der Menschen gar nichts in Ihren Augen?« fragte sie, um zu erfahren, was er davon hielt.
     </p>
-    <p xml:id="eco_de_0000144_12420">
+    <p xml:id="eco_de_0000214_12420">
      »Die Taten der Menschen? Was meinen Sie damit?«
     </p>
-    <p xml:id="eco_de_0000144_12430">
+    <p xml:id="eco_de_0000214_12430">
      »Ich meine, wenn man vielleicht einen Menschen pflegt und in seiner Todesstunde ihn tröstet, oder wenn eine Mutter alles für ihre Kinder tut.«
     </p>
-    <p xml:id="eco_de_0000144_12440">
+    <p xml:id="eco_de_0000214_12440">
      »Nein, nein,« sagte er heftig, »das alles nebenbei; aber der Gedanke, der Gedanke! Die Erkenntnis macht erst zum Menschen. Dann erst ist man froh und stark und frei – das Selbstdenken!
     </p>
-    <p xml:id="eco_de_0000144_12450">
+    <p xml:id="eco_de_0000214_12450">
      Dann erst ist man ein lebendiger Mensch.«
     </p>
-    <p xml:id="eco_de_0000144_12460">
+    <p xml:id="eco_de_0000214_12460">
      Sie war wie berauscht von ihm, und das zarteste Gefühl, das in einer Menschenbrust sich regen kann, wurde in ihr wach. Sie, mit einer so viel jüngeren Seele, breitete die Hände nach der seinen aus, um sie zu lieben und zu behüten. Noch versteht sie ihn kaum. Doch ist sie schon voll Mütterlichkeit für seine Seele, denkt und sinnt, wie ihm zu helfen sei.
     </p>
-    <p xml:id="eco_de_0000144_12470">
+    <p xml:id="eco_de_0000214_12470">
      Die Blicke ihrer Freier taten ihr noch in der Erinnerung weh. Sie verstanden ihn nicht. Sie begriffen eben nicht, daß er ein lebendiger Mensch war.
     </p>
-    <p xml:id="eco_de_0000144_12480">
+    <p xml:id="eco_de_0000214_12480">
      Wunderlich, wie sie forschend in ihn eindrang, sehnsüchtig, klug – und ernst und voller Wahrheit – und er ging neben ihr her als ein Mann, der etwas von sich hält, als ein Einsamer, Geprüfter, Wohlgeglühter – und dachte: ›Eine hübsche Person. Schade. Was macht sie sich denn für nutzlose Gedanken für ein Frauenzimmer?« – Er war etwas ungeduldig.
     </p>
-    <p xml:id="eco_de_0000144_12490">
+    <p xml:id="eco_de_0000214_12490">
      Schwer hatte die Einsamkeit auf ihn die Hand gelegt, und nun fühlte er nicht, wie ein junger, eben erwachter Geist bang und voller Freundschaft um seine einsame Seele rang.
     </p>
-    <p xml:id="eco_de_0000144_12500">
+    <p xml:id="eco_de_0000214_12500">
      Die Sinne schliefen ihr noch. Es war etwas ganz Unirdisches, was er da erlebte, und wußte nicht, daß er's erlebte. Hätte er's verstanden, wer weiß, ob seine dicke Haut, die sich durch Abwehr und Kampf um ihn gebildet hatte, es auch noch durchfühlen konnte.
     </p>
-    <p xml:id="eco_de_0000144_12510">
+    <p xml:id="eco_de_0000214_12510">
      Er mußte sich sagen, daß der Zufall ihn vor die merkwürdigste Entscheidung seines Lebens stellen würde, denn daß er Herr dieses verliebten Mädchens war, daran konnte er nicht mehr zweifeln.
     </p>
-    <p xml:id="eco_de_0000144_12520">
+    <p xml:id="eco_de_0000214_12520">
      Nie hatte er an eine Verbesserung seiner Lage gedacht, hatte sie nicht einmal gewünscht, denn ein bedürfnisloses Leben ist ein bekömmliches Leben, gut für Geist und Körper. Er liebte seine Freiheit.
     </p>
-    <p xml:id="eco_de_0000144_12530">
+    <p xml:id="eco_de_0000214_12530">
      Er war überhaupt das, was er sein wollte.
     </p>
-    <p xml:id="eco_de_0000144_12540">
+    <p xml:id="eco_de_0000214_12540">
      Und doch schien das Schicksal zu wollen, daß er sich mit einem Weibe, mit Pflichten, nicht nur gegen sich selbst, und mit Wohlhabenheit beladen sollte. Wehren wollte er sich nicht, aber die Sache, ohne selbst zu handeln, an sich herankommen lassen, mochte es kommen, wie es wollte.
     </p>
-    <p xml:id="eco_de_0000144_12550">
+    <p xml:id="eco_de_0000214_12550">
      An diesem Tage bummelte er hinunter nach Weimar, seinem Reiseziel, um Wege und Straßen zu gehen, die der alte Herr zu gehen gewohnt war; ging auch ins Theater und kam spät abends wieder in den Gutshof auf dem Ettersberge an.
     </p>
-    <p xml:id="eco_de_0000144_12560">
+    <p xml:id="eco_de_0000214_12560">
      Alles schlief, nur die Rabenmutter kam, um ihm noch etwas zum Abendessen aufzutragen.
     </p>
-    <p xml:id="eco_de_0000144_12570">
+    <p xml:id="eco_de_0000214_12570">
      So strich er auch am andern Tage umher. Beate ließ sich nicht sehen. Die Rabenmutter sagte ihm, daß er jederzeit zu den Mahlzeiten willkommen sei, aber er solle sich keinerlei Zwang auferlegen.
     </p>
-    <p xml:id="eco_de_0000144_12580">
+    <p xml:id="eco_de_0000214_12580">
      ›Sie ist ein ganz schlauer kleiner Balg,« dachte er, ›meine hübsche Wirtin.«
     </p>
-    <p xml:id="eco_de_0000144_12590">
+    <p xml:id="eco_de_0000214_12590">
      Am Nachmittag begegnete er ihr, aber außerhalb des Gartens. Es fiel ihm auf, daß sie nicht errötete, sondern nur erfreut aussah. Ihr ganzes Wesen hatte etwas Freies, Leichtes. Der rote Haarschopf glühte in der Spätnachmittagssonne. Sommerlich frei und glücklich sah sie aus.
     </p>
-    <p xml:id="eco_de_0000144_12600">
+    <p xml:id="eco_de_0000214_12600">
      Herr Kosch hatte das Gefühl, daß er zu dieser schönen Heiterkeit nicht viel beigetragen hatte.
     </p>
-    <p xml:id="eco_de_0000144_12610">
+    <p xml:id="eco_de_0000214_12610">
      Er war schließlich nicht allzu vertraut mit den Verhältnissen dieser Leute und hatte die Vielumworbene mitten unter ihren Freiern angetroffen.
     </p>
-    <p xml:id="eco_de_0000144_12620">
+    <p xml:id="eco_de_0000214_12620">
      Die Verliebtheit, die sie ihm gegenüber an den Tag gelegt hatte, erschien ihm nicht mehr so ganz einwandfrei.
     </p>
-    <p xml:id="eco_de_0000144_12630">
+    <p xml:id="eco_de_0000214_12630">
      Entschieden hatte er das, was man Glück bei den Weibern nennt. ›Sie lieben«, so überlegte er, ›das Außergewöhnliche; so ein grauer Kerl, fest und energisch gefügt, mit unregelmäßigen Zügen, einem Auftreten, so ein wenig werwolfsartig und geheimnisvoll, das ist diesen Romantikerinnen der Menschheit eben recht.«
     </p>
-    <p xml:id="eco_de_0000144_12640">
+    <p xml:id="eco_de_0000214_12640">
      ›Sie sind stolz auf solch einen Liebhaber; aber den Ehemann wählen sie aus anderem Holz geschnitzt. Der muß verläßlich sein, gut bürgerlich.« Herr Kosch hatte seine Erfahrungen und beschloß – einfach liebenswürdig zu sein.
     </p>
-    <p xml:id="eco_de_0000144_12650">
+    <p xml:id="eco_de_0000214_12650">
      So gingen sie miteinander. Das Gras quoll in seiner grünen Fülle aus dem Erdreich und duftete, wehte im sanften Maiwind weich wie aus Seide. Das Laub der Buchen am Waldessaum saß noch zusammengefaltet wie zarte grüne Schmetterlinge, die sich zum Weiterfliegen anschicken, an den Zweigen. Die Bäume im freien Feld bekamen ihre festen Formen. Die Linden glichen ihrem Blatt. Sie standen wie große grüne Herzen.
     </p>
-    <p xml:id="eco_de_0000144_12660">
+    <p xml:id="eco_de_0000214_12660">
      Und das sprach Herr Kosch aus.
     </p>
-    <p xml:id="eco_de_0000144_12670">
+    <p xml:id="eco_de_0000214_12670">
      »Ja, wie Herzen,« antwortete sie und lächelte. »Jeder Baum gleicht seinem Blatt, das sah ich oft. Haben Sie die Wipfel der Bäume schon miteinander reden sehen?« fragte sie. »Sie machen Bewegungen oft wie alte Frauen, neigen sich so behutsam und würdig; oft sieht man sie wie Kinder miteinander reden und oft wie ernste Männer.«
     </p>
-    <p xml:id="eco_de_0000144_12680">
+    <p xml:id="eco_de_0000214_12680">
      »Ja, ein Landkind!« sagte er. »Ein Landkind!– Sei'n Sie froh!«
     </p>
-    <p xml:id="eco_de_0000144_12690">
+    <p xml:id="eco_de_0000214_12690">
      Jetzt dachte er, sie wird zu erzählen anheben von ihrem Leben, von ihren Eltern, von ihrer Kindheit, daß sie das Landleben satt habe oder liebe.
     </p>
-    <p xml:id="eco_de_0000144_12700">
+    <p xml:id="eco_de_0000214_12700">
      ›Das tun sie alle, sie reden von sich und ihrer Vergangenheit, sobald sie etwas zahmer werden.
     </p>
-    <p xml:id="eco_de_0000144_12710">
+    <p xml:id="eco_de_0000214_12710">
      Sie sind nur auf sich selbst angewiesen im engsten Kreise. Es ist bei ihnen nichts gewachsen als sie selbst.
     </p>
-    <p xml:id="eco_de_0000144_12720">
+    <p xml:id="eco_de_0000214_12720">
      Der Mann spricht nicht von seinem Wachsprozeß. Er spricht von dem, was er geworden ist, was durch ihn wurde. Langweilig sind diese Frauenzimmer!«
     </p>
-    <p xml:id="eco_de_0000144_12730">
+    <p xml:id="eco_de_0000214_12730">
      Zu seinem Erstaunen, ja, seinem unliebsamen Erstaunen schwieg sie aber und sprach nicht von sich.
     </p>
-    <p xml:id="eco_de_0000144_12740">
+    <p xml:id="eco_de_0000214_12740">
      »Ich habe nachgesonnen,« hub sie nach einer Weile an, »wieso es kommt, daß Sie voller Gedanken sind, und wieso es kommt, daß alle, die ich kenne, und auch ich selbst, ohne Gedanken sind.«
     </p>
-    <p xml:id="eco_de_0000144_12750">
+    <p xml:id="eco_de_0000214_12750">
      »O,« sagte er, »meine liebe, schöne Mamsell, weil ihr alle das Leben nicht heiß genug liebt.«
     </p>
-    <p xml:id="eco_de_0000144_12760">
+    <p xml:id="eco_de_0000214_12760">
      »Nicht heiß genug?« fragte sie nachsinnend.
     </p>
-    <p xml:id="eco_de_0000144_12770">
+    <p xml:id="eco_de_0000214_12770">
      »Ja,« sagte er, »es ist nichts anderes. Ihr nehmt alles so kühl hin, so bürgerlich. Es kommt nicht zum Kochen, daher werden die Gedanken nicht gar.
     </p>
-    <p xml:id="eco_de_0000144_12780">
+    <p xml:id="eco_de_0000214_12780">
      Sind die Leute jung, so sind sie jung, ohne diese Wonne, diese Glut, dies herzverzehrende, selige Bewußtsein.
     </p>
-    <p xml:id="eco_de_0000144_12790">
+    <p xml:id="eco_de_0000214_12790">
      Trunken müßten sie sein voll seliger Gedanken!
     </p>
-    <p xml:id="eco_de_0000144_12800">
+    <p xml:id="eco_de_0000214_12800">
      Wär' ich ein Weib und hätte ich einen solch roten Schopf voll Haare – und solche Glieder voller Schönheit; – Herr Gott im Himmel! selig würde ich umherrennen, im vollen Bewußtsein meiner Kräfte, keine Stunde des Tages sollte verloren gehen. Ich würde die Jugend auskosten mit all' ihren Gefühlen und Gedanken, Sünden und Herrlichkeiten. – Und käme das Alter, würde ich mich auf die Erde werfen und rasen und toben und mir die Kleider zerreißen und Asche auf die Haare streuen und ersticken vor Gram.
     </p>
-    <p xml:id="eco_de_0000144_12810">
+    <p xml:id="eco_de_0000214_12810">
      Aber weil sie nichts denken und nichts wissen, können sie eine bürgerlich dumpfe Jugend führen und ein behagliches Alter. Wüßten die Menschen, was Jugend ist – nie wäre die Welt zu bezwingen. Alle Jugend würde so brausen und gären, daß kein Herrscher der Welt sie unterdrücken könnte.«
     </p>
-    <p xml:id="eco_de_0000144_12820">
+    <p xml:id="eco_de_0000214_12820">
      »So scheint die Welt fürs Denken nicht gemacht zu sein?« sagte das Mädchen ernst.
     </p>
-    <p xml:id="eco_de_0000144_12830">
+    <p xml:id="eco_de_0000214_12830">
      »Nein,« antwortete er heftig, »wenn alle dächten und nicht nur einer unter Hunderttausenden, würde sie unmöglich sein.
     </p>
-    <p xml:id="eco_de_0000144_12840">
+    <p xml:id="eco_de_0000214_12840">
      Stellen Sie sich vor, schönste Mamsell, die Weiber begännen zu denken! Nicht auszusinnen wäre das. – Prost Mahlzeit! – Die größte Revolution auf Erden bräche an, ein Vulkan verschüttete alles. – Es ist ganz recht: Denken soll bei wenigen sein. Tote, willenlose Körper sind notwendig, die mechanisch leben, mechanisch tun, was sie sollen. Ich danke für eine denkende Welt! Nein, Mamsell, bleiben wir beim alten.«
     </p>
-    <p xml:id="eco_de_0000144_12850">
+    <p xml:id="eco_de_0000214_12850">
      So waren sie miteinander durch die volle Frühlingspracht gegangen; da klang Musik.
     </p>
-    <p xml:id="eco_de_0000144_12860">
+    <p xml:id="eco_de_0000214_12860">
      »Woher?« fragte der Kupferstecher.
     </p>
-    <p xml:id="eco_de_0000144_12870">
+    <p xml:id="eco_de_0000214_12870">
      »Aus dem Rödchen,« sagte sie ganz versunken.
     </p>
-    <p xml:id="eco_de_0000144_12880">
+    <p xml:id="eco_de_0000214_12880">
      »Lassen Sie uns dahin gehen. Tanzmusik! – Ich hätte nicht übel Lust, unter Bauernvolk – – Wie wär's?«
     </p>
-    <p xml:id="eco_de_0000144_12890">
+    <p xml:id="eco_de_0000214_12890">
      »Bauernvolk ist da nicht,« sagte sie, »dort kehren die Weimaraner beim Förster ein. – Was mag denn los sein?«
     </p>
-    <p xml:id="eco_de_0000144_12900">
+    <p xml:id="eco_de_0000214_12900">
      »Werden wir ja sehen,« meinte er.
     </p>
-    <p xml:id="eco_de_0000144_12910">
+    <p xml:id="eco_de_0000214_12910">
      So gingen sie einen schmalen Weg durch dichtes Waldesdickicht. Deutlicher drang die Musik durchs Maiengrün. Und jetzt standen sie vor dem niederen Försterhaus und sahen die langen, grauen Holzbänke wohlbesetzt, und unter der Linde wurde im letzten Abendsonnenschein getanzt.
     </p>
-    <p xml:id="eco_de_0000144_12920">
+    <p xml:id="eco_de_0000214_12920">
      Beate Rauchfuß begrüßte die Förstersleute, stellte ihren Gast vor: »Herr Kupferstecher Robert Kosch.«
     </p>
-    <p xml:id="eco_de_0000144_12930">
+    <p xml:id="eco_de_0000214_12930">
      »Wer sind die denn?« fragte Herr Kosch.
     </p>
-    <p xml:id="eco_de_0000144_12940">
+    <p xml:id="eco_de_0000214_12940">
      »Eine Kegelgesellschaft, nichts weiter, 's ist doch erlaubt, da mitzutanzen?«
     </p>
-    <p xml:id="eco_de_0000144_12950">
+    <p xml:id="eco_de_0000214_12950">
      Herr Kosch führte seine schöne Wirtin auf den gedielten Tanzplatz unter der Linde, schlang seinen Arm um sie und reihte sich mit ihr den tanzenden Paaren ein.
     </p>
-    <p xml:id="eco_de_0000144_12960">
+    <p xml:id="eco_de_0000214_12960">
      Er tanzte so sonderbar, wie seine ganze Art war, leidenschaftlich, unregelmäßig und doch mit Kraft und Gewandtheit und fand ein wunderliches Sich-an-ihn-anschmiegen bei seiner Tänzerin. Sie tanzte ganz im Verständnis seiner Tanzart.
     </p>
-    <p xml:id="eco_de_0000144_12970">
+    <p xml:id="eco_de_0000214_12970">
      ›Ei verflucht!« dachte er.
     </p>
-    <p xml:id="eco_de_0000144_12980">
+    <p xml:id="eco_de_0000214_12980">
      Aber es behagte ihm. Er hatte sich bisher, wenn es einmal zum Tanzen bei ihm kam, redlich geplagt und im Tanz denselben Kampf wie im Leben gefunden, nämlich Widerstand statt Anpassung.
     </p>
-    <p xml:id="eco_de_0000144_12990">
+    <p xml:id="eco_de_0000214_12990">
      Diesmal empfand er den Tanz als ein Wohlbehagen, als eine Bejahung seiner selbst – wie ein guter, starker Wein rann es ihm durch den Körper. Er fühlte sich frei und ungehemmt, wie er sich selten fühlte, so ganz er selbst ohne Kampf.
     </p>
-    <p xml:id="eco_de_0000144_13000">
+    <p xml:id="eco_de_0000214_13000">
      Atemlos war seine Tänzerin. Ihm fehlte der Atem noch keineswegs. Jetzt – ein Schwanken, etwas Unrhythmisches, was ihn störte.
     </p>
-    <p xml:id="eco_de_0000144_13010">
+    <p xml:id="eco_de_0000214_13010">
      Seine junge Wirtin hatte ihn, erschöpft, wie sie war, aus der Reihe der Tanzenden gezogen und sank schwindelnd einem kleinen dicken Herrn fast in die Arme.
     </p>
-    <p xml:id="eco_de_0000144_13020">
+    <p xml:id="eco_de_0000214_13020">
      Der lachte auf. – »Ja, schönes Kind, ich seh' schon lange zu, wer tanzt denn auch so aus dem Vollen.«
     </p>
-    <p xml:id="eco_de_0000144_13030">
+    <p xml:id="eco_de_0000214_13030">
      Verwirrt sah der Kupferstecher seine Gefährtin werden, verwirrter, als dieser Zufall es eigentlich wohl mit sich brachte.
     </p>
-    <p xml:id="eco_de_0000144_13040">
+    <p xml:id="eco_de_0000214_13040">
      »Verzeihung,« hörte er sie sagen, »Königliche Hoheit, – Verzeihung, daß ich so ungeschickt war.«
     </p>
-    <p xml:id="eco_de_0000144_13050">
+    <p xml:id="eco_de_0000214_13050">
      ›Da hat sie Karl August fast umgestoßen,« dachte Herr Kosch.
     </p>
-    <p xml:id="eco_de_0000144_13060">
+    <p xml:id="eco_de_0000214_13060">
      Richtig, am Hause hielt die Jagdkalesche, die er aus einer Abbildung wohl kannte, und seine Augen suchten heftig weiter; da sah er in seiner nächsten Nähe einen vornehmen alten Herrn steh'n, im grauschwarzen Rock, den Hals mit blütenweißem Batist umwunden, in dem ein gelbroter Stein glühte, den Hut in der Hand, das Haar wie einen wohlfrisierten grauen Nebel um die hohe Stirn, die sich rein wie eine Tempelkuppel wölbte – und dieser Blick! Da, da war er tanzend an das Ziel seiner Reise gelangt.
     </p>
-    <p xml:id="eco_de_0000144_13070">
+    <p xml:id="eco_de_0000214_13070">
      Zu diesem aber sagte man nicht »Bruder«.
     </p>
-    <p xml:id="eco_de_0000144_13080">
+    <p xml:id="eco_de_0000214_13080">
      Er stand und starrte.
     </p>
-    <p xml:id="eco_de_0000144_13090">
+    <p xml:id="eco_de_0000214_13090">
      ›Herrgott im Himmel, welch ein Mensch! Der hatte sich sein Menschentum wie einen Thron auferbaut. Der stand einsam unter allen. Sie waren vor ihm wie fortgewischt.«
     </p>
-    <p xml:id="eco_de_0000144_13100">
+    <p xml:id="eco_de_0000214_13100">
      Der Kupferstecher sah seinen Freund, den er in einsamen Stunden so heiß begehrte, in einer ungeglaubten Entfernung vor sich stehen.
     </p>
-    <p xml:id="eco_de_0000144_13110">
+    <p xml:id="eco_de_0000214_13110">
      ›Ja, solch eine Mauer muß sich einer bauen, wenn er schaffen will und sich ausleben will, wie dieser.
     </p>
-    <p xml:id="eco_de_0000144_13120">
+    <p xml:id="eco_de_0000214_13120">
      Nein, der hat nichts bei den Elenden zu tun und zu suchen. Was für ein Plebejer bin ich,« dachte er, ›daß so etwas mir nicht in den Sinn konnte!«
     </p>
-    <p xml:id="eco_de_0000144_13130">
+    <p xml:id="eco_de_0000214_13130">
      Da sah er, wie der Fürst Beate Rauchfuß, deren Schönheit Herrn Kosch im Augenblick erschreckte – so groß und stark war sie –, lächelnd dem vornehmen alten Menschen zuführte und sagte: »Das ist ja der Rotkopf oben vom Rauchfußschen Gute, der uns als wildes Kind so manches Mal bei unseren Streifereien auf dem Ettersberge die Wege kreuzte. Solche Wunder wachsen hier oben.«
     </p>
-    <p xml:id="eco_de_0000144_13140">
+    <p xml:id="eco_de_0000214_13140">
      Das Mädchen neigte sich vor dem vornehmen Mann und küßte ehrfürchtig seine Hand.
     </p>
-    <p xml:id="eco_de_0000144_13150">
+    <p xml:id="eco_de_0000214_13150">
      Er strich ihr über den roten Haarschopf mit einer sanften Bewegung.
     </p>
-    <p xml:id="eco_de_0000144_13160">
+    <p xml:id="eco_de_0000214_13160">
      »Wohl dem, dem dieser Sonnenkopf leuchten wird. Aus den Augen strahlt Freude und Liebe.«
     </p>
-    <p xml:id="eco_de_0000144_13170">
+    <p xml:id="eco_de_0000214_13170">
      Er wendete sich zu dem fürstlichen Freund. »Welches Uebermaß von gebenden Glückseligkeiten liegt in den jungen Geschöpfen dieser Erde!«
     </p>
-    <p xml:id="eco_de_0000144_13180">
+    <p xml:id="eco_de_0000214_13180">
      »Wenn das verfluchte Abbröckeln nicht wäre!« brummte der fürstliche Herr, hob das stumpfnasige Gesicht und winkte, daß die Kalesche vorführe.
     </p>
-    <p xml:id="eco_de_0000144_13190">
+    <p xml:id="eco_de_0000214_13190">
      »Zerbröckeln, vom andern Standpunkt aus: Erbauen. Ohne Sorgen, schöner Rotkopf –, wie es auch komme.«
     </p>
-    <p xml:id="eco_de_0000144_13200">
+    <p xml:id="eco_de_0000214_13200">
      Der vornehme ruhige Mann folgte seinem Fürsten in den Wagen, und beide grüßten im Fortgehen das schöne Mädchen, das eine tiefe Verbeugung machte, die sie bei der alten Kummerfelden von Grund aus gelernt hatte. In Weimar verstand jedes Mädchen, das seine Nähstunden bei der alten Schauspielerin gehabt, seinen regelrechten Hofknix zu machen, ›denn«, sagte die prächtige Frau, ›in einer so kleinen Stadt, wo so viel fürstliche Leute und Geistesfürsten leben, muß auch auf den Straßen ein gewisses Savoir-vivre herrschen.« – Sie verstand sich auf so etwas.
     </p>
-    <p xml:id="eco_de_0000144_13210">
+    <p xml:id="eco_de_0000214_13210">
      Der Kupferstecher hatte wie betäubt gestanden; da war nun die Begegnung mit dem Bruder, dem alten Herrn, vor sich gegangen. Er selbst hatte keine Rolle dabei gespielt.
     </p>
-    <p xml:id="eco_de_0000144_13220">
+    <p xml:id="eco_de_0000214_13220">
      Er sah seine knorrigen, sehnigen Hände an. ›Das sind Hände!« dachte er. ›Um nichts zu erreichen, als eine halbwegs mögliche Jacke und Hose, vier Hemden, zwei Paar Schuhe und ein unwirtliches Loch zum Wohnen, sind sie knöchern und flachsig geworden, als hätten sie eine Welt erobert. Der andere hat eine erobert – und seine Hände sind im hohen Alter sanft geblieben, von der Seele bewegt.
     </p>
-    <p xml:id="eco_de_0000144_13230">
+    <p xml:id="eco_de_0000214_13230">
      Dem pochst du nicht an den Fensterladen, Plebejer!
     </p>
-    <p xml:id="eco_de_0000144_13240">
+    <p xml:id="eco_de_0000214_13240">
      Aber das Mädchen, das er mit den Augen küßte, dem er über das Haar fuhr. Diese kleine Gans!«
     </p>
-    <p xml:id="eco_de_0000144_13250">
+    <p xml:id="eco_de_0000214_13250">
      Er nahm seine Wirtin heftig bei der Hand: »Gehen wir, Mamsell,« sagte er, »gehen wir!«
     </p>
-    <p xml:id="eco_de_0000144_13260">
+    <p xml:id="eco_de_0000214_13260">
      Und mitten im stillen Maiengrün, unter seidenzarten Büschen, riß er die Erschreckte an sich, küßte sie und wühlte sein Gesicht ein in die rote Haarpracht, die sein »Bruder« gestreift hatte und deren junger Duft ihn betäubte.
     </p>
-    <p xml:id="eco_de_0000144_13270">
+    <p xml:id="eco_de_0000214_13270">
      »Herrgott – in deine Hände!« schluchzte er fast auf.
     </p>
-    <p xml:id="eco_de_0000144_13280">
+    <p xml:id="eco_de_0000214_13280">
      In einen solchen Sturm von heißen Zärtlichkeiten war sie unversehens und ahnungslos geraten, daß ihr der Atem verging wie bei einem Schloßenwetter; sie wehrte ihn ab und barg sich zu gleicher Zeit bei ihm.
     </p>
-    <p xml:id="eco_de_0000144_13290">
+    <p xml:id="eco_de_0000214_13290">
      »Liebst du mich denn? – Liebst du mich?« fragte sie erschüttert und zitternd.
     </p>
-    <p xml:id="eco_de_0000144_13300">
+    <p xml:id="eco_de_0000214_13300">
      »Lieben? Ja, um Herrgotts willen, so Junges, Wundervolles liebt einer, wenn, er's spürt und sieht. Was denkst du denn? – Haut und Haar maienduftend!«
     </p>
-    <p xml:id="eco_de_0000144_13310">
+    <p xml:id="eco_de_0000214_13310">
      Sie riß sich los von ihm und ging schweigend neben ihm her.
     </p>
-    <p xml:id="eco_de_0000144_13320">
+    <p xml:id="eco_de_0000214_13320">
      »Liebst du mich?« fragte sie ebenso verwirrt und erschüttert wie er. – »Kennst du mich? – Weißt du, was ich auf Erden will?«
     </p>
-    <p xml:id="eco_de_0000144_13330">
+    <p xml:id="eco_de_0000214_13330">
      »Mich!« sagte er heiß.
     </p>
-    <p xml:id="eco_de_0000144_13340">
+    <p xml:id="eco_de_0000214_13340">
      Sie wollte sprechen – sie suchte – suchte – suchte. Die Verwirrung war zu groß. »Willst du mein Freund sein?« fragte sie angstvoll.
     </p>
-    <p xml:id="eco_de_0000144_13350">
+    <p xml:id="eco_de_0000214_13350">
      »Ja – ja, gewiß,« sagte er.
     </p>
-    <p xml:id="eco_de_0000144_13360">
+    <p xml:id="eco_de_0000214_13360">
      »Willst du mich denken lehren? Ich will so lebendig werden, wie du bist.«
     </p>
-    <p xml:id="eco_de_0000144_13370">
+    <p xml:id="eco_de_0000214_13370">
      »Närrchen.«
     </p>
-    <p xml:id="eco_de_0000144_13380">
+    <p xml:id="eco_de_0000214_13380">
      Leidenschaftlich hielt sie ihn von sich ab. »Ich liebe dich, weil du anders bist als die anderen, und damit du mit mir sprichst wie mit einem Freund, wie mit einem Menschen.«
     </p>
-    <p xml:id="eco_de_0000144_13390">
+    <p xml:id="eco_de_0000214_13390">
      »Tu' ich's denn nicht?«
     </p>
-    <p xml:id="eco_de_0000144_13400">
+    <p xml:id="eco_de_0000214_13400">
      »Ich will nicht schlafend leben, hörst du!«
     </p>
-    <p xml:id="eco_de_0000144_13410">
+    <p xml:id="eco_de_0000214_13410">
      »Was für ein sonderbares Weiblein du bist. Küssen zu seiner Zeit, alles zu seiner Zeit, du junges Geschöpf.«
     </p>
-    <p xml:id="eco_de_0000144_13420">
+    <p xml:id="eco_de_0000214_13420">
      »Nach Leben verlangt mich'sl« rief sie, durchschauert von dem Unbestimmten, was sie wollte.
     </p>
-    <p xml:id="eco_de_0000144_13430">
+    <p xml:id="eco_de_0000214_13430">
      »Nach Leben? – Liebe ist Leben.«
     </p>
-    <p xml:id="eco_de_0000144_13440">
+    <p xml:id="eco_de_0000214_13440">
      »Nein, nein!« sagte sie. »Verstehen ist Leben. Wenn ich mein Leben an deines hänge, will ich lebendig werden und nicht tot und stumm, wie meine Mutter war.«
     </p>
-    <p xml:id="eco_de_0000144_13450">
+    <p xml:id="eco_de_0000214_13450">
      »Du denkst dir das sehr komisch. Glaubst du denn, man kann das Denken lernen wie irgendeine andere Sache? Ich sage dir, liebe das Leben, so heiß du kannst. Ich will schon sorgen, daß du's lieben sollst.«
     </p>
-    <p xml:id="eco_de_0000144_13460">
+    <p xml:id="eco_de_0000214_13460">
      »Ich möchte nicht weggeworfen werden,« sagte sie herb, »wenn du findest, daß ich nicht mehr schön bin. Ich lauf' dir davon, wenn du mich täuschest und mein Freund nicht bist.«
     </p>
-    <p xml:id="eco_de_0000144_13470">
+    <p xml:id="eco_de_0000214_13470">
      »Recht so,« sagte er lachend.
     </p>
-    <p xml:id="eco_de_0000144_13480">
+    <p xml:id="eco_de_0000214_13480">
      So gingen sie nebeneinander her, und er hielt den Arm fest und schwer um sie geschlungen.
     </p>
-    <p xml:id="eco_de_0000144_13490">
+    <p xml:id="eco_de_0000214_13490">
      »Du gehst gebunden«, sagte er, »freier und seliger als ungebunden. Alles ist so nicht, wie es uns scheint? Du siehst irgendeinen Gedanken oder ein Gefühl und glaubst, es ist so ureinfach und beschränkt wie ein Punkt. Du trittst näher, und es wächst, wird ein Garten mit Wegen und Irrgängen. Du gehst darin umher und staunst. Da wird er dir unter den Füßen und vor den Augen zu einer Wildnis mit Abgründen und Undurchdringlichkeiten. Zu einer Welt wird diese Wildnis, die du nie überschauen und nie durchwandern kannst. Alles umschließt diese Welt, alles und jedes.
     </p>
-    <p xml:id="eco_de_0000144_13500">
+    <p xml:id="eco_de_0000214_13500">
      Es ist viel behaglicher, so glattweg die Dinge zu nehmen, wie sie den Leuten vorkommen, als Gedankenblöcke zu wälzen.
     </p>
-    <p xml:id="eco_de_0000144_13510">
+    <p xml:id="eco_de_0000214_13510">
      Denken ist wie Trinken – das gewöhnt sich einer leicht an, wenn ihn irgendwo der Schuh drückt.
     </p>
-    <p xml:id="eco_de_0000144_13520">
+    <p xml:id="eco_de_0000214_13520">
      Und was hat er davon? Einen unaufhörlichen Kampf mit den Katzenjammern.
     </p>
-    <p xml:id="eco_de_0000144_13530">
+    <p xml:id="eco_de_0000214_13530">
      Er muß ein Held werden.
     </p>
-    <p xml:id="eco_de_0000144_13540">
+    <p xml:id="eco_de_0000214_13540">
      »Würdest du dir das Trinken angewöhnen wollen?« fragte der Kupferstecher.
     </p>
-    <p xml:id="eco_de_0000144_13550">
+    <p xml:id="eco_de_0000214_13550">
      »Ich denke nicht,« lachte sie.
     </p>
-    <p xml:id="eco_de_0000144_13560">
+    <p xml:id="eco_de_0000214_13560">
      »Gerade so wenig das Denken. Diese Katzenjammer sind für ein Weib noch beschwerlicher, da muß einer frei sein – frei, wie ein Mannsbild es ist, ohne Kind und Kegel und ohne Ach und Weh. Er muß sich hinfläzen können in seinem großen Elend.«
     </p>
-    <p xml:id="eco_de_0000144_13570">
+    <p xml:id="eco_de_0000214_13570">
      Sie sah ihn fremd und staunend an.
     </p>
-    <p xml:id="eco_de_0000144_13580">
+    <p xml:id="eco_de_0000214_13580">
      »Siehst du,« sagte er, »jetzt rollst du kleine, weiche, zarte Frühlingswelt neben einer ausgeglühten, felsigen, starren, steinharten Winterwelt im Raum dahin. Ei verflucht – werden die Leute sagen, was tun die miteinander? Die hübsche Frühlingswelt wird verbrannt und zerdrückt werden – das sieht man kommen.«
     </p>
-    <p xml:id="eco_de_0000144_13590">
+    <p xml:id="eco_de_0000214_13590">
      »Mag sie es werden!« antwortete das junge Geschöpf ruhig und fest. »Wir verbrennen ja alle,« – und er spürte wieder den Maienduft der Frühlingswelt, der ihm, dem unverwöhnten Mann, die Sinne verwirrte.
     </p>
-    <p xml:id="eco_de_0000144_13600">
+    <p xml:id="eco_de_0000214_13600">
      Sie war zu schönheitsvoll für ihn, zu hingebend, zu weicher Seele voll und zu sehnsüchtigen Herzens.
     </p>
-    <p xml:id="eco_de_0000144_13610">
+    <p xml:id="eco_de_0000214_13610">
      Es hätte etwas Kargeres für ihn besser getan.
     </p>
-    <p xml:id="eco_de_0000144_13620">
+    <p xml:id="eco_de_0000214_13620">
      Ueberfluß, der ihn bedrängte.
     </p>
-    <p xml:id="eco_de_0000144_13630">
+    <p xml:id="eco_de_0000214_13630">
      Seine Asketenkammer stand ihm vor der Seele, sein Lager aus ein paar wollenen Decken und Fetzen, ein rechtes Wolfslager, sein Arbeitstisch, der ganze Raum, die trüben Fenster, seine Bedrücktheit, wenn er ein paar Goldstücke bei sich im Kasten wußte und sich, davon beladen, verbürgerlicht erschien – ein Protz.
     </p>
-    <p xml:id="eco_de_0000144_13640">
+    <p xml:id="eco_de_0000214_13640">
      Die karge Beute erjagen mit großen Mühen, war ihm Bedürfnis geworden. Die Wohlhabenheit, der er jetzt entgegenging, beängstigte ihn. Was würde diese aus ihm machen und er aus ihr?
     </p>
-    <p xml:id="eco_de_0000144_13650">
+    <p xml:id="eco_de_0000214_13650">
      Er kannte nur die paar Pflichten für sich selbst, und die waren ihm zuviel. Nun rollte so eine kleine Frühlingswelt daher und bewegte sich in seinem Dunstkreis um ihn her. Herrgott noch einmal, da galt es, aufzupassen.
     </p>
-    <p xml:id="eco_de_0000144_13660">
+    <p xml:id="eco_de_0000214_13660">
      Das war keine einfache Geschichte mehr.
     </p>
-    <p xml:id="eco_de_0000144_13670">
+    <p xml:id="eco_de_0000214_13670">
      Tiefbewegt kamen sie beide auf dem Rauchfußschen Gute an und fanden allerhand Gäste vor. Die Kirstensmädchen mit ihren Freunden, Frau Mariannes Kostgänger mit ihrer kleinen Freßmadame und auch einige der Junggesellen.
     </p>
-    <p xml:id="eco_de_0000144_13680">
+    <p xml:id="eco_de_0000214_13680">
      Diesen war der hergeschneite Gast nicht unbedenklich erschienen.
     </p>
-    <p xml:id="eco_de_0000144_13690">
+    <p xml:id="eco_de_0000214_13690">
      Sie kamen, um einmal nachzuschauen, und fanden die Vielumworbene rosig und wie in Freude getaucht.
     </p>
-    <p xml:id="eco_de_0000144_13700">
+    <p xml:id="eco_de_0000214_13700">
      Sie begrüßte alle wärmer als sonst. Jeder kam sich besonders bewillkommnet vor.
     </p>
-    <p xml:id="eco_de_0000144_13710">
+    <p xml:id="eco_de_0000214_13710">
      Der Gast stand eckig hager in seiner grauen Montur, in der er wie ein Hecht aus den Fluten aufgetaucht war, und schaute scheinbar mißlaunig auf das Treiben und Kommen, Gehen, Schwatzen und Lachen.
     </p>
-    <p xml:id="eco_de_0000144_13720">
+    <p xml:id="eco_de_0000214_13720">
      »Ausgerichtet hat der hier nichts, so 'n Gestell,« sagte einer der Kostgänger.
     </p>
-    <p xml:id="eco_de_0000144_13730">
+    <p xml:id="eco_de_0000214_13730">
      Der Kostgänger selbst war durch Frau Mariannens Fürsorge vorzüglich instand gehalten. Einen von beiden fütterte sie dennoch für sich, das war bei ihr ausgemachte Sache. Einen würde sie auf alle Fälle zu trösten haben.
     </p>
-    <p xml:id="eco_de_0000144_13740">
+    <p xml:id="eco_de_0000214_13740">
      Die Rabenmutter brummte, daß sie heut' abend schon wieder alle zum Abendessen versorgen sollte; aber der Tisch unter der Linde wurde gedeckt, und der alte Sperber, der einmal zuschauen kam, verkündete, daß er eine Bowle stiften werde.
     </p>
-    <p xml:id="eco_de_0000144_13750">
+    <p xml:id="eco_de_0000214_13750">
      Die Kirstensmädchen und die Kameraden holten den Wein vom Sperberschen Gut und brauten dann andächtig und eifrig, und während das Gebräu seinen Duft mit dem Duft des jungen Laubes und des blühenden Flieders mischte, wurde die Stimmung eine gar festliche.
     </p>
-    <p xml:id="eco_de_0000144_13760">
+    <p xml:id="eco_de_0000214_13760">
      Die Mädchen begannen zu nippen und zu lachen, die jungen Leute wurden aufgeräumter, der alte Sperber hielt seine beiden lebensfrohen Hände um das Glas gelegt, als wollte er die zarte goldne Flut liebkosen. Der Kupferstecher trank nicht wie in Feststimmung, sondern in der gemessenen, aber nicht unausgiebigen Weise, wie er es daheim an seinem Stammtisch gewohnt war. Es war ihm nichts so Außerordentliches, wie es den bescheidenen Gästen hier oben war.
     </p>
-    <p xml:id="eco_de_0000144_13770">
+    <p xml:id="eco_de_0000214_13770">
      Sperbers wie auch die Weimaraner waren allabendlich gewohnt, den braven Hausmuff zu trinken, der im offenen Eimer aus dem Rathaus geholt und auf Flaschen gefüllt wurde.
     </p>
-    <p xml:id="eco_de_0000144_13780">
+    <p xml:id="eco_de_0000214_13780">
      Es waren genügsame Leute.
     </p>
-    <p xml:id="eco_de_0000144_13790">
+    <p xml:id="eco_de_0000214_13790">
      Der Kupferstecher hielt sein Glas in der Hand und schaute darauf hin.
     </p>
-    <p xml:id="eco_de_0000144_13800">
+    <p xml:id="eco_de_0000214_13800">
      »Auf meinem Wege hier ins gelobte Land«, sagte er, »saß ich in einem Dorfwirtshause und trank das schlechte Bier, das sie dort hatten. Da kam ein altes, elendes Weib, verdorrt von Alter und Mühsal, rührte mich an der Schulter und sagte:
     </p>
-    <p xml:id="eco_de_0000144_13810">
+    <p xml:id="eco_de_0000214_13810">
      ›Laßt mich 'nen Schluck trinken, um Christi willen!«
     </p>
-    <p xml:id="eco_de_0000144_13820">
+    <p xml:id="eco_de_0000214_13820">
      ›Hier, alter Saufaus!«
     </p>
-    <p xml:id="eco_de_0000144_13830">
+    <p xml:id="eco_de_0000214_13830">
      Und ich gab ihr mein Glas.
     </p>
-    <p xml:id="eco_de_0000144_13840">
+    <p xml:id="eco_de_0000214_13840">
      Sie setzte an und trank es bis auf den letzten Tropfen, schaute mich mit ihren alten, großen Augen an und sagte: ›Das soll mir jetzt Ihr Leidenskelch gewesen sein.««
     </p>
-    <p xml:id="eco_de_0000144_13850">
+    <p xml:id="eco_de_0000214_13850">
      Der Kupferstecher schwieg – die anderen schauten.
     </p>
-    <p xml:id="eco_de_0000144_13860">
+    <p xml:id="eco_de_0000214_13860">
      »Hut ab davor!« sagte er und brach wie in sich zusammen.
     </p>
-    <p xml:id="eco_de_0000144_13870">
+    <p xml:id="eco_de_0000214_13870">
      »Das war das größte Liebeswort, das ich mein Lebtag hörte! – Amen.«
     </p>
-    <p xml:id="eco_de_0000144_13880">
+    <p xml:id="eco_de_0000214_13880">
      Die jungen Leute lachten.
     </p>
-    <p xml:id="eco_de_0000144_13890">
+    <p xml:id="eco_de_0000214_13890">
      Der alte Sperber liebkoste sein Glas und blickte schelmisch auf den Zugelaufenen.
     </p>
-    <p xml:id="eco_de_0000144_13900">
+    <p xml:id="eco_de_0000214_13900">
      Der Kupferstecher aber antwortete: »Alle Kirchenglocken hätten läuten müssen, als das alte Weib sagte: »Das soll mir jetzt Ihr Leidenskelch gewesen sein.« Aus den Häusern müßten die Leute stürzen, zu sehen, was es gäbe. Hosianna sollten sie rufen. Verseht keiner diese unergründliche Tiefe solcher Armut und Güte?
     </p>
-    <p xml:id="eco_de_0000144_13910">
+    <p xml:id="eco_de_0000214_13910">
      Ich fiel auf die Knie vor der Alten, küßte ihren verschleppten Kleidersaum –, und sie – spie mir ins Gesicht – Amen.
     </p>
-    <p xml:id="eco_de_0000144_13920">
+    <p xml:id="eco_de_0000214_13920">
      Das heißt: Keiner weiß, was er hier redet und tut, nicht im höchsten Sinne, nicht im niedersten.
     </p>
-    <p xml:id="eco_de_0000144_13930">
+    <p xml:id="eco_de_0000214_13930">
      Sie sprechen Dinge aus wie Götter und verstehen nichts davon.
     </p>
-    <p xml:id="eco_de_0000144_13940">
+    <p xml:id="eco_de_0000214_13940">
      Sie sind wütend aufeinander und wissen nicht, weshalb.
     </p>
-    <p xml:id="eco_de_0000144_13950">
+    <p xml:id="eco_de_0000214_13950">
      Eine Welt des Schlafes! – Prosit!« Damit hob er sein Glas.
     </p>
-    <p xml:id="eco_de_0000144_13960">
+    <p xml:id="eco_de_0000214_13960">
      »'n rechter Narr,« flüsterte ärgerlich Herr Sperber seinem Nachbar zu. »Kann er denn nicht reden wie andere Leute auch?«
     </p>
-    <p xml:id="eco_de_0000144_13970">
+    <p xml:id="eco_de_0000214_13970">
      ›Ein verrücktes Tier!« stand in aller Blicken.
     </p>
-    <p xml:id="eco_de_0000144_13980">
+    <p xml:id="eco_de_0000214_13980">
      Das trieb der Wirtin des Zugelaufenen alles Blut in die Wangen. Eine heiße, schützende Liebe faßte sie für ihn; eine warme, gute, unverlöschbare Flamme schlug aus ihrem Herzen auf. Ihr war, als könnte ihre junge Seele in der seinen untertauchen und voll Lebenskraft und Reichtum wieder auftauchen.
     </p>
-    <p xml:id="eco_de_0000144_13990">
+    <p xml:id="eco_de_0000214_13990">
      Offenbarung war er für sie. Ihr schien, als rettete sie sich aus einer dunklen, stummen Welt zu ihm ins Licht.
     </p>
-    <p xml:id="eco_de_0000144_14000">
+    <p xml:id="eco_de_0000214_14000">
      Nicht allzulange währte es, da merkten die Freier, daß der fremde Kupferstecher dabei war, ihnen das schöne, wohlhabende Mädchen vor der Nase wegzuschnappen.
     </p>
-    <p xml:id="eco_de_0000144_14010">
+    <p xml:id="eco_de_0000214_14010">
      Auch Herrn Sperber schien es nicht recht geheuer, und Herr Kosch bekam einen schweren Stand. Die Mannsbilder stichelten auf ihn und wollten ihn lächerlich machen.
     </p>
-    <p xml:id="eco_de_0000144_14020">
+    <p xml:id="eco_de_0000214_14020">
      Er hielt wacker stand, gab gute, tüchtige Gegenrede. Er war das vom Stammtisch her gewöhnt und tat's anfangs in aller Gemütsruhe; aber schließlich war er der Mann, der nicht hören konnte, daß seiner Ansicht entgegen die Pferde kluge Tiere sein sollten.
     </p>
-    <p xml:id="eco_de_0000144_14030">
+    <p xml:id="eco_de_0000214_14030">
      So goß er auf seinen Jähzorn ziemlich von der vortrefflichen Bowle, trotzdem er wußte, daß das ein gefährliches Unternehmen war.
     </p>
-    <p xml:id="eco_de_0000144_14040">
+    <p xml:id="eco_de_0000214_14040">
      »Herr Kupferstecher Kosch, was sagten Sie eben, erlauben Sie mal?« fragte der Hofmann verschmitzt höflich. »Wie sagten Sie? – Alle diese Spinathühner, die um Seine Exzellenz herumscharwenzeln? Spinathühner, dächt' ich, sagten Sie?«
     </p>
-    <p xml:id="eco_de_0000144_14050">
+    <p xml:id="eco_de_0000214_14050">
      »Ja,« meinte der Kupferstecher borstig. »Spinathühner! – Das kratzt um ihn herum, stell' ich mir vor, daß es nicht schön ist. Spinathühner und Spinathähne.«
     </p>
-    <p xml:id="eco_de_0000144_14060">
+    <p xml:id="eco_de_0000214_14060">
      »O,« sagte der Hofmann geflissentlich, »machen Sie sich, verehrter Herr, sonderbare Vorstellungen von unserer Gesellschaft!«
     </p>
-    <p xml:id="eco_de_0000144_14070">
+    <p xml:id="eco_de_0000214_14070">
      »Gesellschaft!« höhnte der Zugelaufene. »Zweibeiner eben, wie sie überall umherlaufen, gackerndes, krähendes Volk. – Und da ist nun einmal eines auf dem großen Hühnerhof als Halbgott ausgekrochen. Herrgott, muß der Kerl sich langweilen. Schwarz muß er werden!«
     </p>
-    <p xml:id="eco_de_0000144_14080">
+    <p xml:id="eco_de_0000214_14080">
      »Nun, und wie steht's mit Ihnen, Herr Spinathahn?« fragte der Sperbersche Neffe und hob sein Glas: »Prost!«
     </p>
-    <p xml:id="eco_de_0000144_14090">
+    <p xml:id="eco_de_0000214_14090">
      »Prost!« sagte Herr Kosch und bog sich merkwürdig zu ihm herüber und fixierte den Neffen mit unsicher schillerndem Blick. Es war, als wenn dieser in sich fest gefaßten Gestalt die Augen nicht so recht gehorchten.
     </p>
-    <p xml:id="eco_de_0000144_14100">
+    <p xml:id="eco_de_0000214_14100">
      »Spinathahn? – Spinathahn? – Spinathahn? – Herr, ich komme aus den schillernden Untiefen – aus den Trichtern dieser Erde aufgestiegen. Ihr meint, es ist zu Ende da, wo ihr geht? Ihr meint, unter euren Füßen regt sich nichts? – Das Künkelin, das Karnickel gräbt aber unbillig tief – schürft unbillig tief. Nun – nun, Spinathuhn – Hahn – Huhn, bin ich nicht – gewiß nicht.« Damit schüttelte er seine harte, flächsige Hand. – »Nee, nee.«
     </p>
-    <p xml:id="eco_de_0000144_14110">
+    <p xml:id="eco_de_0000214_14110">
      »Der Kerl ist besoffen,« murmelte Herr Sperber. Er hielt nicht mehr die klare Flut seines Glases wie liebkosend umschlossen, sondern blickte auf seines alten Freundes Tochter und sah, wie diese bleich, mit großen weiten Augen angstvoll an jeder Bewegung des Zugelaufenen hing.
     </p>
-    <p xml:id="eco_de_0000144_14120">
+    <p xml:id="eco_de_0000214_14120">
      Der alte Sperber erhob sich, trat sachte hinter ihren Stuhl, rührte sie an der Schulter und sagte: »Den Esel bring' ich dir gleich fort, nur ruhig, Badewännchen.«
     </p>
-    <p xml:id="eco_de_0000144_14130">
+    <p xml:id="eco_de_0000214_14130">
      Da traf ihn aber ein Blick voller Empörung und doch unsicher, wie nach Hilfe suchend.
     </p>
-    <p xml:id="eco_de_0000144_14140">
+    <p xml:id="eco_de_0000214_14140">
      »Hör' mal, Kind, komm' mit mir durch den Garten.« sagte der alte Herr jovial und treuherzig.
     </p>
-    <p xml:id="eco_de_0000144_14150">
+    <p xml:id="eco_de_0000214_14150">
      Sie schüttelte den Kopf, und ihre Blicke hingen wieder an dem Kupferstecher.
     </p>
-    <p xml:id="eco_de_0000144_14160">
+    <p xml:id="eco_de_0000214_14160">
      »Ein Mann,« sagte der soeben zu seinem Nachbar, dem Sperberschen Neffen, »dem man auch nur das Leiseste anmerkt in Gang und Haltung und Ausdruck, daß er zuviel des Guten tat – ist eine Memme! – Im Manne tobt eine Welt. Der Mikrokosmus ist im Aufruhr! Stürme wüten im Hirn – ein Weltbrand! Er steht unbewegt, ein Gott im Aufruhr! Was meinen Sie? Das ist die höchste Selbstbezwingung, die Urmännlichkeit, der Kampf und Sieg sondergleichen!«
     </p>
-    <p xml:id="eco_de_0000144_14170">
+    <p xml:id="eco_de_0000214_14170">
      »'n Schwipps, 'n Affe – no, ich sag' ja nichts dagegen, kann mal vorkommen; aber«, meinte der Neffe sehr ruhig, »Ihre Auffassung scheint mir doch sehr grandios.«
     </p>
-    <p xml:id="eco_de_0000144_14180">
+    <p xml:id="eco_de_0000214_14180">
      »Oho!« Der Kupferstecher reckte sich und dehnte sich, rang sich wie aus sich selbst heraus und blickte herausfordernd über den Tisch.
     </p>
-    <p xml:id="eco_de_0000144_14190">
+    <p xml:id="eco_de_0000214_14190">
      Sein Blick streifte das schöne Mädchen, das ihm sein gutes Herz geschenkt. Er gewahrte ihre tiefe Blässe, die Augen, die in Verzweiflung schauten.
     </p>
-    <p xml:id="eco_de_0000144_14200">
+    <p xml:id="eco_de_0000214_14200">
      ›Gott steh' mir bei, die schöne Seele!« fuhr es Herrn Kosch durch den Kopf, ›'s ist doch kein Lot Kraft und Saft in so'n Frauenzimmer. Wasch' mich, aber mach' mich nicht naß! Die will nun 'nen Kerl mit Spiritus, aber das Auffüllen kann sie nun wieder nicht vertragen. – Ja, so!« –
     </p>
-    <p xml:id="eco_de_0000144_14210">
+    <p xml:id="eco_de_0000214_14210">
      Da nahm er sich gewaltig zusammen und schwieg fortan.
     </p>
-    <p xml:id="eco_de_0000144_14220">
+    <p xml:id="eco_de_0000214_14220">
      Die junge Wirtin erhob sich jetzt, und mit ihr die Gäste. Die letzte halbe Stunde an der ländlichen Tafel unter der Linde war schwül gewesen. Der alte Rauchfuß ging um vor manchem Auge und schüttelte dem Kupferstecher verständnisvoll die Hand, weil der ihm aus dem Herzen sprach und bei weitem schwungvoller, als er es je gekonnt hatte.
     </p>
-    <p xml:id="eco_de_0000144_14230">
+    <p xml:id="eco_de_0000214_14230">
      Der Kupferstecher trat jetzt zu seiner Wirtin und sagte etwas undeutlich: »Und richtet über die Lebendigen und die Toten. – In Gottes Namen also, gute Nacht – so reise ich morgen.«
     </p>
-    <p xml:id="eco_de_0000144_14240">
+    <p xml:id="eco_de_0000214_14240">
      Da sah sie ihn mit sterbensbangen Augen an, sprach kein Wort, aber hielt ihn mit ihren Blicken.
     </p>
-    <p xml:id="eco_de_0000144_14250">
+    <p xml:id="eco_de_0000214_14250">
      Er schwieg und schaute vor sich hin. Zu spüren war, daß er sich innerlich und äußerlich zusammenraffte.
     </p>
-    <p xml:id="eco_de_0000144_14260">
+    <p xml:id="eco_de_0000214_14260">
      »Ich bin, der ich bin,« sagte er. »Zu deuten ist ja nichts. – Was so gewachsen ist,« – er hielt seine sehnigen Fäuste vor sich hin – »ist so gewachsen. – Leb' wohl! – Deine Küsse, Königinnenküsse! – Behüt dich Gott!«
     </p>
-    <p xml:id="eco_de_0000144_14270">
+    <p xml:id="eco_de_0000214_14270">
      »Bleib'« – sagte sie, »bleib'!« Ihre Züge aber erblaßten, sie schwankte, ihr Kopf sank an den Lindenstamm. Herr Kosch fing sie in seinen Armen auf. Die Windlichter auf dem Tisch warfen ihren gelben Schein.
     </p>
-    <p xml:id="eco_de_0000144_14280">
+    <p xml:id="eco_de_0000214_14280">
      Herr Sperber und einige noch sahen das Mädchen in den Armen des Zugelaufenen ruhen.
     </p>
-    <p xml:id="eco_de_0000144_14290">
+    <p xml:id="eco_de_0000214_14290">
      »Herr, du mein Gott!« So schnell es seine kurzen Beinchen gestatteten, war er zur Stelle. »Ja, was denn?« rief er. »Was ist denn?«
     </p>
-    <p xml:id="eco_de_0000144_14300">
+    <p xml:id="eco_de_0000214_14300">
      »Meiner Braut«, sagte Herr Kosch ernst, »scheint es nicht wohl zumute.«
     </p>
-    <p xml:id="eco_de_0000144_14310">
+    <p xml:id="eco_de_0000214_14310">
      »Ihrer Braut?« rief Herr Sperber. »Das ist ja aber – aber … ›ganz entsetzlich« wollte er sagen, besann sich, schaute nur mit Blicken, die keinen Zweifel aufkommen ließen, und nahm das Mädchen ohne alle Umstände in seine festen Arme.
     </p>
-    <p xml:id="eco_de_0000144_14320">
+    <p xml:id="eco_de_0000214_14320">
      Da schlug sie die Augen auf und sagte leise, als sie das freundliche, aber erschreckte Gesicht ihres alten Sperber über sich sah: »Ich liebe ihn über alles auf Erden.«
     </p>
-    <p xml:id="eco_de_0000144_14330">
+    <p xml:id="eco_de_0000214_14330">
      Der Kupferstecher nahm ihre beiden Hände und küßte sie.
     </p>
-    <p xml:id="eco_de_0000144_14340">
+    <p xml:id="eco_de_0000214_14340">
      »Geh',« sagte sie, »ich will allein sein. Du versprachst mir, mein Freund zu sein. So lebendig will ich werden, wie du bist. Das ist, was du verstehen mußt.«
     </p>
-    <p xml:id="eco_de_0000144_14350">
+    <p xml:id="eco_de_0000214_14350">
      »Gute Nacht.«
     </p>
-    <p xml:id="eco_de_0000144_14360">
+    <p xml:id="eco_de_0000214_14360">
      Er küßte ihr wieder die Hand, grüßte Herrn Sperber. »Ich gehe,« sagte er, und so ging er hocherhobenen Hauptes, wie Herr Rauchfuß einst gegangen, wenn er der Welt beweisen wollte, daß er ein ganzer Mann war.
     </p>
-    <p xml:id="eco_de_0000144_14370">
+    <p xml:id="eco_de_0000214_14370">
      In heißen Tränen blieb das Mädchen zurück. Herr Sperber führte sie an die verlassene Tafel und setzte sich neben sie. Die Resttropfen in den Gläsern dufteten herb.
     </p>
-    <p xml:id="eco_de_0000144_14380">
+    <p xml:id="eco_de_0000214_14380">
      Die zwei Lichter schufen eine kleine weiße Insel mitten in der Dunkelheit, in der Gestalten auf und nieder gingen in erregten Gesprächen.
     </p>
-    <p xml:id="eco_de_0000144_14390">
+    <p xml:id="eco_de_0000214_14390">
      Dem Mädchen rannen unaufhaltsam Tränen über die Wangen.
     </p>
-    <p xml:id="eco_de_0000144_14400">
+    <p xml:id="eco_de_0000214_14400">
      »Badewännchen,« sagte Herr Sperber, »was hast du angestellt! – Den wildfremden Menschen! Seid ihr Frauenzimmer denn ganz verrückt? Seit einem Jahr läuft alles, was Beine hat und reputierlich ist, zu dir herauf – und du? – Ein Mann, wie unser Neffe! – Kind! – So schlicht und ruhig – rein und gut; – der macht eine Frau glücklich.«
     </p>
-    <p xml:id="eco_de_0000144_14410">
+    <p xml:id="eco_de_0000214_14410">
      »Laß! – Laß!« sagte sie.
     </p>
-    <p xml:id="eco_de_0000144_14420">
+    <p xml:id="eco_de_0000214_14420">
      Sie saßen stumm beieinander.
     </p>
-    <p xml:id="eco_de_0000144_14430">
+    <p xml:id="eco_de_0000214_14430">
      »Braucht noch niemand zu wissen; komm, Kind, gehen wir zu den anderen.«
     </p>
-    <p xml:id="eco_de_0000144_14440">
+    <p xml:id="eco_de_0000214_14440">
      Willenlos folgte sie, nahm wie im Traum Abschied von ihren Gästen. Die Freier gingen in tiefer, stummer Erregung.
     </p>
-    <p xml:id="eco_de_0000144_14450">
+    <p xml:id="eco_de_0000214_14450">
      Die Kirstensmädchen küßten ihre Freundin herzlich auf die Wangen, und die Kameraden drückten ihr die Hand.
     </p>
-    <p xml:id="eco_de_0000144_14460">
+    <p xml:id="eco_de_0000214_14460">
      »Um Gottes willen, Kind,« rief die Rabenmutter, als der letzte gegangen war, »bist du denn ganz des Kuckucks?«
     </p>
-    <p xml:id="eco_de_0000144_14470">
+    <p xml:id="eco_de_0000214_14470">
      »Lassen Sie sie,« sagte Herr Sperber, »wir brauchen niemand. Gehen Sie schlafen. Ich bleib' bei unserem Kind. Laßt uns allein!«
     </p>
-    <p xml:id="eco_de_0000144_14480">
+    <p xml:id="eco_de_0000214_14480">
      Und sie blieben allein.
     </p>
-    <p xml:id="eco_de_0000144_14490">
+    <p xml:id="eco_de_0000214_14490">
      Sie gingen miteinander in das Wohnzimmer. Herr Sperber hatte eines der großen Windlichter mit hinauf genommen.
     </p>
-    <p xml:id="eco_de_0000144_14500">
+    <p xml:id="eco_de_0000214_14500">
      »Nun sag' mir, Kind, wie ist das alles gekommen?«
     </p>
-    <p xml:id="eco_de_0000144_14510">
+    <p xml:id="eco_de_0000214_14510">
      Sie kniete vor dem kleinen, kurzen Herrn, der in Rittmeister Rauchfußens Lehnstuhl sorgenvoll saß, und wieder quollen heiße, heiße Tränen.
     </p>
-    <p xml:id="eco_de_0000144_14520">
+    <p xml:id="eco_de_0000214_14520">
      »Die Nacht wissen wir noch, als dein armer Vater starb und wir hier miteinander saßen und auf den letzten Atemzug warteten. Nicht wahr, Kind?«
     </p>
-    <p xml:id="eco_de_0000144_14530">
+    <p xml:id="eco_de_0000214_14530">
      Das Mädchen nickte.
     </p>
-    <p xml:id="eco_de_0000144_14540">
+    <p xml:id="eco_de_0000214_14540">
      »Weißt du, daß Herr Kosch nicht übel Lust hat, sich das Trinken anzugewöhnen?«
     </p>
-    <p xml:id="eco_de_0000144_14550">
+    <p xml:id="eco_de_0000214_14550">
      Sie nickte. Ihre Augen blickten starr vor Angst und Qual.
     </p>
-    <p xml:id="eco_de_0000144_14560">
+    <p xml:id="eco_de_0000214_14560">
      »Na, und trotzdem?
     </p>
-    <p xml:id="eco_de_0000144_14570">
+    <p xml:id="eco_de_0000214_14570">
      Sag' mal, ist das notwendig, daß ein Frauenzimmer ganz vernunftlos ist? Glaubst du, daß du ihn hindern kannst, wenn er Trinker werden will?«
     </p>
-    <p xml:id="eco_de_0000144_14580">
+    <p xml:id="eco_de_0000214_14580">
      »Nein,« sagte sie.
     </p>
-    <p xml:id="eco_de_0000144_14590">
+    <p xml:id="eco_de_0000214_14590">
      »Und was ist denn das, altes Mägen, was sagtest du denn da? Lebendig willst du werden, wie er ist? Und dein Freund soll er sein? – Was ist denn das? – Siehst du, ich leg' mir da so was zurecht. – Du mußt wissen, deine Mutter war auch so 'ne kleene überspannte Seele, so gut und lieb sie war
     </p>
-    <p xml:id="eco_de_0000144_14600">
+    <p xml:id="eco_de_0000214_14600">
      Sieh' dir mal meine Alte an und auch die alte Kummerfelden. Alle Frauenzimmer von besserer Art haben in ihrer Jugend so ihre Flausen gehabt. Siehst du, aber anders lernen die Weiber denken, als die Männer. Die Männer kommen früher dazu, man lehrt es sie. Siehst du, ich sag' dir es so, wie ich's meine. Sie gehen mehr in die Schule, sie lernen ihr Gewerbe. Sie müssen ihren Mann stellen. Da wird ihnen gar manches künstlich beigebracht. Es geht nicht so ganz natürlich zu; aber immerhin, es muß sein.
     </p>
-    <p xml:id="eco_de_0000144_14610">
+    <p xml:id="eco_de_0000214_14610">
      Eine Generation sagt der anderen ihre Gedanken. Wie eine Lawine wälzen sich die Gedanken über die Mannsbilder her, alles, was je gedacht ist.
     </p>
-    <p xml:id="eco_de_0000144_14620">
+    <p xml:id="eco_de_0000214_14620">
      Oder, wenn du mich besser verstehst, alles bekommen sie vorgekaut.
     </p>
-    <p xml:id="eco_de_0000144_14630">
+    <p xml:id="eco_de_0000214_14630">
      Ihr Weiber aber lernt anders denken. In der ersten Jugend läßt euch das Leben ruhig, spannt euch nicht zu sehr an. Dann aber lehrt euch das Leben selbst denken. Die Gedankenlawine wälzt sich nicht über euch. Es wird euch auch nichts vorgekaut. Aus euch selbst wachsen die Gedanken und das Verstehen des Lebens.
     </p>
-    <p xml:id="eco_de_0000144_14640">
+    <p xml:id="eco_de_0000214_14640">
      Sieh dir meine Alte an und die Kummerfelden. Hut ab! vor diesen lieben, alten Frauen. Einfach denken sie über die Dinge; aber da ist nichts Fremdes, nichts Gelerntes. Es ist alles ihr Eigentum, ihr schwer errungenes Eigentum. Wir Männer sind selten so ganz natürlich wie sie, so ganz durchdrungen und so einfach. Wir haben viel Fremdes, Totes in uns. Ich rede nicht von mir, ich bin auch so ein alter Kauz, so ein einfacher Mann. Aber weißt du, dumm ist der alte Sperber deshalb nicht. Glaubst du, er kennt dich nicht? – – O je!
     </p>
-    <p xml:id="eco_de_0000144_14650">
+    <p xml:id="eco_de_0000214_14650">
      Wenn einer in dich verliebt ist, ist er nichts weniger als dein Freund. Er kann dein Freund einst werden, wenn die Verliebtheit sich gelegt hat; aber noch ist er nicht dein Freund. Das mußt du dir verdienen!
     </p>
-    <p xml:id="eco_de_0000144_14660">
+    <p xml:id="eco_de_0000214_14660">
      Das ist des Lebens höchstes Gut; das fällt niemand in den Schoß. Ja, du kannst es dir nicht einmal verdienen, so wenig wie das große Los.
     </p>
-    <p xml:id="eco_de_0000144_14670">
+    <p xml:id="eco_de_0000214_14670">
      Siehst du, nun kommen wir auch noch darauf: Wir sind dir zu einfach, du willst höher hinauf. Du willst nicht wachsen, wie wir gewachsen sind, denk' ich mir, nicht so still dahinwachsen wie meine Alte; du willst drauf losgehen.
     </p>
-    <p xml:id="eco_de_0000144_14680">
+    <p xml:id="eco_de_0000214_14680">
      Die Luft aus Weimar hat dich vergiftet, die schöne Seelenluft. Siehst du, dabei kommt gar nichts heraus. Zeit lassen, Zeit lassen, Zeit lassen. – Was der Herrgott will, das wir hier spüren sollen, das werden wir schon, dafür sorgt Mutter Natur. Dafür braucht's kein Treibhaus.
     </p>
-    <p xml:id="eco_de_0000144_14690">
+    <p xml:id="eco_de_0000214_14690">
      Schau, 's ist noch Zeit, – ich geh' morgen früh zu deinem Kupferstecher und sag' ihm: ›Sie, mein Lieber, Sie wissen's ja jedenfalls, wie die Mägens sind, oben aus und nirgends an. Ein alter Mann hat mit ihr geredet und hat sie andern Sinnes gemacht.« Für euch beide wär's ein Unheil.«
     </p>
-    <p xml:id="eco_de_0000144_14700">
+    <p xml:id="eco_de_0000214_14700">
      »Laß mich, Onkel Sperber, laß mich,« sagte sie. »Ich kann nicht ohne ihn leben!«
     </p>
-    <p xml:id="eco_de_0000144_14710">
+    <p xml:id="eco_de_0000214_14710">
      »Badewännchen, gerade so hat deine Mutter gesprochen. Ich gebe gar nichts auf eine gar so große Liebe. Kein Geschöpf Gottes ist einer so großen Liebe wert. – Keines. Meine Alte und ich liebten uns immer sachtchen, und so sachtchen ist's geblieben. Das wär' mir ein schöner Hafen, wo die Wellen so hoch gingen, daß die Schiffe darin nicht ruhen könnten.
     </p>
-    <p xml:id="eco_de_0000144_14720">
+    <p xml:id="eco_de_0000214_14720">
      Hör mal, altes Mägen, willst du denn so all seinen Unsinn nachmachen? Ich weiß nicht, ich müßte lügen, wollte ich sagen, mir gefiel's so besonders.«
     </p>
-    <p xml:id="eco_de_0000144_14730">
+    <p xml:id="eco_de_0000214_14730">
      »Nein,« sagte sie, »das glaub' ich dir, Onkel Sperber. Das kann dir auch nicht so gefallen. Jeder spricht nur für seinesgleichen, die anderen verstehen ihn nicht, jeder versteht nur, was er selbst schon ist. Mein Verlobter wird hier nur von mir verstanden, und spräche er zu euch mit Engelszungen, ganz unnötig wär's – und ich! Mein Herz flog ihm nur so zu. Ich kannte ihn von Anfang an wie einen alten Freund.«
     </p>
-    <p xml:id="eco_de_0000144_14740">
+    <p xml:id="eco_de_0000214_14740">
      »Badewännchen,« seufzte der alte Herr. »Dir brauch' ich nicht zu sagen, was du dir möglicherweise mit ihm aufladest. – Dir gab Gott deinen Vater zur Warnung. Was du tust, ist gegen Gottes Willen. Deine heißen Tränen sprechen gegen dich.«
     </p>
-    <p xml:id="eco_de_0000144_14750">
+    <p xml:id="eco_de_0000214_14750">
      »Onkel Sperber,« sagte sie ernst. »Deshalb ist jedes Wort unnötig. Meine heißen Tränen müssen dir sagen: ich weiß alles – verstehe alles, und kann von ihm doch nicht lassen.«
     </p>
-    <p xml:id="eco_de_0000144_14760">
+    <p xml:id="eco_de_0000214_14760">
      »Dann sei Gott mit dir, mein Kind. Ist dem so, so weißt du, was du tust, so geh' deinen Weg, der dir auferlegt wurde.
     </p>
-    <p xml:id="eco_de_0000144_14770">
+    <p xml:id="eco_de_0000214_14770">
      Ich sehe nichts Gutes.
     </p>
-    <p xml:id="eco_de_0000144_14780">
+    <p xml:id="eco_de_0000214_14780">
      Gerade so sprach ich mit deiner Mutter – gerade so. Die hat ihren Liebsten genommen aus keinem anderen Grund, wie mir's jetzt vorkommt, damit du so würdest, wie du nun bist. Du wolltest ins Leben. Und nun – wollen wieder andere ins Leben und scheinen, Gott sei's geklagt, dich und den Zugelaufenen zu brauchen.
     </p>
-    <p xml:id="eco_de_0000144_14790">
+    <p xml:id="eco_de_0000214_14790">
      Kind, wenn die Liebe bliebe!
     </p>
-    <p xml:id="eco_de_0000144_14800">
+    <p xml:id="eco_de_0000214_14800">
      So 'ne Liebesheirat soll jeden bedenklich anschau'n; ja, wenn's für 'ne kurze Spanne Zeit wäre – dann alle Achtung! – Aber für immer 'nen Menschen in bengalischer Beleuchtung kaufen! Nicht anders ist's, als kaufte ich meine Kühe und Ochsen in bengalischer Beleuchtung oder im Rausch.
     </p>
-    <p xml:id="eco_de_0000144_14810">
+    <p xml:id="eco_de_0000214_14810">
      Siehste, wenn du mich hören könntest! Stehen lassen, Badewännchen, stehen lassen! sage ich dir; nimm unsern Neffen. Besser kann dir nicht gedient sein.«
     </p>
-    <p xml:id="eco_de_0000144_14820">
+    <p xml:id="eco_de_0000214_14820">
      Da reckte sich das Mädchen fest in die Höh'. »Genug, Onkel Sperber,« sagte sie mit leuchtenden Augen und gab ihm die Hand.
     </p>
-    <p xml:id="eco_de_0000144_14830">
+    <p xml:id="eco_de_0000214_14830">
      »Du bist gut; aber wenn er mich morgen noch will, bleibt's dabei. Ich bin so voll Kraft und Mut und Freude, weil er mich liebt, und überhaupt voll Kraft und Freude. Ich werde dem Schicksal dafür dienen. Das weiß ich, daß jedes Glück mit Leid gezahlt wird.«
     </p>
-    <p xml:id="eco_de_0000144_14840">
+    <p xml:id="eco_de_0000214_14840">
      »Gut,« sagte der alte Sperber, »wenn du deine Dummheiten mit Kraft und Freude tust, mag sein, was sein muß! – Aber mit heißen Tränen? – – Hab' ich da nicht recht, altes Mägen?
     </p>
-    <p xml:id="eco_de_0000144_14850">
+    <p xml:id="eco_de_0000214_14850">
      Hast du Mut, wirst du mit diesem Teufelskerl fertig werden; aber wehleidig? – Nee!«
     </p>
-    <p xml:id="eco_de_0000144_14860">
+    <p xml:id="eco_de_0000214_14860">
      Und so kamen sie zusammen, wie Tausende und aber Tausende, von Liebe getrieben, gegen alle Vernunft. Sie führten ihre Ehe, wie eben eine Ehe geführt wird, wenn sie von jungen Tagen bis ins hohe Alter hineinreicht. Einander beglücken und enttäuschen, wohltun und peinigen, einander langweilen und gewöhnt werden. Oft lag über weiten Strecken des Lebens wie bei allen Sterblichen Dumpfheit, wie eine Decke dichtgefilzten Seegrases. Unter dieser Decke hatten die Lebenswellen sich schwerfällig bewegt, waren nicht ans Tageslicht gekommen, und nur eine mächtige Freuden- oder Schmerzenswelle war durchgebrochen und hatte gen Himmel gespritzt.
     </p>
-    <p xml:id="eco_de_0000144_14870">
+    <p xml:id="eco_de_0000214_14870">
      Nun saß Beate Rauchfuß als alte Frau spät nachmittags in ihrem Garten auf dem Ettersberge. Alles ist dahin, was einst war: Freuden, Verlangen, Hoffnungen, Lebenskraft und Sehnsucht, – auch Herr Kosch ist dahin. Sie, die am tiefsten liebte, trug am schwersten, denn sie trug ihn ihr Leben lang. Seine Qualen wurden ihre Qualen, seine Lebensbewegungen ihre Lebensbewegungen.
     </p>
-    <p xml:id="eco_de_0000144_14880">
+    <p xml:id="eco_de_0000214_14880">
      So hatte sie das schwere Doppeldasein des Weibes geführt, das schwere, vielfache Dasein des Weibes.
     </p>
-    <p xml:id="eco_de_0000144_14890">
+    <p xml:id="eco_de_0000214_14890">
      Mit ihren Kindern war sie jugendselig, jugendtraurig gewesen, hatte ihre Enttäuschungen und Wonnen mitgefühlt; mit zweien ihrer Lieben war sie gestorben, Herrn Koschs steile Pfade war sie mitgegangen, ohne gerufen zu sein. Sie war ihm nachgeschlichen, hatte gelernt, mit ihm Schritt halten, als unbeachteter Begleiter. Und als er, müde gewandert, den hilfreichen, treuen Gefährten seiner ringenden Wege neben sich fand – hatte sie das Ziel ihres Lebens erreicht.
     </p>
-    <p xml:id="eco_de_0000144_14900">
+    <p xml:id="eco_de_0000214_14900">
      Anders lernen die Weiber denken als die Männer. Für den Spruch ihres alten Freundes war ihr Verständnis aufgegangen. Wie sie ihre Kinder geboren hatte, so auch ihre Gedanken. Jeder war eine schwere Errungenschaft aus dem Kern der Dinge heraus, nicht überkommen, nicht gelehrt, nicht fremd, – aber urlebendig aus ihr selbst geboren und mit Menschenleid gezahlt.
     </p>
-    <p xml:id="eco_de_0000144_14910">
+    <p xml:id="eco_de_0000214_14910">
      Wie sie als alte Frau im Spätsonnenschein saß voller Frieden, war ihre Seele rund wie in erster Jugendzeit, hatte keine Ecken, keinen Riß, an dem Sorge sich hätte einhaken, oder in den sie hätte eindringen können.
     </p>
-    <p xml:id="eco_de_0000144_14920">
+    <p xml:id="eco_de_0000214_14920">
      Wie ein fernes Rauschen und Lärmen und Läuten tönte das Treiben des Lebens in den unstörbaren Frieden. Zum zweitenmal im Leben glich ihre Seele einer sonnenklaren Kristallkugel: in erster Jugend, als noch kein Flecken und Schatten des Daseins sie trübte, und jetzt, als alle Flecken und Schatten wieder gewichen waren.
     </p>
-    <p xml:id="eco_de_0000144_14930">
+    <p xml:id="eco_de_0000214_14930">
      Ob nun das Leben leicht war oder schwer, die Ehe glücklich oder unglücklich, die Arbeit gesegnet oder nicht, – ganz gleich – ganz gleichgültig.
     </p>
-    <p xml:id="eco_de_0000144_14940">
+    <p xml:id="eco_de_0000214_14940">
      Nur eins war hier nicht gleich, daß die alte Frau jetzt im Spätsonnenschein saß mit einer Seele, die sonnenklar und durchsichtig, wie eine helle Kugel im Raume schwebte, still nachträumend und nichts fragend – weltabgetan.
     </p>
    </div>
@@ -4589,337 +4589,337 @@
     <head>
      Der dichtverwachsene Garten
     </head>
-    <p xml:id="eco_de_0000144_14950">
+    <p xml:id="eco_de_0000214_14950">
      Als Weimar noch, von aller Welt verlassen, von niemandem gekannt und besucht, in der großen, stillen Einöde lag, mit seinem Häuflein Weimaranern, die in dem grauen Steinnest seit Jahrhunderten kamen und gingen, wie es der Lauf der Welt ist, da gab es Einsamkeit rings um das Städtchen her – Einöde – von der wir in unserer Zeit, in der die Lokomotive jede Ecke ausschnüffelt, jede Verborgenheit wie ein Maulwurf aufwühlt, uns keine Vorstellung mehr machen können.
     </p>
-    <p xml:id="eco_de_0000144_14960">
+    <p xml:id="eco_de_0000214_14960">
      Solche Verschneitheit und solches In-Grün-vergrabensein gibt's nicht mehr, – gewiß nicht.
     </p>
-    <p xml:id="eco_de_0000144_14970">
+    <p xml:id="eco_de_0000214_14970">
      Und wer meine kleine Geschichte verstehen will, vergesse alles, was in unserer Zeit Menschen mit Menschen verbindet, und gehe mit mir an einem alten Städtchen vorüber, das mit Mauern sich gegen die Stille ringsumher wehrt – und wandere auf holperigen Wegen weiter, immer weiter, wie ins Grenzenlose hinein, an armseligen Weilern und Dörfern vorüber, in denen seit Jahrhunderten die Bauerngeschlechter wie die Unken im Sumpfe leben, oder wie die Wilden im dunkelsten Erdteil, hinsterbend wie Wasserblasen im Ozean. In solcher Weltabgeschiedenheit ein Garten.
     </p>
-    <p xml:id="eco_de_0000144_14980">
+    <p xml:id="eco_de_0000214_14980">
      Um den Garten wogt von drei Seiten junger Winterroggen, wie ein Meer, und wenn der Wind über das Meer dahinfährt, bläst er breite graue Spiegel auf die lebensgrüne Fläche und weht Erdgeruch auf und den Geruch einer Unendlichkeit von grünem Leben.
     </p>
-    <p xml:id="eco_de_0000144_14990">
+    <p xml:id="eco_de_0000214_14990">
      Das Roggenmeer dehnt sich, soweit das Auge reicht. Kein Baum – kein Strauch – nur grünes, silbergraues Gewoge und der schwere Roggenduft, der darüber liegt.
     </p>
-    <p xml:id="eco_de_0000144_15000">
+    <p xml:id="eco_de_0000214_15000">
      Der Garten ragt wie eine kleine Insel in das Meer hinein. Mit seinen festen Laubmassen, die rund und ungegliedert mächtig aus dem Getreidegewoge herauswachsen, wirkt er wie aus Bronze gegossen.
     </p>
-    <p xml:id="eco_de_0000144_15010">
+    <p xml:id="eco_de_0000214_15010">
      Das Getreidemeer brandet sanft an ihn an.
     </p>
-    <p xml:id="eco_de_0000144_15020">
+    <p xml:id="eco_de_0000214_15020">
      O du duftende Einsamkeit! Wer am Ende des Gartens vor dem festen Laubwall steht und hinausschaut auf Grün und Silbergrau, das sich in weichen, grauen Tönen wechselnd und vibrierend bis in den Horizont hineinzieht – dem ist die Welt versunken.
     </p>
-    <p xml:id="eco_de_0000144_15030">
+    <p xml:id="eco_de_0000214_15030">
      Das Haus, hinter dem sich der Garten in das Feld hineindehnt, gehört wahrlich auch nicht zur Welt, – ein stilles Landpfarrhaus mit hohem Dach und niederen Fenstern, weinumsponnen.
     </p>
-    <p xml:id="eco_de_0000144_15040">
+    <p xml:id="eco_de_0000214_15040">
      Verträumt steht es so seit ein paar Menschenaltern, öffnet seine Tür, um einen Mann Gottes nach dem anderen einziehen und wieder ausziehen zu lassen.
     </p>
-    <p xml:id="eco_de_0000144_15050">
+    <p xml:id="eco_de_0000214_15050">
      Wohl beherbergt hat es sie alle. Jeder von ihnen kam würdig erfreut, denn es schien noch keinem ein übler Platz. Still wurde dann einer nach dem anderen, nach sanftem, weltabgeschiedenem Leben hinausgetragen.
     </p>
-    <p xml:id="eco_de_0000144_15060">
+    <p xml:id="eco_de_0000214_15060">
      Damals wohnte ein Ehrenmann im Haus, mit Weib und Sohn und Tochter. Ihm waren die Kinder hier geboren und auch herangewachsen.
     </p>
-    <p xml:id="eco_de_0000144_15070">
+    <p xml:id="eco_de_0000214_15070">
      Ja, zu seinem Erstaunen waren sie auch herangewachsen – denn hier stand die Zeit still!
     </p>
-    <p xml:id="eco_de_0000144_15080">
+    <p xml:id="eco_de_0000214_15080">
      Das große Zifferblatt, die weiten Felder mit ihrem weiten Horizont zeigten wohl die braune Stunde, die grüne, die goldene, die weiße Stunde an, aber so unmerklich ging eine dieser Stunden in die andere über, daß es dem Bewußtsein nicht weh tat. Und wie oft war die goldene Stunde gekommen? Wie oft wohl?
     </p>
-    <p xml:id="eco_de_0000144_15090">
+    <p xml:id="eco_de_0000214_15090">
      O, das war alles so verschwommen, das hatte sich dem Hirn nicht eingeprägt. Es war alles hier eine zeitlose Gewohnheit – aber die Kinder waren dennoch herangewachsen. Und die grüne Stunde war wieder einmal sanft hereingebrochen. Um den Garten brandete das grüne Halmenmeer, und der mächtige Laubwall quoll zusehends. Die Wege wurden eng und immer enger vom dichten Laub, das sich dehnte und streckte. Der Flieder blühte und der Goldregen und der Rotdorn.
     </p>
-    <p xml:id="eco_de_0000144_15100">
+    <p xml:id="eco_de_0000214_15100">
      Der Garten lag im Paradiesesschmuck. Ein kurzes Weilchen sollte er schön sein, ein kurzes Weilchen sollte er auch dieses Jahr wieder jung sein.
     </p>
-    <p xml:id="eco_de_0000144_15110">
+    <p xml:id="eco_de_0000214_15110">
      Das Gras stand saftig und hoch, und hin und wieder schimmerten die roten, schweren Köpfe der Pfingstrosen aus hellem Grün. Ein Duft stieg auf wie von einem Opfer. »Heuer schaut man nicht einmal mit einem Blick hinaus, so dicht ist's Laub. Man riecht's nur, daß der Roggen blüht.« Das sagte eine kleine, sanfte Stimme, in der ein großes Weh klang.
     </p>
-    <p xml:id="eco_de_0000144_15120">
+    <p xml:id="eco_de_0000214_15120">
      Es war nicht mehr die volle Tageshelle. Die weiche Sommerdämmerung floß durch das dichte Grün.
     </p>
-    <p xml:id="eco_de_0000144_15130">
+    <p xml:id="eco_de_0000214_15130">
      Die verschleierte, sanfte Stimme gehört zu einer schlanken, jungen Mädchengestalt. Ein einfaches, geduldiges Gesichtchen neigt sich wie eine vom Regen schwere Blüte der Erde zu.
     </p>
-    <p xml:id="eco_de_0000144_15140">
+    <p xml:id="eco_de_0000214_15140">
      Die schmale Mädchenhand ruht ratlos in der Hand eines jungen Mannes, der auch wie in tiefer Bewegung geht. Aber etwas Unantastbares liegt in seiner Persönlichkeit, seiner Kleidung, seinem Gang. Es ist Rückgrat in der Haltung, Rückgrat, das von Generation auf Generation vererbt ist.
     </p>
-    <p xml:id="eco_de_0000144_15150">
+    <p xml:id="eco_de_0000214_15150">
      Das war so eine formvolle Bewegtheit, die er dulden durfte, weil sie am Platz schien. In seinem ritterlichen Hinneigen zu seiner Gefährtin liegt eine gewisse Achtung vor ihrem Schmerz, etwas Tröstendes, – etwas … Ja, sie tragen nicht an einem Schmerz – nicht an einem gleich großen Schmerz, der seine wiegt leichter.
     </p>
-    <p xml:id="eco_de_0000144_15160">
+    <p xml:id="eco_de_0000214_15160">
      Er hat seine Gestalt nicht durchdrungen, seine Beweglichkeit und vornehme Eleganz nicht beeinträchtigt. Er ist nicht um einen Zoll gebeugter durch diesen Schmerz geworden – und doch, es ist auch ihm nicht leicht ums Herz.
     </p>
-    <p xml:id="eco_de_0000144_15170">
+    <p xml:id="eco_de_0000214_15170">
      Hier in diesem stillen Erdenwinkel ist er und seine Schwester auf dem Gut einer nahen Verwandten der verstorbenen Mutter erzogen worden. Mit den beiden Pfarrerskindern hatten sie alles geteilt, Unterricht, Kinderwonne – alles – alles.
     </p>
-    <p xml:id="eco_de_0000144_15180">
+    <p xml:id="eco_de_0000214_15180">
      Und nun sollte es hinaus ins Leben gehen, – die Schwester zum Vater und er – – für ihn lag die Welt offen. Er steht auf der Höhe des Lebens.
     </p>
-    <p xml:id="eco_de_0000144_15190">
+    <p xml:id="eco_de_0000214_15190">
      Er ist sicher, wo er sich auch zeigen wird, wohl empfangen zu werden als ein schon Gekannter, als einer, von dem sich nur das Beste erwarten läßt.
     </p>
-    <p xml:id="eco_de_0000144_15200">
+    <p xml:id="eco_de_0000214_15200">
      Seine Ahnen hatten für ihn vorgesorgt. Ihm konnte es kaum fehlen. Das Leben lag vor ihm wie eine sichere Ernte. Nun galt es, sich von der stillen ersten Jugendzeit loszureißen.
     </p>
-    <p xml:id="eco_de_0000144_15210">
+    <p xml:id="eco_de_0000214_15210">
      Vor noch nicht vier Wochen hatten sie am Sterbebett ihrer treuen zweiten Mutter gestanden; da war es fast ähnlich gewesen wie heute. Banger Abschied und dazwischen wie Sonnenblitze das künftige lockende Leben.
     </p>
-    <p xml:id="eco_de_0000144_15220">
+    <p xml:id="eco_de_0000214_15220">
      »Was tust du denn nun, wenn wir gehen, und wenn auch dein Bruder fort ist?« fragte er seine stille Gefährtin.
     </p>
-    <p xml:id="eco_de_0000144_15230">
+    <p xml:id="eco_de_0000214_15230">
      Da war kein Haltens mehr, da stürzten die Tränen aus den armen Augen.
     </p>
-    <p xml:id="eco_de_0000144_15240">
+    <p xml:id="eco_de_0000214_15240">
      »Ach, ich –,« sagte sie leise.
     </p>
-    <p xml:id="eco_de_0000144_15250">
+    <p xml:id="eco_de_0000214_15250">
      So sah und verstand er ihre große Armut, so offenbarte sich ihm ihre Armut für einen Augenblick, und er schloß das Mädchen in seine Arme und küßte sie und empfand die ganze süße Bedeutung, die seine Gefährtin für ihn hatte.
     </p>
-    <p xml:id="eco_de_0000144_15260">
+    <p xml:id="eco_de_0000214_15260">
      Ja, die hatte sie für ihn, denn sie war seine erste Liebe, seine Jugendliebe, an die er als alter, vornehmer Herr noch wehmütig lächelnd sich erinnern wollte.
     </p>
-    <p xml:id="eco_de_0000144_15270">
+    <p xml:id="eco_de_0000214_15270">
      Das Mädchen aber schlang voll banger, verzweifelter Leidenschaft die Arme um ihn und flüsterte heiß: »Bleib', was wird aus mir!«
     </p>
-    <p xml:id="eco_de_0000144_15280">
+    <p xml:id="eco_de_0000214_15280">
      Das tat seiner jungen Kraft wohl, dies Geliebtsein, dies An-ihm-hängen, dies Hinsterben ohne ihn. Und er zog sie empor zu sich heran, und sie hingen aneinander in heißen Küssen, als wollten sie eins werden.
     </p>
-    <p xml:id="eco_de_0000144_15290">
+    <p xml:id="eco_de_0000214_15290">
      Ihm war so wohl, so weh; aber keinen Augenblick verlor er den Sinn der Stunde.
     </p>
-    <p xml:id="eco_de_0000144_15300">
+    <p xml:id="eco_de_0000214_15300">
      Es war ein Abschiedsschmerz fürs Leben. – Du hier – ich dort!
     </p>
-    <p xml:id="eco_de_0000144_15310">
+    <p xml:id="eco_de_0000214_15310">
      Beileibe nichts, was Bindekraft haben könnte, nichts Hinderndes, nichts Lastendes.
     </p>
-    <p xml:id="eco_de_0000144_15320">
+    <p xml:id="eco_de_0000214_15320">
      Da hörten sie Schritte.
     </p>
-    <p xml:id="eco_de_0000144_15330">
+    <p xml:id="eco_de_0000214_15330">
      Seine jüngere Schwester und der Pfarrerssohn kommen ihnen auf dicht verwachsenen Wegen entgegen.
     </p>
-    <p xml:id="eco_de_0000144_15340">
+    <p xml:id="eco_de_0000214_15340">
      »Anne Marie!« sagte die junge Komtesse zärtlich, »Anne Marie!«
     </p>
-    <p xml:id="eco_de_0000144_15350">
+    <p xml:id="eco_de_0000214_15350">
      Was lag in diesem Aussprechen des Namens. Hatte sie verstanden oder gesehen?
     </p>
-    <p xml:id="eco_de_0000144_15360">
+    <p xml:id="eco_de_0000214_15360">
      Mochte sie gesehen haben! Mochte sie verstanden haben!
     </p>
-    <p xml:id="eco_de_0000144_15370">
+    <p xml:id="eco_de_0000214_15370">
      Sie war eine zarte, süße, kleine Weltdame trotz der Abgeschiedenheit, in der sie bisher gelebt. Alle Weltdamen ihres uralten Geschlechts hatten sie mit ihrem Vermächtnis bedacht.
     </p>
-    <p xml:id="eco_de_0000144_15380">
+    <p xml:id="eco_de_0000214_15380">
      Alles war ihr nur so zugeflogen. Auch ihre Gefühle, sie kamen und gingen wie Launen.
     </p>
-    <p xml:id="eco_de_0000144_15390">
+    <p xml:id="eco_de_0000214_15390">
      Aber auch sie war bewegt, auch sie war den Pfarrerskindern eine gute Gefährtin gewesen, eine reizvolle, schnellblütige; – auch sie hatte, wie soeben ihr Bruder die Pfarrerstochter – den Pfarrerssohn geküßt und mit süßem Bewußtsein ihrer ersten vergänglichen Liebe, dieser reizenden Tollheit, die ihr nun in allerlei Gestalt lebendig werden sollte.
     </p>
-    <p xml:id="eco_de_0000144_15400">
+    <p xml:id="eco_de_0000214_15400">
      Ach, und was war er für ein guter, lieber Junge, dieser »erste«! – und wie liebte er sie! Ganz unsinnig!
     </p>
-    <p xml:id="eco_de_0000144_15410">
+    <p xml:id="eco_de_0000214_15410">
      Reizend zum Verrücktwerden, eine Gottheit zu sein, die ein Mensch anbetet, der ein Mensch sich hinopfern möchte, die ein Mensch wirklich und wahrhaftig anbetet, der ein Mensch sagt, daß sie das Höchste sei, zum Totlachen schön!
     </p>
-    <p xml:id="eco_de_0000144_15420">
+    <p xml:id="eco_de_0000214_15420">
      Und sie hörte es im voraus draußen in der Welt in süßer Anbetung von vielen, vielen Lippen nachbeten, was der eine, erste hier gestammelt hatte, und ihre kleine Gottesseele war hungrig nach Gebet und Opfer.
     </p>
-    <p xml:id="eco_de_0000144_15430">
+    <p xml:id="eco_de_0000214_15430">
      Am anderen Abend zur selben Stunde gingen die beiden Pfarrerskinder Hand in Hand die dicht verwachsenen Wege auf und nieder. Beide stumm. Sie waren beide vereinsamt, und beide waren hilflos in ihrer Vereinsamung – und scheu. Keins sah dem anderen in die Augen. Sie trugen jedes für sich ihr großes, wehes Geheimnis. Drinnen im Haus schrieb der Vater an seiner Predigt, und die Mutter buk zu Pfingsten Festkuchen.
     </p>
-    <p xml:id="eco_de_0000144_15440">
+    <p xml:id="eco_de_0000214_15440">
      Niemand dachte an die beiden großen, hilflosen Kinder im dunklen Garten, in dem die Laubmassen leise rauschten, die Juniopferdüfte aufstiegen und der schwüle Kornblütengeruch durch den festen Laubwall strömte.
     </p>
-    <p xml:id="eco_de_0000144_15450">
+    <p xml:id="eco_de_0000214_15450">
      Der Pfarrer und sein Weib wußten nicht, daß aus ihren kleinen, sorglosen Kindern Menschen geworden waren mit Glückshunger und Menschenweh.
     </p>
-    <p xml:id="eco_de_0000144_15460">
+    <p xml:id="eco_de_0000214_15460">
      Es wurde gedankenlos Predigt geschrieben und Kuchen gebacken. Derweilen sanken die beiden endlich eng verschlungen auf eine alte Gartenbank, an der sie als Kinder gespielt – uns hingen aneinander wie zwei Verzweifelte, die in einem tiefen See sich eins dem anderen retten wollen. Es war ein so großer, bitterer, junger Schmerz, der schwerste Schmerz der Jugend, der noch keine Scharte, keine Stumpfheit an seiner Schneide hat.
     </p>
-    <p xml:id="eco_de_0000144_15470">
+    <p xml:id="eco_de_0000214_15470">
      Es war der Schmerz »derer ohne Ahnen«, die ihr Wesen nicht von Generation zu Generation in vornehmen Formen aufgelöst haben, es war der echte, alte Volksschmerz, der schon den Vorfahren die schutzlosen Herzen gemartert hatte.
     </p>
-    <p xml:id="eco_de_0000144_15480">
+    <p xml:id="eco_de_0000214_15480">
      Aber sie wurden in dieser Stunde eins miteinander, weil sie sich in ihrer großen Einfachheit durchschauten.
     </p>
-    <p xml:id="eco_de_0000144_15490">
+    <p xml:id="eco_de_0000214_15490">
      Treuer Bruder – treue Schwester fürs Leben, und sie besiegelten den Bund mit einem Kuß, der so mild und sanft war gegen die Feuerküsse, die ihnen das Blut in Brand gesetzt hatten. »Anne Marie,« sagte er. – »Was wirst du tun, wenn ich nun auch fort bin?«
     </p>
-    <p xml:id="eco_de_0000144_15500">
+    <p xml:id="eco_de_0000214_15500">
      »Ach, ich!« antwortete sie und schritt dabei wie über sich selbst hinweg.
     </p>
-    <p xml:id="eco_de_0000144_15510">
+    <p xml:id="eco_de_0000214_15510">
      Sie sagte es unter Tränen und wußte nichts anderes.
     </p>
-    <p xml:id="eco_de_0000144_15520">
+    <p xml:id="eco_de_0000214_15520">
      Und so sah und verstand auch er ihre Armut, und er zog die Schwester an sich, als wollte er sie schützen, als wollte er ihr etwas geben.
     </p>
-    <p xml:id="eco_de_0000144_15530">
+    <p xml:id="eco_de_0000214_15530">
      Aber da war nichts, was er ihr geben konnte. Er wußte nichts.
     </p>
-    <p xml:id="eco_de_0000144_15540">
+    <p xml:id="eco_de_0000214_15540">
      Und die Zeit kam bald, wo er sie verlassen mußte, seine Schmerzensgefährtin.
     </p>
-    <p xml:id="eco_de_0000144_15550">
+    <p xml:id="eco_de_0000214_15550">
      Er ging hinaus ins Leben, das hinter dem Roggenmeer lag.
     </p>
-    <p xml:id="eco_de_0000144_15560">
+    <p xml:id="eco_de_0000214_15560">
      Sie aber, Anne Marie, wurde von keiner Stimme gerufen. Sie blieb ganz allein, sie hatte keinen Grund, ins Leben zu gehen. Sie blieb da, wo die Zeit stillsteht.
     </p>
-    <p xml:id="eco_de_0000144_15570">
+    <p xml:id="eco_de_0000214_15570">
      Und noch immer wußten die Pfarrersleute nicht, daß die Zeit aus ihrem kleinen Kinde ein lebenshungriges, sehnsüchtiges, armes Weib gemacht hatte.
     </p>
-    <p xml:id="eco_de_0000144_15580">
+    <p xml:id="eco_de_0000214_15580">
      Sie freuten sich ihres guten Mädchens, freuten sich, wie es so wohlbewahrt im stillen Garten und im stillen Haus lebte, und glaubten, daß alles Leid der Welt ihrem Kinde fern lag.
     </p>
-    <p xml:id="eco_de_0000144_15590">
+    <p xml:id="eco_de_0000214_15590">
      Kein Vater- und kein Mutterauge folgten ihr, wenn sie an dem Laubwall stand und hinaus über das Halmenmeer schaute, oder wenn sie durch den verschneiten Garten stapfte, um in die weiße Leere um sie her zu starren.
     </p>
-    <p xml:id="eco_de_0000144_15600">
+    <p xml:id="eco_de_0000214_15600">
      Da war es ihr, als söge die große Leere um sie her ihr das lebendige Herz aus, als söge die große Leere und Einsamkeit ihr auch gierig die Seele aus.
     </p>
-    <p xml:id="eco_de_0000144_15610">
+    <p xml:id="eco_de_0000214_15610">
      Wie vor einem Riesenungeheuer fürchtete sie sich vor dieser toten Einsamkeit, die sich von ihrem jungen Leben nährte, verbarg sich vor ihr und gab sich ihr wieder hin in Sinnlosigkeit.
     </p>
-    <p xml:id="eco_de_0000144_15620">
+    <p xml:id="eco_de_0000214_15620">
      Den, der eilig ihrer zu gedenken vergessen, liebte sie mit der ganzen Glut ihres Wesens, das umsonst in Lebensfeuer brannte.
     </p>
-    <p xml:id="eco_de_0000144_15630">
+    <p xml:id="eco_de_0000214_15630">
      Ihre heilige Pflicht, ihr Gelübde wurde es, Treue und Angedenken zu halten.
     </p>
-    <p xml:id="eco_de_0000144_15640">
+    <p xml:id="eco_de_0000214_15640">
      Daran hielt sie sich, klammerte sie sich: Treue und Angedenken! Das wurde ihr ganzer Lebensinhalt.
     </p>
-    <p xml:id="eco_de_0000144_15650">
+    <p xml:id="eco_de_0000214_15650">
      Mitten unter Rosen und Güte und Liebe wurde sie zur Märtyrerin.
     </p>
-    <p xml:id="eco_de_0000144_15660">
+    <p xml:id="eco_de_0000214_15660">
      Niemand aber verstand die große Marter.
     </p>
-    <p xml:id="eco_de_0000144_15670">
+    <p xml:id="eco_de_0000214_15670">
      Die vielfarbigen Stunden aber kamen und gingen im Wechsel. Der Bruder kehrte nach langen Jahren heim, ein tüchtiger Mann, kraftstrotzend.
     </p>
-    <p xml:id="eco_de_0000144_15680">
+    <p xml:id="eco_de_0000214_15680">
      Ein Mensch, den der Vater segnete, zu dem die Mutter, die ihm das Leben gegeben, staunend aufblickte.
     </p>
-    <p xml:id="eco_de_0000144_15690">
+    <p xml:id="eco_de_0000214_15690">
      Und als er am Abend mit der Schwester wie sonst wohl im Garten auf und nieder ging, sagte er wohlgemut: »Entsinnst du dich der Dummheiten noch – damals, als die beiden Schlingel gingen?«
     </p>
-    <p xml:id="eco_de_0000144_15700">
+    <p xml:id="eco_de_0000214_15700">
      Da sah sie ihn mit großen, irren Augen an und schwieg.
     </p>
-    <p xml:id="eco_de_0000144_15710">
+    <p xml:id="eco_de_0000214_15710">
      Er aber fing ihren leeren, toten Blick auf und suchte ihn sich zu deuten.
     </p>
-    <p xml:id="eco_de_0000144_15720">
+    <p xml:id="eco_de_0000214_15720">
      Und als hätte er ein armseliges, kaltes Sumpftier berührt, eine im Sumpf eingeschlossene Kröte, so war es ihm, als seine Finger der Schwester kraftlose Hände faßten. »Ist das möglich? So etwas!« murmelte er.
     </p>
-    <p xml:id="eco_de_0000144_15730">
+    <p xml:id="eco_de_0000214_15730">
      »Was denn?« fragte sie, wie eine arme Seele. »Was sagst du?«
     </p>
-    <p xml:id="eco_de_0000144_15740">
+    <p xml:id="eco_de_0000214_15740">
      »Nichts, Anne Marie. Möge ein jeder mit dem Leben fertig werden, wie er kann und mag.«
     </p>
-    <p xml:id="eco_de_0000144_15750">
+    <p xml:id="eco_de_0000214_15750">
      »Da ist nichts zu machen,« dachte er bei sich, und ein Ekel faßte ihn. »Sie ist ein Weib. Gott erbarme sich ihrer.«
     </p>
-    <p xml:id="eco_de_0000144_15760">
+    <p xml:id="eco_de_0000214_15760">
      Er mußte wohlgefällig lächeln, wenn er sein Leben mit dem ihren verglich. Aber weil er ihr Bruder war und einst ihr Kamerad, tat sie ihm leid.
     </p>
-    <p xml:id="eco_de_0000144_15770">
+    <p xml:id="eco_de_0000214_15770">
      »Sie sind alle so!« dachte er bei sich – »so – oder anders, – aber immer dasselbe! Liebe, die ein kräftiger Trunk sein soll, ist ihnen Nahrung, die sie verzehrt. Immer das eine – immer trinken. Nichts anderes hat Platz in ihrem Kopf – bis der eine Gedanke alles verschluckt hat – dann der leere Blödsinn.«
     </p>
-    <p xml:id="eco_de_0000144_15780">
+    <p xml:id="eco_de_0000214_15780">
      Zornig war er und schlug mit einem Stecken im Vorübergehen auf die dichten Büsche.
     </p>
-    <p xml:id="eco_de_0000144_15790">
+    <p xml:id="eco_de_0000214_15790">
      ›Das ist etwas, worüber man mit ihr nicht reden kann,« dachte er. ›Mag sie's haben!«
     </p>
-    <p xml:id="eco_de_0000144_15800">
+    <p xml:id="eco_de_0000214_15800">
      »Weshalb sagst du nicht, was du sagen wolltest?« fragte sie mit bebender Stimme.
     </p>
-    <p xml:id="eco_de_0000144_15810">
+    <p xml:id="eco_de_0000214_15810">
      Sie wollte reden. Sie wollte sich an ihn hängen und sagen: ›Du bist mein Bruder, hilf mir.«
     </p>
-    <p xml:id="eco_de_0000144_15820">
+    <p xml:id="eco_de_0000214_15820">
      Aber sie fand kein Wort. Eine drückende Scham, eine unbewußte Schmach machte es ihr nicht möglich.
     </p>
-    <p xml:id="eco_de_0000144_15830">
+    <p xml:id="eco_de_0000214_15830">
      Sie blieb stumm.
     </p>
-    <p xml:id="eco_de_0000144_15840">
+    <p xml:id="eco_de_0000214_15840">
      Und als er wieder gegangen war, da küßte sie Gras und Kraut in ihrer Einsamkeit und Verlassenheit, da sang sie so wild, lebenshungrig in die Oede hinaus, von keinem Menschenohr gehört. –
     </p>
-    <p xml:id="eco_de_0000144_15850">
+    <p xml:id="eco_de_0000214_15850">
      Die beiden Pfarrersleute lebten wohlgemut und seelenruhig. Es ging ihnen gut. Das Alter ließ sich freundlich an. Sie waren beide rund und rotbäckig und in ihrem Gott vergnügt. Das Essen schmeckte ihnen.
     </p>
-    <p xml:id="eco_de_0000144_15860">
+    <p xml:id="eco_de_0000214_15860">
      Allabendlich bekam der Pfarrer seine Pfeife vom lieben Kind gestopft, und es wurde ihm vorgelesen: von jungen, herben Lippen behagliche Dinge, die ihm paßten.
     </p>
-    <p xml:id="eco_de_0000144_15870">
+    <p xml:id="eco_de_0000214_15870">
      Das gutartige, freundliche Alter, das alles vergessen hat, machte sich im stillen Hause breit und erstickte und überwucherte mit seinem fetten Kraut einen kräftigen Lebenstrieb, der zur Sonne wollte.
     </p>
-    <p xml:id="eco_de_0000144_15880">
+    <p xml:id="eco_de_0000214_15880">
      Du einsamer Vogel, der du im Käfig gefangen sitzt unter dem Menschenvolk und mit deiner Stimme Menschenvolk erfreust, bist nicht einsamer als einsame Jugend zwischen Alter.
     </p>
-    <p xml:id="eco_de_0000144_15890">
+    <p xml:id="eco_de_0000214_15890">
      »Heiraten sollte unser Kindchen,« sagte die Pfarrerin zum öftern – »ja – ja.«
     </p>
-    <p xml:id="eco_de_0000144_15900">
+    <p xml:id="eco_de_0000214_15900">
      »Laß sie, Weib, kommt Zeit, kommt Rat; so gut wie daheim bekommt sie's nirgends wieder,« meinte der Pfarrer.
     </p>
-    <p xml:id="eco_de_0000144_15910">
+    <p xml:id="eco_de_0000214_15910">
      So verstrich eine weiße Stunde um die andere – und die Alten merkten nichts.
     </p>
-    <p xml:id="eco_de_0000144_15920">
+    <p xml:id="eco_de_0000214_15920">
      Die Einsamkeit und die Oede sogen das junge Leben in sich ein, ohne davon Gewinn zu haben.
     </p>
-    <p xml:id="eco_de_0000144_15930">
+    <p xml:id="eco_de_0000214_15930">
      Das junge Weib aber konnte all dem nutzlosen Zehren und Saugen nicht widerstehen, sie wurde welk und matt.
     </p>
-    <p xml:id="eco_de_0000144_15940">
+    <p xml:id="eco_de_0000214_15940">
      Ihr heißes Jugendfeuer war wie ein von keinem Gott empfangenes Opfer, das ungesehen im dichtverwachsenen Garten verbrennt und auch keinen lieben Menschen gewärmt hatte.
     </p>
-    <p xml:id="eco_de_0000144_15950">
+    <p xml:id="eco_de_0000214_15950">
      Ihre kluge Seele war erwacht, ohne jemand erfreut zu haben, ihre süße Stimme hatte niemand getröstet und beglückt, ihr Verstand war eingeschlafen, ohne wach geworden zu sein.
     </p>
-    <p xml:id="eco_de_0000144_15960">
+    <p xml:id="eco_de_0000214_15960">
      Und einst kam der Bruder wieder mit seinem Weib und mit Kindern, und das alte Pfarrhaus zitterte durch junges Lachen und zärtliche Töne und tollen Jubel.
     </p>
-    <p xml:id="eco_de_0000144_15970">
+    <p xml:id="eco_de_0000214_15970">
      Und bei Tisch waren die Alten ganz außer dem Häuschen über all das junge Volk, das von ihnen ausgegangen war. Stolz wurden sie, und wichtig kamen sie sich vor, und über die Maßen zufrieden waren sie.
     </p>
-    <p xml:id="eco_de_0000144_15980">
+    <p xml:id="eco_de_0000214_15980">
      Der Pfarrherr hielt eine vor Rührung überlaufende kleine Familienrede und lobte sein Leben und den alten Gott und sein Weib und den starken, tüchtigen Sohn und dessen Weib und segnete die Enkel, und zuallerletzt pries er es als eine Gnade Gottes und besondere Fürsorge, daß er die Tochter dem stillen Haus erhalten, die Pflegerin der Alten.
     </p>
-    <p xml:id="eco_de_0000144_15990">
+    <p xml:id="eco_de_0000214_15990">
      »Hoch lebe unser altes Jüngferchen, die Anne Marie!«
     </p>
-    <p xml:id="eco_de_0000144_16000">
+    <p xml:id="eco_de_0000214_16000">
      »Gott segne die ersten Fältchen im lieben Angesicht unseres Kindes!« sagte die Pfarrerin. »Ja – ja, mein Herzel,« nickte sie weltfremd schelmisch.
     </p>
-    <p xml:id="eco_de_0000144_16010">
+    <p xml:id="eco_de_0000214_16010">
      Ein komisches Zucken ging über ein armes Gesicht.
     </p>
-    <p xml:id="eco_de_0000144_16020">
+    <p xml:id="eco_de_0000214_16020">
      »Verschluckt?« fragte der Pfarrer besorgt.
     </p>
-    <p xml:id="eco_de_0000144_16030">
+    <p xml:id="eco_de_0000214_16030">
      Und Anne Marie stand auf und stürzte zur Türe und stürzte hinaus in den dichtverwachsenen Garten, der sie ihr Lebtag vor der Welt verborgen hatte.
     </p>
-    <p xml:id="eco_de_0000144_16040">
+    <p xml:id="eco_de_0000214_16040">
      Das weite, öde Halmenfeld brandete sanft am mächtigen Laubwall an, der wie aus Bronze gegossen starrte.
     </p>
-    <p xml:id="eco_de_0000144_16050">
+    <p xml:id="eco_de_0000214_16050">
      Und ins hohe Gras warf sie sich auf ihr Angesicht und weinte nicht und klagte nicht. Sie küßte längst nicht mehr Baum und Kraut in ihrer Verlassenheit. Sie legte sich hin wie eine Tote, die nach nichts mehr faßt, die sich an nichts mehr hält, die mit Mutter Erde nichts mehr gemein hat.
     </p>
    </div>
@@ -4927,1528 +4927,1528 @@
     <head>
      Muttersehnsucht
     </head>
-    <p xml:id="eco_de_0000144_16060">
+    <p xml:id="eco_de_0000214_16060">
      »Gott nein,« sagte sie, »nie« – und lachte.
     </p>
-    <p xml:id="eco_de_0000144_16070">
+    <p xml:id="eco_de_0000214_16070">
      Er hatte sie gefragt, ob sie hier das ganze Jahr über nicht Langeweile spürte.
     </p>
-    <p xml:id="eco_de_0000144_16080">
+    <p xml:id="eco_de_0000214_16080">
      Er ist der Hausgast und Jugendfreund ihres Vaters.
     </p>
-    <p xml:id="eco_de_0000144_16090">
+    <p xml:id="eco_de_0000214_16090">
      Sommerfrieden liegt über dem weiten Gutsgarten ausgebreitet. Hochwipflige Bäume und fruchttragende, schwerbeladene, die dem Erdreich mit ihren Kronen näher bleiben als die vornehmen Laubbäume; weiche Rasenflächen, auf denen durchsichtige, kühle Schatten lagern; Beerensträucher mit leuchtenden, rotbehangenen Zweigen.
     </p>
-    <p xml:id="eco_de_0000144_16100">
+    <p xml:id="eco_de_0000214_16100">
      Der lange, gerade Weg, der zum Hause von der Landstraße führt, ist dicht mit Sommerblumen eingefaßt, nach Altväter Weise, mit bunten, duftenden Blumen aller Art, die ihre Häupter im lustigen Durcheinander neigen oder sie in die blaue Sommerluft hineinheben und den geraden Weg in eine Atmosphäre von sonnedurchwärmten Düften hüllen. Bienen und tausendfältiges Geschwirr und Gesumm. Hoch oben im Himmelsraum die pfeilschnellen Sommerverkünder, die ihre spitzen Töne wie goldne Saiten über den Himmel sponnen.
     </p>
-    <p xml:id="eco_de_0000144_16110">
+    <p xml:id="eco_de_0000214_16110">
      Sie stehen beide abseits vom Weg, mitten im Obstgarten.
     </p>
-    <p xml:id="eco_de_0000144_16120">
+    <p xml:id="eco_de_0000214_16120">
      Sie beugt sich über den kleinen Quell, der kristallklar durch den Rasen fließt und nimmt eine purpurrote Apfelschale, die auf dem Grunde des Wässerleins lag, heraus.
     </p>
-    <p xml:id="eco_de_0000144_16130">
+    <p xml:id="eco_de_0000214_16130">
      Tropfend und rotleuchtend glänzt sie in des Mädchens fester Hand.
     </p>
-    <p xml:id="eco_de_0000144_16140">
+    <p xml:id="eco_de_0000214_16140">
      »Das tat die Marianne,« sagte sie beiläufig.
     </p>
-    <p xml:id="eco_de_0000144_16150">
+    <p xml:id="eco_de_0000214_16150">
      »Die muß besser eingespannt werden – die. Die zieht nicht an.«
     </p>
-    <p xml:id="eco_de_0000144_16160">
+    <p xml:id="eco_de_0000214_16160">
      »Wenn ich einmal heirate, hat sie alles zu übernehmen, was ich jetzt tue.«
     </p>
-    <p xml:id="eco_de_0000144_16170">
+    <p xml:id="eco_de_0000214_16170">
      »Maria, seit wann ist denn von einer Heirat die Rede? Das ist das erste Wort, das ich davon höre,« fragte der ernste, distinguiert aussehende Mann, der Typus des feinen Gelehrten aus gutem Hause; ein zartgliederiger, tadellos gekleideter Mensch, an dem vielleicht nur die Art zu blicken verrät, daß er zu der Menschenklasse gehört, die ein zu einseitiges, geistiges Leben führt.
     </p>
-    <p xml:id="eco_de_0000144_16180">
+    <p xml:id="eco_de_0000214_16180">
      Er hat etwas in der Art zu schauen, als hätte er die Kunst des Umherblickens nicht gelernt, etwas Weltfremdes, trotz seines weltmännischen Aeußern.
     </p>
-    <p xml:id="eco_de_0000144_16190">
+    <p xml:id="eco_de_0000214_16190">
      Und dies Weltfremde ließ ihn jünger erscheinen, als er wirklich war.
     </p>
-    <p xml:id="eco_de_0000144_16200">
+    <p xml:id="eco_de_0000214_16200">
      »Nein,« sagte das große, blonde Mädchen ruhig. »Es ist auch jetzt niemand da, den ich heiraten möchte; aber was nicht ist, kann werden. Ich bin vierundzwanzig.« Sie warf die Apfelschale wie eine rotleuchtende Schlange weit von sich auf einen Komposthaufen, der neben einer Reihe von Gemüsebeeten aufgeschichtet war, und schaute ihr nach.
     </p>
-    <p xml:id="eco_de_0000144_16210">
+    <p xml:id="eco_de_0000214_16210">
      »Du bist Erde und sollst zu Erde werden,« sagte sie behaglich vor sich hin.
     </p>
-    <p xml:id="eco_de_0000144_16220">
+    <p xml:id="eco_de_0000214_16220">
      Der Gelehrte blickte sinnend vor sich hin.
     </p>
-    <p xml:id="eco_de_0000144_16230">
+    <p xml:id="eco_de_0000214_16230">
      »Ich muß jetzt sehen, daß ordentlich gedeckt wird. In einer halben Stunde ist Essenszeit.«
     </p>
-    <p xml:id="eco_de_0000144_16240">
+    <p xml:id="eco_de_0000214_16240">
      »Sie verwöhnen Marianne.«
     </p>
-    <p xml:id="eco_de_0000144_16250">
+    <p xml:id="eco_de_0000214_16250">
      »Vor der Hand muß sie erzogen werden. Nein, nein, verwöhnen tue ich nicht. Bei uns muß jedes an seine Pflicht glauben, sonst ging's vollends drunter und drüber.« Er begleitete sie.
     </p>
-    <p xml:id="eco_de_0000144_16260">
+    <p xml:id="eco_de_0000214_16260">
      »Sagen Sie, Maria, – es steht nicht gut mit Ihrem Vater?«
     </p>
-    <p xml:id="eco_de_0000144_16270">
+    <p xml:id="eco_de_0000214_16270">
      »Nein.«
     </p>
-    <p xml:id="eco_de_0000144_16280">
+    <p xml:id="eco_de_0000214_16280">
      »Ei – ei – ei –, daß …«
     </p>
-    <p xml:id="eco_de_0000144_16290">
+    <p xml:id="eco_de_0000214_16290">
      »Da ist gar nichts zu wollen, das ist eine alte Geschichte, die Immenbachs kommen auf keinen grünen Zweig, und der arme Vater ist nicht der Mann, der Glück hat. Hier hätte eine harte Hand was ausgerichtet. – Und dann haben die letzten Krankheitsjahre der Mutter ihn stark mitgenommen.«
     </p>
-    <p xml:id="eco_de_0000144_16300">
+    <p xml:id="eco_de_0000214_16300">
      Das Mädchen sprach ruhig und einfach, wie Städtekinder nicht zu sprechen pflegen.
     </p>
-    <p xml:id="eco_de_0000144_16310">
+    <p xml:id="eco_de_0000214_16310">
      Kurz und gut, die Immenbachs kommen auf keinen grünen Zweig. Das war eine ganz einfache Tatsache, mit der sie sich abgefunden hatte. Es klang nicht traurig, nicht bedrückt, nicht klagend.
     </p>
-    <p xml:id="eco_de_0000144_16320">
+    <p xml:id="eco_de_0000214_16320">
      Sie sagte das so kernig kräftig wie jenes: Du bist Erde und sollst zu Erde werden.
     </p>
-    <p xml:id="eco_de_0000144_16330">
+    <p xml:id="eco_de_0000214_16330">
      Sie hat eine sonnedurchschienene Stimme, so warm, man denkt an Erd- und Laubgeruch, an Bäume mit Obst beladen, an wogende, gelbe Kornfelder, wenn sie spricht.
     </p>
-    <p xml:id="eco_de_0000144_16340">
+    <p xml:id="eco_de_0000214_16340">
      Oder erschien das dem Professor nur so, weil er seit Tagen diese Stimme unter beladenen Bäumen, im duftenden Garten, auf schmalen Wegen zwischen unermeßlich weitem, goldenem Korngewoge gehört hatte.
     </p>
-    <p xml:id="eco_de_0000144_16350">
+    <p xml:id="eco_de_0000214_16350">
      Ihm schien's, als wäre er in diesen Tagen an dieser Stimme gesundet.
     </p>
-    <p xml:id="eco_de_0000144_16360">
+    <p xml:id="eco_de_0000214_16360">
      So hirnmüde, so abgearbeitet und gehetzt ist er gewesen, als er sich entschlossen hatte, bei seinem alten Jugendfreund einzukehren und einmal in dieser Stille auszuruhen.
     </p>
-    <p xml:id="eco_de_0000144_16370">
+    <p xml:id="eco_de_0000214_16370">
      Hier, in diesem alten, einfachen Gutshause hatte er den Laub- und Wiesen- und Waldfrieden gefunden, – den sommerlichen Gartenfrieden. Er war hier in etwas ganz Sonderbares hineingeraten, ins Träumen mit wachen Augen, in ein junges, längst vergessenes Träumen. Das war ihm über die Glieder geflossen wie ein laues Bad. Ja, aber er hatte auch noch nie den wahren und vollen Landfrieden genossen, nie in seinem ganzen Leben wie jetzt.
     </p>
-    <p xml:id="eco_de_0000144_16380">
+    <p xml:id="eco_de_0000214_16380">
      Sommerfrischen aller Art, mit so und so viel abgehetzten Städtemenschen, die sich in irgendeinem Hotel zusammengefunden, das hatte er alljährlich immer wieder kennen gelernt; das fieberhaft eilige Naturgenießen von einem möglichst lärmreichen, unruhigen Hotelzentrum aus.
     </p>
-    <p xml:id="eco_de_0000144_16390">
+    <p xml:id="eco_de_0000214_16390">
      Aber hier! da war man außer der Welt, wie in Korngewoge begraben, wie eins mit dem Laub- und Erdgeruch – da gehörte man mit dazu, da wurde man eingesogen. Da ging man ein und aus und war daheim unter der großen Himmelsglocke.
     </p>
-    <p xml:id="eco_de_0000144_16400">
+    <p xml:id="eco_de_0000214_16400">
      Ach – das war so einfach – so einfach, so wehmütig zu Herzen gehend.
     </p>
-    <p xml:id="eco_de_0000144_16410">
+    <p xml:id="eco_de_0000214_16410">
      Immer und immer wieder war es ihm zumute, als hätte er Unsägliches verloren. Oft überkam ihn eine große Traurigkeit. Sein Leben erschien ihm so unsinnig, so ungemütlich, so unheimisch auf Erden. Er, der hochangesehene Mann, kam sich arm und elend vor.
     </p>
-    <p xml:id="eco_de_0000144_16420">
+    <p xml:id="eco_de_0000214_16420">
      Ja, weshalb eigentlich? Hätte er mit seinem Freunde tauschen mögen? – oder mit irgend einem Feldarbeiter? Nicht um die Welt – nein. Und doch diese wie im Raum schwebende Traurigkeit, die ihn manchmal überkam, die Traurigkeit des Kulturmenschen, den ein uraltes Heimweh zu Mutter Erde packt.
     </p>
-    <p xml:id="eco_de_0000144_16430">
+    <p xml:id="eco_de_0000214_16430">
      Und die Stimme des kräftigen, blonden Mädchens weckte diese Gefühle, wie Musik das Weh nach ewig Verlorenem, nie Gekanntem weckt. Für ihn lag in dieser Stimme ein Geheimnis. Er erwartete etwas von dieser Stimme. Und dieses unbestimmte Erwarten durchwebte das junge Träumen eines alten, müden Menschen.
     </p>
-    <p xml:id="eco_de_0000144_16440">
+    <p xml:id="eco_de_0000214_16440">
      In dem einfachen Eßzimmer saßen sie miteinander beim Mittagsmahl.
     </p>
-    <p xml:id="eco_de_0000144_16450">
+    <p xml:id="eco_de_0000214_16450">
      Es war ein großer, viereckiger, ebenerdiger Raum mit niederer Decke und niederen Fenstern.
     </p>
-    <p xml:id="eco_de_0000144_16460">
+    <p xml:id="eco_de_0000214_16460">
      Vor den Ostfenstern floß ein Bach vorüber. Man hörte, wenn es still im Zimmer war, ein feines Plätschern und Glucksen. Die Südfenster vom Weinlaube dicht umsponnen. Eine Rebe war zwischen Fensterrahmen und Mauer hindurchgewachsen und grünte in das Zimmer hinein, ja, war der Hauptschmuck des Raumes.
     </p>
-    <p xml:id="eco_de_0000144_16470">
+    <p xml:id="eco_de_0000214_16470">
      Ein altmodischer Sekretär, auf dem Säckchen mit Namen und allerhand Krimskrams stand, hielt sich bescheiden und unauffällig in einer Ecke und machte den Eindruck eines mißachteten und mißhandelten Möbels.
     </p>
-    <p xml:id="eco_de_0000144_16480">
+    <p xml:id="eco_de_0000214_16480">
      Um den Tisch saß ein kräftiges Geschlecht. Alles blonde, große Gestalten, rosige Menschen, die das Maß gewöhnlicher Sterblichen um ein Beträchtliches überschritten hatten. Die jüngeren Kinder trugen Mähnen von blondem, lockigem Haar. Den älteren Mädchen war dies feste Haar in einen Knoten gedreht. Die beiden großen Buben waren jetzt auch daheim in den Ferien und trugen in die Höh' starrende blonde Schöpfe über den großzügigen Gesichtern, die nicht gerade nach allzuviel Festigkeit aussahen, etwas Träumerisches, ein ganz klein wenig Verbummeltes lag ihnen im Ausdruck, als – wären sie hauptsächlich Phantasiemenschen.
     </p>
-    <p xml:id="eco_de_0000144_16490">
+    <p xml:id="eco_de_0000214_16490">
      Ihr Großvater war ein Dichter gewesen, weit berühmt über Deutschland hinaus. Und diese blonden Enkel sahen insgesamt so aus, als hätte der dichterische Genius des Großvaters sie sich ausgedacht.
     </p>
-    <p xml:id="eco_de_0000144_16500">
+    <p xml:id="eco_de_0000214_16500">
      Schöne Menschen, überaus schöne Menschen. Auch der Vater dieser blonden Rangen war eine prächtige Persönlichkeit. Hochgradig Phantasiemensch. Seine großen Glieder hatten eine gewisse Weichheit, die man fortgewünscht hätte.
     </p>
-    <p xml:id="eco_de_0000144_16510">
+    <p xml:id="eco_de_0000214_16510">
      All' diese sonnigen Leute, an diesem mächtigen Tisch, in dem bäuerlichen Raum, ließen den Ausdruck von Dürftigkeit nicht aufkommen.
     </p>
-    <p xml:id="eco_de_0000144_16520">
+    <p xml:id="eco_de_0000214_16520">
      Es waren ihrer so viele, und jeder von ihnen strahlte so viel Wärme, Heiterkeit und Blondheit aus, daß man den Eindruck von etwas Goldigem, Ueberschwänglichem nicht los wurde. Sie brauchten keine Möbel, keine Vorhänge. Jeder hatte seinen Platz, auf dem er sitzen konnte, den Tisch, an dem er essen konnte, und die weite Sommernatur draußen.
     </p>
-    <p xml:id="eco_de_0000144_16530">
+    <p xml:id="eco_de_0000214_16530">
      Es gab da auch etwas, wie einen Salon, einen dumpfen, unbelebten Raum, in dem nie jemand zu finden war.
     </p>
-    <p xml:id="eco_de_0000144_16540">
+    <p xml:id="eco_de_0000214_16540">
      Sie steckten immer zusammen, wenn sie nicht draußen sich umhertrieben, und immer in dem großen niedern Zimmer. Da machten die Kinder die Schularbeiten, da wurde geflickt und genäht, da zahlte der Vater die Leute aus, da hielten sie ihre Mahlzeiten, kernige Mahlzeiten, an die der Professor sich erst gewöhnen mußte.
     </p>
-    <p xml:id="eco_de_0000144_16550">
+    <p xml:id="eco_de_0000214_16550">
      Heute war, so schien es ihm, ein halbes Schaf auf den Tisch gekommen. In einer Riesenschüssel schwammen Riesenstücke in einer braunen Sauce, und Klöße gab es dazu, groß wie Kanonenkugeln; aber von allem, was auf dem Tisch stand, stieg ein Duft auf wie ein Opfergeruch aus fernen Zeiten.
     </p>
-    <p xml:id="eco_de_0000144_16560">
+    <p xml:id="eco_de_0000214_16560">
      Und sie erhoben die Hände zum lecker bereiteten Mahle.
     </p>
-    <p xml:id="eco_de_0000144_16570">
+    <p xml:id="eco_de_0000214_16570">
      Der Professor dachte an seine Mahlzeiten daheim mit seinen beiden Töchtern und seinem Sohne. Da war ihm nicht aufgefallen, daß die Speisen dufteten. Jeder aß gleichgültig etwas Gleichgültiges.
     </p>
-    <p xml:id="eco_de_0000144_16580">
+    <p xml:id="eco_de_0000214_16580">
      Sie waren alle übermüdet und hatten alle den Kopf voll.
     </p>
-    <p xml:id="eco_de_0000144_16590">
+    <p xml:id="eco_de_0000214_16590">
      Das war nicht anders gewesen, als die Frau noch lebte. Sie waren daheim alle geistige Naturen, alle Intelligenzen. Die Frau hatte bald nach diesem, bald nach jenem Regime kochen lassen, Speisen, die das Hirn am besten nährten, den Organen die denkbar geringste Arbeit verursachten.
     </p>
-    <p xml:id="eco_de_0000144_16600">
+    <p xml:id="eco_de_0000214_16600">
      Nie hatte er aber gesehen, daß die Kinder mit Appetit gegessen hatten, ja, daß sie mit Appetit gelebt hätten.
     </p>
-    <p xml:id="eco_de_0000144_16610">
+    <p xml:id="eco_de_0000214_16610">
      Von früh an waren sie alle auf Ziele losgegangen, bewußt, brav und pflichttreu, voller nervöser Eigenheiten, die von der Mutter respektiert wurden; – unbehagliche Menschen, Hirnmenschen ohne Wärme! Niemand hatte Freude gehabt an den häuslichen Dingen, am Nestbau, an den Dingen, die von uralt tierischer Wärme durchdrungen sind, die den Tiermenschen so nahe angehen, die den geistigen Menschen aufrecht erhalten. Ja, sie hatten immer wie ohne festen Unterbau gelebt, nicht erdensicher.
     </p>
-    <p xml:id="eco_de_0000144_16620">
+    <p xml:id="eco_de_0000214_16620">
      Und diese hier lebten erdensicher. Mit ihren großen Füßen standen sie alle so fest und liefen so dröhnend und lebenslustig durchs Haus, dem es am Oberbau fehlte.
     </p>
-    <p xml:id="eco_de_0000144_16630">
+    <p xml:id="eco_de_0000214_16630">
      Ja, denn ihr Dasein streckte sich nicht in die Höhe, ging in die Breite, dem Erdboden nah.
     </p>
-    <p xml:id="eco_de_0000144_16640">
+    <p xml:id="eco_de_0000214_16640">
      Im Salon, im ersten Stock, waren sie schon nicht erdensicher und erdenheimisch.
     </p>
-    <p xml:id="eco_de_0000144_16650">
+    <p xml:id="eco_de_0000214_16650">
      Aus der Zimmertür hinaus ins Freie, mit ein paar Schritten, das mußte so sein. Sie wären sich sonst gefangen vorgekommen.
     </p>
-    <p xml:id="eco_de_0000144_16660">
+    <p xml:id="eco_de_0000214_16660">
      Wie dem Professur hier alles zu Herzen sprach.
     </p>
-    <p xml:id="eco_de_0000144_16670">
+    <p xml:id="eco_de_0000214_16670">
      Ja, und das gefiel ihm, die solide, einfache Ordnung im Haus. Was man berührte: verbraucht, wie abgeschliffen, aber blank und rein.
     </p>
-    <p xml:id="eco_de_0000144_16680">
+    <p xml:id="eco_de_0000214_16680">
      Da war eine tüchtige Hand zu spüren. Marias Hand.
     </p>
-    <p xml:id="eco_de_0000144_16690">
+    <p xml:id="eco_de_0000214_16690">
      Die verstorbene Frau mußte eine brave Hauswirtin gewesen sein, denn es waren alte, ausgefahrene Geleise, in denen die Räder der Wirtschaft liefen.
     </p>
-    <p xml:id="eco_de_0000144_16700">
+    <p xml:id="eco_de_0000214_16700">
      Von der Mutter trugen auch die meisten der Kinder feste und schöne Linien in der Mundbildung, die den weichen Gesichtern sehr zugute kamen.
     </p>
-    <p xml:id="eco_de_0000144_16710">
+    <p xml:id="eco_de_0000214_16710">
      Und diese Gesundheit im Hause!
     </p>
-    <p xml:id="eco_de_0000144_16720">
+    <p xml:id="eco_de_0000214_16720">
      Unwillkürlich hielt sich der Gast hier aufrechter als gewöhnlich. Er kam sich kräftiger vor.
     </p>
-    <p xml:id="eco_de_0000144_16730">
+    <p xml:id="eco_de_0000214_16730">
      Der Hauch dieser blonden, herrlichen Geschöpfe belebte seine Nerven. Ja, in diesem großen Raum, an diesem breiten Tisch, da stieg die Lebenskraft, wie nach einem Frühlingsregen die Erdkraft aus der Erde auf.
     </p>
-    <p xml:id="eco_de_0000144_16740">
+    <p xml:id="eco_de_0000214_16740">
      Die seine, ausgearbeitete Intelligenz des Gastes wurde hier von Bildern berührt, die die Feinheit dieser Intelligenz dem Manne wie eine langwierige, schmerzhafte Krankheit erscheinen ließen.
     </p>
-    <p xml:id="eco_de_0000144_16750">
+    <p xml:id="eco_de_0000214_16750">
      Wenn er abends, als der letzte zur Ruhe ging, standen auf dem Treppenabsatz die Schuhe der Familie, um am andern Morgen von der Hausmagd gereinigt zu werden.
     </p>
-    <p xml:id="eco_de_0000144_16760">
+    <p xml:id="eco_de_0000214_16760">
      Und es verging kein Abend, an dem er nicht diese unabsehbare Reihe dräuender Stiefel, mit dicken Sohlen und urweltlichen Gesichtern, betrachtete.
     </p>
-    <p xml:id="eco_de_0000144_16770">
+    <p xml:id="eco_de_0000214_16770">
      Sie standen immer der Größe nach geordnet. Zuerst des Vaters Riesenkähne, darauf die Schuhe der vier großen Töchter und darauf drei Paar kräftige, unausgewachsene. Und alle standen sie so unschuldsvoll da, so treuherzig, schämten sich nicht ihrer Mängel und Flicken. Es war, als wenn sie sagten: Da sind wir! – Da! So wie wir sind, sind wir. Wir sind zufrieden. Uns war's den ganzen Tag über wohl an unsern lebendigen, warmen Füßen.
     </p>
-    <p xml:id="eco_de_0000144_16780">
+    <p xml:id="eco_de_0000214_16780">
      Ihren Schmutz und Staub trugen sie stolz wie Ehrenzeichen. Sie hatten weiß Gott nicht gefaulenzt.
     </p>
-    <p xml:id="eco_de_0000144_16790">
+    <p xml:id="eco_de_0000214_16790">
      Es war so ein gesunder, luftiger Schmutz an ihnen, der von tollen, übermütigen Streichen erzählte und von einem intimen Verkehr mit allerhand Viehvolk.
     </p>
-    <p xml:id="eco_de_0000144_16800">
+    <p xml:id="eco_de_0000214_16800">
      Da waren Marias Schuhe, die steckte in ihren freien Stunden am liebsten bei den Fohlen. Heute war er ihr draußen auf der Wiese begegnet. Die fünf braunen Fohlen hatten sie umgeben. Mit ihren weichen Nüstern hatten sie an ihr geschnuppert.
     </p>
-    <p xml:id="eco_de_0000144_16810">
+    <p xml:id="eco_de_0000214_16810">
      Sie lief, und die Fohlen trotteten mit ihr in großen, steifen Sprüngen.
     </p>
-    <p xml:id="eco_de_0000144_16820">
+    <p xml:id="eco_de_0000214_16820">
      Dieses braune, flockige Volk mit den stumpfschwarzen Mähnen und Schwanzhaar! Wie köstlich war das große, blonde Mädchen da gewesen, wie unvergeßlich.
     </p>
-    <p xml:id="eco_de_0000144_16830">
+    <p xml:id="eco_de_0000214_16830">
      Ja, die Schuhe der jungen Geschöpfe taten es jeden Abend dem zartnervigen, sensiblen Manne an.
     </p>
-    <p xml:id="eco_de_0000144_16840">
+    <p xml:id="eco_de_0000214_16840">
      Das waren die Schuhe urwüchsiger, lustiger, weltfremder Göttinnen.
     </p>
-    <p xml:id="eco_de_0000144_16850">
+    <p xml:id="eco_de_0000214_16850">
      Er dachte dann an die schmalen, winzigen Fußbekleidungen seiner verstorbenen Frau, an die noch zierlicheren seiner Töchter. Er sah die blutarmen, bleichen, klugen Füßchen, die nicht mußten, was Laufen ist, die mit kurzen Schritten Zielen zustrebten, die angestrengt, geistiger Art waren. Da liefen diese klugen Füßchen in die Staatsbibliothek, zu Versammlungen, zu Vorlesungen; in Ateliers, jetzt in die Hörsäle – ach, zu Gott weiß was, und mußten immer still unter den dunkeln Kleidern stehen, ohne Luft und Licht, bis sie wieder einen kurzen Weg auf hartem Straßenpflaster machen durften.
     </p>
-    <p xml:id="eco_de_0000144_16860">
+    <p xml:id="eco_de_0000214_16860">
      Ja, der Professor war hier in dieser Luft zu dem Hang gekommen, seinen Phantasien nachzugehen. Dies Haus und dieser Garten beeinflußten ihn.
     </p>
-    <p xml:id="eco_de_0000144_16870">
+    <p xml:id="eco_de_0000214_16870">
      Und seine Phantasie beschäftigte sich zumeist mit Maria.
     </p>
-    <p xml:id="eco_de_0000144_16880">
+    <p xml:id="eco_de_0000214_16880">
      Wenn er auf den holprigen Feldwegen, mitten zwischen den goldnen Kornfluten ging, begleitete ihn ihr Bild, gleichgültig, ob sie leibhaftig neben ihm schritt oder nicht, ob er die blonde, sonnige Stimme hörte oder nicht.
     </p>
-    <p xml:id="eco_de_0000144_16890">
+    <p xml:id="eco_de_0000214_16890">
      Sie war seinem Wohlbefinden notwendig geworden.
     </p>
-    <p xml:id="eco_de_0000144_16900">
+    <p xml:id="eco_de_0000214_16900">
      Ihre wundervolle Gesundheit erquickte ihn und auch die Liebe, mit der sie jedes wachsende Leben umschloß, jedes Tier, jede Pflanze.
     </p>
-    <p xml:id="eco_de_0000144_16910">
+    <p xml:id="eco_de_0000214_16910">
      Er empfand, als hätte sie ihn selbst mit mütterlicher, heiterer Fürsorge berührt, wenn sie es irgendeinem Geschöpf tat. Wie sie einem Halm, dessen schweres Haupt ihn auf den Weg niedergezogen hatte, aufhalf, ihn mit einer weichen, zärtlichen Handbewegung dem Meere seiner Brüder wieder zugesellt, erschien ihm wie eine rührende, heilige Handlung.
     </p>
-    <p xml:id="eco_de_0000144_16920">
+    <p xml:id="eco_de_0000214_16920">
      Nie im Leben war ihm das mütterliche Weib begegnet.
     </p>
-    <p xml:id="eco_de_0000144_16930">
+    <p xml:id="eco_de_0000214_16930">
      Selten begegnet es einem.
     </p>
-    <p xml:id="eco_de_0000144_16940">
+    <p xml:id="eco_de_0000214_16940">
      Ja, und es ist kein Wunder, dachte er, als er wieder einmal neben ihr herging: – das Mütterliche hat man in euch verkümmern lassen, alles hat man verkümmern lassen – und auch dies, – dies Innigste. Ein falsches, häßliches Schamgefühl ist darüber gebreitet. Ihr solltet euch eurer Mütterlichkeit nicht bewußt werden. Eure geistige Mütterlichkeit wächst nicht wie eine schöne Blume unschuldig in der Sonne; sie verkümmert in Dumpfheit, als wäre sie etwas Schmachvolles; und wenn ihr Mütter werdet, werdet ihr's ohne die geistige, süße, warme Vorbereitung dazu.
     </p>
-    <p xml:id="eco_de_0000144_16950">
+    <p xml:id="eco_de_0000214_16950">
      Maria ging oft schweigsam mit ihm.
     </p>
-    <p xml:id="eco_de_0000144_16960">
+    <p xml:id="eco_de_0000214_16960">
      Er frug sie einmal: »Nicht wahr, Sie sagen es offen, wenn Sie lieber einmal mich nicht begleiteten?«
     </p>
-    <p xml:id="eco_de_0000144_16970">
+    <p xml:id="eco_de_0000214_16970">
      »Gewiß,« antwortete sie; »aber ich gehe gern mit Ihnen, wenn Sie mich wollen.
     </p>
-    <p xml:id="eco_de_0000144_16980">
+    <p xml:id="eco_de_0000214_16980">
      Wir haben noch nie solch einen Gast gehabt. Wir leben, wie die Bauern, nicht viel anders, und wir sind alle immer glücklich dabei gewesen. Aber wir alle, die Marianne auch, werden Sie sehr vermissen. Es ist durch Sie etwas gekommen, was niemand kannte, so etwas Rastloses.«
     </p>
-    <p xml:id="eco_de_0000144_16990">
+    <p xml:id="eco_de_0000214_16990">
      Er frug sie, was sie damit meinte. Sie wußte sich nicht recht auszudrücken, wie es schien, und sagte nach, einer Weile:
     </p>
-    <p xml:id="eco_de_0000144_17000">
+    <p xml:id="eco_de_0000214_17000">
      »Sie denken immer; es erweckt in Ihnen alles Gedanken. Wir alle fühlen nur. Das ist ein großer Unterschied. Sie müssen doch nicht viel jünger wie der Vater sein und sind doch so viel jünger. Das macht, weil Ihr Geist lebendig ist. Hier auf dem Lande altert der Mensch, wenn der Körper altert. Sehen Sie den Vater. Aber, man ist viel ruhiger, wie Sie es sind. Es hat alles sein Gutes.« Sie sagte das vornehm und setzte sich und die Ihrigen damit nicht herab. Es klang nur heraus: Wir sind anders wie du.
     </p>
-    <p xml:id="eco_de_0000144_17010">
+    <p xml:id="eco_de_0000214_17010">
      Er mußte ihr von seinen Töchtern und seinem Sohn erzählen, von der verstorbenen Frau und von seinem Leben.
     </p>
-    <p xml:id="eco_de_0000144_17020">
+    <p xml:id="eco_de_0000214_17020">
      Er klagte ihr, daß es bei ihm daheim nicht behaglich sei.
     </p>
-    <p xml:id="eco_de_0000144_17030">
+    <p xml:id="eco_de_0000214_17030">
      »Das glaub' ich,« sagte sie, »bei euch hat ja niemand die Dinge und das Haus lieb. Es will alles geliebt sein, und ihr seid viel zu gescheit dazu.«
     </p>
-    <p xml:id="eco_de_0000144_17040">
+    <p xml:id="eco_de_0000214_17040">
      Er lächelte.
     </p>
-    <p xml:id="eco_de_0000144_17050">
+    <p xml:id="eco_de_0000214_17050">
      Aber von dieser Stunde an wurden seine Träume und Phantasien faßlicher – beängstigender.
     </p>
-    <p xml:id="eco_de_0000144_17060">
+    <p xml:id="eco_de_0000214_17060">
      Stundenlang wandelte er im Garten auf und nieder, unausgesetzt mit dem Wunsche beschäftigt, dies sonnige, starke Weib in sein eigenes Haus zu verpflanzen.
     </p>
-    <p xml:id="eco_de_0000144_17070">
+    <p xml:id="eco_de_0000214_17070">
      Es schwebte ihm dabei etwas ganz Wunderliches, Gestaltungsloses vor, etwas, was seinen Ursprung in alten, fast vergessenen, vielleicht biblischen Eindrücken haben mochte. Eine herrliche, sorgsame Hausmagd – ein Kleinod, etwas, was es nicht gibt und nicht gab, etwas Alttestamentarisches, etwas Wundervolles.
     </p>
-    <p xml:id="eco_de_0000144_17080">
+    <p xml:id="eco_de_0000214_17080">
      Sein ganzes Haus schien ihm warm und sonnig zu werden, wenn er sich vorstellte, daß sie darin waltete. Die freudlosen Töchter erblühten, das entsetzliche Dienstbotenvolk zerstob wie unreines Gesindel.
     </p>
-    <p xml:id="eco_de_0000144_17090">
+    <p xml:id="eco_de_0000214_17090">
      Ja, er war in dieser Abgeschiedenheit in das weltfremde Träumen tief hineingekommen – so tief, daß er seine Träume leidenschaftlich zu lieben begann, wie ein junger Mann die Qualitäten des Lebens.
     </p>
-    <p xml:id="eco_de_0000144_17100">
+    <p xml:id="eco_de_0000214_17100">
      Wenn er sich vorstellte, daß er sie zur Frau Professor machen könnte, so erschien ihm das beunruhigend, unmöglich: – nicht seiner Kinder wegen – das nicht. Er war ein wohlhabender Mann, und seinen Töchtern, deren Eigenart sie zur Ehelosigkeit zu führen schien, würde er durch diese Frau einen Lebenshalt geben.
     </p>
-    <p xml:id="eco_de_0000144_17110">
+    <p xml:id="eco_de_0000214_17110">
      Auf Kinder aus zweiter Ehe rechnete er nicht mehr, – wünschte sie nicht.
     </p>
-    <p xml:id="eco_de_0000144_17120">
+    <p xml:id="eco_de_0000214_17120">
      Es würde im Grunde eine ruhige, friedliche Angelegenheit werden, diese Sonne in sein Haus zu bringen.
     </p>
-    <p xml:id="eco_de_0000144_17130">
+    <p xml:id="eco_de_0000214_17130">
      Aber da war etwas, weshalb er Maria nicht als Frau, sondern als biblische, urweltliche Hausmagd wollte, so ein sonderbarer Gedanke es auch war.
     </p>
-    <p xml:id="eco_de_0000144_17140">
+    <p xml:id="eco_de_0000214_17140">
      Es lag für ihn in der Idee einer zweiten Ehe der Welt gegenüber so viel Peinliches. Er mit seinen siebenundfünfzig Jahren, Vater von längst erwachsenen Töchtern. Jede Auffälligkeit war ihm unsäglich zuwider.
     </p>
-    <p xml:id="eco_de_0000144_17150">
+    <p xml:id="eco_de_0000214_17150">
      Liebe konnte er auch das Gefühl, das ihn zu dem Mädchen hinzog, kaum nennen. Nein, es war weit mehr ein ästhetisches Bedürfnis, sie in seiner Nähe zu haben; eine Sehnsucht nach Wärme und Behagen.
     </p>
-    <p xml:id="eco_de_0000144_17160">
+    <p xml:id="eco_de_0000214_17160">
      Aber dies Bedürfnis war stark, fast leidenschaftlich und peinigte ihn.
     </p>
-    <p xml:id="eco_de_0000144_17170">
+    <p xml:id="eco_de_0000214_17170">
      So vergingen sechs Wochen. Für ihn sechs aufregende, merkwürdige Wochen, in denen er empfand, daß sein Wesen durchaus nicht so in sich abgeschlossen war, wie er wähnte.
     </p>
-    <p xml:id="eco_de_0000144_17180">
+    <p xml:id="eco_de_0000214_17180">
      Der Landaufenthalt bei dem Jugendfreund schloß damit, daß sich der Professor mit der ältesten Tochter des Hauses feierlich verlobte. Maria hatte sich vordem kurze Bedenkzeit ausgebeten. Und in diesen Tagen war sie mit ihrem Vater jeden Nachmittag weit über Land gegangen.
     </p>
-    <p xml:id="eco_de_0000144_17190">
+    <p xml:id="eco_de_0000214_17190">
      Da schritten die beiden großen Gestalten meist schweigend nebeneinander her, und hin und wieder fielen Worte wie: »Ja, wie soll ich dir da zureden. – – – Ich wollt', er hätte seine zwanzig Jahr weniger auf dem Buckel – aber – aber –«
     </p>
-    <p xml:id="eco_de_0000144_17200">
+    <p xml:id="eco_de_0000214_17200">
      Dann wieder Schweigen. »Er ist brav, reich, angesehen. – Wie soll ich denn meine Kinder an den Mann bringen? – Und eine solche Verwandtschaft! – Maria, widerlich ist er dir doch nicht? – was man so widerlich nennt?« »Vater! nein, – gewiß nicht. – So ein edler, guter Mensch.«
     </p>
-    <p xml:id="eco_de_0000144_17210">
+    <p xml:id="eco_de_0000214_17210">
      »Aber die großen Kinder, Maria!« Ja, das war auch ihr das ärgste. »Und alle noch im Haus.«
     </p>
-    <p xml:id="eco_de_0000144_17220">
+    <p xml:id="eco_de_0000214_17220">
      Dann sprachen sie von den drückenden Familienverhältnissen – über die Unmöglichkeit, die Töchter daheim zu behalten; über das »Unter fremde Leute gehen« – das Brotverdienen, über die großen Ausgaben, die die Söhne verursachen würden.
     </p>
-    <p xml:id="eco_de_0000144_17230">
+    <p xml:id="eco_de_0000214_17230">
      Sie breiteten voreinander die Lasten aus, die auf der starken, lebenskräftigen Familie lagen und sie langsam zu ersticken drohten.
     </p>
-    <p xml:id="eco_de_0000144_17240">
+    <p xml:id="eco_de_0000214_17240">
      »So ein Halt in der Welt, Maria, ist für Leute, wie wir sind, von großem Wert.«
     </p>
-    <p xml:id="eco_de_0000144_17250">
+    <p xml:id="eco_de_0000214_17250">
      Dann wieder: »Aber ganz nach deinem Gutdünken, denke nicht an uns; denke an dich!«
     </p>
-    <p xml:id="eco_de_0000144_17260">
+    <p xml:id="eco_de_0000214_17260">
      Sie redeten miteinander, wie die Menschen es tun, die etwas wollen und zu gleicher Zeit nicht wollen, die den Mut nicht haben, etwas aus den Händen gleiten zu lassen, und die Kraft nicht haben, es zu halten.
     </p>
-    <p xml:id="eco_de_0000144_17270">
+    <p xml:id="eco_de_0000214_17270">
      Aber schließlich hatte Maria die Kraft gefunden, zu halten, was das Schicksal ihr bestimmen wollte. Ja, und mit einer ehrlichen Freudigkeit hielt sie es. Sie wollte ihre Pflicht tun, wie sie ihre Pflicht bis jetzt immer getan hatte. Sie wollte dem guten, klugen Menschen sein Heim behaglich machen. Nein – es war ihrer Natur kein Opfer, das sie brachte, so schien es ihr.
     </p>
-    <p xml:id="eco_de_0000144_17280">
+    <p xml:id="eco_de_0000214_17280">
      Die Verlobung wurde also gefeiert und die Hochzeit auf sechs Wochen später angesetzt.
     </p>
-    <p xml:id="eco_de_0000144_17290">
+    <p xml:id="eco_de_0000214_17290">
      Sie sollte den Kindern des Professors erst als junge Frau entgegentreten.
     </p>
-    <p xml:id="eco_de_0000144_17300">
+    <p xml:id="eco_de_0000214_17300">
      Die Kinder schrieben kühle, formgewandte, höfliche Briefe an die Braut ihres Vaters, wie sie dieselben kaum anders hätten schreiben können.
     </p>
-    <p xml:id="eco_de_0000144_17310">
+    <p xml:id="eco_de_0000214_17310">
      Kein Mißklang störte das Verhältnis zwischen ihr und dem Professor.
     </p>
-    <p xml:id="eco_de_0000144_17320">
+    <p xml:id="eco_de_0000214_17320">
      Sie schrieb, als er wieder nach München zurückgekehrt war, ihre einfachen, natürlichen Briefchen an ihn, und er vertrauensvolle, sie ehrende Briefe an sie.
     </p>
-    <p xml:id="eco_de_0000144_17330">
+    <p xml:id="eco_de_0000214_17330">
      Eine wahre Liebe hatte Maria ihr Lebtag noch nicht kennen gelernt. Gefeiert hatte man sie natürlich, wo sie sich zeigte, und wenn sie und Marianne im Winter einigemal in die Stadt zu Bällen gefahren waren, hatten die Immenbachschen Töchter an Anbetern keinen Mangel gehabt; aber die Immenbachschen Vermögensverhältnisse waren hinreichend bekannt. Da gab's nichts zu holen. So war Marias Herz kühl und stolz geblieben. Ueber ihre Schwester Marianne ärgerte sie sich oftmals, weil die es nicht lassen konnte, einen oder den anderen am Bändel zu halten, bis es mit Tränen endete.
     </p>
-    <p xml:id="eco_de_0000144_17340">
+    <p xml:id="eco_de_0000214_17340">
      Die Hochzeit sollte ganz still im Gutshaus gefeiert werden ohne allen Aufwand.
     </p>
-    <p xml:id="eco_de_0000144_17350">
+    <p xml:id="eco_de_0000214_17350">
      Maria hatte jetzt schon seit Wochen alle Hände voll zu tun, um mit den geringsten Mitteln eine kleine Wäscheaussteuer zu richten – und dann die Hochzeitsvorbereitungen. Der Vater sollte keine Last davon haben.
     </p>
-    <p xml:id="eco_de_0000144_17360">
+    <p xml:id="eco_de_0000214_17360">
      Maria buk und wirtschaftete, damit am Hochzeitstage alle, die zum Hause gehörten, befriedigt werden konnten, die Knechte, die Mägde und die Leute im Dorf. Das war die Hauptsache.
     </p>
-    <p xml:id="eco_de_0000144_17370">
+    <p xml:id="eco_de_0000214_17370">
      Maria war seit Wochen gar nicht zu sich selbst gekommen. Am Vorabend ihrer Hochzeit, bevor der Professor kam, ging sie leicht ermattet von aller Arbeit und allem Schaffen einen stillen, einsamen Weg, einen Hügel hinan, durch liebes, heimisches Gehölz.
     </p>
-    <p xml:id="eco_de_0000144_17380">
+    <p xml:id="eco_de_0000214_17380">
      Die Blutwellen waren ihr noch nicht beruhigt nach dem großen Arbeitssturm.
     </p>
-    <p xml:id="eco_de_0000144_17390">
+    <p xml:id="eco_de_0000214_17390">
      Mild, wie lauwarm war es heut; aber die modernde Laubdecke unter den Bäumen duftete schon herbstlich scharf.
     </p>
-    <p xml:id="eco_de_0000144_17400">
+    <p xml:id="eco_de_0000214_17400">
      Und wie sie so wandelte, legte sich ihr etwas schwer über die Glieder, über ihr ganzes Wesen, etwas wie eine große Hoffnungslosigkeit.
     </p>
-    <p xml:id="eco_de_0000144_17410">
+    <p xml:id="eco_de_0000214_17410">
      Neben einer schlanken Buche setzte sie sich auf den Waldgrund nieder und legte den Kopf an den Stamm, und schwer, weich, erstickend sank etwas Unbekanntes auf sie nieder, etwas Trostloses, etwas, das sie nicht benennen konnte, etwas ganz Freudloses.
     </p>
-    <p xml:id="eco_de_0000144_17420">
+    <p xml:id="eco_de_0000214_17420">
      Und sonderbar, sie fühlte zum erstenmal im Leben, daß sie Maria Immenbach war.
     </p>
-    <p xml:id="eco_de_0000144_17430">
+    <p xml:id="eco_de_0000214_17430">
      Sie preßte ihren Kopf fest an die glatte Buche und weinte herzbrechend wie ein armes, großes Kind, dann sank sie mit dem Angesicht auf die Erde und küßte diese liebe Erde wie ihre Mutter.
     </p>
-    <p xml:id="eco_de_0000144_17440">
+    <p xml:id="eco_de_0000214_17440">
      Heiß und leidenschaftlich küßte sie, daß es schwarz und feucht ihr zwischen die Lippen kam. »Ich liebe dich!« schluchzte sie, »du bist gut!«
     </p>
-    <p xml:id="eco_de_0000144_17450">
+    <p xml:id="eco_de_0000214_17450">
      Als sie ihr rosiges Gesicht verwundert von seinem Tränenstrom getrocknet und mit dem Taschentuch sich angefächelt hatte, ging sie langsam zum Gutshof zurück, feierlich durch alle Ställe.
     </p>
-    <p xml:id="eco_de_0000144_17460">
+    <p xml:id="eco_de_0000214_17460">
      Die Hündin hatte am Tage vorher Junge geworfen und lag mit ihren Kleinen schwerfällig und geduldig im Pferdestall auf einer Schütte Stroh. Ihrer sechs tranken an ihr und rissen an den starken Brüsten des Tieres und marterten es. Die Hündin hatte einen geduldigen, leidenden Blick, in dem eine große, stumme Klage lag, ein großes, stummes Weh und eine stumme Freude.
     </p>
-    <p xml:id="eco_de_0000144_17470">
+    <p xml:id="eco_de_0000214_17470">
      So lag sie zu Marias Füßen und klopfte leise, wie müde mit dem buschigen Schwanz auf das Stroh.
     </p>
-    <p xml:id="eco_de_0000144_17480">
+    <p xml:id="eco_de_0000214_17480">
      Maria kniete zu ihr nieder und neigte ihr Gesicht zum Kopf der Hündin, nahm ihn zärtlich zwischen ihre beiden Hände und sagte wieder schluchzend und erregt: »Ein Kind! – dann ist alles – alles gut.«
     </p>
-    <p xml:id="eco_de_0000144_17490">
+    <p xml:id="eco_de_0000214_17490">
      Dann neigte sie sich noch tiefer und drückte ihr Gesicht an das Gesicht der Hündin stumm und zärtlich und leidenschaftlich.
     </p>
-    <p xml:id="eco_de_0000144_17500">
+    <p xml:id="eco_de_0000214_17500">
      Der Professor reiste mit dem jungen, weltfremden Weib und zeigte ihr ein neues Stück der guten Erde.
     </p>
-    <p xml:id="eco_de_0000144_17510">
+    <p xml:id="eco_de_0000214_17510">
      Sie gingen miteinander durch Italiens Galerien und Kirchen und Museen, wie sie miteinander auf den schmalen, holperigen Wegen zwischen dem goldigen Korngewoge gegangen waren.
     </p>
-    <p xml:id="eco_de_0000144_17520">
+    <p xml:id="eco_de_0000214_17520">
      Er, liebenswürdig und klug, ihr allerhand von seiner aufgespeicherten Weisheit mitteilend, und sie freundlich, folgsam und aufmerkend, nicht scheu, nicht bedrückt, eine in sich geschlossene Persönlichkeit, die sich in ihrem ruhigen Menschentum wohl und sicher fühlt.
     </p>
-    <p xml:id="eco_de_0000144_17530">
+    <p xml:id="eco_de_0000214_17530">
      Ihr ist davon nichts aufgegangen, daß ihre stolze, frohe Weibseele etwas Geringeres ist als die mit Wissen und Weisheit ausgefüllte ihres Gatten.
     </p>
-    <p xml:id="eco_de_0000144_17540">
+    <p xml:id="eco_de_0000214_17540">
      Für sie ist Gelehrsamkeit ein Geschäft, etwa wie ein Krämergeschäft, und hat mit dem eigentlichen Menschentum nichts gemein.
     </p>
-    <p xml:id="eco_de_0000144_17550">
+    <p xml:id="eco_de_0000214_17550">
      Ein Krämer muß seine Ware haben und ist sonst ein Mensch wie andere, und ein Professor muß seine Ware haben und ist sonst ein Mensch wie andere.
     </p>
-    <p xml:id="eco_de_0000144_17560">
+    <p xml:id="eco_de_0000214_17560">
      Davon aber war sie überzeugt, daß ihr Gatte die feinste und beste Ware führte, daß er durchaus reell war, und daß man ihm jedes Wort, was er sagte, unbesorgt glauben konnte. Sie fand es höchst natürlich, daß er alles wußte, daß ihnen nichts begegnete, was er nicht erklären konnte, und fand es sehr hübsch, so vielerlei zu erfahren. Ja, sie lebte in einer ganz neuen Welt.
     </p>
-    <p xml:id="eco_de_0000144_17570">
+    <p xml:id="eco_de_0000214_17570">
      Gewohnt, die Dinge zu nehmen, wie sie kamen, war ihr Leben so ein gleichmäßiges, arbeitsreiches gewesen, so ein völlig traumloses, wie auch ein guter, gesunder Schlaf traumlos sein muß. Sie hatte ganz ohne Liebesduselei gelebt, ganz ohne Sehnsucht.
     </p>
-    <p xml:id="eco_de_0000144_17580">
+    <p xml:id="eco_de_0000214_17580">
      So schön war es bei ihnen daheim gewesen, so lebendig, – so viel Jugend, daß niemand an schwindende Jahre dachte und an Liebesernte. Sie lebten alle ins Blaue hinein; von einem Tag zum andern. So war Marias Seele in ihrem vierundzwanzigsten Jahre noch so ruhig und unerregt, wie die Seele eines Kindes, und sie nahm des Professors weise geregelte Ehemannsgewohnheiten für den Inbegriff von Liebe und Leidenschaft. Ja, nun kannte sie die Liebe, nun kannte sie das große Geheimnis, und die Welt war deshalb nicht schöner und anders geworden. Auf dieser Reise hatte sie unmenschlich viel Bilder gesehen.
     </p>
-    <p xml:id="eco_de_0000144_17590">
+    <p xml:id="eco_de_0000214_17590">
      Ihr wäre viel lieber gewesen, an dem schönen blauen Meer länger zu bleiben, als so von Galerie zu Galerie getrieben zu werden. Für jedes fremde Kraut fühlte sie wärmeres Interesse, als für das berühmteste Kunstwerk.
     </p>
-    <p xml:id="eco_de_0000144_17600">
+    <p xml:id="eco_de_0000214_17600">
      Für die liebe Wirklichkeit zeigte ihr Professor aber wenig Neigung und Achtung. Draußen im Freien mußte er immer eilen, um zu einem Ziel zu kommen, und ein Ziel war immer ein Kunstgenuß. Maria kam es vor, als hätten die Dinge erst Wert für ihn, wenn sie im Goldrahmen steckten und von einem Menschen nachgebildet worden waren. Komisch – sehr – sehr komisch.
     </p>
-    <p xml:id="eco_de_0000144_17610">
+    <p xml:id="eco_de_0000214_17610">
      Es strengte sie auch namenlos an, der Geschmacksrichtung ihres Professors zu folgen. Lieber wie ein Ackerknecht durch die Furchen stapfen, als auf dem harten Estrich der Galerien stundenlang von Bild zu Bild gehen.
     </p>
-    <p xml:id="eco_de_0000144_17620">
+    <p xml:id="eco_de_0000214_17620">
      Und er teilte die Bilder in Schulen und wollte, daß sie diese Einteilung behalten sollte. Sie bemühte sich, dies zu tun; aber es langweilte sie unsäglich und war ihr völlig gleichgültig.
     </p>
-    <p xml:id="eco_de_0000144_17630">
+    <p xml:id="eco_de_0000214_17630">
      Ihr Professor aber schien in den Galerien übermenschliche Kräfte zu erhalten; wenn ihr schwindelte und übel und weh war, hörte er noch längst nicht auf, zu dozieren und sein Opfer zu examinieren.
     </p>
-    <p xml:id="eco_de_0000144_17640">
+    <p xml:id="eco_de_0000214_17640">
      Nein, sie konnte gar nicht mehr und kam, von der Not gedrängt, auf eine List.
     </p>
-    <p xml:id="eco_de_0000144_17650">
+    <p xml:id="eco_de_0000214_17650">
      »Nichts von alledem ist mir doch so lieb wie die Kaiserin Agrippina auf ihrem schönen Sessel. Laß mich ein bissel da –,« sie hätte fast gesagt »verschnaufen«, besann sich aber beizeiten.
     </p>
-    <p xml:id="eco_de_0000144_17660">
+    <p xml:id="eco_de_0000214_17660">
      »O,« meinte der Professor, »du hast keinen üblen Geschmack, das freut mich, Maria. Du weißt aber, daß die Kaiserin ein schändliches Weib war,« sagte er scherzend.
     </p>
-    <p xml:id="eco_de_0000144_17670">
+    <p xml:id="eco_de_0000214_17670">
      »Das macht nichts.«
     </p>
-    <p xml:id="eco_de_0000144_17680">
+    <p xml:id="eco_de_0000214_17680">
      Er ließ sie also bei der Kaiserin Agrippina.
     </p>
-    <p xml:id="eco_de_0000144_17690">
+    <p xml:id="eco_de_0000214_17690">
      Maria aber hatte schon längst einen Rohrstuhl bemerkt, der hinter der Kaiserin stand.
     </p>
-    <p xml:id="eco_de_0000144_17700">
+    <p xml:id="eco_de_0000214_17700">
      Das war der »schöne Sessel«.
     </p>
-    <p xml:id="eco_de_0000144_17710">
+    <p xml:id="eco_de_0000214_17710">
      Von diesem Sessel aus sah man nichts als die Rückseiten der Statuen und die lange Fensterreihe der Galerie.
     </p>
-    <p xml:id="eco_de_0000144_17720">
+    <p xml:id="eco_de_0000214_17720">
      Als der Professor zurückkam, fand er Maria eingeschlafen.
     </p>
-    <p xml:id="eco_de_0000144_17730">
+    <p xml:id="eco_de_0000214_17730">
      »Maria!« rief er lachend und legte ihr die Hand auf die Schulter.
     </p>
-    <p xml:id="eco_de_0000144_17740">
+    <p xml:id="eco_de_0000214_17740">
      Sie starrte ihn an. Wie kam der hierher? Was wollte er? So tief hatte sie geschlafen und von daheim geträumt.
     </p>
-    <p xml:id="eco_de_0000144_17750">
+    <p xml:id="eco_de_0000214_17750">
      Ja, als der Professor sie endlich in seinem eigenen Hause hatte, da empfand er, daß es so besser war. Sie hätten nicht so lang' unterwegs bleiben sollen. Maria brauchte Arbeit. Das verstand sie nicht, die Kunst wie einen Lebensinhalt für sich zu genießen. Nein, sie war kein Genußmensch, auch im besten Sinne nicht, und sie gehörte nicht zu den Weibern, die als Herrinnen, Kritikerinnen und Gönnerinnen, von allem, was Männerhand schuf, fühlen sah. O nein, diese Vermessenheit im Kunstgenuß lag ihr fern.
     </p>
-    <p xml:id="eco_de_0000144_17760">
+    <p xml:id="eco_de_0000214_17760">
      Ihm war das eine ganz neue Erfahrung – eine sehr wohltuende Erfahrung. Die Weiber seines Kreises hatten diese demütig-vornehme Zurückhaltung nicht. Erst jetzt empfand er dies Ueberall-mit-hineinreden, diese unbegründete Souveränität in allen Dingen als etwas Qualvolles und freute sich seiner ruhigen, ehrlichen, jungen Frau.
     </p>
-    <p xml:id="eco_de_0000144_17770">
+    <p xml:id="eco_de_0000214_17770">
      »Mir scheint,« sagte sie, »daß dies oder jenes schön oder nicht schön ist.« »Das ist schön oder nicht schön,« wäre ihr nie über die Lippen gekommen.
     </p>
-    <p xml:id="eco_de_0000144_17780">
+    <p xml:id="eco_de_0000214_17780">
      Daß seine beiden Töchter ihr sehr kühl entgegenkamen, schmerzte ihn. Er achtete in dieser Kühle die Treue gegen die Tote – und wagte nicht, sich darüber zu äußern.
     </p>
-    <p xml:id="eco_de_0000144_17790">
+    <p xml:id="eco_de_0000214_17790">
      Maria nahm ihre Pflichten als Hausfrau mit Gewissenhaftigkeit und Ruhe auf sich.
     </p>
-    <p xml:id="eco_de_0000144_17800">
+    <p xml:id="eco_de_0000214_17800">
      Sie fand einen verwahrlosten, mit reichen Mitteln geführten Hausstand vor, ein liebloses Durcheinander von Verschwendung und Unachtsamkeit.
     </p>
-    <p xml:id="eco_de_0000144_17810">
+    <p xml:id="eco_de_0000214_17810">
      »Nicht wahr, ich habe das Recht, hier so zu handeln, als wäre es mein Eigentum, ich darf alles so ordnen und einrichten, wie es mir gut scheint. Ich kränke damit nicht?« frug sie ihren Gatten.
     </p>
-    <p xml:id="eco_de_0000144_17820">
+    <p xml:id="eco_de_0000214_17820">
      »Natürlich, mein Kind, mache es uns behaglich.«
     </p>
-    <p xml:id="eco_de_0000144_17830">
+    <p xml:id="eco_de_0000214_17830">
      Sie richtete dieselbe Frage auch an ihre beiden Stieftöchter, nur in einer etwas anderen Form.
     </p>
-    <p xml:id="eco_de_0000144_17840">
+    <p xml:id="eco_de_0000214_17840">
      »Bitte, ganz wie es dir beliebt, du bist die Hausfrau.«
     </p>
-    <p xml:id="eco_de_0000144_17850">
+    <p xml:id="eco_de_0000214_17850">
      Im Ton aber lag die große Kühle, das Unnahbare.
     </p>
-    <p xml:id="eco_de_0000144_17860">
+    <p xml:id="eco_de_0000214_17860">
      Maria aber hatte sich so ihr Recht gesichert, um ihre Pflicht tun zu können.
     </p>
-    <p xml:id="eco_de_0000144_17870">
+    <p xml:id="eco_de_0000214_17870">
      Sie griff mit an bei der Arbeit wie eine treue Magd, die in ihres Herrn Besitz redlich Ordnung schaffen will. Die toten Dinge des täglichen Lebens begannen unter ihren Händen Seele zu bekommen. Ja, es war, als hätte alles im Schatten gestanden und wäre jetzt in die Sonne gerückt, begann zu grünen und zu blühen.
     </p>
-    <p xml:id="eco_de_0000144_17880">
+    <p xml:id="eco_de_0000214_17880">
      Die beiden Töchter widmeten sich nun ganz ungestört ihren eigenen Bestrebungen. Die eine der Musik, die andere hatte schon ihr Maturitätsexamen hinter sich und wollte Philosophie studieren. Der Sohn studierte Jura. Sie waren alle vollauf beschäftigt und ernste, strebsame Menschen.
     </p>
-    <p xml:id="eco_de_0000144_17890">
+    <p xml:id="eco_de_0000214_17890">
      Während der Mahlzeiten war es, als wollten sie dem Eindringling beweisen, wie sie alle zum Vater gehörten, so viel seiner, enger, als das magdhafte Weib, das er ihnen aufgedrungen.
     </p>
-    <p xml:id="eco_de_0000144_17900">
+    <p xml:id="eco_de_0000214_17900">
      Besonders die Mädchen waren unerschöpflich, seinen Rat in Anspruch zu nehmen, mit ihm über die schwierigsten Dinge zu streiten, die dem großen, jungen Weibe völlig fern lagen. Sie hatten immer Anliegen, und so vergingen die Mahlzeiten in anregenden, anstrengenden Gesprächen.
     </p>
-    <p xml:id="eco_de_0000144_17910">
+    <p xml:id="eco_de_0000214_17910">
      Dem Bruder wurde dieses Sich-geistig-montieren bei Tisch zu viel.
     </p>
-    <p xml:id="eco_de_0000144_17920">
+    <p xml:id="eco_de_0000214_17920">
      »Na, na,« sagte er, »gebt a Ruh,« als die eine sich über Idealität der Zeit und des Raumes ereiferte. »Dabei soll einem nun das Essen bekommen! Diese Weiber!«
     </p>
-    <p xml:id="eco_de_0000144_17930">
+    <p xml:id="eco_de_0000214_17930">
      Für Maria ward diese gesunde Anmerkung wohltuend und brachte sie ihrem großen Stiefsohn etwas näher.
     </p>
-    <p xml:id="eco_de_0000144_17940">
+    <p xml:id="eco_de_0000214_17940">
      Die beiden Mädchen aber erreichten, was sie im dumpfen Aerger wollten, – sie erreichten noch weit mehr, denn ihr wehe zu tun, war nicht die Absicht gewesen. Sie hatten ihr nur zeigen wollen, daß sie über ihr ständen; – aber sie trieben das junge Weib in die Einsamkeit. Sie verschloß sich ganz in sich selbst, wie es die Art starker Naturen ist. Ihr Gatte verstand es nicht, sie zu schützen, ja, er kam kaum auf diesen Gedanken, denn er wurde seinen Kindern gegenüber ein Gefühl der Schuld nicht los und gab ihnen sein junges Weib, aus einem Gefühl gerecht zu sein, preis.
     </p>
-    <p xml:id="eco_de_0000144_17950">
+    <p xml:id="eco_de_0000214_17950">
      Wer aber konnte dies »preisgeben« nennen? Gewiß keine Menschenseele, ja, wer konnte hier überhaupt etwas Greifbares finden, um es zu benennen?
     </p>
-    <p xml:id="eco_de_0000144_17960">
+    <p xml:id="eco_de_0000214_17960">
      Und doch – und doch. – So ein hilfloses Herz fühlt Streiche, die niemand fallen sieht, wird verwundet, ohne daß jemand einen Angreifer gewahr wird. Maria begann unter einem großen Druck zu leben, fühlte sich von nun an unsicherer und fremder im fremden Haus.
     </p>
-    <p xml:id="eco_de_0000144_17970">
+    <p xml:id="eco_de_0000214_17970">
      Nur in den Pflichten, die sie übernommen, blieb sie heimisch und war rastlos bis in die Nacht.
     </p>
-    <p xml:id="eco_de_0000144_17980">
+    <p xml:id="eco_de_0000214_17980">
      Die Rastlosigkeit und angestrengte Aufmerksamkeit gab ihr das Magdhafte – Demütige, Stille. Die klugen, gelehrten Leute hatten ein armes, großes Kind in ihrer Mitte, ein Kind, das nach Wärme und Liebe verlangte.
     </p>
-    <p xml:id="eco_de_0000144_17990">
+    <p xml:id="eco_de_0000214_17990">
      Sie sahen aber etwas anderes: Eine blonde Hausfrau, so eine von der echten Sorte, so eine von den ganz Engen, von denen, deren Horizont nicht über die vier Wände hinausgeht.
     </p>
-    <p xml:id="eco_de_0000144_18000">
+    <p xml:id="eco_de_0000214_18000">
      Und die Kinder begriffen den Vater nicht, wie er nach dem Verlust einer geistig bedeutenden Frau so etwas ins Haus hatte bringen können.
     </p>
-    <p xml:id="eco_de_0000144_18010">
+    <p xml:id="eco_de_0000214_18010">
      Sie waren alle zu wohlerzogen, um ihre Stiefmutter direkt etwas von ihren Empfindungen fühlen zu lassen; aber, ohne daß sie es beabsichtigten, sickerte ihre Gesinnung durch die guten Formen hindurch und wirkte vergiftend.
     </p>
-    <p xml:id="eco_de_0000144_18020">
+    <p xml:id="eco_de_0000214_18020">
      Maria, die nur die allerreinste Luft daheim geatmet, nie etwas Verstecktes empfunden hatte, war wie in eine Welt ohne sicheren Boden geraten.
     </p>
-    <p xml:id="eco_de_0000144_18030">
+    <p xml:id="eco_de_0000214_18030">
      Sie empfand, als sollte sie an der Höflichkeit ihrer großen Stiefkinder verschmachten.
     </p>
-    <p xml:id="eco_de_0000144_18040">
+    <p xml:id="eco_de_0000214_18040">
      Und wunderlich, Vater und Kinder schlossen sich eng und enger aneinander – enger als je zuvor.
     </p>
-    <p xml:id="eco_de_0000144_18050">
+    <p xml:id="eco_de_0000214_18050">
      »Maria,« sagte ihr Gatte manchmal zu ihr, wenn er sie so ganz in ihren Hausfrauensorgen aufgehen sah, »du solltest dich uns mehr widmen, mein Herz.«
     </p>
-    <p xml:id="eco_de_0000144_18060">
+    <p xml:id="eco_de_0000214_18060">
      Er gedachte seiner sonderbar träumerischen Idee, die er während jener goldenen Sommertage gehegt hatte, daß er Maria am liebsten als alttestamentarische Hausmagd in sein Haus führen wollte, als urweltliche, treue, aufopfernde Magd, als etwas, was es nirgends gab und wohl auch nie gegeben hatte.
     </p>
-    <p xml:id="eco_de_0000144_18070">
+    <p xml:id="eco_de_0000214_18070">
      Aber sonderbar, die Wirklichkeit war seinem Traume nahe gekommen, und er hätte lügen müssen, wenn er sich in diesem Traume nicht recht wohl befunden hätte.
     </p>
-    <p xml:id="eco_de_0000144_18080">
+    <p xml:id="eco_de_0000214_18080">
      Diese ruhige, geduldige Seele im Hause war allen, ohne daß sie es sich selbst zugaben, eine Wohltat.
     </p>
-    <p xml:id="eco_de_0000144_18090">
+    <p xml:id="eco_de_0000214_18090">
      Sie hatten so viel mit ihren eigenen Persönlichkeiten zu tun, und sie gehörten zu den modernen Menschen, die ihre Individualität wie ein Kunstwerk ausarbeiten, und die jene mit Recht oder Unrecht mißachten, die sich selbst auflösen, die aus der eigenen Persönlichkeit Freude, Nahrung, Lebensstärkung für andere bereiten.
     </p>
-    <p xml:id="eco_de_0000144_18100">
+    <p xml:id="eco_de_0000214_18100">
      Je hilfreicher und treuer Maria wurde, je mehr gab sie sich preis und sank im Wert, denn sie war nicht hilfreich und treu aus innerer Freudigkeit heraus, sondern, weil sie sich nicht behaupten konnte, weil sie sich betäuben wollte.
     </p>
-    <p xml:id="eco_de_0000144_18110">
+    <p xml:id="eco_de_0000214_18110">
      So vergingen die Jahre.
     </p>
-    <p xml:id="eco_de_0000144_18120">
+    <p xml:id="eco_de_0000214_18120">
      Die Familie lebte ihre stillen Tage, so ein gut bürgerliches Leben. Drei-, viermal gab es im Winter Einladung, wo sich des Professors Haus im vollen Glanze zeigte. An solchen Tagen pries man ihn glücklich seiner schönen, tüchtigen Frau wegen, bewunderte der einen Tochter Virtuosentum, das vorzügliche Souper, die guten Weine, tat des Professors Gesellschafts-Zigarren alle Ehre an.
     </p>
-    <p xml:id="eco_de_0000144_18130">
+    <p xml:id="eco_de_0000214_18130">
      An solchen Abenden hörte Maria freundlich lächelnd ihrer Stieftochter Klavierspiel zu, diesem Klavierspiel, dem sie, wo sie konnte, auswich; denn es riß ihr am Herzen. Es tat ihr weh. Sie verlor die Fassung. Ungestüme Lebenssehnsucht ergriff sie. Sie hatte in dem vornehmen behaglichen Salon, in dem der Flügel stand, oft aufschreien mögen in heißem Glückesverlangen. Ihre beiden Stieftöchter aber meinten: »Ein schlimmes Zeichen.«
     </p>
-    <p xml:id="eco_de_0000144_18140">
+    <p xml:id="eco_de_0000214_18140">
      Nein, zwischen den beiden Mädchen und des Vaters junger Frau war auch nicht das leiseste Verständnis füreinander aufgegangen.
     </p>
-    <p xml:id="eco_de_0000144_18150">
+    <p xml:id="eco_de_0000214_18150">
      »Gottlob,« sagten die beiden manchmal zueinander, »daß sie uns wenigstens mit Stiefgeschwisterchen verschont, das kann man ihr nicht hoch genug anrechnen.«
     </p>
-    <p xml:id="eco_de_0000144_18160">
+    <p xml:id="eco_de_0000214_18160">
      Niemand im Hause war sich der Brutalität bewußt, mit der man gegen sie empfand, und niemand ahnte die Einsamkeit, in der sie lebte, und sie waren alle feine, hochentwickelte, vortreffliche Menschen. Von Pflichttreue, Aufopferung überdeckt, brannte in dem jungen Weib ein sie quälendes, verzehrendes Feuer. Ihr starkes, natürliches Wesen wollte unbewußt sein vollgerüttelt Maß Lebensfreude und Befriedigung. Sie lebte vornehm und besser, als sie es sich je geträumt hatte. In allen Dingen war sie wohlversorgt und hungerte doch nach dem starken Lebensbrot. Diese aus Hunger und Ueberfluß zusammengebraute Daseinsform war schmerzlich und erregend zu tragen. Der Ueberfluß tat weh, wie die Sehnsucht.
     </p>
-    <p xml:id="eco_de_0000144_18170">
+    <p xml:id="eco_de_0000214_18170">
      Diese prächtigen, schönen Glieder des jungen Weibes, diese rosige Haut, die in der großen, vollen Sonne aufgeblüht war, das getreidefarbene, starke Haar, alles schrie nach Glück und Sonne.
     </p>
-    <p xml:id="eco_de_0000144_18180">
+    <p xml:id="eco_de_0000214_18180">
      Nichts an ihr war geschaffen, um in frommer Unnatur dahinzuleben.
     </p>
-    <p xml:id="eco_de_0000144_18190">
+    <p xml:id="eco_de_0000214_18190">
      Sie war an die Stelle der ersten, längst gealterten Frau des Professors getreten. Dieser Platz, der der kleinen, verblühten Dame völlig genügt hatte, beengte die junge Riesin, ließ ihr keine freie Bewegung, nicht Luft genug für die tiefen, sehnsuchtsvollen Atemzüge. Was ihr eigentlich fehlte, wußte sie selbst nicht, denn als gutes Kind scheute sie das Wesen ihrer Gefühle zu ergründen. Ein Wissen ihres Zustandes wäre ihr als undankbares Verbrechen erschienen. Eins, das wußte sie aber peinigend klar, die kalte, sich immer gleich bleibende Höflichkeit ihrer Stiefkinder, ließ sie nach der süßen Zärtlichkeit ihres eigenen Kindes leidenschaftlich verlangen. Und das sollte und konnte nicht sein. Sie war nun fast schon vier Jahre verheiratet.
     </p>
-    <p xml:id="eco_de_0000144_18200">
+    <p xml:id="eco_de_0000214_18200">
      Nachts biß sie sich voll hoffnungsloser Verzweiflung in den festen Arm, auf dem ihr Haupt ruhte. Sie wollte ihr eigenes Leben spüren – nur das eine nicht – diese vernünftige Hoffnungslosigkeit.
     </p>
-    <p xml:id="eco_de_0000144_18210">
+    <p xml:id="eco_de_0000214_18210">
      O, diese Nächte voll Sehnsucht! Niemanden hatte sie, an dessen Herz sie hätte ihren Kopf legen können, niemand auf der Welt.
     </p>
-    <p xml:id="eco_de_0000144_18220">
+    <p xml:id="eco_de_0000214_18220">
      Der Professor hatte die lebendige Natur selbst in sein Haus genommen, damit es bei ihm sonnig und warm würde, daß alles im Haus, was verkümmert und überfeinert war, aufblühen sollte; aber er hatte nur an sich und die Seinen dabei gedacht.
     </p>
-    <p xml:id="eco_de_0000144_18230">
+    <p xml:id="eco_de_0000214_18230">
      Er, den die Mütterlichkeit ihres Wesens vor allem bezaubert hatte, war fremd und fast unangenehm berührt, als in tiefer Nacht seine Zimmertür zaghaft geöffnet wurde und ein Lichtschein hereinglitt, der eine weiße Gestalt weich beleuchtete.
     </p>
-    <p xml:id="eco_de_0000144_18240">
+    <p xml:id="eco_de_0000214_18240">
      »Was ist denn?« fragte er schlaftrunken. »Ist was?«
     </p>
-    <p xml:id="eco_de_0000144_18250">
+    <p xml:id="eco_de_0000214_18250">
      »Ach nein,« sagte sie und sank vor seinem Bett in die Knie und verbarg ihr Gesicht in seinen Kissen. »Ich bin nur so traurig.«
     </p>
-    <p xml:id="eco_de_0000144_18260">
+    <p xml:id="eco_de_0000214_18260">
      Mit Mühe scheuchte er den schweren Schlaf von sich.
     </p>
-    <p xml:id="eco_de_0000144_18270">
+    <p xml:id="eco_de_0000214_18270">
      »Na, weshalb denn traurig?« Er konnte sich gar nicht in diese Situation hineinfinden. Da brach aber ein so heißes, von den Kissen ersticktes Schluchzen los. –
     </p>
-    <p xml:id="eco_de_0000144_18280">
+    <p xml:id="eco_de_0000214_18280">
      »Tröste mich! – Sag' was!«
     </p>
-    <p xml:id="eco_de_0000144_18290">
+    <p xml:id="eco_de_0000214_18290">
      »Ja, was denn, um Himmels willen?«
     </p>
-    <p xml:id="eco_de_0000144_18300">
+    <p xml:id="eco_de_0000214_18300">
      Er richtete sich etwas auf.
     </p>
-    <p xml:id="eco_de_0000144_18310">
+    <p xml:id="eco_de_0000214_18310">
      »Ich habe kein Kind!« Wie ein undeutlicher Aufschrei kam das heraus, so ein gequältes Aufschreien.
     </p>
-    <p xml:id="eco_de_0000144_18320">
+    <p xml:id="eco_de_0000214_18320">
      »Ich fürchte mich so allein!«
     </p>
-    <p xml:id="eco_de_0000144_18330">
+    <p xml:id="eco_de_0000214_18330">
      Diese ruhige, pflichttreue, junge Frau so fassungslos zu sehen, war ihm unbegreiflich.
     </p>
-    <p xml:id="eco_de_0000144_18340">
+    <p xml:id="eco_de_0000214_18340">
      »Na, na, was ist denn das?« Ach, wie unbequem das war! So etwas würde doch nicht öfter vorkommen?
     </p>
-    <p xml:id="eco_de_0000144_18350">
+    <p xml:id="eco_de_0000214_18350">
      »Sei ruhig.«
     </p>
-    <p xml:id="eco_de_0000144_18360">
+    <p xml:id="eco_de_0000214_18360">
      Da stand er ja vor einer schönen Geschichte, er, der vor allen Dingen Ruhe brauchte.
     </p>
-    <p xml:id="eco_de_0000144_18370">
+    <p xml:id="eco_de_0000214_18370">
      Und was sollte er nun da sagen?
     </p>
-    <p xml:id="eco_de_0000144_18380">
+    <p xml:id="eco_de_0000214_18380">
      »Aber Maria, mein Herz, es gibt doch genug Frauen, die keine Kinder haben. Ist das so etwas Außergewöhnliches?«
     </p>
-    <p xml:id="eco_de_0000144_18390">
+    <p xml:id="eco_de_0000214_18390">
      »Ja, und was weißt du denn von denen?« frug sie hastig.
     </p>
-    <p xml:id="eco_de_0000144_18400">
+    <p xml:id="eco_de_0000214_18400">
      »Du hast doch alles, was du willst,« fuhr er fort. »Die besten Kinder von der Welt! Na! und du bist nicht zufrieden!«
     </p>
-    <p xml:id="eco_de_0000144_18410">
+    <p xml:id="eco_de_0000214_18410">
      »Tröste mich!« schluchzte sie. »Sag' was!«
     </p>
-    <p xml:id="eco_de_0000144_18420">
+    <p xml:id="eco_de_0000214_18420">
      Er strich ihr über das Haar. »Nu, weißt du, wenn alle Menschen alles und jedes haben wollten; – was würde daraus?
     </p>
-    <p xml:id="eco_de_0000144_18430">
+    <p xml:id="eco_de_0000214_18430">
      Denk' an die armen Menschen ringsumher, an die Kranken und Elenden, die Verbrecher und Hungrigen – und dann denk' an dich – – – und schäm' dich ein wenig, mein Herz. Ei, ei, so undankbar!«
     </p>
-    <p xml:id="eco_de_0000144_18440">
+    <p xml:id="eco_de_0000214_18440">
      »Dir ist's gleichgültig, ob wir ein Kind haben oder nicht?«
     </p>
-    <p xml:id="eco_de_0000144_18450">
+    <p xml:id="eco_de_0000214_18450">
      »Gleichgültig? – nein, mein Herz,« sagte er ruhig.
     </p>
-    <p xml:id="eco_de_0000144_18460">
+    <p xml:id="eco_de_0000214_18460">
      »Ach!« schrie sie auf, kurz wie ein Stöhnen – »und ich – sterbe vor Sehnsucht!«
     </p>
-    <p xml:id="eco_de_0000144_18470">
+    <p xml:id="eco_de_0000214_18470">
      Da lag alles darin. Sie hatte durchschaut. Er, der satte Mann, der alles genossen, bei dem naturgemäß Ruhe und Beschaulichkeit eingetreten waren, und sie, das nach Glück und Liebe und Leben hungernde Weib, das vom Schicksal sein Kind, sein einziges Eigentum auf Erden wollte.
     </p>
-    <p xml:id="eco_de_0000144_18480">
+    <p xml:id="eco_de_0000214_18480">
      »Komm', gieß dir mal in das Glas Wasser hier, aus dem Fläschchen ein paar Baldriantropfen.«
     </p>
-    <p xml:id="eco_de_0000144_18490">
+    <p xml:id="eco_de_0000214_18490">
      Er setzte sich ganz auf, nahm selbst das Fläschchen und tröpfelte ihr behutsam sechzehn Tropfen ins Glas.
     </p>
-    <p xml:id="eco_de_0000144_18500">
+    <p xml:id="eco_de_0000214_18500">
      »So, mein Kind, nun trink.«
     </p>
-    <p xml:id="eco_de_0000144_18510">
+    <p xml:id="eco_de_0000214_18510">
      Sie trank. Sie war ganz ruhig geworden, denn sie hatte durchschaut.
     </p>
-    <p xml:id="eco_de_0000144_18520">
+    <p xml:id="eco_de_0000214_18520">
      Er hatte alles.
     </p>
-    <p xml:id="eco_de_0000144_18530">
+    <p xml:id="eco_de_0000214_18530">
      Sie hatte nichts, und die Lebenstür sollte ihr ewig zugeschlagen bleiben. Nein, er konnte sie nicht verstehen! Nutzlos war es gewesen, daß sie gekommen, daß sie ihn geweckt hatte. Er konnte sie nicht trösten, denn er ahnte ihre tiefe Not nicht.
     </p>
-    <p xml:id="eco_de_0000144_18540">
+    <p xml:id="eco_de_0000214_18540">
      Sie wünschte ihm: Gute Nacht. Er faßte ihre Hand. »Ist dir's besser?«
     </p>
-    <p xml:id="eco_de_0000144_18550">
+    <p xml:id="eco_de_0000214_18550">
      Sie nickte.
     </p>
-    <p xml:id="eco_de_0000144_18560">
+    <p xml:id="eco_de_0000214_18560">
      »Aber auch gewiß besser?«
     </p>
-    <p xml:id="eco_de_0000144_18570">
+    <p xml:id="eco_de_0000214_18570">
      Sie nickte wieder und lächelte.
     </p>
-    <p xml:id="eco_de_0000144_18580">
+    <p xml:id="eco_de_0000214_18580">
      Dann suchte sie ihr Zimmer auf, streckte sich in ihrem Bette aus.
     </p>
-    <p xml:id="eco_de_0000144_18590">
+    <p xml:id="eco_de_0000214_18590">
      Die Tücher waren noch lau, von so einer einschläfernden Lauheit. Die sechzehn Baldriantropfen hatten sie müde gemacht und die Erkenntnis, daß sie niemand auf Erden habe, der sie verstehen und trösten konnte.
     </p>
-    <p xml:id="eco_de_0000144_18600">
+    <p xml:id="eco_de_0000214_18600">
      Mehr und mehr empfand sie das Auf-sich-selbst-angewiesen-sein und trug an diesem Bewußtsein wie an einer schweren Last.
     </p>
-    <p xml:id="eco_de_0000144_18610">
+    <p xml:id="eco_de_0000214_18610">
      Ihre einfache, großzügige Natur lag ihr selbst durchsichtig vor Augen.
     </p>
-    <p xml:id="eco_de_0000144_18620">
+    <p xml:id="eco_de_0000214_18620">
      Sie kannte ihren Schmerz und ihre Verlassenheit – und etwas Nebelgraues zog in sie ein.
     </p>
-    <p xml:id="eco_de_0000144_18630">
+    <p xml:id="eco_de_0000214_18630">
      Ja, es legte sich etwas Nebelgraues über ihr goldiges Haar, ihre rosigen Farben, und sie bekam eine spießbürgerliche, gedrückte Beimischung in ihr freies, frisches Blut. Das Traurigste, was einem Menschen geschehen kann, geschah ihr: Die lebendige Idee ihres Wesens und ihrer Erscheinung schien sich zu verlieren, war nicht mehr in jeder Bewegung zu spüren. Fremdes, das eigentliche Wesen Auflösendes drang ein.
     </p>
-    <p xml:id="eco_de_0000144_18640">
+    <p xml:id="eco_de_0000214_18640">
      Sie suchte Trost in der Religion, saß in stillen, dämmerigen Stunden in der guten, alten, geheimnisvollen Frauenkirche und starrte in das unklare, mystische Licht, das durch mächtige Säulenreihen wie eine trübe, zarte Flut rieselte.
     </p>
-    <p xml:id="eco_de_0000144_18650">
+    <p xml:id="eco_de_0000214_18650">
      Ihre arme, sonnenheiße Seele wollte sich hier kühlen, wollte die Sonne vergessen und die Sonnensehnsucht und die goldenen Aehrenfelder und das fruchtbare, lebendige Menschenleben.
     </p>
-    <p xml:id="eco_de_0000144_18660">
+    <p xml:id="eco_de_0000214_18660">
      Der blaue Himmel oder der graue Regenhimmel tat ihr weh und auch die grünen Bäume, wie alles und jedes Lebendige, denn mit allem, was sie leben sah, wollte sie leben. Deshalb ertrug sie in solchen einsamen, geheimnisvollen Kirchenstunden gar gern einen schweren, steinernen Himmel und steinerne Bäume und einen ewig steinernen Erdboden und eine stille, tote Luft, die die heiligen Sonnenstrahlen nicht kannte.
     </p>
-    <p xml:id="eco_de_0000144_18670">
+    <p xml:id="eco_de_0000214_18670">
      Ja, so etwas dachte und fühlte sie oft. Ihren alten Herrgott hatte sie so recht von Herzen nur immer unter freiem Himmel anbeten können.
     </p>
-    <p xml:id="eco_de_0000144_18680">
+    <p xml:id="eco_de_0000214_18680">
      Hier, in der uralten Kirche, das war ein ganz anderer Gott – ein Gott mit einem kühlen, saugenden Atem, der sehnsüchtigen Menschenseelen ihre heiße Lebenssehnsucht aussog und sie kühl und starr und unbeweglich machte.
     </p>
-    <p xml:id="eco_de_0000144_18690">
+    <p xml:id="eco_de_0000214_18690">
      Ihr war es oft, als ob ihre gleichgültig und müde gemachte Seele von ihr losgelöst an den Säulen hinstrich, zärtlich bang sich an sie schmiegte und die steinerne Kälte in sich einrinnen ließ.
     </p>
-    <p xml:id="eco_de_0000144_18700">
+    <p xml:id="eco_de_0000214_18700">
      So war der arme Gottesdienst des Weibes, das nach Sonne verlangte, dessen Daseinsarbeit darin bestand, im Schatten stehend die Lebenssehnsucht zu ertöten, wie eine Mutter ihr einziges Kind töten würde, um damit ein frommes Opfer zu bringen, mit ebensolchem herzschneidenden Weh.
     </p>
-    <p xml:id="eco_de_0000144_18710">
+    <p xml:id="eco_de_0000214_18710">
      Im Hause des Professors hatten die kühlen, klugen, hochgebildeten Leute jetzt ein wildes, verzweifeltes Stück Natur, das ihnen brav und tadellos das Haus führte.
     </p>
-    <p xml:id="eco_de_0000144_18720">
+    <p xml:id="eco_de_0000214_18720">
      Sie würden sich entsetzt haben, wenn sie es hätten verstehen und durchschauen können.
     </p>
-    <p xml:id="eco_de_0000144_18730">
+    <p xml:id="eco_de_0000214_18730">
      Sie sahen aber alle die magdhafte, pflichttreue Hausfrau, die sie durch und durch und bis zum Ueberdruß zu kennen vermeinten.
     </p>
-    <p xml:id="eco_de_0000144_18740">
+    <p xml:id="eco_de_0000214_18740">
      »Zu all ihren Vorzügen ist sie nun noch fromm geworden,« sagten die Stieftöchter und ahnten noch nicht, was das Leben ist und was es heißt, wenn eine Seele »fromm« wird. Sie wußten nicht, daß die blonde Frau bei ihnen daheim an Kälte gestorben war, und daß ihr armer Körper bei ihnen nur noch umging.
     </p>
-    <p xml:id="eco_de_0000144_18750">
+    <p xml:id="eco_de_0000214_18750">
      Ja, die Menschen wissen nichts voneinander.
     </p>
-    <p xml:id="eco_de_0000144_18760">
+    <p xml:id="eco_de_0000214_18760">
      Ein junger Mann aus Marias Heimat, der ihr Vaterhaus, ihren großen Garten und ihre Geschwister kannte, kam in das Haus des Professors, um Grüße zu bringen.
     </p>
-    <p xml:id="eco_de_0000144_18770">
+    <p xml:id="eco_de_0000214_18770">
      Er war mit den Immenbachschen Kindern aufgewachsen und in Marias Alter, kannte, was sie kannte und liebte, und war ein blonder, frischer Mensch, der Immenbachschen Rasse ähnlich, ein echter Jugendfreund, einer, der zu dem harmlosen, goldigen Riesenvolk gepaßt hatte.
     </p>
-    <p xml:id="eco_de_0000144_18780">
+    <p xml:id="eco_de_0000214_18780">
      In früher Jugend schon war er in die weite Welt verschlagen worden und hatte sein Glück gemacht, ein arbeitsvolles, ganz gesundes Glück.
     </p>
-    <p xml:id="eco_de_0000144_18790">
+    <p xml:id="eco_de_0000214_18790">
      In Mazedonien hatte er seinen Platz als Ingenieur gefunden und war jetzt gekommen, um sich die alte Heimat, die alten Menschen und seine Studienstadt München einmal wieder anzuschauen.
     </p>
-    <p xml:id="eco_de_0000144_18800">
+    <p xml:id="eco_de_0000214_18800">
      Die Immenbachs hatten ihn zu Maria, auf die sie alle stolz waren, geschickt – und er war gern gegangen – denn Maria Immenbach stand ihm in der Erinnerung als die Beste und Schönste des ganzen Nestes –. ja, ihm war, als hätte er eine wundervolle, vergessene Neigung als grüner Bub zu dem herrlichen Kinde gehabt.
     </p>
-    <p xml:id="eco_de_0000144_18810">
+    <p xml:id="eco_de_0000214_18810">
      Vom Professor und der ganzen Familie wurde er gastfreundlich empfangen. Er wohnte im Haus.
     </p>
-    <p xml:id="eco_de_0000144_18820">
+    <p xml:id="eco_de_0000214_18820">
      »Marias Gast!« sagte der Professor. Sie hatte in der ganzen Zeit seit ihrer Verheiratung kaum einmal jemand ihrer Familie bei sich gehabt, so oft der Professor es ihr auch freundlich angeboten, und nun kam gerade dieser Fremde.
     </p>
-    <p xml:id="eco_de_0000144_18830">
+    <p xml:id="eco_de_0000214_18830">
      Sie hatte sich seiner kaum mehr erinnert, nur seine Augen hatte sie nicht vergessen. – Scharf blickende Augen, vor die man nur ganz gesund und schön und seelenruhig treten mochte.
     </p>
-    <p xml:id="eco_de_0000144_18840">
+    <p xml:id="eco_de_0000214_18840">
      Sie hatte als Kind gern diese Augen auf sich ruhen gefühlt, so in dem Gefühl: Schau du nur – ich hab' nichts zu verstecken.
     </p>
-    <p xml:id="eco_de_0000144_18850">
+    <p xml:id="eco_de_0000214_18850">
      Drei Tage wohnte er nun schon bei ihnen und war allen angenehm.
     </p>
-    <p xml:id="eco_de_0000144_18860">
+    <p xml:id="eco_de_0000214_18860">
      Maria aber empfand, als wären ihr die Glieder in Ketten geschlagen.
     </p>
-    <p xml:id="eco_de_0000144_18870">
+    <p xml:id="eco_de_0000214_18870">
      Jetzt erst wurde sie selbst es inne, daß sie ihr Lachen verloren hatte, daß ihre Bewegungen unfrei, unvornehm geworden waren. Ihr war, als lastete das ganze Professorenhaus auf ihr, als stünde sie zu jedem Menschen und jedem Möbel in einem drückenden Verhältnis.
     </p>
-    <p xml:id="eco_de_0000144_18880">
+    <p xml:id="eco_de_0000214_18880">
      Ihn hatte sie in der freien Sonnenluft gekannt und im glitzernden, schneeweißen Winter, in voller Jugendlust, und jetzt sah sie ihn in diesen städtischen Räumen wieder, wo man sie nicht verstand und auch nicht besonders liebte.
     </p>
-    <p xml:id="eco_de_0000144_18890">
+    <p xml:id="eco_de_0000214_18890">
      Er sprach nur wenig mit ihr, seine Blicke aber fühlte sie hin und wieder forschend auf sich ruhen.
     </p>
-    <p xml:id="eco_de_0000144_18900">
+    <p xml:id="eco_de_0000214_18900">
      Und sie verstand diese Blicke. Er suchte die alte Maria Immenbach. »Ewig schade,« dachte er, denn erst jetzt empfand er, daß sie etwas Vollendetes gewesen war.
     </p>
-    <p xml:id="eco_de_0000144_18910">
+    <p xml:id="eco_de_0000214_18910">
      An einem Abend saßen sie miteinander im Salon. Der April hatte Frühlingsschnee gebracht. Die Lampe brannte, und im Ofen knisterten neu aufgeschüttete Kohlen.
     </p>
-    <p xml:id="eco_de_0000144_18920">
+    <p xml:id="eco_de_0000214_18920">
      Marias Stieftochter spielte Chopin.
     </p>
-    <p xml:id="eco_de_0000144_18930">
+    <p xml:id="eco_de_0000214_18930">
      Seit Jahren hatte der Gast ein völlig kunstfremdes Leben geführt und war jetzt durch das sensibel empfundene Spiel des Mädchens in träumerisch weltfremde Stimmung geraten, die für den gesunden Gewohnheitsarbeiter etwas köstlich Seelen und Körper Ausruhendes bedeutet.
     </p>
-    <p xml:id="eco_de_0000144_18940">
+    <p xml:id="eco_de_0000214_18940">
      Sie waren nur zu dreien im Zimmer.
     </p>
-    <p xml:id="eco_de_0000144_18950">
+    <p xml:id="eco_de_0000214_18950">
      Maria saß neben ihrem Gast und lauschte auch auf die weichen, perlenden Töne.
     </p>
-    <p xml:id="eco_de_0000144_18960">
+    <p xml:id="eco_de_0000214_18960">
      Wie schön sie zu spielen verstand, das zarte, fleißige Mädchen.
     </p>
-    <p xml:id="eco_de_0000144_18970">
+    <p xml:id="eco_de_0000214_18970">
      Noch nie hatte Maria die Fläche ihrer Seele dieser Musik so hingegeben wie heute. Sie hatte sich bisher gegen solche Töne innerlich aufgelehnt und jetzt spülten sie wie laue, lösende Wellen über sie hin.
     </p>
-    <p xml:id="eco_de_0000144_18980">
+    <p xml:id="eco_de_0000214_18980">
      Endlos hätte sie hören können.
     </p>
-    <p xml:id="eco_de_0000144_18990">
+    <p xml:id="eco_de_0000214_18990">
      Eine fremde, bewegte Männerstimme flüsterte hin und wieder vorsichtig leise, um die Spielerin nicht zu stören, nach Dingen, von denen hier niemand wußte und nach denen niemand fragte; – und diese Stimme war mit den Tönen wie zu einem Ganzen vermischt und flutete mit ihnen über sie hin, tat ihr körperlich gut. Es kam ihr selbst vor, als wache sie aus einem schweren, ungesunden Schlaf auf.
     </p>
-    <p xml:id="eco_de_0000144_19000">
+    <p xml:id="eco_de_0000214_19000">
      Wie ein warmer Regen über ein sommermattes Blumenbeet fällt und die müden Blüten lebendig macht, so fühlte sie in sich tausend Dinge sich stärken, und alles nur, weil ein Mensch sie warm und dringlich nach ihrem eignen Selbst frug, nach Dingen, die ihre Erinnerung, ihr Bewußtsein ausmachten.
     </p>
-    <p xml:id="eco_de_0000144_19010">
+    <p xml:id="eco_de_0000214_19010">
      Sie antwortete wie ein verlassenes, wieder aufgefundenes Kind, so erregt, so bang, so schmerznachzitternd, so daß auch seine Stimme weich und weicher wurde.
     </p>
-    <p xml:id="eco_de_0000144_19020">
+    <p xml:id="eco_de_0000214_19020">
      Das große, arme Kind mit der verlassenen, einsamen Seele, dem herrlichen, ungeliebten Körper, rührte und bewegte ihn. Ihre, ihr selbst unbewußte Liebes- und Wärmesehnsucht ergriff ihn.
     </p>
-    <p xml:id="eco_de_0000144_19030">
+    <p xml:id="eco_de_0000214_19030">
      Ja, da hatte er ja die Heimat neben sich, nach der er gedurstet, die Heimat, die einem trauten Stück ungepflegter Erde glich.
     </p>
-    <p xml:id="eco_de_0000144_19040">
+    <p xml:id="eco_de_0000214_19040">
      Er war umhergelaufen von Erinnerung zu Erinnerung, und nichts Lebendiges war ihm begegnet. Wie ein abgeschiedener Geist hatte er die Dinge gesehen und war heimatloser wie in der Fremde geblieben; aber hier in dieser Dämmerecke, in dieser leichtdurchheizten, von perlenden Tönen durchzitterten Zimmerluft begann das Heimische zu keimen –, hier war er auf das Lebendige gestoßen wie mit Fühlfäden.
     </p>
-    <p xml:id="eco_de_0000144_19050">
+    <p xml:id="eco_de_0000214_19050">
      Er war so bewegt, so warm.
     </p>
-    <p xml:id="eco_de_0000144_19060">
+    <p xml:id="eco_de_0000214_19060">
      »Lehnen Sie sich besser zurück, Sie sitzen nicht bequem,« sagte er leise zu Maria und schob ihr ein weiches Kissen behaglicher.
     </p>
-    <p xml:id="eco_de_0000144_19070">
+    <p xml:id="eco_de_0000214_19070">
      Weh tat ihr diese Fürsorge bis in die Seele. Diese eine Bewegung sagte ihr: Du lebst ohne Fürsorge.
     </p>
-    <p xml:id="eco_de_0000144_19080">
+    <p xml:id="eco_de_0000214_19080">
      Sie errötete tief. Etwas Verlegenes, Unsicheres sprach sich mit einemmal in ihrer ganzen Haltung aus – etwas Ungeliebtes – Ungepflegtes, das rührte ihn. Es sprach sich so einfach in ihr aus, daß er verstehen mußte.
     </p>
-    <p xml:id="eco_de_0000144_19090">
+    <p xml:id="eco_de_0000214_19090">
      Maria lebte seit diesem Abend träumend. Sie fühlte in sich alle Kräfte blühen wie in einem Sommergarten. Alles war lebendig geworden.
     </p>
-    <p xml:id="eco_de_0000144_19100">
+    <p xml:id="eco_de_0000214_19100">
      Der lebensaugende Atem des kühlen Gottes aus der Frauenkirche war wie ein Nachtwindchen von der großen Lebenssonne fortgewärmt worden.
     </p>
-    <p xml:id="eco_de_0000144_19110">
+    <p xml:id="eco_de_0000214_19110">
      Nur nicht denken, nicht denken! Jede Minute leben.
     </p>
-    <p xml:id="eco_de_0000144_19120">
+    <p xml:id="eco_de_0000214_19120">
      Sie hatte nun tödliche Sehnsucht nach ihm, trotzdem er noch da war. Eine Sehnsucht sondergleichen, die sie fremd und angstvoll bedrängte. – Wenn er ging, nahm er alles mit, alles Leben wieder, was so warm erwacht war, was endlich erwacht war! O, wie sie sich fürchtete. – vor sich selbst, vor ihm – vor allem und jedem. Es konnte ihr nur noch Leid geschehen. Sie war ohne jeden Schutz.
     </p>
-    <p xml:id="eco_de_0000144_19130">
+    <p xml:id="eco_de_0000214_19130">
      Nicht denken – nur nicht denken, denken ist Tod.
     </p>
-    <p xml:id="eco_de_0000144_19140">
+    <p xml:id="eco_de_0000214_19140">
      Wie sie durch ihn nur lebte!
     </p>
-    <p xml:id="eco_de_0000144_19150">
+    <p xml:id="eco_de_0000214_19150">
      Welche Qual!
     </p>
-    <p xml:id="eco_de_0000144_19160">
+    <p xml:id="eco_de_0000214_19160">
      Eine Hand voll Veilchen hatte sie in ihrem langen, lebensdurstigen Traumzustand verstohlen und wie schlafwandelnd gekauft und war in der Dämmerstunde, als sie niemanden daheim wußte, auch ihn nicht, in sein Zimmer geschlüpft.
     </p>
-    <p xml:id="eco_de_0000144_19170">
+    <p xml:id="eco_de_0000214_19170">
      Sie hatte vor, ihm die Veilchen auf sein Lager, zwischen die Decke und das weiße Leintuch zu streuen, damit der Duft ihn berührte, ohne daß er von den Blumen wußte.
     </p>
-    <p xml:id="eco_de_0000144_19180">
+    <p xml:id="eco_de_0000214_19180">
      Mit welcher Angst fürchtete sie, daß er die Blumen doch finden könnte.
     </p>
-    <p xml:id="eco_de_0000144_19190">
+    <p xml:id="eco_de_0000214_19190">
      Aber es mußte sein, mußte sein, daß sie es tat.
     </p>
-    <p xml:id="eco_de_0000144_19200">
+    <p xml:id="eco_de_0000214_19200">
      Ihres Lebens Seligkeit hing daran, daß sie gerade dies tat.
     </p>
-    <p xml:id="eco_de_0000144_19210">
+    <p xml:id="eco_de_0000214_19210">
      Es war auch das einzige, was sie zu tun wußte.
     </p>
-    <p xml:id="eco_de_0000144_19220">
+    <p xml:id="eco_de_0000214_19220">
      Eigentlich das einzige auf der Welt, was es zu tun gab – die einzige Tat. Alles andre war undeutlich und auch ganz verschwunden.
     </p>
-    <p xml:id="eco_de_0000144_19230">
+    <p xml:id="eco_de_0000214_19230">
      Sie kniete vor dem Bett und hatte das Tuch zurückgeschlagen.
     </p>
-    <p xml:id="eco_de_0000144_19240">
+    <p xml:id="eco_de_0000214_19240">
      Die Veilchen lagen in ihrer taufrischen, gebrechlichen Frühlingssaftigkeit auf dem weißen Leinen. Ihr zitterte die Hand. Das Herz schlug ihr laut. Sie drückte die Wange angstvoll zärtlich auf die kühlen Tücher und lebte nur in der Wonne, daß er noch da war – jetzt noch da war!
     </p>
-    <p xml:id="eco_de_0000144_19250">
+    <p xml:id="eco_de_0000214_19250">
      Die Tür tat sich auf und er trat ein, – sah sie in der Dämmerung knien. Der zarte Veilchenduft erfüllte wie ein feiner Opferhauch das kleine Zimmer.
     </p>
-    <p xml:id="eco_de_0000144_19260">
+    <p xml:id="eco_de_0000214_19260">
      Das Weib in seiner tiefen, süßen Torheit blieb fassungslos knien, blickte ihn aus der weichen Dämmerung heraus wie zu Tode getroffen an.
     </p>
-    <p xml:id="eco_de_0000144_19270">
+    <p xml:id="eco_de_0000214_19270">
      Er sah nur das Stück Heimat, nach dem ihm gedürstet, das Stück Heimat, das nach ihm verlangte.
     </p>
-    <p xml:id="eco_de_0000144_19280">
+    <p xml:id="eco_de_0000214_19280">
      Ohne diese wunderliche Stunde wären sie in stummer Qual aneinander vorübergegangen; jetzt aber löste sich jeder Zweifel, jedes Bedenken, und über alles hinweg nahm er sie stumm und heiß in die Arme.
     </p>
-    <p xml:id="eco_de_0000144_19290">
+    <p xml:id="eco_de_0000214_19290">
      Das Uebermaß von Sonnensehnsucht, das in dem bedrückten Weibe lebte, machte sie groß und frei in dieser abgestohlenen, heißen Liebesstunde, im engen, verschlossenen Gemache ihres eignen Heims, das sie mit vollem Pflichtbewußtsein bisher gepflegt und gehütet, als das Eigentum eines guten, edlen Menschen.
     </p>
-    <p xml:id="eco_de_0000144_19300">
+    <p xml:id="eco_de_0000214_19300">
      Gegen ihn ein Unrecht begehen – undenkbar! Für Gut und Recht nicht ganz und gar eintreten – undenkbar! Die Pflichten, die sie übernommen, verraten – undenkbar! – und doch.
     </p>
-    <p xml:id="eco_de_0000144_19310">
+    <p xml:id="eco_de_0000214_19310">
      In das große, schreckliche Liebeswunder versank sie wie eine weltfremde Göttin, die von Menschengesetz und Satzung nie etwas gehört hatte. Im Arm des geliebten Mannes, ganz von heißer Liebe umfangen, von heimatsuchenden Küssen erstickt, empfand sie durch alle Schauer hindurch eine heilige Verheißung, eine sehnsuchtsbange Verkündigung, einen goldenen Lichtstrahl und einen großen Glauben, dem sie sich opfern mußte.
     </p>
-    <p xml:id="eco_de_0000144_19320">
+    <p xml:id="eco_de_0000214_19320">
      Ihr innerstes Wollen, von dem sie ihr Lebtag nichts gewußt, verlangte von ihr das zu tun, was sie tat, mit einer Stimme wie ein großer Gott, und sie erbebte vor diesem ihrem mächtig wollenden Willen, der größer war wie ihre Tugend, reiner wie ihre Reinheit, stärker wie ihre duldende Weibeskraft und über alle Sünde erhaben.
     </p>
-    <p xml:id="eco_de_0000144_19330">
+    <p xml:id="eco_de_0000214_19330">
      Als der geliebte Mann, auf den Knien vor ihr liegend, das Haupt an ihre Brust gepreßt, wie erstickt aufschrie: »Maria, ich muß gehen. – Keine Stunde mehr darf ich bleiben. Wir müssen uns trennen.« Da sagte sie weh, aber mit wunderlicher Ruhe: »Geh'.«
     </p>
-    <p xml:id="eco_de_0000144_19340">
+    <p xml:id="eco_de_0000214_19340">
      Dann banges, banges Schweigen. »Du wirst mich jederzeit finden,« flüsterte er heiß, »du wirst ganz, ganz mein werden, – für immer, Maria!«
     </p>
-    <p xml:id="eco_de_0000144_19350">
+    <p xml:id="eco_de_0000214_19350">
      Da blieb sie stumm.
     </p>
-    <p xml:id="eco_de_0000144_19360">
+    <p xml:id="eco_de_0000214_19360">
      »Maria!«
     </p>
-    <p xml:id="eco_de_0000144_19370">
+    <p xml:id="eco_de_0000214_19370">
      Sie antwortete nicht. »Ich werde dich nie finden,« sagte sie hart.
     </p>
-    <p xml:id="eco_de_0000144_19380">
+    <p xml:id="eco_de_0000214_19380">
      »Jeder trage sein Unrecht – aber nicht miteinander.«
     </p>
-    <p xml:id="eco_de_0000144_19390">
+    <p xml:id="eco_de_0000214_19390">
      Ein wildes Schluchzen erschütterte ihr ganzes Wesen.
     </p>
-    <p xml:id="eco_de_0000144_19400">
+    <p xml:id="eco_de_0000214_19400">
      »Ich wollte keine Liebesgeschichte!« Das kam so heftig, so ursprünglich heraus.
     </p>
-    <p xml:id="eco_de_0000144_19410">
+    <p xml:id="eco_de_0000214_19410">
      Sie warf sich mit dem Kopf auf die Kissen – »ich wollte« – banges, schluchzendes Schweigen – »ich wollte nichts Böses.«
     </p>
-    <p xml:id="eco_de_0000144_19420">
+    <p xml:id="eco_de_0000214_19420">
      Darauf erhob sie sich, schlang die Arme um den Hals des Mannes, sah ihm verweint in die Augen und sagte ganz weich und ganz aufgelöst in Liebe:
     </p>
-    <p xml:id="eco_de_0000144_19430">
+    <p xml:id="eco_de_0000214_19430">
      »Gott behüte dich – du. Geh'. – Geh'. Nie hören wir wieder voneinander. – Geh'. Du hast recht. Noch diese Stunde.«
     </p>
-    <p xml:id="eco_de_0000144_19440">
+    <p xml:id="eco_de_0000214_19440">
      Wie Verzweifelte hielten sie sich umschlungen.
     </p>
-    <p xml:id="eco_de_0000144_19450">
+    <p xml:id="eco_de_0000214_19450">
      Dann ein Sich-von-einander-losreißen – und er stand allein im dunkeln Zimmer.
     </p>
-    <p xml:id="eco_de_0000144_19460">
+    <p xml:id="eco_de_0000214_19460">
      Kein Laut mehr – keine Bewegung, als läge ein Toter hier.
     </p>
-    <p xml:id="eco_de_0000144_19470">
+    <p xml:id="eco_de_0000214_19470">
      Dann endlich ein Sichregen. Er zündete seine Kerze an, packte in wilder Hast seine paar Sachen und verließ das Haus wie ein Trunkener und mit einem Gefühl verzweifelter Heimatlosigkeit.
     </p>
-    <p xml:id="eco_de_0000144_19480">
+    <p xml:id="eco_de_0000214_19480">
      Die ersten Sommerwochen waren gekommen, sonnige, wundervolle Junitage nach einem kalten, regnerischen Frühjahr. Im Hause des Professors rüsteten sie sich zu einer großen Reise.
     </p>
-    <p xml:id="eco_de_0000144_19490">
+    <p xml:id="eco_de_0000214_19490">
      Dem Professor war ein wissenschaftlicher Auftrag geworden, der ihn für lange Zeit in Athen festhalten konnte, und er wollte Maria und seine Töchter mit sich nehmen.
     </p>
-    <p xml:id="eco_de_0000144_19500">
+    <p xml:id="eco_de_0000214_19500">
      Maria war in dieser Zeit allen durch ihr traumhaftes, in sich gekehrtes Wesen aufgefallen. Etwas Verschlossenes, Herbes lag über ihr, und nahezu schien sie verstummt zu sein. Die mit sich selbst Beschäftigten beobachteten oberflächlich – nur halb bewußt. Niemand machte sich irgend eine Sorge um sie. Man war an sie gewöhnt und sah sie kaum mehr, wie das so geht.
     </p>
-    <p xml:id="eco_de_0000144_19510">
+    <p xml:id="eco_de_0000214_19510">
      Nur der Professor machte sich hin und wieder seine Gedanken über die junge Frau, die ihn mit einem häuslichen Behagen umgeben hatte, wie er es nie in seinem Leben gespürt. Unter ihrer Fürsorge war er aufgelebt, fühlte sich verjüngt und zufrieden, und es bedrückte ihn, daß diese sonnige Frau in seinem Hause so verstummt war.
     </p>
-    <p xml:id="eco_de_0000144_19520">
+    <p xml:id="eco_de_0000214_19520">
      Ihretwegen ganz besonders hatte er sich ausgedacht, mit allen seinen Lieben eine neue herrliche Umgebung zu genießen.
     </p>
-    <p xml:id="eco_de_0000144_19530">
+    <p xml:id="eco_de_0000214_19530">
      Als er seiner Frau zum erstenmal Mitteilung von seinem Plan gemacht hatte, war sie wie erschreckt mit ihrer Näherei von ihrem Platz am Fenster aufgestanden, die Hände über der Brust gefaltet, die Augen voll Tränen. »Freut dich das so, mein Herz?« hatte der Professor fröhlich gesagt. »Siehst du, das ist mir aber lieb, daß dir's so nah geht.«
     </p>
-    <p xml:id="eco_de_0000144_19540">
+    <p xml:id="eco_de_0000214_19540">
      Schluchzend war sie zur Tür hinausgestürzt und hatte ihn ganz verblüfft im Zimmer zurückgelassen.
     </p>
-    <p xml:id="eco_de_0000144_19550">
+    <p xml:id="eco_de_0000214_19550">
      »O Frauen! – Was sind Frauen wunderlich!«
     </p>
-    <p xml:id="eco_de_0000144_19560">
+    <p xml:id="eco_de_0000214_19560">
      Wenige Tage nach diesem Vorfall fand er einen Brief von Maria auf seinem Tische liegen, in dem sie ihn bat, sie für ein paar Tage nach Haus zum Vater und zu den Geschwistern zu lassen.
     </p>
-    <p xml:id="eco_de_0000144_19570">
+    <p xml:id="eco_de_0000214_19570">
      »Nun ja,« dachte er, »weshalb denn nicht?«
     </p>
-    <p xml:id="eco_de_0000144_19580">
+    <p xml:id="eco_de_0000214_19580">
      Unnatürliche, unverständliche Wesen sind die Frauen. Was ist das nun? Stimmungen über Stimmungen!
     </p>
-    <p xml:id="eco_de_0000144_19590">
+    <p xml:id="eco_de_0000214_19590">
      Wahrhaftig, du ewige Kausalität, du lückenlose, das Weib ist dir dennoch entkommen. So dachte der gute Mensch in einer Art Professorenhumor.
     </p>
-    <p xml:id="eco_de_0000144_19600">
+    <p xml:id="eco_de_0000214_19600">
      Maria reiste. Ihr Abschied war stumm und erregt.
     </p>
-    <p xml:id="eco_de_0000144_19610">
+    <p xml:id="eco_de_0000214_19610">
      »Weißt du, Maria,« er klopfte ihr väterlich sanft auf die Schulter, als sie ihm die Hand gereicht; »du vernünftiges, tüchtiges Wesen – du solltest doch nicht …«
     </p>
-    <p xml:id="eco_de_0000144_19620">
+    <p xml:id="eco_de_0000214_19620">
      Da schaute sie ihn mit großen, bangen Augen an.
     </p>
-    <p xml:id="eco_de_0000144_19630">
+    <p xml:id="eco_de_0000214_19630">
      »Ich meine,« sagte er. – »Es liegt doch absolut nichts vor. – Du wirst doch nicht, wie sie alle es tun, mit Launen dich abgeben? Weißt du, das wäre schade um dich, mein Kind.« »Wer gibt sich mit Launen ab?« frug sie wie im Traum.
     </p>
-    <p xml:id="eco_de_0000144_19640">
+    <p xml:id="eco_de_0000214_19640">
      »Die Frauen.«
     </p>
-    <p xml:id="eco_de_0000144_19650">
+    <p xml:id="eco_de_0000214_19650">
      »Die Frauen?« frug Maria, »das scheint wohl oft nur so?«
     </p>
-    <p xml:id="eco_de_0000144_19660">
+    <p xml:id="eco_de_0000214_19660">
      Zwei Wochen gingen ins Land, ohne daß Maria an ihren Gatten geschrieben hatte, – da kam ein Brief mit der Bitte, daß er zu ihr kommen möchte, wenn auch nur auf einen Tag, auf wenige Stunden.
     </p>
-    <p xml:id="eco_de_0000144_19670">
+    <p xml:id="eco_de_0000214_19670">
      Der Brief enthielt keine Andeutung, um was es sich handelt – und machte einen dringlichen Eindruck.
     </p>
-    <p xml:id="eco_de_0000144_19680">
+    <p xml:id="eco_de_0000214_19680">
      Der Professor empfand keine besondere Befürchtung. Sehr unbequem war ihm aber dieser Eingriff in sein gewöhntes Dasein. »Herr, mein Gott,« dachte er, »wo soll ich die Zeit hernehmen?«
     </p>
-    <p xml:id="eco_de_0000144_19690">
+    <p xml:id="eco_de_0000214_19690">
      Auf dem Wege zu seiner Vorlesung stand ihm mit einem Mal klar vor Augen: ›Sie will gewiß versuchen, ob es ihr glückt, nicht mitzureisen.« Er erinnerte sich jetzt ihrer Gleichgültigkeit während ihres Aufenthalts in Italien.
     </p>
-    <p xml:id="eco_de_0000144_19700">
+    <p xml:id="eco_de_0000214_19700">
      Dieser Gleichgültigkeit hatte er sich nicht erinnert, als es ihm bequem war, ihr mit der großen Reise eine Freude zu machen.
     </p>
-    <p xml:id="eco_de_0000144_19710">
+    <p xml:id="eco_de_0000214_19710">
      Jetzt war er verstimmt, sie gehörte zu seinem Behagen; die Reise bekam ein ganz anderes Gesicht, wenn sie nicht mit wollte, wurde für alle so viel mühseliger. Schon die zwei Wochen Strohwitwerschaft waren ihm nicht recht. Alles, besonders das Essen hatte etwas Liebloses bekommen, fast wie früher.
     </p>
-    <p xml:id="eco_de_0000144_19720">
+    <p xml:id="eco_de_0000214_19720">
      In Marias Art, die Speisen zu bereiten, lag Zärtlichkeit. Ja, er hatte ihre Güte, ihre Lebensfreudigkeit gewissermaßen gegessen.
     </p>
-    <p xml:id="eco_de_0000144_19730">
+    <p xml:id="eco_de_0000214_19730">
      Ganz grob sinnlich war es sein Magen gewesen, der ein Urteil über sie gewonnen hatte – und zwar ein recht freundliches.
     </p>
-    <p xml:id="eco_de_0000144_19740">
+    <p xml:id="eco_de_0000214_19740">
      Nun, er reiste also. –
     </p>
-    <p xml:id="eco_de_0000144_19750">
+    <p xml:id="eco_de_0000214_19750">
      Da ließ sich nichts machen.
     </p>
-    <p xml:id="eco_de_0000144_19760">
+    <p xml:id="eco_de_0000214_19760">
      Auf dem Wege zum Bahnhof kam es ihm wie ein Epigramm in den Sinn, das folgendermaßen lautete: »Die beste Frau ist die, von der man nichts merkt.« So sollte es sein.
     </p>
-    <p xml:id="eco_de_0000144_19770">
+    <p xml:id="eco_de_0000214_19770">
      ›Und es war bisher so,« dachte er nebelhaft weiter, wie bei dämmerndem Bewußtsein.
     </p>
-    <p xml:id="eco_de_0000144_19780">
+    <p xml:id="eco_de_0000214_19780">
      Die Immenbachs fand er im vollen Sommerglück. Der Garten glühte von Blumen, die Obstbäume beugten sich, wie damals, als er sich sein Weib heimholte. Die Sonne lag brütend über der ganzen fruchtbaren Herrlichkeit, und über der weiten, goldgelben Ebene wölbte sich der Himmel wie eine blaue Glocke.
     </p>
-    <p xml:id="eco_de_0000144_19790">
+    <p xml:id="eco_de_0000214_19790">
      Der gehetzte, eifrige Mann spürte hier wieder Mutter Erdens Nähe so seelenlösend. Seine wissenschaftliche Bedeutung, seine ganze Wichtigkeit begann wie tropfend von ihm abzutauen, und so etwas Fremdes, Weiches, Menschliches rührte sich. Ihm war, als strichen duftende Hände über ihn hin und strichen alles fort, was er war, was er zu sein glaubte.
     </p>
-    <p xml:id="eco_de_0000144_19800">
+    <p xml:id="eco_de_0000214_19800">
      Unerwartet kam er an, und wie er den Weg, der zwischen dem langen Streifen Sommerblumen auf das Haus zuführte, ging, mußte er stehen bleiben und lauschen und schauen.
     </p>
-    <p xml:id="eco_de_0000144_19810">
+    <p xml:id="eco_de_0000214_19810">
      Aus der weiten Laube nahe am Haus hob eben ein wundervolles, süßes Lied vielstimmig an. Ein so einfaches, gutes, starkes Lied, ein Lied wie der Sommer selbst. Was es Schönes auf Erden gibt, Sonne und Liebe und Sehnsucht und die große Freude am Leben lagen darin.
     </p>
-    <p xml:id="eco_de_0000144_19820">
+    <p xml:id="eco_de_0000214_19820">
      Wie der Professor so stand, stieg es ihm warm zum Herzen und in die Augen.
     </p>
-    <p xml:id="eco_de_0000144_19830">
+    <p xml:id="eco_de_0000214_19830">
      Alle Erinnerung war wie von ihm gewichen und nur noch ein paar liebe, freie Jugendstunden waren noch mit ihm verbunden.
     </p>
-    <p xml:id="eco_de_0000144_19840">
+    <p xml:id="eco_de_0000214_19840">
      Die Immenbachschen Töchter und Maria sah er um einen mächtigen Tisch stehen, einen Haufen duftender Gartenerdbeeren ordneten sie in Körbe. Sie waren ganz versunken in ihre Arbeit und ihren Gesang.
     </p>
-    <p xml:id="eco_de_0000144_19850">
+    <p xml:id="eco_de_0000214_19850">
      So schön und stark standen die jungen, frischen Geschöpfe da.
     </p>
-    <p xml:id="eco_de_0000144_19860">
+    <p xml:id="eco_de_0000214_19860">
      Aus der weiten Laube strömten mit dem Gesang Lebensfreudigkeit und Jugendwonne in die blaue, warme Sommerluft hinaus.
     </p>
-    <p xml:id="eco_de_0000144_19870">
+    <p xml:id="eco_de_0000214_19870">
      Wie fremd erschien ihm sein Weib unter diesen köstlichen Gestalten, selbst so schön und jung und froh.
     </p>
-    <p xml:id="eco_de_0000144_19880">
+    <p xml:id="eco_de_0000214_19880">
      Er sah sie mit einem Mal wieder in demselben Zauber, in dem er sie früher gesehen.
     </p>
-    <p xml:id="eco_de_0000144_19890">
+    <p xml:id="eco_de_0000214_19890">
      Wie hatte er wagen können, dieses Geschöpf in sein Haus, das der großen, freien Natur so fern stand, zu verpflanzen? Da war nichts Magdhaftes, nichts Gedrücktes, nichts Verstummtes, königlich stand sie und sang und arbeitete mit dem anderen blonden prächtigen Volke.
     </p>
-    <p xml:id="eco_de_0000144_19900">
+    <p xml:id="eco_de_0000214_19900">
      Sie bemerkten ihn erst, als er ganz nahe bei ihnen war. Da sah er, wie Maria bei seinem Anblick erbleichte.
     </p>
-    <p xml:id="eco_de_0000144_19910">
+    <p xml:id="eco_de_0000214_19910">
      Freundlich und erstaunt wurde er von den andern begrüßt.
     </p>
-    <p xml:id="eco_de_0000144_19920">
+    <p xml:id="eco_de_0000214_19920">
      »Ja, hat euch denn meine Frau nicht gesagt, daß ich kommen sollte?«
     </p>
-    <p xml:id="eco_de_0000144_19930">
+    <p xml:id="eco_de_0000214_19930">
      »Nicht ein Wort davon,« und alle Blauaugen richteten sich fragend auf Maria.
     </p>
-    <p xml:id="eco_de_0000144_19940">
+    <p xml:id="eco_de_0000214_19940">
      Die stand noch immer tief erbleicht und sagte: »Ich erwartete dich noch nicht, – aber alles ist bereit. Komm ins Haus und ruh'.«
     </p>
-    <p xml:id="eco_de_0000144_19950">
+    <p xml:id="eco_de_0000214_19950">
      Dann saßen sie alle miteinander am Teetisch, die Immenbachs-Mädel noch immer in der sanften Wellenbewegung eines fröhlichen Erstaunens. Maria eigentümlich fremd und ernst, versäumte aber keinen Augenblick, eine aufmerksame Wirtin zu sein.
     </p>
-    <p xml:id="eco_de_0000144_19960">
+    <p xml:id="eco_de_0000214_19960">
      Einen ganz eigentümlichen Eindruck machte sie auf den Professor, schön und vornehm in ihrer gehaltenen Ruhe.
     </p>
-    <p xml:id="eco_de_0000144_19970">
+    <p xml:id="eco_de_0000214_19970">
      Hier war sie daheim, – bei ihm nicht. »Willst du nun etwas auf dein Zimmer gehen?« fragte sie.
     </p>
-    <p xml:id="eco_de_0000144_19980">
+    <p xml:id="eco_de_0000214_19980">
      »Nein, Maria, laß uns den Tag genießen. Geh' mit mir solch einen Weg wie einst.«
     </p>
-    <p xml:id="eco_de_0000144_19990">
+    <p xml:id="eco_de_0000214_19990">
      »Ja,« sagte Maria, erhob sich langsam, schritt zögernd auf die stattliche Reihe wetterharter Gartenhüte zu, die noch immer ihren alten Platz hatten, nahm einen davon und setzte ihn sich auf ihr blondes Haupt.
     </p>
-    <p xml:id="eco_de_0000144_20000">
+    <p xml:id="eco_de_0000214_20000">
      »Ich bin bereit,« sagte sie.
     </p>
-    <p xml:id="eco_de_0000144_20010">
+    <p xml:id="eco_de_0000214_20010">
      Er mußte lächeln, das paßte so ganz zu ihr, dieser langsame Griff nach irgend einem der abenteuerlichen Hüte. Sie brauchte einen Schutz gegen die Sonne. Alles andre war Nebensache, ob dieser Schutz sie kleidete oder nicht.
     </p>
-    <p xml:id="eco_de_0000144_20020">
+    <p xml:id="eco_de_0000214_20020">
      Sie war, die sie war.
     </p>
-    <p xml:id="eco_de_0000144_20030">
+    <p xml:id="eco_de_0000214_20030">
      Er sah sie heute, wie er sonst nur Kunstwerke zu sehen verstand.
     </p>
-    <p xml:id="eco_de_0000144_20040">
+    <p xml:id="eco_de_0000214_20040">
      So gingen sie miteinander.
     </p>
-    <p xml:id="eco_de_0000144_20050">
+    <p xml:id="eco_de_0000214_20050">
      Es mochte gegen sechs Uhr abends sein. Die Sonne hielt in ihrem Sommerrecht; ihr gehörte jetzt diese Stunde, die sie durchwärmte, mit ihrer Liebeskraft durchströmte.
     </p>
-    <p xml:id="eco_de_0000144_20060">
+    <p xml:id="eco_de_0000214_20060">
      Mochten Herbst und Winter die Stunden dann wieder auskühlen.
     </p>
-    <p xml:id="eco_de_0000144_20070">
+    <p xml:id="eco_de_0000214_20070">
      Heute aber lebte die Sonne, strahlte in warmem Nachmittagslicht, voll und tief.
     </p>
-    <p xml:id="eco_de_0000144_20080">
+    <p xml:id="eco_de_0000214_20080">
      Die Felder dufteten. Sie hatten schon einen warmen Goldton. Wie in endloses Blau hinein, schmetterte eine Lerche ihr starkes Lied von der Lebenswonne, die wie ein Wunder in diesem heißen, lebendigen Federstäubchen lebte, das da oben im Sonnenlichte wirbelte.
     </p>
-    <p xml:id="eco_de_0000144_20090">
+    <p xml:id="eco_de_0000214_20090">
      Maria ging stumm neben ihrem Manne her.
     </p>
-    <p xml:id="eco_de_0000144_20100">
+    <p xml:id="eco_de_0000214_20100">
      Er sah, wie sie sich niederbeugte und einen schweren, müden Halm mit einer mütterlichen Bewegung wieder mit dem Meer seiner Brüder vereinigte.
     </p>
-    <p xml:id="eco_de_0000144_20110">
+    <p xml:id="eco_de_0000214_20110">
      Aus dieser selben Bewegung war einst bei ihm der Wunsch entstanden, sie bei sich zu haben und sich mit ihr zu verbinden.
     </p>
-    <p xml:id="eco_de_0000144_20120">
+    <p xml:id="eco_de_0000214_20120">
      Sonderbar, nun hatte er wieder daran gedacht, daß seine Liebe zu ihr in ihrer Mütterlichkeit Wurzel geschlagen.
     </p>
-    <p xml:id="eco_de_0000144_20130">
+    <p xml:id="eco_de_0000214_20130">
      Auch jetzt dämmerte es ihm nur leicht, berührte ihn kaum.
     </p>
-    <p xml:id="eco_de_0000144_20140">
+    <p xml:id="eco_de_0000214_20140">
      »Sage mir,« fragte Maria nach langem Schweigen, »aber so wahr wie ein Mensch zum andern überhaupt sein kann: Gehöre ich notwendig zu dir?«
     </p>
-    <p xml:id="eco_de_0000144_20150">
+    <p xml:id="eco_de_0000214_20150">
      »Wie denn, mein Kind, was willst du denn?«
     </p>
-    <p xml:id="eco_de_0000144_20160">
+    <p xml:id="eco_de_0000214_20160">
      »Es ist eine ernste Frage, du mußt mir antworten.«
     </p>
-    <p xml:id="eco_de_0000144_20170">
+    <p xml:id="eco_de_0000214_20170">
      »Ich dir? Weshalb denn?«
     </p>
-    <p xml:id="eco_de_0000144_20180">
+    <p xml:id="eco_de_0000214_20180">
      »Es ist notwendig,« sagte Maria.
     </p>
-    <p xml:id="eco_de_0000144_20190">
+    <p xml:id="eco_de_0000214_20190">
      »Nun aber, natürlich gehörst du zu mir?«
     </p>
-    <p xml:id="eco_de_0000144_20200">
+    <p xml:id="eco_de_0000214_20200">
      »Wie Geist zum Geist und Leib zum Leib?« frug sie weiter – und sagte selbst ruhig und entschieden: »Nein.«
     </p>
-    <p xml:id="eco_de_0000144_20210">
+    <p xml:id="eco_de_0000214_20210">
      »Wie kommst du darauf?« frug er unwillig erstaunt. »Laß das!«
     </p>
-    <p xml:id="eco_de_0000144_20220">
+    <p xml:id="eco_de_0000214_20220">
      »Nein,« sagte sie. »Ich muß das alles fragen, denn ich muß dich vor etwas, soviel in meiner Macht steht, bewahren.«
     </p>
-    <p xml:id="eco_de_0000144_20230">
+    <p xml:id="eco_de_0000214_20230">
      »Was hast du denn, Kind?«
     </p>
-    <p xml:id="eco_de_0000144_20240">
+    <p xml:id="eco_de_0000214_20240">
      »Laß mich reden,« bat sie, »deinetwegen. Du kennst meine Seele nicht und ich nicht deine. Meine Jahre sind dir fremd und mir deine. Dein ganzes Leben ist mir fremd und dir meins. Uns ist gegenseitig an uns beiden alles fremd.
     </p>
-    <p xml:id="eco_de_0000144_20250">
+    <p xml:id="eco_de_0000214_20250">
      Du brauchst mich gar nicht.«
     </p>
-    <p xml:id="eco_de_0000144_20260">
+    <p xml:id="eco_de_0000214_20260">
      »Maria, was soll das alles?«
     </p>
-    <p xml:id="eco_de_0000144_20270">
+    <p xml:id="eco_de_0000214_20270">
      »Sag' mir, im Namen Gottes,« bat sie flehend, »ob ich dir irgendwie nahestehe, ob ihr alle euch nicht viel besser befändet, wenn irgend jemand wie ich euer Haus führte, so wie ich es tat, ohne zu euch zu gehören?«
     </p>
-    <p xml:id="eco_de_0000144_20280">
+    <p xml:id="eco_de_0000214_20280">
      »Soll das heißen, du willst wieder frei werden?« fragte er gereizt.
     </p>
-    <p xml:id="eco_de_0000144_20290">
+    <p xml:id="eco_de_0000214_20290">
      »Was ich frage, muß gefragt sein. Ich bitte dich, denke mit mir! – Wenn ich stürbe, – stirbt dir nur eine gute Magd, – sagen wir so. Wenn du über mich trauertest, wärest du dir selbst nicht klar. Ihr würdet auch alle nicht um mich trauern, es würde euch nur unbequem sein. – Im Grunde nur das.«
     </p>
-    <p xml:id="eco_de_0000144_20300">
+    <p xml:id="eco_de_0000214_20300">
      Sie sprach seltsam ruhig.
     </p>
-    <p xml:id="eco_de_0000144_20310">
+    <p xml:id="eco_de_0000214_20310">
      Sie standen sich jetzt gegenüber. Der Professor hatte seine Hand auf ihre Schulter gelegt. »Kind! Kind! versündige dich nicht.«
     </p>
-    <p xml:id="eco_de_0000144_20320">
+    <p xml:id="eco_de_0000214_20320">
      »Nein, es ist alles so, wie ich's sage.«
     </p>
-    <p xml:id="eco_de_0000144_20330">
+    <p xml:id="eco_de_0000214_20330">
      »So – nun also.« In dem braven Manne stieg der Zorn auf. – Er legte seine Hände auf dem Rücken zusammen und ging, als bereite er sich zu einer seiner Vorlesungen vor, ganz in sich selbst versunken.
     </p>
-    <p xml:id="eco_de_0000144_20340">
+    <p xml:id="eco_de_0000214_20340">
      »Wenn ich dir sage,« begann er heftig, »daß ich dich wie eine Tochter liebe, – genügt dir das?«
     </p>
-    <p xml:id="eco_de_0000144_20350">
+    <p xml:id="eco_de_0000214_20350">
      »Nein,« sagte sie.
     </p>
-    <p xml:id="eco_de_0000144_20360">
+    <p xml:id="eco_de_0000214_20360">
      Er schaute auf.
     </p>
-    <p xml:id="eco_de_0000144_20370">
+    <p xml:id="eco_de_0000214_20370">
      »Ich bin dein Weib und nicht deine Tochter.«
     </p>
-    <p xml:id="eco_de_0000144_20380">
+    <p xml:id="eco_de_0000214_20380">
      »Nun – mein Gott – ja. Du hast gewußt, daß ich kein Jüngling bin. Hätte uns Gott ein Kind schenken wollen, so hättest du dies Glück wie andere auch genossen. – Ja, aber es sollte nicht sein. Es war dir nicht bestimmt.«
     </p>
-    <p xml:id="eco_de_0000144_20390">
+    <p xml:id="eco_de_0000214_20390">
      »Also, du liebst mich nicht mehr wie dein Weib?« fragte sie weich – wie beseligt. »Sag' es noch einmal!«
     </p>
-    <p xml:id="eco_de_0000144_20400">
+    <p xml:id="eco_de_0000214_20400">
      »Nun, – was willst du denn?« Er war ungeduldig. »Ich denke nicht, Maria, – aber ich liebe dich dennoch.«
     </p>
-    <p xml:id="eco_de_0000144_20410">
+    <p xml:id="eco_de_0000214_20410">
      »O – du!« rief sie. In ihren Augen standen Tränen. »Ich danke dir! – Nächtelang hab' ich Gott gebeten, – daß es so sein möchte, daß du so antworten müßtest. – Nicht um meinetwillen, aber um deinetwillen.«
     </p>
-    <p xml:id="eco_de_0000144_20420">
+    <p xml:id="eco_de_0000214_20420">
      Dann brach sie ab, über ihr Gesicht zog ein leiser Ernst. Sie stand immer noch vor ihm, faßte seine beiden Hände und sagte, wie es nur die weltfremde Göttin tun konnte, um die er hier einst gefreit: »Ich war eine Nacht das Weib eines andern und fühle mich Mutter.«
     </p>
-    <p xml:id="eco_de_0000144_20430">
+    <p xml:id="eco_de_0000214_20430">
      Er ließ ihre Hände fahren und starrte sie an.
     </p>
-    <p xml:id="eco_de_0000144_20440">
+    <p xml:id="eco_de_0000214_20440">
      Ihr war, als wenn er taumelte, und sie machte eine Bewegung, um ihn zu stützen.
     </p>
-    <p xml:id="eco_de_0000144_20450">
+    <p xml:id="eco_de_0000214_20450">
      »Laß! – laß! – Geh'!«
     </p>
-    <p xml:id="eco_de_0000144_20460">
+    <p xml:id="eco_de_0000214_20460">
      Das wurde hastig, wie außer sich hervorgestoßen!
     </p>
-    <p xml:id="eco_de_0000144_20470">
+    <p xml:id="eco_de_0000214_20470">
      »Laß dich nicht hinreißen – sei ruhig –,« bat sie – »um deinetwillen. Gott behüte dich.« Sie faßte seine Hand. So mütterlich, so hingebend gut stand sie vor ihm, so einzig in ihrer Art.
     </p>
-    <p xml:id="eco_de_0000144_20480">
+    <p xml:id="eco_de_0000214_20480">
      »Du armer Mann – du armer. – Gönn' mir's – um deinetwillen. Glaub' doch nicht, daß du unglücklich sein mußt! Ich will dir dienen, und wenn du mich nicht mehr magst, bleib' ich hier beim Vater; die beiden Schwestern heiraten nun, da bin ich am Platz.
     </p>
-    <p xml:id="eco_de_0000144_20490">
+    <p xml:id="eco_de_0000214_20490">
      Ohne Kind wäre ich verschmachtet.«
     </p>
-    <p xml:id="eco_de_0000144_20500">
+    <p xml:id="eco_de_0000214_20500">
      Das war alles so einfach, so richtig und so weltfremd.
     </p>
-    <p xml:id="eco_de_0000144_20510">
+    <p xml:id="eco_de_0000214_20510">
      Hier unter dieser großen, blauen Himmelsglocke, vom goldenen Getreide unabsehbar umwogt, begleitet von dem unausgesetzten, erdenwohligen Lerchentriller, fühlte er gegen seinen Willen ringsumher eine Macht aufgerichtet, gegen die er nicht konnte, wie er wollte, die ihn sanft überwältigte und gleichsam erstickte.
     </p>
-    <p xml:id="eco_de_0000144_20520">
+    <p xml:id="eco_de_0000214_20520">
      Mutter Erde duftete nach Korn, blühte betäubend, einschläfernd, und das blonde, ruhige Weib mit der weichen, vollen Stimme, die in Angst um ihn bebte. Große, gewaltige Mutter Erde, die hier in der kornwogenden Einsamkeit wie unmittelbar mit diesem naturfremden Manne in Berührung kam!
     </p>
-    <p xml:id="eco_de_0000144_20530">
+    <p xml:id="eco_de_0000214_20530">
      Ihm war, als schaute er in ein uraltes Mysterium, ihm schwindelte.
     </p>
-    <p xml:id="eco_de_0000144_20540">
+    <p xml:id="eco_de_0000214_20540">
      Nie hätte er sich in eine solche Lage, wie er sie jetzt im schweren Traume erlebte, hineindenken können. Taumelnd ließ er sich auf einen alten Meilenstein nieder. –
     </p>
-    <p xml:id="eco_de_0000144_20550">
+    <p xml:id="eco_de_0000214_20550">
      Ja, und sie stützte ihn. Mütterlich schützte sie ihn, wie den Halm, den sie dem Meere seiner Brüder wieder anschloß – nicht anders.
     </p>
-    <p xml:id="eco_de_0000144_20560">
+    <p xml:id="eco_de_0000214_20560">
      Er empfand ihre starke Mütterlichkeit wie einen Schauer. Das Weltfremde in ihr, das Ureinfache hatte es ihm wieder angetan.
     </p>
-    <p xml:id="eco_de_0000144_20570">
+    <p xml:id="eco_de_0000214_20570">
      Verfluchen, mißachten und verstoßen sollte er sie.
     </p>
-    <p xml:id="eco_de_0000144_20580">
+    <p xml:id="eco_de_0000214_20580">
      Ihm war betäubt zumute, – die schwere Betäubung nach einem großen Schreck.
     </p>
-    <p xml:id="eco_de_0000144_20590">
+    <p xml:id="eco_de_0000214_20590">
      Daß ihm so etwas passieren konnte – so etwas ihm! Das war einfach undenkbar! – und doch!
     </p>
-    <p xml:id="eco_de_0000144_20600">
+    <p xml:id="eco_de_0000214_20600">
      Er sah, wie sein Weib die gefalteten Hände zu ihm aufhob – da winkte er ihr, zu gehen.
     </p>
-    <p xml:id="eco_de_0000144_20610">
+    <p xml:id="eco_de_0000214_20610">
      Wie ein Bann lag eine schwere, lähmende Dumpfheit über ihm. Die Art aber, wie er Maria zugewinkt, mußte etwas Tröstendes für sie haben; denn sie faßte seine Hand und küßte sie demütig.
     </p>
-    <p xml:id="eco_de_0000144_20620">
+    <p xml:id="eco_de_0000214_20620">
      Die Hand sank matt herab; mit der andern stützte er sein Haupt. So blieb er sitzen, und sie ging.
     </p>
-    <p xml:id="eco_de_0000144_20630">
+    <p xml:id="eco_de_0000214_20630">
      Das Außerordentliche hielt ihn wie in Ketten. Er stand ihm hilflos wie ein Kind gegenüber.
     </p>
-    <p xml:id="eco_de_0000144_20640">
+    <p xml:id="eco_de_0000214_20640">
      Was sollte geschehen?
     </p>
-    <p xml:id="eco_de_0000144_20650">
+    <p xml:id="eco_de_0000214_20650">
      Nein, so weit dachte er noch gar nicht. Er fühlte das Altsein wie eine wehe Trauer – und Mutter Erde war so stark und jung und gleichmütig. In ihrer Werdewonne erschien sie ihm, dem Alten, so fremd.
     </p>
-    <p xml:id="eco_de_0000144_20660">
+    <p xml:id="eco_de_0000214_20660">
      Wie es um ihn her wogte und glänzte und jubilierte! Es trieb und wuchs und wollte in die Unendlichkeit hinein sich fortsetzen.
     </p>
-    <p xml:id="eco_de_0000144_20670">
+    <p xml:id="eco_de_0000214_20670">
      Er selbst erschien sich hier wie etwas Vergangenes, wie er so gebeugt und widerstandslos saß, und fühlte das Gegenwärtige wie über sich hinwegwachsen.
     </p>
-    <p xml:id="eco_de_0000144_20680">
+    <p xml:id="eco_de_0000214_20680">
      Ach – wie er ermattet war von diesem Schreck.
     </p>
-    <p xml:id="eco_de_0000144_20690">
+    <p xml:id="eco_de_0000214_20690">
      Sie hatte seine große Güte getreten. Pfui!
     </p>
-    <p xml:id="eco_de_0000144_20700">
+    <p xml:id="eco_de_0000214_20700">
      Da stieg sie vor seiner Seele auf wie ein Kunstwerk – und er konnte sie nicht mißachten.
     </p>
-    <p xml:id="eco_de_0000144_20710">
+    <p xml:id="eco_de_0000214_20710">
      Als er in der Dämmerung mit schweren Schritten ratlos, was zu tun, auf Immenbachs Haus zuging, ja selbst ratlos, was er fühlen sollte, da stand sie an der Gartentür.
     </p>
-    <p xml:id="eco_de_0000144_20720">
+    <p xml:id="eco_de_0000214_20720">
      Sie wartete auf ihn.
     </p>
-    <p xml:id="eco_de_0000144_20730">
+    <p xml:id="eco_de_0000214_20730">
      Mit einem demütigen Mut ging sie ihm entgegen und sagte:
     </p>
-    <p xml:id="eco_de_0000144_20740">
+    <p xml:id="eco_de_0000214_20740">
      »Mir war so angst um dich, tue mit mir, was du willst.« – Und wieder küßte sie ihm die Hand; nicht sklavisch, nicht unterwürfig, sondern wie ein Mensch, der dem andern wider Willen wehe getan und ihn wieder heilen möchte.
     </p>
-    <p xml:id="eco_de_0000144_20750">
+    <p xml:id="eco_de_0000214_20750">
      »Maria – Maria,« sagte er. »Mein ganzes Leben war rein.«
     </p>
-    <p xml:id="eco_de_0000144_20760">
+    <p xml:id="eco_de_0000214_20760">
      Sie preßte die Hände vor die Stirn. Ein Schluchzen erschütterte sie.
     </p>
-    <p xml:id="eco_de_0000144_20770">
+    <p xml:id="eco_de_0000214_20770">
      »Geh mit mir,« sagte er kurz und tonlos.
     </p>
-    <p xml:id="eco_de_0000144_20780">
+    <p xml:id="eco_de_0000214_20780">
      Sie führte ihn in das Fremdenzimmer, in dem er vor Jahren schon gewohnt. Die Lampe brannte, der Tisch zur Abendmahlzeit war für ihn allein gedeckt. Ein Rosenstrauß duftete, der Teekessel summte bald.
     </p>
-    <p xml:id="eco_de_0000144_20790">
+    <p xml:id="eco_de_0000214_20790">
      »Darf ich dir helfen?«
     </p>
-    <p xml:id="eco_de_0000144_20800">
+    <p xml:id="eco_de_0000214_20800">
      Sie goß ihm den Tee ein und schnitt ihm ein kaltes Hühnchen zurecht.
     </p>
-    <p xml:id="eco_de_0000144_20810">
+    <p xml:id="eco_de_0000214_20810">
      »Iß bitte. – Du wirst sonst krank!« Demütig und ruhig schien sie zu sein, ein Weib, das bereit war, jedes Schicksal zu tragen und doch sich nicht selbst verloren hat.
     </p>
-    <p xml:id="eco_de_0000144_20820">
+    <p xml:id="eco_de_0000214_20820">
      Keins von beiden sprach mehr ein Wort. Er aß ein paar Bissen, trank eine Tasse Tee. Sie reichte ihm Brot und Salz.
     </p>
-    <p xml:id="eco_de_0000144_20830">
+    <p xml:id="eco_de_0000214_20830">
      »Schlaf wohl, Maria,« sagte er dann und gab ihr die Hand.
     </p>
-    <p xml:id="eco_de_0000144_20840">
+    <p xml:id="eco_de_0000214_20840">
      Somit hatten sie sich fürs erste zum letztenmal für lange Zeit gesehn.
     </p>
-    <p xml:id="eco_de_0000144_20850">
+    <p xml:id="eco_de_0000214_20850">
      Vor Tagesanbruch machte sich der Professor zur Bahnstation auf und hinterließ seiner Frau einen verschlossenen Brief.
     </p>
-    <p xml:id="eco_de_0000144_20860">
+    <p xml:id="eco_de_0000214_20860">
      Maria findet diesen Brief im Zimmer ihres Gatten, öffnet ihn mit bebender Hand und liest:
     </p>
-    <p xml:id="eco_de_0000144_20870">
+    <p xml:id="eco_de_0000214_20870">
      »Ich bleibe dein Freund. – Erwarte mich bei deinem Pater. Wir reisen jetzt. Du hörst von mir.«
     </p>
-    <p xml:id="eco_de_0000144_20880">
+    <p xml:id="eco_de_0000214_20880">
      Sie hatte die ganze Nacht kein Auge geschlossen und sank nun in die Knie und weinte und lachte und hätte die Luft umarmen können.
     </p>
-    <p xml:id="eco_de_0000144_20890">
+    <p xml:id="eco_de_0000214_20890">
      Dann geht sie hinaus in die wundervolle Sommermorgenfrische – so voller Glück und Frieden.
     </p>
-    <p xml:id="eco_de_0000144_20900">
+    <p xml:id="eco_de_0000214_20900">
      Hinter dem Gemüsegarten dehnten sich die Felder aus.
     </p>
-    <p xml:id="eco_de_0000144_20910">
+    <p xml:id="eco_de_0000214_20910">
      Auf dem grünen Grasrain, zwischen Feld und Gartenmauer, läßt sie sich nieder – ganz in sich zusammengekauert.
     </p>
-    <p xml:id="eco_de_0000144_20920">
+    <p xml:id="eco_de_0000214_20920">
      Sie ist müde – so müde – müde nach langer Angst und erlöst von langer Angst.
     </p>
-    <p xml:id="eco_de_0000144_20930">
+    <p xml:id="eco_de_0000214_20930">
      Jetzt ist sie gerettet! – und alle sind gerettet!
     </p>
-    <p xml:id="eco_de_0000144_20940">
+    <p xml:id="eco_de_0000214_20940">
      Ihren Kopf birgt sie ins volle Gras und küßt die kühlen, festen Halme, die ihr die Lippen streifen.
     </p>
-    <p xml:id="eco_de_0000144_20950">
+    <p xml:id="eco_de_0000214_20950">
      Nun streckt sie sich.
     </p>
-    <p xml:id="eco_de_0000144_20960">
+    <p xml:id="eco_de_0000214_20960">
      Wie wohl es ihr ist.
     </p>
-    <p xml:id="eco_de_0000144_20970">
+    <p xml:id="eco_de_0000214_20970">
      Und so versteckt vom wogenden Korn liegt sie wie ein Kind in Mutterarmen.
     </p>
-    <p xml:id="eco_de_0000144_20980">
+    <p xml:id="eco_de_0000214_20980">
      Niemand sucht sie hier.
     </p>
-    <p xml:id="eco_de_0000144_20990">
+    <p xml:id="eco_de_0000214_20990">
      Niemand ahnt die große Seligkeit.
     </p>
-    <p xml:id="eco_de_0000144_21000">
+    <p xml:id="eco_de_0000214_21000">
      Niemand weiß von ihrer Not, die ihr guter Freund von ihr genommen.
     </p>
-    <p xml:id="eco_de_0000144_21010">
+    <p xml:id="eco_de_0000214_21010">
      Sie ist freigesprochen.
     </p>
-    <p xml:id="eco_de_0000144_21020">
+    <p xml:id="eco_de_0000214_21020">
      Und keiner kannte ihre Sünde.
     </p>
-    <p xml:id="eco_de_0000144_21030">
+    <p xml:id="eco_de_0000214_21030">
      Und voller Sommer ist's!
     </p>
-    <p xml:id="eco_de_0000144_21040">
+    <p xml:id="eco_de_0000214_21040">
      Und sie ist Mutter.
     </p>
-    <p xml:id="eco_de_0000144_21050">
+    <p xml:id="eco_de_0000214_21050">
      Das ist alles so schön.
     </p>
-    <p xml:id="eco_de_0000144_21060">
+    <p xml:id="eco_de_0000214_21060">
      Sie ist befriedigt, wie sie es nicht als Kind war.
     </p>
-    <p xml:id="eco_de_0000144_21070">
+    <p xml:id="eco_de_0000214_21070">
      Ein Windchen weht über die Aehren. Das Licht liegt warm und golden über der Welt. Ihr Zopf hat sich gelöst und schimmert auch wie Gold in der Sonne.
     </p>
-    <p xml:id="eco_de_0000144_21080">
+    <p xml:id="eco_de_0000214_21080">
      Sie schläft fest ein und träumt von etwas Weichem, Zartem, Goldigem, das sich ihr in den Armen, an der Brust regt – ihr Kind! – Nein. – Ja – nein. Ja, – es ist das Köpfchen eines Küchleins, was sie da sieht, groß wie ein Kinderköpfchen – ganz goldig, flaumig, warm pulsierend – und duftet nach Kornblüte.
     </p>
-    <p xml:id="eco_de_0000144_21090">
+    <p xml:id="eco_de_0000214_21090">
      Und eine Liebe – eine Liebe – regt sich in ihr zum Hinsterben, da hört sie sich singen: »Goldvogel weint – Goldvögelein lacht.«
     </p>
-    <p xml:id="eco_de_0000144_21100">
+    <p xml:id="eco_de_0000214_21100">
      Da liegt die ganze große Seligkeit darin, wie in einem Zauber.
     </p>
-    <p xml:id="eco_de_0000144_21110">
+    <p xml:id="eco_de_0000214_21110">
      Ihr erscheint das so wundervoll schön.
     </p>
-    <p xml:id="eco_de_0000144_21120">
+    <p xml:id="eco_de_0000214_21120">
      »Goldvogel« heißt es –! Da kommen ihr süße, selige Tränen in die Augen.
     </p>
-    <p xml:id="eco_de_0000144_21130">
+    <p xml:id="eco_de_0000214_21130">
      Und still, ohne Regung liegt sie und spürt erschauernd den Traum.
     </p>
    </div>

--- a/tei/Buechner_Luise_Der_kleine_Vagabund.xml
+++ b/tei/Buechner_Luise_Der_kleine_Vagabund.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000145" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000215" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000145_20">
+   <p xml:id="eco_de_0000215_20">
     Der kleine Vagabund
    </p>
   </front>
@@ -92,331 +92,331 @@
    <div type="group">
     <head>
     </head>
-    <p xml:id="eco_de_0000145_30">
+    <p xml:id="eco_de_0000215_30">
      Es mögen etwa dreißig Jahre her sein, als an einem wonnigen, sonnigen Nachmittage des Monat Mai die rüstige Wirthin zum »goldnen Löwen« in Zwingenberg, dem reizend gelegenen Landstädtchen an der Bergstraße, ihren Jüngsten, einen stämmigen, vierjährigen Knaben, von dem Arm auf die Erde setzte und zu einem blondgezöpften Mädchen von ungefähr zehn Jahren die eiligen Worte sprach: »Hier, Marie, nimm den Hans an die Hand, packt eure Schulsachen zusammen, Gretchen und Jakob, und geht mit hinauf in das Schloß. Ich weiß heute wieder einmal nicht, wo mir der Kopf steht; in einer Stunde kommen die Maler und Sänger hungrig und durstig aus dem Gebirg. Ich laufe vom Keller in die Küche, von der Küche in den Speisesaal – und ihr seid mir dabei fortwährend zwischen den Füßen. Also, marsch hinauf! und gehorcht der Marie, das will ich euch gesagt haben!« Die letzten Worte richtete sie an die zwei Krausköpfe von sieben und neun Jahren, die muthwillig zu dem drohend erhobenen Finger der Mutter hinaufschauten, jetzt aber freundlich nickten, als ein zweites: »Hört ihr?« nochmals Gehorsam einschärfte.
     </p>
-    <p xml:id="eco_de_0000145_40">
+    <p xml:id="eco_de_0000215_40">
      Die muntere Schaar zog dann vergnügt über den Marktplatz und die bergartige Straße hinauf; Mariechen, die ihr sanftes, gutmüthiges Gesicht schnell als eine Vice-Mama auswies, der man nicht allzu ungern gehorchte, führte den Hans, der mit einer Gerte bewaffnet war und nicht verfehlte, damit nach jeder Gans zu schlagen, die ihm in die Nähe kam. Ihnen folgten Jakob und Gretchen; der erstere, als der stärkere, hatte sich mit den Schiefertafeln, der Fibel und dem Katechismus bepackt, während Gretchen das kleine Wägelchen zog, in welches die Mutter das Vieruhrbrod nebst einigen rothbackigen Aepfeln gelegt hatte, die sie als sorgsame Hausfrau bis spät in das Frühjahr hinein aufzubewahren wußte. Bald waren sie an ihrem Bestimmungsort angelangt, in der »Kinderstube der Frau Martha«, wie die Stammgäste des »goldnen Löwen« scherzweise den alten, verfallnen, mit Gras überwucherten Schloßhof nannten, wo die Wirthin in der Sommerzeit, an besonders geschäftigen Tagen, die Kinder gerne sicher unterbrachte. Eine geräumigere, freundlichere und gesündere Kinderstube möchte auch schwerlich sonst wieder gefunden werden, als dieser von zerbröckelnden Mauern rings eingeschlossene Raum, der allein noch daran erinnerte, daß hier einst ein wirkliches Schloß gestanden, als dessen einziger Rest sich eben dieser Hof noch erhalten hatte. Man schonte ihn auch wohl nur darum, weil sich unter ihm große, tiefe, in den Fels gehauene Kellerwölbungen befinden, welche dem edlen Wein, der an diesen Bergabhängen wächst, eine kühle Wohnstätte bieten. Unten, neben den Kellern, hatte ein Küfer seine Werkstatt eingerichtet und bildete damit gleichsam eine Schutzwache für den inneren Hofraum, dessen Mauerreste im Sommer fast verschwinden unter dem dichten Gestrüppe der Brombeer- und Weißdornhecken, über die sich in buntem Gemische lange Epheuranken und blühende Winden hinziehen, als wollten sie die Menge von Vogelnestern, welche in den Hecken Schutz finden, noch sicherer verstecken. Darum wird es aber auch vom Mai bis zum Spätherbst in dem lauschigen Raume kaum stille von Vogelgezwitscher und süßen Melodieen, die sich gar lieblich unter dem Schatten der dichten Hollunderbüsche anhören, welche die Mauerecken und Fenstervorsprünge schmücken. Neben diesen Resten des alten Schlosses erhebt sich malerisch die alte Kirche.
     </p>
-    <p xml:id="eco_de_0000145_50">
+    <p xml:id="eco_de_0000215_50">
      Mit fröhlichen Sprüngen betraten die Kinder jetzt ihren Spielplatz, und jauchzend hüpften sie in dem saftigen, mit gelben Kuhblumen übersäeten Grase umher. Sie schlüpften in jedes Eckchen, um zu sehen, ob es dort nichts Neues gäbe, und freuten sich über ein paar dicke Baumstämme, welche der Küfer herausgelegt hatte und die bequeme Sitzplätze darboten. Die zwei Aeltesten waren bald auf den breiten Rand des Gemäuers geklettert und spähten hinaus in die sonnenbeglänzte Ebene, welche das Silberband des Rheines durchschlängelt, und welche von dem langen, blauen Rücken des fernen Donnersberges begrenzt wird. Aber ihr Ausschauen währte nicht lange. »Ein Storch, ein Storch!« riefen die Kleinen, und richtig, rückwärts über dem Thurme des Melibokus, des schönen Berges, der sich hier so majestätisch erhebt, zog oben im blauen Aether ein Storch seine luftige Bahn.
     </p>
-    <p xml:id="eco_de_0000145_60">
+    <p xml:id="eco_de_0000215_60">
      »Ja, ja, Gevatter Storch ist wieder da!« rief jetzt eine fröhliche Stimme, und vom Wege her, der weiter hinauf in den Wald führt, lenkte ein kräftiger Junge von etwa zwölf Jahren seine Schritte dem verfallnen Schloßthore zu. Er war viel ärmlicher und nachlässiger gekleidet, als Frau Marthens Sprößlinge, aber das schwere Tuch-Wams und die geflickten Hosen waren reinlich, und das grobe Hemde war schneeweiß. In der Hand hielt er einen dicken Knotenstock, und an seinem linken Arm trug er einen Korb, aus dem eine Masse lieblich duftender Kräuter hervorsah. Sein von langen, braunen Haaren umflogenes Gesicht strahlte von Frische und Gesundheit, und die braunen Augen blickten so lange recht treuherzig in die Welt, bis ein starker Zug von Schelmerei und Pfiffigkeit, der sich öfter um den breiten Mund lagerte, sie blinzeln machte.
     </p>
-    <p xml:id="eco_de_0000145_70">
+    <p xml:id="eco_de_0000215_70">
      Kaum hatten die Kinder des Knaben Ruf gehört, als sie mit dem freudigen Gruße: »Ach, der Philipp!« nach dem Thore und ihm entgegenstürzten.
     </p>
-    <p xml:id="eco_de_0000145_80">
+    <p xml:id="eco_de_0000215_80">
      »Na, seid ihr wieder einmal im alten Revier?« sagte er ruhig, sich den Schweiß von der Stirne wischend; »das ist schön, da kann ich mich auch hier ein wenig ausruhen«. »Es ist noch nicht spät!« fügte er hinzu, nach der Sonne schauend, die noch hoch am Himmel stand. Dann stellte er seinen Korb auf die Erde und warf sich daneben in's Gras, während Hans und Gretchen sich über den Korb hermachten und die Kräuter herauskramten. »Bst«, warnte Philipp, »laßt mir den Korb in Ruhe, es hat Schweiß genug gekostet, das Kraut zusammenzufinden«. »Wie köstlich es riecht«, sagte Mariechen, ihr Näschen in ein Bündel des duftenden Waldmeisters steckend; »da gibt es heute wohl Maitrank unten?«
     </p>
-    <p xml:id="eco_de_0000145_90">
+    <p xml:id="eco_de_0000215_90">
      »Ja freilich«, antwortete Philipp, »die bringen durstige Kehlen mit von droben, ich glaube, sie könnten das Heidelberger Faß austrinken; es ist freilich auch heiß genug!«
     </p>
-    <p xml:id="eco_de_0000145_100">
+    <p xml:id="eco_de_0000215_100">
      Hans hatte inzwischen den Korb ganz ausgeleert und rief jetzt ärgerlich: »Philipp, Du hast mir doch kein Kuckucksei mitgebracht, wie Du es versprochen«, und Gretchen stimmte bei: »Ja, Philipp, Du führst uns immer an, mir hast Du versprochen, den Kuckuck zu fangen, aber Du kannst es wohl gar nicht«.
     </p>
-    <p xml:id="eco_de_0000145_110">
+    <p xml:id="eco_de_0000215_110">
      »Na«, sagte Philipp begütigend, »sei mir nicht böse, lieb Gretchen, mit dem Kuckuck war es nur Spaß, der fliegt mir zu hoch, aber ich bringe Dir schon sehr bald rothe, süße Erdbeeren, die schmecken gut«. – Mariechen schüttelte mißbilligend den Kopf und erwiederte: »Nein, Philipp, es ist nicht recht, Du führst die Kleinen beständig an der Nase herum, zuletzt glauben sie Dir gar nichts mehr«. Jakob aber rief: »Der Meister Philipp hat auch heute wieder die Schule geschwänzt. ›Wo läuft denn der Vagabund wieder herum?‹ hat der Herr Lehrer gestern Nachmittag gefragt!« –
     </p>
-    <p xml:id="eco_de_0000145_120">
+    <p xml:id="eco_de_0000215_120">
      Der Junge richtete sich halb auf: »Der Vagabund? Nun, da hättest Du ihm nur sagen sollen, daß mich die Frau Löwenwirthin in den Wald geschickt hat, um Maikraut zu holen, und daß Keiner so gut weiß, wo das frischeste und duftigste steht, als der Philipp. Aber mir däucht, es eilt Euch auch nicht sonderlich mit Euren Aufgaben, denn Buch und Tafel liegen gleich mir im Grase«.
     </p>
-    <p xml:id="eco_de_0000145_130">
+    <p xml:id="eco_de_0000215_130">
      Diese Mahnung genügte; die pflichtgetreue Marie nahm Griffel und Schieferstein schnell zur Hand, während Jakob mit seiner Peitsche gleichmüthig fortknallte, und Gretchen, sich vor Philipp niederkauernd, sein heißes Gesicht mit ihren kleinen Patschhänden streichelte. »Ich bin Dir doch wieder gut, Philipp«, sagte sie, »wenn Du mich auch angeführt hast. Bringe mir nur recht bald die Erdbeeren; nicht war, das ist kein Spaß?«
     </p>
-    <p xml:id="eco_de_0000145_140">
+    <p xml:id="eco_de_0000215_140">
      Der Junge drückte mit seinen kleinen, braunen, schon von der Arbeit gehärteten Händen die weichen Finger des Kindes einen Augenblick fest auf seine Stirne und erwiederte: »Nein, das ist voller Ernst; aber weißt Du was, Gretchen, jetzt räumst Du mit dem Hans meinen Korb wieder schön ein, und nachher erzähle ich Euch auch etwas«. –
     </p>
-    <p xml:id="eco_de_0000145_150">
+    <p xml:id="eco_de_0000215_150">
      Philipp war das älteste Kind einer armen Wittwe, die in einem alten, schlechten Häuschen hinter dem Garten des Löwenwirthes wohnte. Sie hatte sich mit vier kleinen Kindern gar kümmerlich durchzuarbeiten und betrachtete es als ein wahres Glück, daß ihr Philipp anstellig war und wohlgelitten im »goldnen Löwen«, wo er auch seine meiste Zeit zubrachte; denn immer gab es dort etwas für ihn zu thun, womit er manchen Sechser und fast täglich sein Mittagbrod verdiente. Er that Botengänge, arbeitete im Garten, fegte den Hof oder lief in die Weinberge und in den nahen Wald, wenn es dort etwas zu besorgen gab, und am Abend stellte er den Stammgästen die Kegel auf. Es hieß im Löwen den ganzen Tag: »Wo ist der Philipp? dies muß der Philipp thun! wo bleibt der Philipp?«
     </p>
-    <p xml:id="eco_de_0000145_160">
+    <p xml:id="eco_de_0000215_160">
      Die Löwenwirths-Kinder betrachteten ihn naturgemäß fast wie einen älteren Bruder, und wie manchmal schon hatte er die Stelle des Kindermädchens bei ihnen vertreten, was ganz gewiß auch heute der Fall gewesen sein würde ohne die dringendere Aufgabe, die ihn in den Wald rief.
     </p>
-    <p xml:id="eco_de_0000145_170">
+    <p xml:id="eco_de_0000215_170">
      Eine fröhliche Genossenschaft junger Männer aus der nahen Residenz, meist aus Künstlern bestehend, ließ sich zu keiner Maienzeit die Lust entgehen, nach tageslanger Streiferei auf den Höhen der Bergstraße und des Odenwaldes am Abend im »goldnen Löwen« einzukehren, um sich an der köstlichen Maibowle zu erquicken, deren Grundelement, einen guten, reinen Wein, man stets bei Frau Martha vorfand.
     </p>
-    <p xml:id="eco_de_0000145_180">
+    <p xml:id="eco_de_0000215_180">
      Aus diesem Grunde hatte Philipp abermals die Schule versäumen müssen; seine Armuth nöthigte ihn dazu, und es that ihm bitter wehe, wenn dann der Lehrer so hart über ihn urtheilte. Freilich ging Philipp auch gerne hinaus in Feld und Wald, dies läßt sich nicht läugnen. Was selten auf dem Lande ist und bei Kindern, er liebte und kannte die Schönheiten der Natur, in deren Mitte er lebte, und wenn man ihn auch sonst noch hie und da einen »Vagabunden« nannte, so geschah es halb in Scherz, weil er so viel im Freien zu finden war. Im Scherze sagte er dann auch wohl manchmal, er werde sich den Namen noch verdienen, denn nichts wünsche er sich so lebhaft, als viele fremde Länder zu sehen und die Merkwürdigkeiten aufzusuchen, von denen Abends die Herren in der Wirthsstube so mancherlei erzählten oder vorlasen.
     </p>
-    <p xml:id="eco_de_0000145_190">
+    <p xml:id="eco_de_0000215_190">
      Auch jetzt träumte er sich wieder hinaus in's Weite, bis ihn endlich Gretchen, die neben ihm kauerte und unablässig drängte: »Jetzt erzähle aber auch!« seinem Sinnen entriß.
     </p>
-    <p xml:id="eco_de_0000145_200">
+    <p xml:id="eco_de_0000215_200">
      »Ja nun«, sagte Philipp und fuhr sich mit den Händen durch die Haare, »wenn ich Euch auch erzähle, was ich gesehen, glaubt ihr's am Ende wieder nicht, und doch ist es wahr!«
     </p>
-    <p xml:id="eco_de_0000145_210">
+    <p xml:id="eco_de_0000215_210">
      »Nun, so fange nur an«, drängte jetzt auch Jakob, der, nachdem er sich müde geknallt, theilnehmend näher getreten war und Mariens ernstliche Ermahnung, nun endlich seinen Fibel-Vers zu lernen, mit verächtlicher Geberde zurückwies.
     </p>
-    <p xml:id="eco_de_0000145_220">
+    <p xml:id="eco_de_0000215_220">
      »Also«, begann Philipp, »ihr wißt doch, daß die Herren aus der Stadt heute früh auf den Melibokus gegangen sind, und sobald die Schule zu Ende war, lief ich auch hinauf, denn ich höre sie so gar zu gerne singen, und der lustige Maler, der mit der Guitarre im Arm immer den Andern vorangeht und die schönsten Lieder weiß, war auch dabei. Sie lagerten oben auf den Felsen oder im Grase und hatten ein seltsames Ding mitgebracht, das ihnen der lange Peter aus Alsbach hinaufgeschleppt hatte. Es ist ein schwarzer Kasten, der sieht von vorn genau wie eine Kanone aus, und diesen Kasten stellten sie vor den Thurm in die Sonne, richteten die Kanone, steckten bald die eine, bald die andere schwarze Tafel, die genau aussahen, wie unsere Schiefertafeln, nur daß kein Holz ringsum war, in den Kasten, und wenn sie dieselben wieder hervorholten, dann betrachteten sie das Ding genau und freuten sich darüber oder schüttelten die Köpfe. Ich dachte, sie seien wohl nicht recht bei Sinnen und getraute mich lange nicht herbei, bis mich einer von den Herren sah und mir zurief: ›Hier, komm' einmal her, Junge, was siehst Du auf dieser Tafel?‹«
     </p>
-    <p xml:id="eco_de_0000145_230">
+    <p xml:id="eco_de_0000215_230">
      Ich guckte darauf, da stand wahrhaftig das Auerbacher Schloß, zwar sehr, sehr klein, aber ganz deutlich und genau. ›Weißt Du, wer das gemalt hat?‹ lachte der Herr, und als ich natürlich den Kopf schüttelte, rief er: ›Kein Anderer als die Sonne!‹
     </p>
-    <p xml:id="eco_de_0000145_240">
+    <p xml:id="eco_de_0000215_240">
      ›Die Sonne?‹ sagte ich, ›unsere Sonne?‹
     </p>
-    <p xml:id="eco_de_0000145_250">
+    <p xml:id="eco_de_0000215_250">
      Da fingen sie alle laut zu lachen an, der Herr nahm mich am Kopfe, zog ihn nach hinten und rief lustig: ›Ja, die Sonne, die dort oben am Himmel steht!‹«
     </p>
-    <p xml:id="eco_de_0000145_260">
+    <p xml:id="eco_de_0000215_260">
      Marie, die sich schon längst nicht mehr mit dem Einmaleins plagte, sondern auch zuhörte, erhob jetzt drohend den Finger: »Philipp, Du willst uns wieder einmal etwas weiß machen!«
     </p>
-    <p xml:id="eco_de_0000145_270">
+    <p xml:id="eco_de_0000215_270">
      »Nein, wahrhaftig nicht«, rief der Junge aufspringend; »ich war nun natürlich mäuschenstill, denn ich wollte mich nicht noch einmal auslachen lassen, aber gesehen habe ich es, mit diesen meinen Augen. Es erschienen Bilder auf den leeren Tafeln, und es hat Keiner etwas dabei gezeichnet oder gemalt«.
     </p>
-    <p xml:id="eco_de_0000145_280">
+    <p xml:id="eco_de_0000215_280">
      »Die Sonne«, sagte Mariechen nachsinnend, »die Sonne kann viel, sie lockt das Grün hervor und die Blumen, aber, daß sie soll malen können« – Philipp's ganzes Gesicht verzog sich in eitel Schelmerei, er hatte seinen Korb wieder an den Arm genommen, den Stock ergriffen und rief jetzt mit lustigem Ton: »Ei, so probirt es doch einmal selbst! Probiren geht über Studiren! Da, hier stehe ich vor Euch in der Sonne, sehr einmal zu, ob etwas davon auf Eure Tafeln kommt, Ihr könnt ja mit dem Griffel immer noch ein wenig nachhelfen!«
     </p>
-    <p xml:id="eco_de_0000145_290">
+    <p xml:id="eco_de_0000215_290">
      Mit diesen Worten stellte er sich gravitätisch dicht vor Marie hin, die ganz betreten ihre Zahlenreihe auslöschte, während Gretchen trotz Jakobs Widerspruch dessen Tafel erwischte und sich hinter Marie setzte. Eine Minute lang blieben sie alle ruhig mit angehaltenem Athem, begierig, ob die liebe Sonne wirklich so freundlich sein werde, ihnen das Bild des Kameraden hinzumalen; dann blinzelte Eines nach der Tafel des Andern, um zu sehen, ob sich wohl dort das Wunder zu vollziehen beginne, welches bei ihm noch nicht erscheinen wollte – es war ein kurzer, aber allerliebster Anblick, den ein junger Mann, der schon seit einigen Minuten an dem Thorwege hinter einem Mauervorsprung verborgen stand, mit lächelnder Miene genoß.
     </p>
-    <p xml:id="eco_de_0000145_300">
+    <p xml:id="eco_de_0000215_300">
      Noch eine Sekunde, dann war es vorbei, – da wußten Marie und Jakob, daß Philipp, der Schalk, dessen lachender Mund immer größer geworden, wieder eine Hänselei an ihnen verübt hatte. Jakob warf zornig den Katechismus, den er in der Hand hielt, auf den Boden und hob die Peitsche, während Marie, aufspringend und die kleine Faust ballend, halb weinend ausrief: »Du schlechter Junge, Du hast uns wieder zum Besten gehabt, diesesmal sage ich es der Mutter – und nun habe ich auch noch meine Rechnung ausgewischt!« – Diesem Zornesausbruch folgte ein vernehmliches Schluchzen, welches aber Philipp kaum noch hörte, denn er hatte sich eilends auf den Weg gemacht und trottete schon die Bergstraße hinunter, mit lauter Stimme zurückrufend: »Die Sonne malt aber doch! ihr habt nur den schwarzen Kasten nicht, ohne den ist es freilich nichts!«
     </p>
-    <p xml:id="eco_de_0000145_310">
+    <p xml:id="eco_de_0000215_310">
      Jakob, den es wunderbar beruhigte, daß in diesem Falle die altkluge Marie mit unter den Angeführten war, knallte wieder gleichmüthig mit seiner Peitsche und sagte: »Diesesmal kriegt es der Philipp! Morgen muß mir die ganze Schule helfen ihm den Kopf zausen!« Hans hatte sich während aller dieser Vorfälle stillvergnügt an die Aepfel gemacht, und sein Beispiel wirkte jetzt besänftigend auf die übrigen. Gretchen fuhr das Wäglein mit dem Viehruhrbrod zu den Holzstämmen heran und suchte dann den dicksten Apfel heraus, welchen sie Jakob mit den Worten gab: »Du darfst aber auch dem Philipp morgen nichts thun«.
     </p>
-    <p xml:id="eco_de_0000145_320">
+    <p xml:id="eco_de_0000215_320">
      »Hast Du denn den ungezognen Philipp so lieb?« fragte Marie, nun auch, trotz ihres Kummers, herzhaft in einen Apfel beißend. »Ja«, antwortete die Kleine, »weil er mich auch lieb hat«, und darauf hatte Niemand etwas einzuwenden.
     </p>
-    <p xml:id="eco_de_0000145_330">
+    <p xml:id="eco_de_0000215_330">
      Noch ein Stündchen, dann stand der Melibokusthurm wie im rothen Feuer, umglänzt von den Strahlen der sinkenden Sonne, und sagte den Kindern, daß es nun Zeit für sie sei heimzukehren. Sie packten ihre Sachen zusammen, und hui! ging es die Straße hinab zu der Mutter, welche bereits an der Thüre stand und besorgt nach ihrer kleinen Schaar ausschaute, die sie bald lärmend und liebkosend umringte.
     </p>
-    <p xml:id="eco_de_0000145_340">
+    <p xml:id="eco_de_0000215_340">
      Sie traten in die Thüre, aber, o Schreck! da stand wahrhaftig der schwarze Kasten, von welchem Philipp erzählt hatte, und er, der Missethäter, lehnte ganz vergnügt neben einem blonden, jungen Mann an dem Stamm der Linde, unter deren Dach sich die Gesellschaft bereits um die Maibowle versammelt hatte.
     </p>
-    <p xml:id="eco_de_0000145_350">
+    <p xml:id="eco_de_0000215_350">
      Neugierig drängten sich Marie und Jakob – Hans und Gretchen hatte die Mutter bereits fortgeführt – nach der Thüre, um sogleich wieder mit blutrothem Gesichte zu entfliehen, denn der hübsche Maler im schwarzen Sammtrock hielt ein kleines, offenes Buch in der Hand und erzählte den Andern: »Seht, so führt uns der Zufall oft die nettesten Bilder in den Weg; diese Skizze fiel mir recht eigentlich im Vorüberlaufen in die Hand. Es sind die Kinder unserer Wirthin nebst diesem Schelm hier, der die armen Tröpfe im wahren Sinn des Wortes hinter das Licht geführt hat«, und lachend vernahmen nun die Andern die Veranlassung der kleinen Scene.
     </p>
-    <p xml:id="eco_de_0000145_360">
+    <p xml:id="eco_de_0000215_360">
      »Du hast immer Glück, Arthur«, sagte ein älterer Mann, der neben dem Maler saß, »aber diesesmal mußt Du es mit mir theilen, ich möchte die kleine Gruppe photographisch aufnehmen; man kann sie ja gerade noch einmal so stellen«.
     </p>
-    <p xml:id="eco_de_0000145_370">
+    <p xml:id="eco_de_0000215_370">
      »Sie aufnehmen? die Sonne wirklich zur Malerin dessen machen, was meine flüchtige Bleistiftzeichnung hinwarf? Ich dächte, so weit dürfte uns doch die neue Kunst, die Lichtmalerei, noch nicht in's Handwerk pfuschen, daß sie ganze Gruppen, vier bis fünf Personen zugleich auf die Platte zaubert«! »Und wenn sie es dennoch vermöchte?« lachte der Andere; »wir sind mit der Lichtmalerei erst am Anfang vom Ende. Daguerre gab uns die Metallplatten, und auf diesen Gruppenbilder festzuhalten, will allerdings kaum gelingen; aber in der jüngsten Zeit hat man es nach vielen Versuchen zu Stande gebracht, ein Papier herzustellen, welches die gleichen Dienste thut und weit weniger kostspielig ist. Auch hat man den Apparat so vervollkommnet, daß es nun möglich wird, mehrere Gegenstände oder Personen zugleich zu fixiren. Die Versuche, die ich bereits bei Aufnahmen von allerlei Gegenständen angestellt, sind trefflich gelungen, morgen soll mir dann die kleine Schaar daran, die Dein Stift so glücklich skizzirte«.
     </p>
-    <p xml:id="eco_de_0000145_380">
+    <p xml:id="eco_de_0000215_380">
      »Bravo! Bravo!« riefen die Freunde, und, nachdem der Sprecher geendet, stießen sie an auf glückliches Gelingen. Während nun Philipp die Herren bediente und dabei keines ihrer Worte verlor, saßen die Wirthskinder drinnen bei der Mutter in der Hinterstube, verzehrten ihre Milchsuppe und erzählten ihr mit Entrüstung, wie der Philipp sie wieder einmal zum Besten gehabt.
     </p>
-    <p xml:id="eco_de_0000145_390">
+    <p xml:id="eco_de_0000215_390">
      Am nächsten Morgen in der Frühe fuhren die Gäste des »goldenen Löwen« wieder nach der Stadt zurück; nur der junge Maler und sein Freund, der Photograph, welcher früher Porträtmaler gewesen war, nun aber, die Concurrenz der neuen Erfindung fürchtend, sich dieselbe angeeignet hatte, blieben nebst dem großen schwarzen Kasten zurück, weil sie die Gegend noch ein paar Tage länger zu durchstreifen gedachten. Ehe sie jedoch eine neue Wanderung in die Berge antreten wollten, sollte der Versuch gemacht werden, die Kinder aufzunehmen.
     </p>
-    <p xml:id="eco_de_0000145_400">
+    <p xml:id="eco_de_0000215_400">
      Die guten Zwingenberger hatten schon hie und da in den Zeitungen von der »Potografie«, wie es die ungebildeten Leute nennen, gelesen, auch wohl einmal ein solches Bild gesehen; aber einen klaren Begriff hatte doch Niemand von der Sache, und als nun die beiden Künstler ihren geheimnißvollen Kasten, die camera obsurca, auf dem Marktplatze aufstellten, standen die Zuschauer bald Kopf an Kopf gedrängt, das merkwürdige Schauspiel mit anzusehen. Aber das neue Papier sollte nicht so schnell seine Güte erproben dürfen, das Bild kam nicht zu Stande, weil die zunächst dabei Betheiligten den hartnäckigsten Widerstand entgegensetzten. »Wir stellen uns nicht vor die Kanone, nein, um Alles nicht!« so versicherten Jakob, Mariechen und Gretchen im Chore, als sie, aus der Schule heimkehrend, den ganzen Aufzug und die erwähnten Vorbereitungen vor ihrem elterlichen Hause fanden und vernahmen, daß sie als Hauptschauspieler mitwirken sollten. Auch Frau Marthen war die Sache nicht geheuer; sie hielt Hans, der ihr nicht vom Rocke ging, fest an der Hand und schöpfte nun selber Muth zur entschiedenen Weigerung, als sie die Angst und Furcht ihrer Lieblinge sah. »Nichts für ungut, ihr Herrn«, sagte sie, »aber laßt mir die Kinder in Ruhe, mir gruselt auch bei der Geschichte; daß man da in das Rohr hineinsehen und als Bild wieder herauskommen soll, erscheint mir halb wie ein Hexenwerk, Gott weiß, was da passirt. Daß die liebe Sonne viel vermag, das wissen wir, daß sie aber auch noch malen und zeichnen soll, dies geht mir doch über den Verstand!«
     </p>
-    <p xml:id="eco_de_0000145_410">
+    <p xml:id="eco_de_0000215_410">
      Ja, so dachten die Leute damals noch von der Lichtmalerei, die doch gewiß eine der merkwürdigsten Erfindungen ist, welche der Menschengeist in diesem Jahrhundert gemacht hat!
     </p>
-    <p xml:id="eco_de_0000145_420">
+    <p xml:id="eco_de_0000215_420">
      Vergnügt sprangen die Kinder jetzt hinter der Mutter die hohe Steintreppe hinauf, von wo aus sie Alles bequem übersehen konnten, ohne selbst Mitwirkende sein zu müssen, und rathlos blickten die Freunde einander an, was nun zu thun sei, als Philipp, der natürlich mit im Vordergrunde stand, laut ausrief: »Herr Maler, ich fürchte mich gar nicht, stellen Sie mich nur vor die Kanone, ich will stocksteif stehen bleiben, wenn Sie ein Bild von mir machen wollen.« Der Photograph lachte: »Nun wohl, mein Junge, so will ich es mit Dir allein versuchen, da deine Kamerädchen sich fürchten«, und während nun Arthur den Jungen in die rechte Stellung brachte, Rudolph aber, so hieß der Andere, hinter dem schwarzen Tuche verschwand, um die Glastafel zu richten, und dann schnell den Messigdeckel abnahm, welcher die Glaslinse in der Röhre verdeckte, stießen sich die Leute an und zischelten: »Ja, ja, der Philipp mag es thun, der ist zu Allem gut – die Löwenwirthin hat Recht, wir geben unsere Kinder auch nicht dazu her«.
     </p>
-    <p xml:id="eco_de_0000145_430">
+    <p xml:id="eco_de_0000215_430">
      Der Philipp aber stand wie eine Mauer, und Alles hielt mit ihm den Athem an, so lange der Maler neben ihm, die Uhr in der Hand die Minuten zählte; denn damals ging es noch so schnell nicht wie jetzt, da brauchte man noch doppelt so viele Minuten, als heute Secunden. Endlich gab er das Zeichen, der Andere schob wieder den Messingdeckel auf die Röhre, nahm rasch die Tafel aus dem Kasten, und Beide stürzten nun hinein in das dunkle Kämmerchen, welches sie sich zuvor eingerichtet hatten. – Philipp sah sich ganz heldenhaft im Kreise um, der nun näher und näher an ihn herandrängte; war er doch jetzt der erste im Dorfe, der durch sein Lichtbild verewigt werden sollte; und als ihn seine gute Mutter, die ganz stolz darauf war, daß ihr Philipp so an Ansehen gewann, nun halblaut fragte: »Hast du denn gar nichis gespürt?« rief er lachend: »Was hätte ich denn spüren sollen?« aber dennoch wurde er blaß, als jetzt der Maler auf die Treppe trat und unter die Leute rief: »Das Bild ist prächtig gelungen, schon bei der ersten Aufnahme; wenn ihr heute am Abend wieder hierher kommt, sollt ihr den Philipp sehen, wie er leibt und lebt!«
     </p>
-    <p xml:id="eco_de_0000145_440">
+    <p xml:id="eco_de_0000215_440">
      Philipp war glückselig: also wirklich, sein Bild war in diesem Augenblicke entstanden? Er warf die Mütze hoch in die Luft und rief: »Hurrah! die liebe Frau Sonne hat mich gemalt! Wie man dabei hilft, dies muß ich auch einmal lernen!«
     </p>
-    <p xml:id="eco_de_0000145_450">
+    <p xml:id="eco_de_0000215_450">
      Gegen Abend stand dann der Platz wieder fast so voll mit Menschen, wie am Morgen, und Philipp's Mutter zeigte wonnestrahlend das wohlgetroffene Bildniß ihres Jungen im Kreise herum. Ja, man konnte ihn wirklich ganz deutlich erkennen, wenn auch diese ersten Versuche der Photographie kaum noch mit dem zu vergleichen sind, was sie heute leistet. Lächelnd verfolgten die beiden Freunde, die behaglich auf der Bank vor dem Hause saßen, den Ausdruck des Staunens und der Verwunderung auf den harten, gebräunten Gesichtern. Neben ihnen hatte Frau Martha Platz genommen, ihren Hans auf den Knieen, und als jetzt Philipp das kostbare Blättchen, das er kaum zu berühren wagte, den Herrn zurückbrachte, sagte sie: »Ja man sollt' es kaum glauben, wenn man es nicht selbst gesehen; aber mich selbst vor das Ding da zu setzen, dies könnte ich auch jetzt noch nicht!«
     </p>
-    <p xml:id="eco_de_0000145_460">
+    <p xml:id="eco_de_0000215_460">
      Rudolph brach in herzliches Lachen aus und rief: »Nun, Frau Martha, Ihr könnt es Euch ja immerhin überlegen, bis ich nächstes Jahr wiederkomme, und um Euch Muth zu machen, lasse ich das Bild vom Philipp hier. Ich schenke es Euch und schicke aus der Stadt noch einen kleinen Rahmen dazu, da könnt ihr es drinnen unter dem Spiegel aufhängen!«
     </p>
-    <p xml:id="eco_de_0000145_470">
+    <p xml:id="eco_de_0000215_470">
      Frau Martha dankte herzlich, bis Arthur ihren Redefluß mit den Worten unterbrach, daß doch auch dem Philipp für die Courage, mit der er stille gehalten, ein Abdruck seines eigenen Conterfei gebühre.
     </p>
-    <p xml:id="eco_de_0000145_480">
+    <p xml:id="eco_de_0000215_480">
      »Ganz recht«, erwiderte Rudolph, »er soll das Bild haben, welches noch droben auf meiner Stube liegt, und kommst Du einmal in die Stadt, so besuche mich und bringe mir dagegen einen schönen, duftigen Waldstrauß mit«.
     </p>
-    <p xml:id="eco_de_0000145_490">
+    <p xml:id="eco_de_0000215_490">
      Wer war seliger, als Philipp, da er diese Worte hörte, und doch wurde sein Entzücken noch gesteigert, als Gretchen zutraulich zu dem Photographen sagte: »Der Philipp will auch so einer werden wie du!« und dieser darauf erwiederte: »Nun, dazu kann ja vielleicht Rath werden, wenn er älter ist und brav bleibt«.
     </p>
-    <p xml:id="eco_de_0000145_500">
+    <p xml:id="eco_de_0000215_500">
      An diesem Abend sah man ihn im »goldnen Löwen« nicht mehr, wie es auch überall nach Philipp rief; kaum hielt er seinen Schatz, sein eignes Bild in Händen und hatte er seinen heißen Dank dafür gestammelt, als er hinüberlief, in sein elendes Dachkämmerchen, den Abdruck auf den einzigen Stuhl stellte, den es enthielt, und ihn so rückte, daß das Mondlicht sein Bild hell überstrahlte. Dann kniete er davor, stützte den Kopf in beide Hände und träumte die halbe Nacht von der Zukunft, wie er die neue seltne Kunst erlernen, und dann mit seinem Kasten die halbe Welt durchstreifen wollte, um Alles abzubilden, was ihm und Andern gefallen mochte. –
     </p>
-    <p xml:id="eco_de_0000145_510">
+    <p xml:id="eco_de_0000215_510">
      Es ist wieder einmal Mai geworden – aber zwanzig Jahre später als zu Anfang unserer Erzählung – die Natur war dieselbe geblieben in ihrer Pracht und Schönheit. Auf den Feldern wogte wieder das junge Korn, auf den Bergen prangten wieder die Wälder im glänzenden Frühlingsgrün, und an dem lichtblauen Himmel, der sich über den Thurm des Melibokus wölbte, zog Gevatter Storch seine weiten Kreise. Die Menschen dagegen hatten sich recht sehr verändert; aus den Kindern, die im Schloßhofe einst so fröhlich gespielt, waren Leute geworden, und die rüstige Frau Martha hatte ihr Amt als Löwenwirthin abgeben müssen, denn die viele Arbeit und die Sorgen hatten sie mürbe gemacht. Sie saß jetzt ruhig in der Hinterstube, der kleinen Enkel wartend, während statt ihrer Mariechen schaltete und waltete.
     </p>
-    <p xml:id="eco_de_0000145_520">
+    <p xml:id="eco_de_0000215_520">
      Jakob war ein tüchtiger Müller geworden, was ihm besser zusagte, als Löwenwirth zu sein, und Hans hatte sich's nicht nehmen lassen, unter die Soldaten zu gehen, wo er es gerade jetzt bis zum Feldwebel gebracht hatte. Den beiden Mädchen fehlte es dagegen nicht an Freiern, namentlich Marien nicht, die nun noch das Vorrecht hatte, Frau Löwenwirthin zu werden. Sie wählte lange, bis sie den Rechten gefunden, brav, still und fleißig genug, um ihr zu gefallen; dann aber machten sie bald Hochzeit, und es ging im »goldnen Löwen« Alles im alten Geleise fort.
     </p>
-    <p xml:id="eco_de_0000145_530">
+    <p xml:id="eco_de_0000215_530">
      Die junge Frau hatte eine sehr wichtige Stütze, die Tag und Nacht sorgte und der keine Mühe zu viel sein konnte, dies war das muntere, lockenköpfige Gretchen. Sie blieb stets, wie wir sie als Kind kennen gelernt, gefällig, freundlich und stets bereit diejenigen zu vertheidigen oder zu beruhigen, die angegriffen wurden.
     </p>
-    <p xml:id="eco_de_0000145_540">
+    <p xml:id="eco_de_0000215_540">
      Nur ein einziges Mal hätte sie beinahe ernstlichen Streit mit Marien bekommen, als diese sich verheirathete, und als nun der »goldne Löwe« von oben bis unten neu vergoldet, das heißt, auswendig und inwendig frisch angestrichen und aufgeputzt wurde. Ja, das große Gastzimmer, das seitdem nur gelb getünscht gewesen, bekam zum ersten Mal eine schöne blaue Tapete, mit großen dunkelrothen Rosen und grasgrünen Blättern, worauf Marie nicht wenig stolz war. Als nun, nachdem diese Pracht an den Wänden glänzte, die beiden Schwestern die Stube wieder einräumten, den blank geputzten Spiegel und die neuen weißen Vorhänge aufhingen, nahm Gretchen noch einmal Hammer und Nagel zur Hand.
     </p>
-    <p xml:id="eco_de_0000145_550">
+    <p xml:id="eco_de_0000215_550">
      »Was willst du damit?« fragte Marie, »wir haben nichts mehr aufzuhängen«.
     </p>
-    <p xml:id="eco_de_0000145_560">
+    <p xml:id="eco_de_0000215_560">
      »Doch, erwiederte Gretchen, »wir haben ja noch Philipp's Bild, das immer unter dem Spiegel hing«.
     </p>
-    <p xml:id="eco_de_0000145_570">
+    <p xml:id="eco_de_0000215_570">
      »Ach, laß' mir das alte verstaubte Bild weg, ich mag es nicht mehr in meiner neuen Stube haben!« rief Marie eifrig.
     </p>
-    <p xml:id="eco_de_0000145_580">
+    <p xml:id="eco_de_0000215_580">
      Gretchen wurde roth bis unter die braunen Locken. »Das ist nicht recht von dir, Marie«, sagte sie, »der Philipp war doch unser bester Jugendfreund«.
     </p>
-    <p xml:id="eco_de_0000145_590">
+    <p xml:id="eco_de_0000215_590">
      »Ach, ich habe mir nie viel aus ihm gemacht, und dann – Gott weiß, was aus dem geworden ist, er war und blieb ein Herumstreicher, ein Thunichtgut; ich will das häßliche Bild nicht mehr!« Damit ging sie sehr entschlossen zur Thüre hinaus.
     </p>
-    <p xml:id="eco_de_0000145_600">
+    <p xml:id="eco_de_0000215_600">
      Gretchen hielt traurig das verschmähte Bild in Händen; es war in der That sehr verblichen, der Rahmen alt und wurmstichig, aber sie konnte sich doch nicht dazu entschließen, es zu vernichten. Die ganze selige, fröhliche Jugendzeit sah sie aus dem Bilde an; sie riß den Rahmen ab, nahm das Glas herunter, blies den Staub weg, der sich hinter dasselbe auf das Papier gelagert hatte, und trug es hinauf in ihre Stube. Dort legte sie es zu unterst in den Nähkasten und schlug den Deckel wieder zu mit den Worten: »Ich möchte doch wissen, ob der Philipp noch lebt, und wo er steckt!«
     </p>
-    <p xml:id="eco_de_0000145_610">
+    <p xml:id="eco_de_0000215_610">
      Ja, wenn wir das selber wüßten! Es hatte seine Richtigkeit, der Philipp war verschollen, seitdem er Herrn Rudolph, der ihn wirklich in die Lehre genommen, heimlich verlassen hatte. –
     </p>
-    <p xml:id="eco_de_0000145_620">
+    <p xml:id="eco_de_0000215_620">
      Als Philipp confirmirt und gerade aus der Schule entlassen war, traf ihn das Unglück, seine brave Mutter zu verlieren, der zu Liebe er seinen Hang, draußen herumzustreifen, und seine Sehnsucht nach fremden Ländern möglichst bekämpft hatte. Nun wurden ihr kleines Häuschen und das bißchen Hausgeräth versteigert, um für den Erlös die kleineren Kinder bei entfernt wohnenden Verwandten unterzubringen. Was Philipp betraf, so versprach die gutherzige Löwenwirthin, ihn mit dem Nothwendigen zu versorgen, bis er seine Lehrzeit bei einem Handwerker durchgemacht habe und dann für sich selbst aufkommen könne. Aber Philipp zeigte wenig Neigung für ein bestimmtes Gewerbe; er hatte die Freundschaft mit Herrn Rudolph, so weit er es vermochte, durch zeitweilige Besuche unterhalten, denen die Ueberbringung eines Straußes, eines Körbchens voll Walderdbeeren oder eines Säckchens mit Hasselnüssen zum Vorwand diente. Sein ganzes Sinnen und Denken war davon eingenommen, bei ihm in die Lehre zu kommen; aber er durfte dies Niemanden sagen, man würde ihn ausgelacht haben, und nur seiner Freundin Gretchen vertraute er sich an, die aber auch nichts davon wissen wollte, weil er dann nicht mehr mit ihr spielen oder in den Wald gehen könne.
     </p>
-    <p xml:id="eco_de_0000145_630">
+    <p xml:id="eco_de_0000215_630">
      So standen die Sachen, als er am Abend, nachdem das Häuschen geschlossen war und seine Geschwister weggebracht waren, mit dem Bündelchen, das seine paar Habseligkeiten enthielt, niedergeschlagen auf der Bank vor dem goldnen Löwen saß. Eine Weile darnach kam Jakob, setzte sich zu ihm und sagte geheimnißvoll: »Ich weiß jetzt auch, was du werden sollst! ich habe zugehört, wie sich die Mutter mit dem Bürgermeister über dich besprach. Du wirst ein Schneider!«
     </p>
-    <p xml:id="eco_de_0000145_640">
+    <p xml:id="eco_de_0000215_640">
      »Ein Schneider?« schrie Philipp entsetzt.
     </p>
-    <p xml:id="eco_de_0000145_650">
+    <p xml:id="eco_de_0000215_650">
      »Ja«, antwortete Jakob, »du kommst zu dem alten Matthes in die Lehre, er sieht nicht mehr recht und braucht Jemand, der ihm die Nadeln einfädelt;« ein halb spöttisches Lachen flog dabei über Jakobs Gesicht.
     </p>
-    <p xml:id="eco_de_0000145_660">
+    <p xml:id="eco_de_0000215_660">
      Philipp sprang auf: »Ich zu dem alten Matthes? Nein, nimmermehr!«
     </p>
-    <p xml:id="eco_de_0000145_670">
+    <p xml:id="eco_de_0000215_670">
      Der alte lahme Schneider Matthes war schon seit Jahren das Stichblatt und die Zielscheibe aller Streiche und Spöttereien der Zwingenberger Schuljugend, die sich keinen besseren Zeitvertreib bereiten konnte, als den Matthes zu hänseln, bis er öfter voll Wuth mit der Elle drein schlug und den Quälgeistern seine alten Lappen an die Köpfe warf; und nun sollte Philipp neben ihm sitzen und all den Hohn mit über sich ergehen lassen?
     </p>
-    <p xml:id="eco_de_0000145_680">
+    <p xml:id="eco_de_0000215_680">
      Er aß ruhig mit den Kindern zu Nacht, nachdem er seinen Bündel, der als kostbarste Gabe seine Photographie enthielt, unter der Bank verborgen hatte; dann, ehe das Haus geschlossen wurde, ging er noch einmal über den Hof und blieb im Schatten eines großen Fasses sitzen, bis alle Lichter erloschen waren. Nun schwang er sich über die Staketen, holte seinen Bündel hervor, hing ihn an den Knotenstock, und ging mit schnellen Schritten den Weg nach der Stadt zu.
     </p>
-    <p xml:id="eco_de_0000145_690">
+    <p xml:id="eco_de_0000215_690">
      Am nächsten Abende, als Frau Martha wie gewöhnlich bei Sonnenuntergang ein Viertelstündchen vor dem Hause rastete, ihre Kinder um sie her, unterhielt sie sich über die Straße lebhaft mit der Nachbarin wegen des ungerathenen Philipp, der, wie es scheine, ernstlich fortgelaufen sei, weil er nicht Schneider werden wolle. Da rief Gretchen plötzlich, die Hand ausstreckend: »Dort kommt ja der Philipp!«
     </p>
-    <p xml:id="eco_de_0000145_700">
+    <p xml:id="eco_de_0000215_700">
      In der That, dort kam er des Weges her, bestaubt, erhitzt, aber mit strahlender Freude im Angesicht, wenn ihn auch die Füße kaum zu tragen vermochten; als er nun am »goldnen Löwen« angelangt war, fiel er erschöpft auf der untersten Treppenstufe nieder, sich den Schweiß von der Stirne wischend. Es war gut, daß Gretchen gerade ihr Abendbrod, ein Glas frische Milch an den Mund führte, welches sie nun schnell absetzte und den durstigen Lippen ihres Spielkameraden bot, der sich dann auch rasch erholte und mit demüthiger Miene an seine Beschützerin wendete. »Seid mir nicht böse, liebe Frau Martha, daß ich Euch durch mein Fortlaufen Sorgen und Aerger gemacht, aber es war mir gar zu schrecklich, daß ich zu dem alten Matthes in die Lehre sollte. Da lief ich dann spornstreichs und ohne lange zu überlegen in die Stadt zu Herrn Rudolph, um ihn zu fragen, ob er Wort halten und mich wirklich die Lichtmalerei lehren wolle. Nun denkt Euch, welches Glück, er will es thun, wenn ich drei Jahre bei ihm bleibe und Ihr mir nur so lange Kleider und Wäsche geben wollt. Etwas Taschengeld, meinte er, würde schon durch Trinkgelder und dergleichen abfallen. Ich war so froh, ich versprach Herrn Rudolph Alles; wenn Ihr nun auch Ja! dazu sagen wollt, dann gehe ich in die Stadt und werde ein Lichtmaler. Juchje, das wird schön!« Er warf dabei seine Mütze in die Luft, kramte dann einen Brief aus der Tasche und fuhr fort: »Diesen Brief schickt Euch Herr Rudolph, Sonntag will er selbst heraus kommen, sich die Antwort zu holen; als ich aber so weit mit ihm war, da hielt es mich nicht lange, in der vollen Mittagshitze lief ich wieder hierher – und, nicht wahr, liebe Frau Martha, Ihr gebt Eure Zustimmung?«
     </p>
-    <p xml:id="eco_de_0000145_710">
+    <p xml:id="eco_de_0000215_710">
      Alle hatten ihm schweigend und erstaunt zugehört, nur Gretchen schmiegte sich an ihn und sagte leise: »Du sollst nicht in die Stadt gehen!« Aber Philipp achtete nicht darauf, als Frau Martha jetzt erwiederte: »Wär' es mir nachgegangen, Philipp, dann würdest Du ein Schneider werden, denn ein Handwerk hat einen güldnen Boden, und die Sonnenmalerei will mir immer noch nicht recht einleuchten. Aber der Herr Rudolph ist ein erfahrener Mann, und wenn er dich denn durchaus haben will, na, meinetwegen, so gebe ich auch meinen Segen dazu!«
     </p>
-    <p xml:id="eco_de_0000145_720">
+    <p xml:id="eco_de_0000215_720">
      Damit war die Sache abgemacht, und als Herr Rudolph wirklich kam, um Rücksprache mit dem Bürgermeister und Frau Marthen zu nehmen, durfte ihn am Abend der überglückliche Philipp nach der Stadt zurückbegleiten, und selbst Gretchen's Thränen vermochten sein lachendes Gesicht nicht zu trüben.
     </p>
-    <p xml:id="eco_de_0000145_730">
+    <p xml:id="eco_de_0000215_730">
      Anfänglich ging auch Alles sehr gut; Philipp war brav und fleißig, und gelegentliche Ausflüge nach dem heimathlichen Zwingenberg waren für ihn und die Kinder im »goldnen Löwen« stets Freudenfeste.
     </p>
-    <p xml:id="eco_de_0000145_740">
+    <p xml:id="eco_de_0000215_740">
      Die Kinder empfingen ihn stets wie einen lieben, älteren Bruder; als aber das zweite Jahr seiner Lehrzeit zu Ende ging, ward er von Tag zu Tag mißmuthiger und kleinlauter, wenn man ihn fragte, ob er nun auch bald selbst Aufnahmen machen und ein Photograph werden könne. Er fühlte sehr wohl, daß dies nicht der Fall sein würde, aber die Schuld lag nicht an Philipp, sondern an Herrn Rudolph, und noch mehr an den Verhältnissen. In dessen Atelier häufte sich die Arbeit von Tag zu Tag; als früherem Maler gelang ihm vornehmlich das Arrangement der Bilder gut, und Alles drängte sich zu ihm, der auch im Retouchiren oder Uebermalen der damals noch sehr mangelhaften Bilder Vorzügliches leistete. So war seine Zeit vollständig in Anspruch genommen, er konnte sich nicht viel um Philipp kümmern, und überdem gab es in dem Atelier eine solche Menge mechanischer Arbeiten zu verrichten, daß jener auch kaum zu Athem kam. Sein gefälliges und anstelliges Wesen machte ihn überaus brauchbar, und es erging dem armen Schelm in der Stadt genau so, wie einst im »goldnen Löwen«: Jedermann rief nach Philipp, er mußte überall helfen und versäumte beständig die Gelegenheit, für sich selbst etwas Förderliches zu erlernen. Manchmal erinnerte er Herrn Rudolph an dessen Versprechen, ihn in alle Geheimnisse der Lichtmalerei einzuführen, ihn namentlich Aufnahmen machen zu lassen, und dieser zeigte gleich immer den besten Willen dazu, bis die überhäufte Arbeit den lebhaften, aufgeregten Mann alle guten Vorsätze wieder vergessen ließ. Ein neuer bedeutender Fortschritt in der Lichtmalerei war gemacht worden: man übergoß die Glasplatten jetzt mit einer Flüssigkeit, dem Collodium, welches eine dünne Haut bildete, auf der sich das Bild fixirte, und mit Hülfe dieses Mittels konnte man die Bilder weit schneller und billiger als früher herstellen. Es hat die Collodiumhaut nur den Nachtheil, sich nicht gleichmäßig auf das Glas zu lagern, so daß in Folge dessen eine Menge kleiner Unebenheiten in Gestalt von winzigen Puncten in den Bildern zurückbleiben, welche durch die Retouche beseitigt werden müssen. Diese niedrige Art des Retouchirens, eine der einförmigsten und langweiligsten Arbeiten, wurde nun Philipp zugewiesen, und er saß oft Tage lang in der dumpfen, beständig von Aethergeruch erfüllten Stube neben dem Glashaus, wenn ihn nicht eine andere mechanische Arbeit, wie das Aufkleben und Einrahmen der fertigen Bilder, hinweg rief. Seltner und seltner wurden ihm nun auch die Spaziergänge nach der Bergstraße gestattet, und als wieder der Frühling mit Blüthen und Sonnenschein herankam, da ward ihm das Atelier, nach dem er sich so sehr gesehnt, zum Kerker. Ja, wenn er noch wenigstens das Zeichnen verstanden und an den Bildern jene Arbeiten hätte vornehmen können, die einigen künstlerischen Werth haben; aber für einen armen Jungen von damals gab es noch keine Sonntags- und Abendschulen, wo man dergleichen erlernen konnte, wie dies heute der Fall ist. – Eines Tages theilte er seinen Kummer dem Maler Arthur mit, der stets noch freundliches Interesse an ihm nahm und ihm nun in seiner gutmüthigen Art anbot, ihm einige Begriffe des Zeichnens beizubringen, damit er wenigstens das eigentliche Retouchiren erlernen könne. Die wenigen Freistunden, die Philipp gegönnt waren, brachte er nun in dessen Atelier zu, wo er gewöhnlich einen andern Maler vorfand, der sich zu einer längeren Kunstreise nach Italien, die er im Herbst anzutreten gedachte, vorbereitete. Bei den Gesprächen, welche beide Freunde führten, bei den Schilderungen der Gegenden, die jener schon zum zweiten Male aufsuchen wollte, erwachte Philipps Reisetrieb auf heftigste. »O, könnte ich mit Ihnen ziehen!« rief er eines Tages ganz überwältigt aus, und der Maler antwortete ihm: »Nun, mir wäre es schon recht; solch einen anstelligen Burschen könnte ich gerade gebrauchen!«
     </p>
-    <p xml:id="eco_de_0000145_750">
+    <p xml:id="eco_de_0000215_750">
      Genug, das Wort ward zur That; Philipp beging das große Unrecht, Herrn Rudolph heimlich zu verlassen, unterstützt von dem leichtsinnigen jungen Manne, der seine Begleitung wünschte und doch voraussah, daß man ihn nicht freigeben werde.
     </p>
-    <p xml:id="eco_de_0000145_760">
+    <p xml:id="eco_de_0000215_760">
      Philipp schrieb noch einen Abschiedsbrief an Herrn Rudolph und Frau Martha, in dem er sich zu rechtfertigen versuchte, und versprach, stets brav und rechtschaffen zu bleiben, was aber Beide, mit vollem Rechte hocherzürnt, bezweifelten und meinten, wenn man ihn im Scherz einen Herumstreicher genannt, so könne es jetzt leicht Ernst damit werden. – Wie man endlich seiner ganz vergaß, davon ist schon oben die Rede gewesen. –
     </p>
-    <p xml:id="eco_de_0000145_770">
+    <p xml:id="eco_de_0000215_770">
      In einer der schönsten und elegantesten Straßen der amerikanischen Bundesstadt Washington, – so genannt nach dem edlen Vorkämpfer der amerikanischen Unabhängigkeit und erstem Präsidenten der jungen Republik der Vereinigten Staaten – erhebt sich ein geschmackvoll zierliches Gebäude, dessen Glasfronte den Beschauer schnell darüber belehrt, daß er sich vor dem Atelier eines Photographen befindet. Vor demselben rollte eine feine Equipage nach der andern vor; ein riesiger Neger in schwarzem Frack und schneeweißer Wäsche half den Damen und Kindern aus dem Wagen und geleitete sie die teppichbelegte Treppe hinan bis zu dem Glashaus des vielgerühmten Photographen, Herrn Philipp Maurer, dessen Bilder nicht allein ausgezeichnet ausgeführt waren, sondern auch die Stellungen der Einzelnen, sowie der Gruppen mit ausgeprägt künstlerischem Geschmack arrangirt zeigten.
     </p>
-    <p xml:id="eco_de_0000145_780">
+    <p xml:id="eco_de_0000215_780">
      Heute aber sehen wir ihn selbst in seinem leichten, eleganten Wagen, mit prächtigen Rappen bespannt, an dem Portale vorfahren; er wirft die Zügel dem Diener zu, der hinter ihm sitzt, und bietet dann einem Herrn die Hand zum Aussteigen, den er jetzt mit besonderer Artigkeit die Treppe hinauf führt. Es ist dies ein deutscher Gelehrter, der Amerika bereist, und zugleich ein engerer Landsmann von Herrn Maurer, der sich ihm vor Kurzem als solcher in seinem Hotel vorgestellt hatte und die Hoffnung darauf baute, den berühmten Mann photographiren zu dürfen. Wie oft nun auch der überall freudig empfangene Mann sich dem unterziehen mußte, konnte er doch dem Landesgenossen die Bitte nicht abschlagen, und zu diesem Zwecke hatte ihn jener persönlich in seinem Wagen abgeholt.
     </p>
-    <p xml:id="eco_de_0000145_790">
+    <p xml:id="eco_de_0000215_790">
      Herr Maurer führte den Herrn in ein Zimmer, und während er selbst noch einige Augenblicke draußen beschäftigt war, sah sich der Professor in dem Atelier um und betrachtete die Menge von Gegenständen, welche herumstanden, um bei den Aufnahmen verwendet zu werden, die hohen Gewächse in kostbaren Gefäßen, die Vasen, Statuetten, Tische und Sessel mit kunstvoller Schnitzerei; dann glitt sein Blick über die zahlreichen großen und kleinen Bilder, die an den Wänden hingen, bis er plötzlich auf einem halb lebensgroßen Bilde haften blieb, welches ohne Zweifel meisterhaft genannt werden konnte. Doch fesselte den Beschauer noch weit mehr der Gegenstand des Bildes, welches einen ärmlich gekleideten Bauernjungen vorstellte, der mit kecken Augen aus dem Rahmen heraussah; eine Mütze bedeckte den von langen Haaren umwallten Kopf, in der rechten Hand hielt er einen Knotenstock, und am linken Arme trug er einen Korb mit Kräutern.
     </p>
-    <p xml:id="eco_de_0000145_800">
+    <p xml:id="eco_de_0000215_800">
      Erröthend sah der Photograph, der eben eintrat, die Aufmerksamkeit, welche sein Besucher dem Bilde schenkte, der sich bei seinem Nahen nun rasch mit den Worten nach ihm umwendete: »Dieses Bild ist mir nicht fremd; wo habe ich es nur schon gesehen – kleiner zwar, unscheinbarer, aber diesem hier ganz ähnlich?«
     </p>
-    <p xml:id="eco_de_0000145_810">
+    <p xml:id="eco_de_0000215_810">
      »Es ist mein Bild,« sagte Herr Maurer lachend, »genau so sah ich aus, als man mich noch daheim in Zwingenberg den ›kleinen Vagabunden‹ nannte, der ich auch wirklich zeitweise geworden bin«.
     </p>
-    <p xml:id="eco_de_0000145_820">
+    <p xml:id="eco_de_0000215_820">
      »Ach, nun erklärt sich Alles«, rief der Professor, »ich sah das Bild in Zwingenberg im ›goldnen Löwen‹, wo es manches Jahr unter dem Spiegel hing, und Sie sind also der Ausreißer, welcher Photograph werden wollte, und dessen traurige Geschichte die gute Frau Wirthin ihren Gästen mehr als einmal kläglich vorerzählte?«
     </p>
-    <p xml:id="eco_de_0000145_830">
+    <p xml:id="eco_de_0000215_830">
      »Hängt denn das Bild noch dort?« fragte Philipp, wie wir den alten Bekannten wieder nennen wollen, mit einiger Spannung.
     </p>
-    <p xml:id="eco_de_0000145_840">
+    <p xml:id="eco_de_0000215_840">
      »Dies kann ich Ihnen wirklich nicht sagen, man gewöhnt sich an solchen Anblick und achtet zuletzt nicht mehr darauf. Im ›goldnen Löwen‹ hat sich ja auch seither mancherlei verändert.«
     </p>
-    <p xml:id="eco_de_0000145_850">
+    <p xml:id="eco_de_0000215_850">
      Philipp ging aufgeregt im Atelier auf und nieder: »Wie wunderbar sich das trifft; ich war so glücklich, Sie, Herr Doctor, aufnehmen zu dürfen, und nun erwecken Sie mir auch noch die alten Jugenderinnerungen, die ich längst vergessen und begraben wähnte. Sie haben mir die Ehre zugesagt, nachher den Lunch mit mir zu nehmen, darf ich dann noch ein wenig nach den alten Bekannten fragen?« »Warum nicht?« antwortete der Professor, »fangen wir nur gleich an, um keine Zeit zu verlieren, denn auch Sie müssen mir etwas von ihren Schicksalen berichten, und wie Sie schließlich noch Lichtmaler geworden sind.«
     </p>
-    <p xml:id="eco_de_0000145_860">
+    <p xml:id="eco_de_0000215_860">
      Philipp gab strengen Befehl, jeden ferneren Besuch abzuweisen, und bald, nachdem die Aufnahme zur Zufriedenheit gelungen war, saßen beide Herrn im Speisezimmer bei einem leckeren Frühstück, welches Philipp jedoch kaum berührte, so versunken war er in die Mittheilungen, die ihm der Gast über Frau Martha und ihre Kinder gemacht. Nach den eignen Geschwistern hatte er nicht zu fragen; waren sie doch gleich nach der Mutter Tode zu entfernt wohnenden Verwandten gekommen, und dann hatte sie Philipp, als es ihm selbst gut ging, mit diesen nach Amerika kommen lassen, wo sie als Farmer angesiedelt waren. Um so mehr war sein eignes Andenken in Zwingenberg verschollen.
     </p>
-    <p xml:id="eco_de_0000145_870">
+    <p xml:id="eco_de_0000215_870">
      Nachdem er Alles vernommen, was der Professor wußte, begann er seine Mittheilungen über sich selbst und erzählte, wie glücklich er anfänglich in Italien gewesen, trotz der Gewissensbisse, die ihn oft gepeinigt. Er habe geschwelgt in der Schönheit des Landes und auch der Kunstschätze, für die sein ungeübtes Auge sich überraschend empfänglich zeigte. »Auch mit der Hand würde es gegangen sein, sie war nicht ungeschickt zum Zeichnen«, fuhr er fort, »und ich übte mich, wo ich nur konnte, aber mein leichtsinniger Herr und Gebieter kümmerte sich nichts darum. Zuerst hatte er mir die Photographie verleidet, die er fortwährend einen langen Abklatsch der Wirklichkeit nannte, aber einen Künstler aus mir zu bilden, wie er es mir versprochen, fiel ihm gar nicht ein. Abermals und nach wie vor war ich wieder nichts als ein Handlanger für Andere, wie zuvor – im ›goldnen Löwen‹, bei Herrn Rudolph und wieder hier, aber ich wollte und mußte doch endlich auch etwas für mich werden! Dabei gefiel mir das herumziehende Leben meines Gebieters, an den ich gebunden war, auf die Dauer gar nicht; er freilich arbeitete dabei, aber ich kam mir jetzt wirklich vor wie ein ächter Vagabund, und ich weinte oft heiße Thränen bei der Erinnerung an die Heimath und an Herrn Rudolph, bei dem ich, wenn auch langsam, am Ende doch wohl noch mein Ziel erreicht haben würde. Da lernte ich nach anderthalb Jahren in Sorrent, wo mein Herr gerade sich aufhielt, einen deutschen Kaufmann kennen, der als Vertreter eines englischen Hauses im Begriff war, auf eine Reihe von Jahren nach Indien zu gehen. Er hatte einen deutschen Diener bei sich, welcher schwer erkrankte, und konnte dessen Genesung nicht abwarten, weil er an einem bestimmten Tage in Triest sein mußte, um mit der Ueberlandpost zu reisen. Er schlug mir vor ihn zu begleiten, und da mein Herr Maler meiner vielleicht ebenso überdrüßig geworden, als ich seiner, ließ er mich ziehen.
     </p>
-    <p xml:id="eco_de_0000145_880">
+    <p xml:id="eco_de_0000215_880">
      Ich blieb fünf bis sechs Jahre in Indien, und gewann dort mit Hülfe meines guten, trefflichen Herrn ein kleines Vermögen, durch den Ankauf und Wiederverkauf jener kunstreichen Arbeiten in Elfenbein, Holz, Silber, Lack oder bunter Seide, welche die Chinesen und Indier so billig verkaufen, und die man in Europa so vortheilhaft wieder verwerthet.
     </p>
-    <p xml:id="eco_de_0000145_890">
+    <p xml:id="eco_de_0000215_890">
      Wie manchmal aber, wenn ich solch ein niedliches Körbchen oder eine bunte Malerei erhandelt hatte, dachte ich: Wenn ich dies doch meinem lieben, guten Gretchen schicken könnte! und in der That, als nun mein Herr wieder nach England zurückkehrte, hielt es mich auch nicht länger. Ich packte ein Kistchen voll mit Geschenken für meine Zwingenberger Freunde, denn ich dachte, nun sei ich ein gemachter Mann und könne trotz der Jugendsünde wieder dreist vor ihnen erscheinen. Aber ich sollte noch ernstlicher gestraft werden. Mein Herr reiste wieder mit der Ueberlandpost, ich aber zog der Ersparniß wegen die Reise mit dem Segelschiff um Afrika vor. An der Guineaküste lief unser Schiff auf einen Felsen, und wenn wir auch das Leben retteten, so war dies doch alles – mein Kistchen mit Geschenken, meine Banknoten, sie liegen drunten im atlantischen Ocean, und ich war gerade wieder so arm, als an dem Tage, da ich Herrn Rudolph heimlich verließ. ›Es ist die gerechte Strafe für deinen damaligen Leichtsinn. Nun, Philipp, fange noch einmal von vorn an!‹ so sagte ich mir selbst mit aufrichtigem Muthe, als ich ein englisches Schiff betrat, das einen Theil der Schiffbrüchigen nach New-York bringen wollte. Am meisten leid that es mir um Gretchen, ich hatte mir schon so lebhaft ihre Freude und ihren Dank vorgestellt!
     </p>
-    <p xml:id="eco_de_0000145_900">
+    <p xml:id="eco_de_0000215_900">
      Ich besaß nichts mehr als eine alte Brieftasche, welche ich mir um den Leib gebunden hatte, und die meinen Tauf-, meinen Heimathsschein, ein paar Goldstücke und die kleine, schlechte Photographie, die Sie kannten, enthielt; aber auf welches Ziel ich nun loszuarbeiten hatte, dies ward mir schnell klar, als ich in New-York mit Staunen sah, welche Fortschritte inzwischen die Lichtmalerei gemacht hatte, und zu wie vielen Dingen sie verwendet werden konnte. Ich bemerkte aber auch, wie sehr die Bilder noch durch entsprechende Anordnung vervollkommnet werden konnten, wie ihnen mehr Leben und größerer Ausdruck zu geben sei; diesen Scharfblick verdankte ich doch wohl meinem Vagabundenthum in Italien, und damit zum Theil die großen Erfolge, die ich hier habe. Mein Entschluß stand fest, doch noch um jeden Preis ein tüchtiger Photograph zu werden, und nachdem meine Bemühungen, in einem Atelier aufgenommen zu werden, erfolglos geblieben, verrichtete ich die schwersten und niedrigsten Arbeiten, vor nichts zurückscheuend, bis ich genug erspart hatte, um mir einen Apparat aus zweiter Hand zu kaufen.
     </p>
-    <p xml:id="eco_de_0000145_910">
+    <p xml:id="eco_de_0000215_910">
      Mein Instrument war gering, um so größer mein Muth und meine Ausdauer, und die liebe Sonne leuchtete dieses Mal keinem Undankbaren. Mein erstes Atelier bestand in einer Bretterbude, mein Publikum zunächst nur aus Matrosen, Negern, Waschfrauen und Kindermädchen, die um billigsten Preis abconterfeit wurden. Aber ich arbeitete unverdrossen fort und fort, lernte durch die Erfahrung, ließ mir nichts Neues entgehen, was auf dem Gebiete der Lichtmalerei geleistet wurde, und bildete endlich meine Specialität heraus, die einestheils in der Anordnung der Bilder, anderntheils in der gewissenhaftesten Vertheilung von Licht und Schatten besteht, wodurch meine Bilder so lebendig und plastisch hervortreten. Als ich es so weit gebracht, hatte ich natürlich schon längst die Bretterbude verlassen, war von Stufe zu Stufe höher gestiegen, hatte mir die vorzüglichsten und kostbarsten Apparate aus München und Wien kommen lassen und siedelte dann endlich nach Washington über, ein, wie die Amerikaner sagen: ›self-made man‹ – und bezeichnend genug ist dieses Wort in der That. Hier zu Lande heißt es: Schwimmen oder untergehen! und wollte man drüben in Europa so arbeiten wie hier, Alles anfassen, vor Nichts zurückschrecken, man könnte auch im alten Vaterlande sich derart in die Höhe arbeiten, wie es mir im neuen gelungen«.
     </p>
-    <p xml:id="eco_de_0000145_920">
+    <p xml:id="eco_de_0000215_920">
      »Ich wünsche Ihnen nochmals Glück dazu«, sagte der Gelehrte sich jetzt erhebend; »aber haben Sie denn keine Sehnsucht, sich wieder einmal nach der alten Heimath und den alten Bekannten umzusehen?«
     </p>
-    <p xml:id="eco_de_0000145_930">
+    <p xml:id="eco_de_0000215_930">
      »Ich dachte bis jetzt nicht daran«, erwiederte Philipp, »ich habe ja eigentlich drüben Niemanden mehr, der sich nach mir sehnte; indessen, seit ich die früheren Erinnerungen aufgefrischt, regt sich doch so etwas wie Heimweh in der Herzgrube, wer weiß darum, was geschieht!«
     </p>
-    <p xml:id="eco_de_0000145_940">
+    <p xml:id="eco_de_0000215_940">
      So trennten sich Beide, der Professor setzte seine Reise weiter fort, Philipp arbeitete nach wie vor, aber das Gefühl, das an jenem Morgen seine Brust bewegte, ward immer lebhafter. Als die Maiensonne zu leuchten begann, die Bäume blühten und die Frühlingsblumen dufteten, war ihm zu Muthe, als erlebe er dies nicht in Amerika, sondern daheim, so lebhaft standen stets vor seinem inneren Blick die hellgrünen Buchenwälder, die bräunlichen Nußbäume, die wogenden Saaten und das Silberband des Rheines. Es hielt ihn nicht länger, der alte Wandertrieb erwachte, er mußte wieder einmal dorthin, mußte den Blick von den Höhen des Melibokus und des Felsberges hinausschweifen lassen in die weite Rheinebene oder ihn in die lauschigen Thäler des Odenwaldes tauchen. Nichts fesselte ihn; sein Geschäft konnten die Gehülfen schon ein paar Monate lang allein besorgen – darum fort, schon mit dem nächsten Dampfer, der ihn nach vierzehn Tagen wohlbehalten nach Hamburg brachte, wo sein Fuß wieder deutsche Erde betrat. Er gönnte sich keine Rast; in raschem Fluge trug ihn das Dampfroß gen Süden den Bergen zu, und hoch schlug ihm das Herz, als jetzt der Schaffner rief: Station Zwingenberg!
     </p>
-    <p xml:id="eco_de_0000145_950">
+    <p xml:id="eco_de_0000215_950">
      Hier sah nun Alles aus, wie ehedem, die alten Häuschen, die Kirche auf der Höhe, die Weinberge, ja, die Gänse schienen ihn noch zu kennen, als sie gackernd auseinanderflogen, da er jetzt mit starken Schritten in die Dorfstraße einbog.
     </p>
-    <p xml:id="eco_de_0000145_960">
+    <p xml:id="eco_de_0000215_960">
      Auf dem Platze vor dem »goldnen Löwen« lag breit und glänzend die Sonne, und im Hause regte sich nichts, als er die Steintreppe hinauf schritt, nur hinten aus der Küche und vom Hofe her hörte man die Stimmen der Mägde und das Plätschern des Brunnens.
     </p>
-    <p xml:id="eco_de_0000145_970">
+    <p xml:id="eco_de_0000215_970">
      Er wendete sich nach dem großen Gastzimmer, und in diesem Augenblick kam aus der Hinterstube eine Frau heraus, das verjüngte Abbild der guten Frau Martha, so sauber, behaglich und frisch, wie sie in Philipps Erinnerung lebte. Es war Marie, die junge Wirthin, die freundlich nach Philipps Begehren fragte. Er bestellte einen Schoppen Wasser und ward feuerroth, als sie ihn lächelnd und fragend ansah, was ihm sein Versehen klar machte; »nein, Wein wollte ich sagen«, entschuldigte er sich rasch und folgte ihr dann in die Gaststube. Aber deren neuer Glanz ließ ihn gleichgültig, sein Blick flog nur hinüber nach dem Spiegel und suchte nach seinem alten Bilde. Vergebens, es war nicht mehr an seiner Stelle, und Philipp setzte sich mechanisch nieder, weil ihm auf einmal zu Muthe war, als läge ihm Blei in den Gliedern. »Vergessen, todt und vergessen!« murmelte er vor sich hin und bemerkte kaum, wie ihm die Wirthin mit einem freundlichen: Wohl bekomm's! den Wein hinsetzte. Es kam ihm auf einmal so ungemein thöricht vor, daß er Amerika, wo er eine Menge von Freunden besaß, verlassen, um hierher zu kommen, wo kein Mensch mehr nach ihm zu fragen schien.
     </p>
-    <p xml:id="eco_de_0000145_980">
+    <p xml:id="eco_de_0000215_980">
      Marie stand noch einen Augenblick zögernd, mit dem Gast ein paar freundliche Worte zu wechseln; als sie aber sah, wie er vor sich hinstarrte, wollte sie ihn nicht stören und verließ leise das Zimmer. Philipp stürzte ein Glas Wein hinunter, dann sprang er auf, riß den Hut vom Nagel und sagte: »Ich will hinauf in den Wald, der wird mich ja noch besser kennen, als die Menschen, und mit dem nächsten Dampfer geht es wieder heimwärts nach Amerika!« Den Stock schwingend ging der stattliche, hochgewachsene Mann rüstig den Bergweg hinan, und schon wollte er seitwärts durch die Weinberge abbiegen, da tönten fröhliche Kinderstimmen an sein Ohr. Er blieb einen Augen blick stehen: »In Frau Marthens Kinderstube ist es wieder lebendig; laß doch sehen, wer jetzt das Revier bevölkert«.
     </p>
-    <p xml:id="eco_de_0000145_990">
+    <p xml:id="eco_de_0000215_990">
      Mit diesen Worten wendete er sich nach links und schritt durch das verfallene Thor in den uns wohlbekannten Schloßraum, der ganz so grün und lauschig, so erfüllt von Blumenduft und Vogelgezwitscher vor ihm lag, wie vor zwanzig Jahren. Drei rothbackige Kinder, zwei Knaben und ein Mädchen, nur kleiner als damals Frau Marthens Sprößlinge gewesen, tummelten sich lustig im Grünen und jagten mit so tollem Geschrei den Schmetterlingen nach, daß jetzt zwischen ihrem Jubel eine sanfte Warnungsstimme laut wurde. Auf den Baumstämmen, die dort lagen, saß ein großes, stattliches Mädchen mit Nähen beschäftigt, das fragend den Blick erhob, als der Fremde ihr näher trat. Dazwischen aber drängte sich die kleine Schaar: »Tante Gretchen, gib uns jetzt zu essen!«, und mit freundlichem Wort reichte die Angeredete aus einem Körbchen jedem ein Butterbrod, mit dem sie sich jubelnd wieder entfernten.
     </p>
-    <p xml:id="eco_de_0000145_1000">
+    <p xml:id="eco_de_0000215_1000">
      Tante Gretchen! Nun, Philipp hätte kaum des Namens bedurft, um nicht an dem krausen Haar, dem freundlichen Blick, der blauen Augen und dem lieblichen Ton der Stimme seine kleine Jugendfreundin zu erkennen. Er begrüßte sie jetzt höflich, bat um die Erlaubniß einen Augenblick hier ausruhen zu dürfen, sprach dann von der Gegend und gab nach und nach zu erkennen, daß er früher hier nicht ganz fremd gewesen, nun aber lange nicht mehr die Bergstraße besucht habe. »Ich kann mich indessen noch auf Alles recht wohl besinnen«, fuhr er fort, »ich war als Kind öfter im goldnen Löwen«.
     </p>
-    <p xml:id="eco_de_0000145_1010">
+    <p xml:id="eco_de_0000215_1010">
      »Wirklich?« rief Gretchen; »ich bin ja die Tochter aus dem Hause, und die Kinder dort gehören der Marie, die jetzt mit ihrem Manne die Wirthschaft führt; da müßt Ihr uns doch wohl auch gekannt haben«.
     </p>
-    <p xml:id="eco_de_0000145_1020">
+    <p xml:id="eco_de_0000215_1020">
      »Ja wohl, kann sein«, antwortete Philipp gleichgültig, »dies vergißt sich; aber an Eines kann ich mich noch sehr gut erinnern, an ein Bild, welches in dem Gastzimmer unter dem Spiegel hing und einen kleinen Betteljungen vorstellte. Es war ein ganz schlechtes Lichtbild, aber man sah damals solche Bilder noch selten, und darum wurde es von den Erwachsenen oft betrachtet und besprochen, was ich dann so mit anhörte. Als ich vorhin meinen Schoppen unten trank, sah ich mich gleich nach dem Bilde um, es fiel mir wieder ein, weil ich selbst Photograph bin; aber es ist jetzt natürlich verschwunden«.
     </p>
-    <p xml:id="eco_de_0000145_1030">
+    <p xml:id="eco_de_0000215_1030">
      Während der Fremde sprach, hatte Gretchen den Blick nicht von ihm verwendet, die Stimme kam ihr so bekannt vor, auch der Zug um den Mund, aber sie wußte sich doch nicht zurecht zu finden; als er jetzt des verschwundenen Bildes erwähnte, lachte sie hell auf und rief: »Das Bild ist noch da, und es stellt keinen Betteljungen vor, sondern einen ganz braven Knaben, der täglich mit uns Kindern spielte. Darum ließ ich auch sein Bild nicht zu Grund gehen, sondern habe es hier in meinem Nähkasten aufgehoben. Ihr könnt es also noch sehen!« Damit schlug sie den Deckel des Kastens zurück, kramte die Zeugstücke heraus und holte endlich Philipps alte Photographie hervor. Dieser konnte sich aber nun nicht länger halten, die hellen Thränen stürzten ihm aus den Augen, und schluchzend rief er: »Gretchen, kennst Du denn den Philipp nicht mehr?« Da fiel es ihr wie Schuppen von den Augen, sie sprang auf, und dann faßten sie einander um den Hals und weinten wie die Kinder. Erst das Erstaunen der wirklichen Kinder brachte sie wieder zu sich; im Sturmschritt ging es jetzt den Berg hinunter, bald lachend, bald weinend, und schon von Weitem rief Gretchen der Schwester zu, die oben auf der Treppe stand: »Ei, sieh doch, Marie, der Philipp ist wieder da, und Du hast ihn nicht einmal erkannt!«
     </p>
-    <p xml:id="eco_de_0000145_1040">
+    <p xml:id="eco_de_0000215_1040">
      Nach zwei Minuten saß der beglückte Philipp in der Hinterstube neben Frau Marthens Sessel, hielt ihre Hände in den seinen, war aber kaum im Stande, seine Freude in Worte zu fassen, ebensowenig, wie er etwas von der Mahlzeit genießen konnte, welche Gretchen nun freudestrahlend vor ihm auftrug, nach und nach in ihrer Aufregung so viele Schüsseln herbeibringend, daß eine große Gesellschaft daran genug gehabt hätte. Als sie dann selber merkte, wie viel sie hergerichtet, mußte sie hell auflachen, und Philipp stimmte so herzlich mit ein, daß auch Frau Martha und die Kinder angesteckt wurden, bis sich die allgemeine Lustigkeit in die Küche und in den Stall verbreitete, weil Mamsell Gretchen in ihrer Herzensfreude so lächerlich viel aufgetragen.
     </p>
-    <p xml:id="eco_de_0000145_1050">
+    <p xml:id="eco_de_0000215_1050">
      Wie ein Lauffeuer ging nun die Kunde von Philipps Wiederkehr durch das Dorf, und als sich am Abend die Gemüther einigermaßen beruhigt hatten, saß er auf der Bank vor dem Hause und erzählte den alten Schulkameraden von seinen Reisen und Schicksalen. Unterdessen schickte Gretchen Boten an die Brüder ab, sie auf den morgenden Sonntag mit Kind und Kegel einzuladen, denn der Philipp sei wieder da und seine Rückkehr solle im »goldnen Löwen« hochgefeiert werden, wie einst die des verlornen Sohnes.
     </p>
-    <p xml:id="eco_de_0000145_1060">
+    <p xml:id="eco_de_0000215_1060">
      So wurde es denn auch ausgeführt, und als sich am Abend nach einem frohbewegten Tage die ganze Familie in der Hinterstube um Frau Marthens Lehnstuhl versammelte, erzählte Philipp geordnet und der Reihe nach seine Erlebnisse, von denen man bis jetzt nur Bruchstücke vernommen hatte. Gretchen stand während dem wie festgebannt hinter dem Stuhle der Mutter, auf dessen Lehne sie die Arme stützte, während ihr Blick an Philipps Munde hing. Wie sie dies alles ergriff und erschütterte, was da an ihrem inneren Auge vorüberging, und wie dieses nun freudig aufleuchtete, als Philipp am Schlusse seiner Erzählung sein schönes Daheim in Washington schilderte, von den Freunden erzählte, die ihm dort weilten, und mittheilte, wie der Besuch des deutschen Gelehrten die alten Erinnerungen so mächtig in ihm erweckte, daß er durchaus die Heimath wiedersehen mußte. »Aber, wer weiß,« fuhr er dann aufspringend fort, »wenn das treue Gretchen mich nicht wieder erkannt, wenn sie mir nicht ein so gutes Andenken bewahrt hätte, ob ich dann nicht wieder gegangen wäre, wie ich kam. Sie hat auf mich im Guten vertraut, und wahrlich, wie viel ich auch erlebt und durchgemacht, ich habe mir nichts Schlechtes vorzuwerfen, ich war ein klein wenig ein Vagabund, aber stets ein ehrlicher und fleißiger, wohin das Schicksal mich auch warf. Gretchen, liebes Gretchen, nimm einmal die Hände von den Augen, und sieh mir in's Gesicht, damit ich Dir sagen kann, daß ich nur noch den einen Wunsch habe, Du mögest es jetzt auch einmal mit dem Vagabundenthum versuchen und mit mir bis Amerika vagabundiren, wo mein nettes Haus schon seit lange auf eine deutsche Hausfrau wartet«. Er trat bei diesen Worten zu Gretchen, nahm ihr die eine Hand von den Augen und führte sie vor Martha:
     </p>
-    <p xml:id="eco_de_0000145_1070">
+    <p xml:id="eco_de_0000215_1070">
      »Liebe, gute Frau Martha, wollt Ihr mir Euer Gretchen zur Frau geben?«
     </p>
-    <p xml:id="eco_de_0000145_1080">
+    <p xml:id="eco_de_0000215_1080">
      »Ja, Philipp, wenn sie will«, erwiederte Frau Martha; »die ist aber gar apart, sie wollte nie etwas vom Heirathen hören!«
     </p>
-    <p xml:id="eco_de_0000145_1090">
+    <p xml:id="eco_de_0000215_1090">
      »Jetzt will sie aber!« rief die Schelmin mit heller Stimme, indem sie die Hand von den Augen zog, in denen es von Thränen blitzte, welche der lachende Mund und die Grübchen in den Wangen Lügen strafte, »ich war ja doch dem Vagabunden immer gut, so lange ich denken kann, so will ich denn in Gottes Namen seine Frau Vagabundin werden!« –
     </p>
-    <p xml:id="eco_de_0000145_1100">
+    <p xml:id="eco_de_0000215_1100">
      Sechs Wochen später war wieder ganz Zwingenberg auf den Füßen; ein stattliches Brautpaar, von einem langen Zuge geleitet, schritt die Bergstraße hinan zur Kirche – es waren Philipp und Gretchen. Oben jedoch hielten Alle wie verabredet einen Augenblick still, da stand ein schwarzer Kasten und dahinter ein junger Mann, der Sohn des Photographen Rudolph, der nahm den ganzen Hochzeitszug auf, wie er es Philipp versprochen hatte.
     </p>
-    <p xml:id="eco_de_0000145_1110">
+    <p xml:id="eco_de_0000215_1110">
      Das junge Paar langte dann rechtzeitig und wohlbehalten in Washington an, und wer etwa von unseren jungen Lesern und Leserinnen dahin kommt, der versäume nicht, das berühmte Atelier von Herrn Philipp Maurer zu besuchen und sich bei ihm vom Sonnenlicht malen zu lassen.
     </p>
    </div>

--- a/tei/Buechner_Luise_Die_Fee_von_Argouges.xml
+++ b/tei/Buechner_Luise_Die_Fee_von_Argouges.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-model href="https://raw.githubusercontent.com/COST-ELTeC/Schemas/master/eltec-1.rng" type="application/xml" 
             schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xml:id="eco_de_0000146" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xml:id="eco_de_0000216" xml:lang="de" xmlns="http://www.tei-c.org/ns/1.0">
  <teiHeader>
   <fileDesc>
    <titleStmt>
@@ -84,7 +84,7 @@
  </teiHeader>
  <text>
   <front>
-   <p xml:id="eco_de_0000146_20">
+   <p xml:id="eco_de_0000216_20">
     Die Fee von Argouges
    </p>
   </front>
@@ -92,121 +92,121 @@
    <div type="group">
     <head>
     </head>
-    <p xml:id="eco_de_0000146_30">
+    <p xml:id="eco_de_0000216_30">
      Der Ritter von Argouges wohnte auf dem Schlosse seiner Väter, in der Nähe der alten Stadt Bayeux, und trieb da all' die Kurzweil, die einem hochgebornen Herrn erlaubt und angenehm ist. Er war tapfer, schön, gewandt und in allen ritterlichen Künsten wohl erfahren. Obgleich er grade nicht an übergroßer Bescheidenheit litt, schien es ihm doch seit einiger Zeit, als ob ihn bei seinen Unternehmungen eine höhere Kraft unterstütze und lenke. Erst in der jüngsten Zeit war ihm die Besiegung eines furchtbaren Riesen, der die ganze Gegend unsicher machte, gelungen, und noch in der Erinnerung dünkte es ihm fast unmöglich, daß er dessen Keulenschlägen hatte entgehen können. Mein Gott, der Ritter hatte eben Glück, und war wenigstens so ehrlich, sich dies selber zuzugestehen.
     </p>
-    <p xml:id="eco_de_0000146_40">
+    <p xml:id="eco_de_0000216_40">
      Eines Tages, – es war im Juli, aber ein köstlicher Seewind lähmte die Kraft der Sonne, die breit und golden auf dem saftigen Grün der Wiesen lag und in lichten Scheiben durch die verschlungenen Aeste einer Lindenallee fiel – durchritt der Herr von Argouges diese Allee langsam, um sich zur Jagd in den nahegelegenen Wald zu begeben.
     </p>
-    <p xml:id="eco_de_0000146_50">
+    <p xml:id="eco_de_0000216_50">
      Da erhob sich am Ende der Allee eine goldglänzende Staubwolke, die näher und näher kam, bis aus dem Rahmen eine Gestalt nach der Andern klar und deutlich hervortrat. Dem Ritter vergingen fast die Sinne, als er nun sah, wie eine Schaar von zwanzig Frauen, so schön, wie er noch keine gekannt, ihm auf prächtigen, schneeweißen Rossen entgegenkam. Sie trugen lange, grüne Jagdgewänder, ein grünes Hütchen mit weißer wallender Feder auf den blonden oder braunen Locken und ein silbernes Hüfthorn an der Seite. Als sie den Ritter gewahrten, blickte die eine schelmisch, die andere stolz, die Dritte schlug die Augen nieder – aber sie hätten sich alle diese Mühe ersparen können, denn er hatte nur Augen für die Eine, die an der Spitze des Zuges ritt, und die Uebrigen, wie unmöglich dies auch fast erschien, doch noch weit an Schönheit übertraf. Sie war frisch und blühend, wie das Land, dem sie entstammte, und recht eigentlich das Urbild seiner starken kräftigen Frauen. Wie der sonnendurchglühte Apfel am Baume, so blühte die Wange, welche die nußbraune Locke umflog und dem Meerschaume, mochte das glänzende Weiß der Stirne entwendet sein, unter der die braunen Augen hell aufblitzten.
     </p>
-    <p xml:id="eco_de_0000146_60">
+    <p xml:id="eco_de_0000216_60">
      Der Herr von Argouges war ehrerbietig zur Seite geritten, den königlichen Zug vorüberzulassen, und sein Blick hing unverwandt an dessen Führerin.
     </p>
-    <p xml:id="eco_de_0000146_70">
+    <p xml:id="eco_de_0000216_70">
      Da, als sie dicht vor ihm war, zog sie den goldnen Zügel ihres Rosses scharf zurück, daß es hoch aufbäumte und sagte mit einer Stimme, die voll und lieblich klang, wie der Ton einer silbernen Glocke: »Mein Herr Ritter, wollt Ihr mir erlauben, mit meinem Gefolge in Eurem Forste zu jagen, und wollt Ihr uns dahin begleiten?«
     </p>
-    <p xml:id="eco_de_0000146_80">
+    <p xml:id="eco_de_0000216_80">
      Der Herr von Argouges war wie verzaubert; er nickte stumm, lenkte seinen Rappen an die Seite der schönen hohen Frau, und nachdem sie noch einen langen Blick mit einander getauscht, setzten sich ihre Pferde in Bewegung. Schneller und immer schneller, wie von der Erde losgelöst, flogen sie dahin über den Wiesenplan, über Gräben und Hecken, und hinein in den Wald. Aber die schattige Kühle, die er ausathmete, vermochte die Gluth, die Beider Herzen schon erfüllte, nicht mehr zu dämpfen. Ohne Rast flohen sie tiefer und tiefer in das grüne Dickicht, bis sie den Blicken ihres Gefolges vollständig entschwunden waren. Schon lange hatten die Schelmische, die Stolze, die Sittsame und alle Uebrigen ihren Lauf gemäßigt – diesem Ritte war weder bei- noch nachzukommen, und Eine nach der Andern blieb zurück, ihre Königin dem Schutze des Herrn von Argouges überlassend.
     </p>
-    <p xml:id="eco_de_0000146_90">
+    <p xml:id="eco_de_0000216_90">
      Diese war in der That wohl aufgehoben; dort wo die Quelle zwischen weichem Moose über glatte Kiesel sprang und ein Kranz von Buchen die breiten Aeste zu einem grünen Dome ineinander flocht, saß die schöne Frau auf einem moosbewachsenen Felsen und fächelte sich die heiße Wange mit einem Buchenzweige, zwischen dessen Blätter nun ihre Augen so goldne Lichter spielen ließen, wie vorhin die Sonne zwischen den Zweigen der Lindenallee. Der Ritter war auch vom Pferde gesprungen, hatte sich der schönen Dame zu Füßen geworfen, sog die gefährlichen Sonnenblicke immer tiefer in das Herz hinein und seufzte laut.
     </p>
-    <p xml:id="eco_de_0000146_100">
+    <p xml:id="eco_de_0000216_100">
      »Was fehlt Euch, Herr Ritter?« fragte die stolze Frau mit freundlichem Lächeln. »Ihr, der tapferste aller Ritter, Ihr, der Ihr erst kürzlich den Riesen besiegtet, Ihr liegt hier wie ein kleiner Knabe, dem man sein Spielzeug genommen«.
     </p>
-    <p xml:id="eco_de_0000146_110">
+    <p xml:id="eco_de_0000216_110">
      »Himmlisches Wesen«, seufzte der Ritter mit bebender Stimme, »holdselige Frau, Deine Schönheit wirft mich tiefer in den Staub, als ich dem Riesen oder einem anderen meiner Gegner gethan!«
     </p>
-    <p xml:id="eco_de_0000146_120">
+    <p xml:id="eco_de_0000216_120">
      »Du sprichst schön«, antwortete die Dame, die Augen niederschlagend, »und ich fühle es am Klopfen meines eigenen Herzens, daß Du die Wahrheit redest!«
     </p>
-    <p xml:id="eco_de_0000146_130">
+    <p xml:id="eco_de_0000216_130">
      Der Ritter seufzte nun nicht mehr, mit einem Freudenschrei sprang er auf seine Füße und ließ sich auf den Felsen neben seiner schönen Freundin nieder.
     </p>
-    <p xml:id="eco_de_0000146_140">
+    <p xml:id="eco_de_0000216_140">
      »Also wirklich – Du liebst mich?«
     </p>
-    <p xml:id="eco_de_0000146_150">
+    <p xml:id="eco_de_0000216_150">
      »Ich liebe Dich!«
     </p>
-    <p xml:id="eco_de_0000146_160">
+    <p xml:id="eco_de_0000216_160">
      »Ach, welch' ein Glück!«
     </p>
-    <p xml:id="eco_de_0000146_170">
+    <p xml:id="eco_de_0000216_170">
      Der Ritter umfaßte die schöne Dame und drückte sie an sein Herz, aber sie machte sich los und sagte, seine beiden Hände mit ihren weißen Fingern umschließend:
     </p>
-    <p xml:id="eco_de_0000146_180">
+    <p xml:id="eco_de_0000216_180">
      »Höre erst, o mein Geliebter, was ich Dir zu sagen habe: Ich bin keine gewöhnliche Sterbliche.«
     </p>
-    <p xml:id="eco_de_0000146_190">
+    <p xml:id="eco_de_0000216_190">
      »Nein, eine Göttin, ein Engel, eine Fee«, rief der verliebte Ritter.
     </p>
-    <p xml:id="eco_de_0000146_200">
+    <p xml:id="eco_de_0000216_200">
      »Du hast es errathen«, sagte sie sanft, »ich bin wirklich eine Fee, die Dich schon lange zärtlich liebt. Mit der überirdischen Kraft, die Dich seit einiger Zeit beseelt, habe ich Dich ausgerüstet, und so groß ist meine Liebe zu Dir, daß ich allen Freuden und Genüssen des Feenlebens entsagen, Dir nach Deinem Schlosse folgen und Deine Gattin werden will!«
     </p>
-    <p xml:id="eco_de_0000146_210">
+    <p xml:id="eco_de_0000216_210">
      So demüthigend für den Ritter auf der einen Seite die Entdeckung war, daß nicht er allein den Riesen besiegt, so schmeichelhaft war hingegen das Bewußtsein, von einer Fee geliebt zu werden. Da seine Hände gefangen waren, so drückte er einen heißen Kuß auf die Stirn seiner geliebten Fee und schwur ihr ewige Treue.
     </p>
-    <p xml:id="eco_de_0000146_220">
+    <p xml:id="eco_de_0000216_220">
      »Dieses Schwures bedarf es nicht«, sagte sie lächelnd, »es ist meine Aufgabe, Deine Treue ohne solchen festzuhalten, wohl aber mußt Du mir schwören, niemals in meiner Gegenwart das Wort ›Tod‹, auszusprechen. Sobald Du es thust, muß ich Dich auf ewig verlassen«.
     </p>
-    <p xml:id="eco_de_0000146_230">
+    <p xml:id="eco_de_0000216_230">
      »Sonst nichts?« rief entzückt der Ritter. »Wie soll ich an den Tod denken, wenn ich Dich, mein Leben, bei mir habe? Ich schwöre Dir bei allen Mächten der Ober- und Unterwelt, daß dieses Wort niemals meinen Lippen entschlüpfen soll!«
     </p>
-    <p xml:id="eco_de_0000146_240">
+    <p xml:id="eco_de_0000216_240">
      Nun ward der Bund geschlossen, man sank einander entzückt in die Arme, und nach einer Weile ward beschlossen, den Heimweg wieder anzutreten.
     </p>
-    <p xml:id="eco_de_0000146_250">
+    <p xml:id="eco_de_0000216_250">
      Wie lange dieser währte, weiß Niemand; langsam ritt man durch den mondbeglänzten Abend, hielt an, um sich in die Augen zu sehen und süße Worte zuzuflüstern, und kam endlich im Schlosse von Argouges an, wo am nächsten Tag die Hochzeit mit aller erdenklichen Pracht und Lustbarkeit gefeiert wurde.
     </p>
-    <p xml:id="eco_de_0000146_260">
+    <p xml:id="eco_de_0000216_260">
      Das Glück des schönen, stolzen Paares war vollkommen und wurde selten durch kleine Zwischenfälle gestört. Die liebenswürdige Frau von Argouges faltete bescheiden ihre Schwingen zusammen, um den Gemahl ihre feenhafte Ueberlegenheit nicht empfinden zu lassen, und der Ritter gewöhnte sich nach und nach an das berauschende Bewußtsein, eine Ueberirdische zur Gemahlin zu haben. Schöne, blühende Kinder belebten bald die sonst so stillen Räume des Schlosses, und in der ganzen Normandie war keine glücklichere Familie aufzufinden. Der Ritter hielt fest an seinem Schwure, obgleich ihm dies anfänglich schwerer fiel, als er selber dachte. Ein Ritter, der nicht fluchte, wäre eine so seltene Erscheinung, wie Schnee und Eis mit ten im Sommer, und: »Tod und Hölle!« oder »Tod und Teufel!« das sind denn doch die echt adligen Ritterflüche, bei denen der Brustharnisch so herrlich rasselt, wie wenn man mit der Eisenfaust darauf schlägt. Aber der Herr von Argouges bezwang sich ritterlich; so oft ihm diese Kraftausdrücke auf die Zunge stiegen, und wenn sein belastetes Herz durchaus einer Explosion bedurfte, begnügte er sich mit einem einfachen »Donnerwetter!« oder mit einem andern plebejischen Fluche, den er seinen Knappen entlehnte.
     </p>
-    <p xml:id="eco_de_0000146_270">
+    <p xml:id="eco_de_0000216_270">
      Die finstern Mächte aber, die nimmer rasten, suchten auch dieses Glück feindlich zu zerstören. – Auf dem Nachbarschlosse des Herrn von Argouges sollte eine große Hochzeit gefeiert werden, zu der man von weit und breit die vornehmsten Gäste geladen hatte. Daß der Ritter mit seiner schönen Frau unter diesen war, versteht sich von selbst. Besonderes Interesse erregte das Fest durch die große Schönheit der jugendlichen Braut, die in dem weißen Atlasgewande, mit dem Schleier und dem Myrthenkranz geradezu wie ein Engel aussehen mußte.
     </p>
-    <p xml:id="eco_de_0000146_280">
+    <p xml:id="eco_de_0000216_280">
      Die Frau von Argouges fühlte sich durch diese Betrachtung weniger erbaut; bis dahin war sie überall, wo sie erschien, unbestritten die Schönste gewesen – sollte ihr nun dieser Rang entgehen? Sie beschloß daher, auf ihre Toilette eine Mühe zu verwenden, wie nie zuvor. Schon seit Wochen bewegte ihr überirdisches Herz die inhaltschwere Frage: »Welches Kleid werde ich anziehen? Das weiße, das die Elfen aus Mondesstrahlen gewoben, oder das himmelblaue aus Aetherduft gebildete, oder das duftige Rosengewand von Nebeln, welche die Abendröthe angehaucht, oder das seegrüne Kleid, gewirkt aus der spiegelglatten Fläche des Oceans?« Weiß – das ging nicht! diese Farbe trug die Braut! Blau – keine rechte Abendfarbe! Rosa – zu mädchenhaft! Seegrün – dies paßte und war zugleich das Neueste!
     </p>
-    <p xml:id="eco_de_0000146_290">
+    <p xml:id="eco_de_0000216_290">
      Der verhängnißvolle Tag erschien, und schon frühzeitig zog sich die schöne Frau in ihr Gemach zurück, ihre Toilette zu beginnen. Der Gemahl begleitete sie bis an die Thüre und sagte, nach einem zärtlichen Abschiedskuß, in etwas gedrücktem Tone: »Nicht wahr, mein Liebchen, Du läßt mich nicht zu lange warten?« Man konnte merken, daß hier ein wunder Fleck war, den er mit demüthiger Scheu berührte. »Sei ohne Sorgen«, antwortete sie, »ich bin in einer Viertelstunde fertig!«
     </p>
-    <p xml:id="eco_de_0000146_300">
+    <p xml:id="eco_de_0000216_300">
      Der Ritter mochte der Viertelstunde nicht ganz trauen, denn er befahl seinem Knappen, die Pferde nach zwei Stunden bereit zu halten.
     </p>
-    <p xml:id="eco_de_0000146_310">
+    <p xml:id="eco_de_0000216_310">
      Im Toilettenzimmer begann die Arbeit. Die Kammerzofen der Frau von Argouges kämmten ihr die langen, braunen Locken und durchflochten sie auf die kunstreichste Weise mit köstlichen Perlen. Aber sie war nicht damit zufrieden; kaum waren sie fertig, als sie erklärte, dieser Kopfputz sei unerträglich steif, sie wolle weiße Rosen haben, und mit diesen müsse auch das grüne Kleid geschmückt werden. Die Zofen flogen hinab in den Garten, kamen mit prachtvollen Rosen zurück und vollbrachten neue Wunder der Geschicklichkeit. Als sie eben fertig waren, wurden die prächtig geschmückten Pferde des edlen Paares vor die Schloßtreppe geführt; denn die zwei Stunden waren verflossen, und der Ritter pochte an die Thüre und fragte bescheiden, ob seine Gemahlin bereit sei.
     </p>
-    <p xml:id="eco_de_0000146_320">
+    <p xml:id="eco_de_0000216_320">
      »Keineswegs!« lautete etwas ärgerlich die Antwort der schönen Frau, indem sie die weißen Rosen wieder aus den Locken riß. Zu ihren Kammerfrauen gewendet, fuhr sie fort: »Ich kann mich so nicht sehen; ich bin wie eine geschmückte Leiche; geschwind das rothe Kleid herbei, grün steht mir heute gar nicht!«
     </p>
-    <p xml:id="eco_de_0000146_330">
+    <p xml:id="eco_de_0000216_330">
      Während der Ritter ungeduldig im Nebensaale auf-und niederschritt, wurde das grüne Kleid ausgezogen und das rothe geholt. Es stand ihr herrlich; aber nun konnte die Frau von Argouges sich nicht entscheiden, ob sie eine weiße oder rothe Schärpe um ihre schlanke Taille binden solle. Der Ritter ging, um nach der Uhr zu sehen. Welche Vortheile bot doch die alte Zeit! Jetzt reißt ein ungeduldiger Gatte die Uhr in einer Stunde zehnmal aus der Westentasche; der Ritter mußte erst hinunter in den Garten gehen und die Sonnenuhr aufsuchen. Ihre Zeiger warfen lange Schatten; die Hände geballt, stieg er wieder hinauf an die verhängnißvolle Thüre: »Bist Du noch nicht fertig? wir müssen fort«.
     </p>
-    <p xml:id="eco_de_0000146_340">
+    <p xml:id="eco_de_0000216_340">
      Zähneknirschend trat der Ritter an das Fenster, die Pferde scharrten den Boden und bäumten sich, in seinem Herzen bäumte sich gleichfalls ein wilder Zorn; die schöne Frau aber stand ruhig vor ihrem Spiegel, hielt sich prüfend blitzende Demantschnüre an die Locken und befahl endlich ihren Zofen, sie damit zu schmücken. Der Ritter raste an der Thüre.
     </p>
-    <p xml:id="eco_de_0000146_350">
+    <p xml:id="eco_de_0000216_350">
      »Bist Du noch nicht fertig? Ich gehe allein!«
     </p>
-    <p xml:id="eco_de_0000146_360">
+    <p xml:id="eco_de_0000216_360">
      »O, es ist schändlich, wie Du mich behandelst! Wenn Du nur eine Minute auf mich warten sollst, so ist es Dir zu viel!« Sie hätte gern geweint, wenn dies den Glanz ihrer schönen Augen nicht beeinträchtigt hätte. Erschöpft, seiner Sinne kaum noch mächtig, sank der Herr von Argouges in einen Sessel.
     </p>
-    <p xml:id="eco_de_0000146_370">
+    <p xml:id="eco_de_0000216_370">
      »Nun hole mir noch eine volle Purpurrose«, sagte indessen seine reizende Quälerin zu ihrer Zofe. Die Rose kam, sie wurde am linken Ohre befestigt – noch einen Blick in den Spiegel, die schöne Fee war mit sich zufrieden; sie konnte es nun mit der jüngsten und schönsten aller Bräute aufnehmen.
     </p>
-    <p xml:id="eco_de_0000146_380">
+    <p xml:id="eco_de_0000216_380">
      Der Ritter hatte unterdessen alle Stadien des Zornes und der Wuth durchlaufen und war auf dem Gipfel der Verzweiflung, bei der Ironie, angekommen, als seine liebreizende Gattin ihm nun entgegentrat. »Schöne Dame«, sagte er mit kaltem Tone und seines Schwures vollständig vergessend, »Ihr brauchet wahrlich so viel Zeit, um Euch schön zu machen, daß man Niemand besser als Euch nach dem Tode schicken könnte!«
     </p>
-    <p xml:id="eco_de_0000146_390">
+    <p xml:id="eco_de_0000216_390">
      Ein furchtbarer Schlag erschütterte das Schloß in seinen Grundvesten, tiefe Finsterniß umgab den Ritter, und als sie gewichen, und er wieder zu sich selbst kam, war seine geliebte Gemahlin auf ewige Zeit verschwunden. Er hatte das entsetzliche Wort ausgesprochen, das sie nicht hören konnte.
     </p>
-    <p xml:id="eco_de_0000146_400">
+    <p xml:id="eco_de_0000216_400">
      Die einzige Spur, die sie von sich zurückließ, war der Abdruck ihrer zarten Hand auf dem Schloßthore; in stillen Nächten aber, da wimmert es heute noch leise und klagend durch die Gärten und Hallen des Schlosses von Argouges: »Tod! Tod!« –
     </p>
-    <p xml:id="eco_de_0000146_410">
+    <p xml:id="eco_de_0000216_410">
      So grausam, aber gerecht wurde der Mann gestraft, der seiner Gemahlin das unschuldige Vergnügen, sich nach Lust und Laune zu putzen, nicht gönnen mochte. Indessen scheint es uns doch ein großes Glück zu sein, daß heutigen Tages die Frauen, die zu lange Toilette machen, nicht mehr kraft des männlichen Zornes zu verschwinden brauchen; denn wir fürchten, es würde da gar manche Fee von Argouges ruhelos zwischen Himmel und Erde umherirren.
     </p>
    </div>


### PR DESCRIPTION
## Summary

- IDs `eco_de_0000138`–`eco_de_0000146` were duplicated between pre-existing files and batch-3 women-author files added in 63e1cf5
- Reassigns the 9 batch-3 files (`Anklam`, `Bernhard`, `Bindschedler` ×2, `Boehlau` ×3, `Büchner` ×2) to `eco_de_0000208`–`eco_de_0000216` (next free range after current max `eco_de_0000207`)
- Pre-existing files are untouched and retain their original IDs